### PR TITLE
typo and rewording of missing serial number or UUID warning

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -31,7 +31,7 @@
 	   <% if (disk.get('serial') == null || disk.get('serial') == '' || disk.get('serial') == disk.get('name')) { %>
 	      <div class="alert alert-error">
        	      <h4>Warning! Disk serial number or UUID is not legitimate or unique.</h4>
-       	      Disk names may change unfavorably upon reboot, errors and replacement resulting in data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding futher
+       	      Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further
      	      </div>
 	    <% } else { %>
 	    <%= disk.get('serial') %>


### PR DESCRIPTION
When reviewing issue #666 noticed typos in Warning message so sorted and reworded.
Does not address #666 but relates to it.