### PR TITLE
Force refresh in 5 minutes during system update

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -25,7 +25,9 @@
     <br>
     <div style="text-align: center">
       <img src="/static/storageadmin/img/ajax-loader-big.gif">
+      <div id="time-left"></div>
     </div>
+    <div id="user-msg" style="display: none">The Rockstor update is still going on. if the page does not automatically refresh after a few minutes, please try manually refreshing after some time.</div>
   </div>
 </div>
 


### PR DESCRIPTION
If the regular check during the update process does not work,
(in case of a cert change for example), force a refresh of the
browser window after 5 minutes.
Display a countdown timer during the update.
