### PR TITLE
Nginx and gunicorn timeouts

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -157,7 +157,7 @@ port = 9001
 logdir = ${buildout:directory}/var/log
 logfile = ${supervisord-conf:logdir}/supervisord.log
 pidfile = ${buildout:directory}/var/run/supervisord.pid
-gunicorn_cmd = ${buildout:directory}/bin/gunicorn --bind=${init-gunicorn:bind}:${init-gunicorn:port} --pid=${init-gunicorn:pidfile} --workers=${init-gunicorn:workers} --log-file=${init-gunicorn:logfile} --pythonpath=${buildout:directory}/src/rockstor --settings=settings wsgi:application
+gunicorn_cmd = ${buildout:directory}/bin/gunicorn --bind=${init-gunicorn:bind}:${init-gunicorn:port} --pid=${init-gunicorn:pidfile} --workers=${init-gunicorn:workers} --log-file=${init-gunicorn:logfile} --pythonpath=${buildout:directory}/src/rockstor --settings=settings --timeout=120 --graceful-timeout=120 wsgi:application
 websocket_cmd = ${buildout:directory}/bin/wc
 smart_manager_cmd = ${buildout:directory}/bin/sm
 input = ${buildout:directory}/conf/supervisord.conf.in

--- a/conf/nginx.conf.in
+++ b/conf/nginx.conf.in
@@ -77,8 +77,8 @@ http {
                         proxy_redirect off;
                         proxy_set_header X-Real-IP $remote_addr;
                         proxy_set_header X-Scheme $scheme;
-                        proxy_connect_timeout 10;
-                        proxy_read_timeout 10;
+                        proxy_connect_timeout 75;
+                        proxy_read_timeout 120;
                         proxy_pass http://${init-gunicorn:bind}:${init-gunicorn:port}/;
                 }
 	}


### PR DESCRIPTION
Fixes #39
Update proxy_read_timeout to 120s and proxy_connect_timeout to 75s (max
allowed) for nginx.
Update timeout and graceful_timeout to 120s for gunicorn.
