### PR TITLE
Fixes #80

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -320,3 +320,11 @@ Maximum number of seconds to keep data collected by smart probes. The logic
 behind this needs to evolve quite a bit.
 """
 PROBE_DATA_INTERVAL = 600
+
+"""
+Minimum share size allowed is 100KB. This is purely arbitrary. 4K is what is
+strictly required by btrfs. Similary, maximum is 2^64 bytes which is more than
+enough for all practical purposes and also is the max allowed in btrfs.
+"""
+MIN_SHARE_SIZE = 100
+MAX_SHARE_SIZE = 18014398509481984L


### PR DESCRIPTION
Fixes #79

Enforce a minimum/maximum allowed size for a share during its creation in the share api
implementation. Make acceptable minimum and maximum values as config variables
in settings.py.

Ensure the above constraint is satisfied for share resize as well. In addition,
throw error when the new size given in the resize request is smaller than the
current usage of the share.
