### PR TITLE
Implement hack for djangorecipe relative-path problem

### DIFF
--- a/conf/django-hack
+++ b/conf/django-hack
@@ -1,0 +1,35 @@
+#!/usr/bin/python2.7
+
+import os
+
+join = os.path.join
+base = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+base = os.path.dirname(base)
+
+import sys
+sys.path[0:0] = [
+  join(base, 'src/rockstor'),
+  join(base, 'eggs/djangorecipe-1.5-py2.7.egg'),
+  join(base, 'eggs/Django-1.4.3-py2.7.egg'),
+  join(base, 'eggs/zc.recipe.egg-2.0.0-py2.7.egg'),
+  join(base, 'eggs/zc.buildout-2.1.0-py2.7.egg'),
+  join(base, 'eggs/South-0.7.6-py2.7.egg'),
+  join(base, 'eggs/pyzmq-13.0.0-py2.7-linux-x86_64.egg'),
+  join(base, 'eggs/requests-1.1.0-py2.7.egg'),
+  join(base, 'eggs/gevent_socketio-0.3.6-py2.7.egg'),
+  join(base, 'eggs/socketIO_client-0.3-py2.7.egg'),
+  join(base, 'eggs/django_pipeline-1.2.23-py2.7.egg'),
+  join(base, 'eggs/pytz-2013b-py2.7.egg'),
+  join(base, 'eggs/djangorestframework-2.1.15-py2.7.egg'),
+  join(base, 'eggs/URLObject-2.1.1-py2.7.egg'),
+  join(base, 'eggs/gevent_websocket-0.3.6-py2.7.egg'),
+  join(base, 'eggs/websocket_client-0.10.0-py2.7.egg'),
+  join(base, 'eggs/anyjson-0.3.3-py2.7.egg'),
+  join(base, 'eggs/greenlet-0.4.0-py2.7-linux-x86_64.egg'),
+  join(base, 'eggs/gevent-0.13.8-py2.7-linux-x86_64.egg'),
+  ]
+
+import djangorecipe.manage
+
+if __name__ == '__main__':
+    sys.exit(djangorecipe.manage.main('rockstor.settings'))


### PR DESCRIPTION
This only effects prod/rpm based installs. bin/django, which is required for db
migrations doesn't get generated with relative paths. As a workaround stage
bin/django and copy during rpm post install.
