### PR TITLE
Humanize file sizes in disks table and shares table and usage.

### DIFF
--- a/src/rockstor/templates/storageadmin/js/js/graph.js
+++ b/src/rockstor/templates/storageadmin/js/js/graph.js
@@ -70,7 +70,7 @@ function displayUsagePieChart(svg, outerRadius, innerRadius, w, h, dataset, data
   })
   .text(function(d,i) {
     percent = Math.round((dataset[i]/total)*100);
-    return percent + '% ' + d + ' - ' + dataset[i] + ' bytes';;
+    return percent + '% ' + d + ' - ' + humanize.filesize(dataset[i]);;
   });
 
 

--- a/src/rockstor/templates/storageadmin/js/js/templates/disk/disks_table_template.jst
+++ b/src/rockstor/templates/storageadmin/js/js/templates/disk/disks_table_template.jst
@@ -47,7 +47,7 @@
             <% disks.each(function(disk, index) { %>
               <tr>
                 <td><%= disk.get('name') %></td>
-                <td><%= humanize.filesize(disk.get('size')) %></td>
+                <td><%= humanize.filesize(disk.get('size')*1024) %></td>
                <td>
                   <a href="#pools/<%= disk.get('pool') %>">
                     <%= disk.get('pool') %>

--- a/src/rockstor/templates/storageadmin/js/js/templates/share/shares_table_template.jst
+++ b/src/rockstor/templates/storageadmin/js/js/templates/share/shares_table_template.jst
@@ -46,7 +46,7 @@
             <tr>
               <td><%= index+1 %></td>
               <td><a href="#shares/<%= share.get('name') %>"><%= share.get('name') %></a></td>
-              <td><%= humanize.filesize(share.get('size')) %></td>
+              <td><%= humanize.filesize(share.get('size')*1024) %></td>
               <td><button id="delete_share_<%= share.get('name') %>" data-name="<%= share.get('name') %>" data-action="delete" data-pool="<%= share.get('pool').name %>" data-size="<%= share.get('size') %>" class="btn btn-danger">Delete</button></td>
 
             </tr>

--- a/src/rockstor/templates/storageadmin/js/js/views/share_usage_module.js
+++ b/src/rockstor/templates/storageadmin/js/js/views/share_usage_module.js
@@ -47,8 +47,8 @@ ShareUsageModule = RockstoreModuleView.extend({
     var outerRadius = 50;
     var innerRadius = 0;
     
-    total = parseInt(this.model.get('size'));
-    free = parseInt(this.model.get('free'));
+    total = parseInt(this.model.get('size')*1024);
+    free = parseInt(this.model.get('free')*1024);
     used = total - free;
     var dataset = [free, used]
     var dataLabels = ['free', 'used']


### PR DESCRIPTION
Multuply file sizes by 1024 in disks table and shares table since
backend returns size in KB.
Convert sizes appropriately and use humanize to display share size in
the usage pie chart.
