### PR TITLE
Disable create pool if all disks are offline or parted

### DIFF
--- a/src/rockstor/templates/storageadmin/js/js/views/pools.js
+++ b/src/rockstor/templates/storageadmin/js/js/views/pools.js
@@ -51,14 +51,16 @@ PoolsView = RockstoreLayoutView.extend({
 
   render: function() {
     this.fetch(this.renderPools,this);
-    $('#pool-table-ph-form :input').tooltip();
     return this;
   },
 
   renderPools: function() {
     var _this = this;
     
-    var freedisks = this.disks.filter(function(disk) { return disk.get('pool') == null; });
+    var freedisks = this.disks.filter(function(disk) { 
+      return (disk.get('pool') == null) && !(disk.get('offline')) && 
+        !(disk.get('parted')); 
+    });
     
     $(this.el).html(this.template({ collection: this.collection, disks: this.disks,noOfFreeDisks: _.size(freedisks)  }));
     
@@ -70,6 +72,7 @@ PoolsView = RockstoreLayoutView.extend({
       collection: this.collection
     }));
     this.$("#pools-table").tablesorter();
+    this.$('#pool-table-ph-form :input').tooltip();
    
     return this;
   },
@@ -87,7 +90,7 @@ PoolsView = RockstoreLayoutView.extend({
         dataType: "json",
         data: { "name": name },
         success: function() {
-          _this.collection.fetch({reset: true});
+          _this.render();
           enableButton(button);
         },
         error: function(xhr, status, error) {


### PR DESCRIPTION
Modify free disk filter to check if disk is offline or parted
Fetch disks and pools after a pool is deleted, because disks may now be
free.

Fixes #330
