### PR TITLE
Issue#673 kvm virtio drive serial

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -32,7 +32,6 @@ from system.exceptions import (CommandException, NonBTRFSRootException)
 from pool_scrub import PoolScrub
 from pool_balance import PoolBalance
 
-
 MKFS_BTRFS = '/sbin/mkfs.btrfs'
 BTRFS = '/sbin/btrfs'
 MOUNT = '/bin/mount'
@@ -530,7 +529,7 @@ def balance_status(pool, pool_device):
         if (re.match('Balance', out[0]) is not None):
             stats['status'] = 'running'
             if ((len(out) > 1 and
-                         re.search('chunks balanced', out[1]) is not None)):
+                    re.search('chunks balanced', out[1]) is not None)):
                 percent_left = out[1].split()[-2][:-1]
                 try:
                     percent_left = int(percent_left)
@@ -607,7 +606,7 @@ def scan_disks(min_size):
                 val_iter = True
                 i = i + 2
             elif (val_iter and sl[i] == '"' and
-                      (i == (len(sl) - 1) or sl[i + 1] == ' ')):
+                    (i == (len(sl) - 1) or sl[i + 1] == ' ')):
                 val_iter = False
                 name_iter = True
                 i = i + 2
@@ -631,7 +630,7 @@ def scan_disks(min_size):
                 if (re.match(dname, dmap['NAME']) is not None):
                     dnames[dname][11] = True
         if (((dmap['NAME'] != root and dmap['TYPE'] != 'part') or
-                 (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'))):
+                (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'))):
             dmap['parted'] = False  # part = False by default
             dmap['root'] = False
             if (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -27,7 +27,7 @@ import subprocess
 import signal
 import shutil
 from system.osi import (run_command, create_tmp_dir, is_share_mounted,
-                        is_mounted)
+                        is_mounted, get_virtio_disk_serial)
 from system.exceptions import (CommandException, NonBTRFSRootException)
 from pool_scrub import PoolScrub
 from pool_balance import PoolBalance
@@ -42,11 +42,11 @@ DEFAULT_MNT_DIR = '/mnt2/'
 RMDIR = '/bin/rmdir'
 WIPEFS = '/usr/sbin/wipefs'
 
-
 import collections
+
 Disk = collections.namedtuple('Disk', 'name model serial size '
-                              'transport vendor hctl type fstype '
-                              'label btrfs_uuid parted root')
+                                      'transport vendor hctl type fstype '
+                                      'label btrfs_uuid parted root')
 
 
 def add_pool(pool, disks):
@@ -84,7 +84,7 @@ def resize_pool(pool, device, dev_list, add=True):
     resize = False
     for d in dev_list:
         if (((resize_flag == 'add' and (d not in cur_dev)) or
-             (resize_flag == 'delete' and (d in cur_dev)))):
+                 (resize_flag == 'delete' and (d in cur_dev)))):
             resize = True
             resize_cmd.append(d)
     if (not resize):
@@ -207,8 +207,8 @@ def subvol_list_helper(mnt_pt):
             return run_command([BTRFS, 'subvolume', 'list', mnt_pt])
         except CommandException, ce:
             if (ce.rc != 19):
-                #rc == 19 is due to the slow kernel cleanup thread. It should
-                #eventually succeed.
+                # rc == 19 is due to the slow kernel cleanup thread. It should
+                # eventually succeed.
                 raise ce
             time.sleep(1)
             num_tries = num_tries + 1
@@ -294,8 +294,8 @@ def add_snap_helper(orig, snap, readonly=False):
         return run_command(cmd)
     except CommandException, ce:
         if (ce.rc != 19):
-            #rc == 19 is due to the slow kernel cleanup thread. snapshot gets
-            #created just fine. lookup is delayed arbitrarily.
+            # rc == 19 is due to the slow kernel cleanup thread. snapshot gets
+            # created just fine. lookup is delayed arbitrarily.
             raise ce
 
 
@@ -530,7 +530,7 @@ def balance_status(pool, pool_device):
         if (re.match('Balance', out[0]) is not None):
             stats['status'] = 'running'
             if ((len(out) > 1 and
-                 re.search('chunks balanced', out[1]) is not None)):
+                         re.search('chunks balanced', out[1]) is not None)):
                 percent_left = out[1].split()[-2][:-1]
                 try:
                     percent_left = int(percent_left)
@@ -573,7 +573,7 @@ def root_disk():
         for line in fo.readlines():
             fields = line.split()
             if (fields[1] == '/' and
-                (fields[2] == 'ext4' or fields[2] == 'btrfs')):
+                    (fields[2] == 'ext4' or fields[2] == 'btrfs')):
                 disk = os.path.realpath(fields[0])
                 return disk[5:-1]
     msg = ('root filesystem is not BTRFS. During Rockstor installation, '
@@ -602,12 +602,12 @@ def scan_disks(min_size):
         sl = l.strip()
         i = 0
         while i < len(sl):
-            if (name_iter and sl[i] == '=' and sl[i+1] == '"'):
+            if (name_iter and sl[i] == '=' and sl[i + 1] == '"'):
                 name_iter = False
                 val_iter = True
                 i = i + 2
             elif (val_iter and sl[i] == '"' and
-                  (i == (len(sl)-1) or sl[i+1] == ' ')):
+                      (i == (len(sl) - 1) or sl[i + 1] == ' ')):
                 val_iter = False
                 name_iter = True
                 i = i + 2
@@ -631,7 +631,7 @@ def scan_disks(min_size):
                 if (re.match(dname, dmap['NAME']) is not None):
                     dnames[dname][11] = True
         if (((dmap['NAME'] != root and dmap['TYPE'] != 'part') or
-             (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'))):
+                 (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'))):
             dmap['parted'] = False  # part = False by default
             dmap['root'] = False
             if (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'):
@@ -652,9 +652,12 @@ def scan_disks(min_size):
                 continue
             if (dmap['SIZE'] < min_size):
                 continue
+            if (dmap['SERIAL'] == ''):
+                # lsblk fails to retrieve SERIAL from KVM VirtIO drives so try specialized function
+                dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
             if (dmap['SERIAL'] == '' or (dmap['SERIAL'] in serials)):
-                # so no serial number or its a repeat so overwrite with drive name
-                # see disks_table.jst for a use of this flag mechanism.
+                # no serial number still or its a repeat
+                # overwrite drive serial entry with drive name: see disks_table.jst for a use of this flag mechanism.
                 dmap['SERIAL'] = dmap['NAME']
             serials.append(dmap['SERIAL'])
             for k in dmap.keys():

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -43,9 +43,9 @@ WIPEFS = '/usr/sbin/wipefs'
 
 import collections
 
-Disk = collections.namedtuple('Disk', 'name model serial size '
-                                      'transport vendor hctl type fstype '
-                                      'label btrfs_uuid parted root')
+Disk = collections.namedtuple('Disk',
+                              'name model serial size transport vendor '
+                              'hctl type fstype label btrfs_uuid parted root')
 
 
 def add_pool(pool, disks):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -652,11 +652,13 @@ def scan_disks(min_size):
             if (dmap['SIZE'] < min_size):
                 continue
             if (dmap['SERIAL'] == ''):
-                # lsblk fails to retrieve SERIAL from KVM VirtIO drives so try specialized function
+                # lsblk fails to retrieve SERIAL from KVM VirtIO drives
+                # so try specialized function.
                 dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
             if (dmap['SERIAL'] == '' or (dmap['SERIAL'] in serials)):
-                # no serial number still or its a repeat
-                # overwrite drive serial entry with drive name: see disks_table.jst for a use of this flag mechanism.
+                # No serial number still or its a repeat.
+                # Overwrite drive serial entry with drive name:
+                # see disks_table.jst for a use of this flag mechanism.
                 dmap['SERIAL'] = dmap['NAME']
             serials.append(dmap['SERIAL'])
             for k in dmap.keys():

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -83,7 +83,7 @@ def resize_pool(pool, device, dev_list, add=True):
     resize = False
     for d in dev_list:
         if (((resize_flag == 'add' and (d not in cur_dev)) or
-                 (resize_flag == 'delete' and (d in cur_dev)))):
+                (resize_flag == 'delete' and (d in cur_dev)))):
             resize = True
             resize_cmd.append(d)
     if (not resize):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -653,6 +653,8 @@ def scan_disks(min_size):
             if (dmap['SIZE'] < min_size):
                 continue
             if (dmap['SERIAL'] == '' or (dmap['SERIAL'] in serials)):
+                # so no serial number or its a repeat so overwrite with drive name
+                # see disks_table.jst for a use of this flag mechanism.
                 dmap['SERIAL'] = dmap['NAME']
             serials.append(dmap['SERIAL'])
             for k in dmap.keys():

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -460,8 +460,7 @@ def get_virtio_disk_serial(device_name):
     Note also that this process may not deal well with spaces in the serial number but VMM does not allow this.
     """
     dev_path = ('/sys/block/%s/serial' % device_name)
-    # out, err, rc = run_command([CAT, dev_path], throw=False)
-    out, err, rc = run_command([CAT, dev_path])
+    out, err, rc = run_command([CAT, dev_path], throw=False)
     if (rc != 0):
         return ''
     # our str(out) string from list looks like ['11111111111111111111'] so [2:-2] strips the surrounding [' ']

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -445,25 +445,29 @@ def is_mounted(mnt_pt):
 
 def get_virtio_disk_serial(device_name):
     """
-    Returns the serial number of device_name virtio disk eg vda
-    Returns empty string if the eg cat /sys/block/vda/serial command fails
-    N.B. there is no serial entry in /sys/block/sda/ for real or KVM sata bus drives
+    Returns the serial number of device_name virtio disk eg /dev/vda
+    Returns empty string if cat /sys/block/vda/serial command fails
+    Note no serial entry in /sys/block/sda/ for real or KVM sata drives
     :param device_name: vda
     :return: 12345678901234567890
 
     Note maximum length of serial number reported = 20 chars
-    But longer serial numbers can be specified in the XML spec of the VM's drive eg /etc/libvirt/qemu/rockstor3.8.xml
-    But the virtio block device is itself limited to 20 chars ie:-
-    https://github.com/qemu/qemu/blob/a9392bc93c8615ad1983047e9f91ee3fa8aae75f/include/standard-headers/linux/virtio_blk.h
+    But longer serial numbers can be specified in the VM XML spec file.
+    The virtio block device is itself limited to 20 chars ie:-
+    https://github.com/qemu/qemu/blob/
+    a9392bc93c8615ad1983047e9f91ee3fa8aae75f/include/standard-headers/
+    linux/virtio_blk.h
     #define VIRTIO_BLK_ID_BYTES	20	/* ID string length */
 
-    Note also that this process may not deal well with spaces in the serial number but VMM does not allow this.
+    This process may not deal well with spaces in the serial number
+    but VMM does not allow this.
     """
     dev_path = ('/sys/block/%s/serial' % device_name)
     out, err, rc = run_command([CAT, dev_path], throw=False)
     if (rc != 0):
         return ''
-    # our str(out) string from list looks like ['11111111111111111111'] so [2:-2] strips the surrounding [' ']
+    # our str(out) string from list looks like ['11111111111111111111']
+    # so [2:-2] strips the surrounding [' ']
     return str(out)[2:-2]
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -102,7 +102,7 @@ def kernel_info(supported_version):
                  'may not work properly.' % uname[2])
         cur_kernel = def_kernel()
         if ((cur_kernel is not None and
-                     cur_kernel == supported_version)):
+                cur_kernel == supported_version)):
             e_msg = ('%s Please reboot and the system will '
                      'automatically boot using the supported kernel(%s)' %
                      (e_msg, supported_version))
@@ -378,10 +378,10 @@ def update_check():
         version = None
         for i in range(len(out)):
             if (re.match('---> Package rockstor.* updated', out[i])
-                is not None):
+                    is not None):
                 cur_version = out[i].split()[3].split(':')[1]
             if (re.match('---> Package rockstor.* be an update', out[i])
-                is not None):
+                    is not None):
                 version = out[i].split()[3].split(':')[1]
             if (re.match('ChangeLog for: ', out[i]) is not None):
                 i = i + 1


### PR DESCRIPTION
Patch to provide an additional mechanism to retrieve drive serial numbers.  Currently only seems necessary for virtio drives as lsblk fails to retrieve their serial which we need.  So when existing mechanisms fail to get a drive serial this patch tries again with for example a cat /sys/block/vda/serial.
This entry seems not to exist with other drive types and we have a fail through to return an empty string if no serial entry is found so (hopefully) no worse off anyway if accidentally called with another device type.
Should only be called when existing mechanism fails to get a serial for a block device listed in lsblk.

N.B. does not address the issue of being able to install on a vda (rather than an sda) device.