### PR TITLE
Fixes #72

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -207,7 +207,7 @@ def disable_quota(pool_name, device):
 def update_quota(pool_name, pool_device, qgroup, size_bytes):
     pool_device = '/dev/' + pool_device
     root_pool_mnt = mount_root(pool_name, pool_device)
-    cmd = [BTRFS, 'qgroup', 'limit', size_bytes, qgroup, root_pool_mnt]
+    cmd = [BTRFS, 'qgroup', 'limit', str(size_bytes), qgroup, root_pool_mnt]
     out, err, rc = run_command(cmd)
     run_command(SYNC)
     umount_root(root_pool_mnt)
@@ -225,7 +225,7 @@ def share_usage(pool_name, pool_device, share_id):
     for line in out:
         fields = line.split()
         if (fields[0] == share_id):
-            usage = fields[-1]
+            usage = int(fields[-1]) / 1024 # usage in KB
             break
     run_command(SYNC)
     umount_root(root_pool_mnt)

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -68,7 +68,7 @@ class ShareView(APIView):
             disk = Disk.objects.filter(pool=share.pool)[0]
             qgroup_id = self._update_quota(share.pool.name, disk.name, sname,
                                            new_size)
-            cur_usage = int(share_usage(share.pool.name, disk.name, qgroup_id))
+            cur_usage = share_usage(share.pool.name, disk.name, qgroup_id)
             share.size = new_size
             share.free = new_size - cur_usage
             share.save()
@@ -99,7 +99,7 @@ class ShareView(APIView):
             qgroup = Qgroup(uuid=qgroup_id)
             qgroup.save()
             s = Share(pool=pool, qgroup=qgroup, name=sname, size=size,
-                    free=(size - cur_usage))
+                      free=(size - cur_usage))
             s.save()
             return Response(ShareSerializer(s).data)
         except RockStorAPIException:
@@ -110,7 +110,7 @@ class ShareView(APIView):
     def _update_quota(self, pool_name, disk_name, share_name, size):
         sid = share_id(pool_name, disk_name, share_name)
         qgroup_id = '0/' + sid
-        update_quota(pool_name, disk_name, qgroup_id, str(size))
+        update_quota(pool_name, disk_name, qgroup_id, size * 1024)
         return qgroup_id
 
     @transaction.commit_on_success

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -70,9 +70,7 @@ def scan_disks(min_size):
                 num_blocks = int(disk_fields[2]) # each block is 1KB
                 if (num_blocks < min_size):
                     continue
-                size = num_blocks / (1024 * 1024) # in GB
-                free = size
-                disk = Disk(name=name, size=size, free=free)
+                disk = Disk(name=name, size=num_blocks, free=num_blocks)
                 disks[name] = disk.__repr__()
             elif (re.match('sd[a-z]+[0-9]+$', disk_fields[3]) is not None):
                 name = disk_fields[3][0:3]


### PR DESCRIPTION
Save disk sizes in KB in the disk model. Update the retrieval code for disks
and shares to consistantly save and return numbers in KB.
