### PR TITLE
Issue#757 mmcblk no serial

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -781,9 +781,9 @@ def scan_disks(min_size):
             if (dmap['SIZE'] < min_size):
                 continue
             if (dmap['SERIAL'] == ''):
-                # lsblk fails to retrieve SERIAL from KVM VirtIO drives
-                # so try specialized function.
-                #dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
+                # lsblk fails to retrieve SERIAL from VirtIO drives and some
+                # sdcard devices so try specialized function.
+                # dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
                 dmap['SERIAL'] = get_disk_serial(dmap['NAME'], None)
             if (dmap['SERIAL'] == '' or (dmap['SERIAL'] in serials)):
                 # No serial number still or its a repeat.

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -719,6 +719,8 @@ def scan_disks(min_size):
     disks = []
     serials = []
     root_serial = None
+    # to use udevadm for serial # rather than lsblk make this True
+    always_use_udev_serial = False
     for l in o:
         if (re.match('NAME', l) is None):
             continue
@@ -780,7 +782,7 @@ def scan_disks(min_size):
                 continue
             if (dmap['SIZE'] < min_size):
                 continue
-            if (dmap['SERIAL'] == ''):
+            if (dmap['SERIAL'] == '' or always_use_udev_serial):
                 # lsblk fails to retrieve SERIAL from VirtIO drives and some
                 # sdcard devices so try specialized function.
                 # dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -27,7 +27,7 @@ import subprocess
 import signal
 import shutil
 from system.osi import (run_command, create_tmp_dir, is_share_mounted,
-                        is_mounted, get_virtio_disk_serial)
+                        is_mounted, get_virtio_disk_serial, get_disk_serial)
 from system.exceptions import (CommandException, NonBTRFSRootException)
 from pool_scrub import PoolScrub
 from pool_balance import PoolBalance
@@ -783,7 +783,8 @@ def scan_disks(min_size):
             if (dmap['SERIAL'] == ''):
                 # lsblk fails to retrieve SERIAL from KVM VirtIO drives
                 # so try specialized function.
-                dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
+                #dmap['SERIAL'] = get_virtio_disk_serial(dmap['NAME'])
+                dmap['SERIAL'] = get_disk_serial(dmap['NAME'], None)
             if (dmap['SERIAL'] == '' or (dmap['SERIAL'] in serials)):
                 # No serial number still or its a repeat.
                 # Overwrite drive serial entry with drive name:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -468,6 +468,7 @@ def get_disk_serial(device_name, test):
     :param test:
     :return: 12345678901234567890
     """
+    # logger.info('get_disk_serial called with device name %s' % device_name)
     serial_num = ''
     line_fields = []
     if test is None:
@@ -507,6 +508,7 @@ def get_disk_serial(device_name, test):
                     serial_num = line_fields[2]
     # should return one of the following in order of priority
     # SCSI_SERIAL, SERIAL_SHORT, SERIAL
+    # logger.info('get_disk_serial returning serial # %s' % serial_num)
     return serial_num
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -453,15 +453,17 @@ def is_mounted(mnt_pt):
 
 def get_disk_serial(device_name, test):
     """
-    Returns the serial number of device_name using udevadm to match that returned by lsblk
-    udevadm has been observed to return the following serial numbers for real and virtual devices.
+    Returns the serial number of device_name using udevadm to match that
+    returned by lsblk. N.B. udevadm has been observed to return the following:-
     ID_SCSI_SERIAL  rarely seen
     ID_SERIAL_SHORT  often seen
     ID_SERIAL        thought to always be seen (see note below)
-    N.B. if used in this order the serial is most likely to resemble that shown on the device as well as that returned
-    by the lsblk. ID_SERIAL seems always to appear but is sometimes accompanied by one or both of the other two.
-    When ID_SERIAL is accompanied by ID_SERIAL_SHORT the short variant is closer to lsblk and the serial label on the
-    device as when they are both present the ID_SERIAL appears to be concatenation of the model and the ID_SERIAL_SHORT
+    N.B. if used in this order the serial is most likely to resemble that shown
+    on the device label as well as that returned by the lsblk. ID_SERIAL seems
+    always to appear but is sometimes accompanied by one or both of the others.
+    When ID_SERIAL is accompanied by ID_SERIAL_SHORT the short variant is
+    closer to lsblk and physical label When they are both present the
+    ID_SERIAL appears to be a combination of the model and the ID_SERIAL_SHORT
     :param device_name:
     :param test:
     :return: 12345678901234567890
@@ -485,16 +487,19 @@ def get_disk_serial(device_name, test):
         # E: ID_SERIAL_SHORT=S1D5NSAF111111K
         line.replace('=', ' ').split()
         if line[1] == 'ID_SCSI_SERIAL':
-            # since SCSI_SERIAL is more reliably unique when present than SERIAL_SHORT or SERIAL we
-            # overwrite whatever we have and look no further by breaking out of the search loop
+            # we have an instance of SCSI_SERIAL being more reliably unique
+            # when present than SERIAL_SHORT or SERIAL so overwrite whatever
+            # we have and look no further by breaking out of the search loop
             serial_num = line[2]
             break
         elif line[1] == 'ID_SERIAL_SHORT':
-            # SERIAL_SHORT is better than SERIAL so just overwrite whatever we have so far with SERIAL_SHORT
+            # SERIAL_SHORT is better than SERIAL so just overwrite whatever we
+            # have so far with SERIAL_SHORT
             serial_num = line[2]
         else:
             if line[1] == 'ID_SERIAL':
-                # SERIAL is sometimes our only option but only use it if we have found nothing else.
+                # SERIAL is sometimes our only option but only use it if we
+                # have found nothing else.
                 if serial_num == '':
                     serial_num = line[2]
     # should return one of the following in order of priority

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -486,6 +486,9 @@ def get_disk_serial(device_name, test):
         line_fields = line.strip().replace('=', ' ').split()
         # fast replace of '=' with space so split() can divide all fields
         # example original line "E: ID_SERIAL_SHORT=S1D5NSAF111111K"
+        # less than 3 fields are of no use so just in case:-
+        if len(line_fields) < 3:
+            continue
         if line_fields[1] == 'ID_SCSI_SERIAL':
             # we have an instance of SCSI_SERIAL being more reliably unique
             # when present than SERIAL_SHORT or SERIAL so overwrite whatever

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -478,16 +478,18 @@ def get_disk_serial(device_name, test):
         return ''
     for line in out:
         line = line.strip()
-        if re.match("ID_SCSI_SERIAL", line) is not None:
+        # Might be better to drop the first 3 chars from each line and use match not search
+        # not sure how stable / consistent the output of udevadm is though.
+        if re.search("ID_SCSI_SERIAL", line) is not None:
             # since SCSI_SERIAL is more reliably unique when present than SERIAL_SHORT or SERIAL we
             # overwrite whatever we have and look no further by breaking out of the search loop
             serial_num = line.split('=')[1]
             break
-        elif re.match("ID_SERIAL_SHORT", line) is not None:
+        elif re.search("ID_SERIAL_SHORT", line) is not None:
             # SERIAL_SHORT is better than SERIAL so just overwrite whatever we have so far with SERIAL_SHORT
             serial_num = out.split('=')[1]
         else:
-            if re.match("ID_SERIAL", line) is not None:
+            if re.search("ID_SERIAL", line) is not None:
                 # SERIAL is sometimes our only option but only use it if we have found nothing else.
                 if serial_num == '':
                     serial_num = out.split('=')[1]


### PR DESCRIPTION
This patch set is to address the no serial returned by lsblk for virtio and mmcblk* (some sdcard devices) block devices.  It deprecates get_virtio_disk_serial with a more robust and generic method that uses udevadm.

Currently it is only called when no serial is returned by the existing lsblk mechanism however I have tested this mechanism using the provided hard wired over ride flag so that it is used by default on all devices. This flag is false by default.  The results are promising and in all cases (multiple mmcblk devices and multiple with and without serial virtio devices and multiple hdd's including a USB bus driven one and the mSATA adapter device sold in Rockstor shop with a KINGSTON SMS200S330G installed and it currently serves as a drop in replacement (returning the exact same serial numbers) for lsblk where lsblk did return serials numbers that is.

I have provided the flag mechanism so that we might trial this mechanism on for example the 16 disk system with Areca ARC1680IX ver 2.3 raid controller that in JOBD (preferred) config lsblk returned non unique serials (they were all the same) where as udevadm returned "disk label looking" serials; as lsblk usually does. The mechanism to prioritize ID_SCSI_SERIAL has not been tested as I don't have such a controller here but the code looks OK for this.

see forum post:- http://forum.rockstor.com/t/s-m-a-r-t-statistics-not-working-with-areca-raid-controller/266/3

Currently non invasive but promising as a replacement for lsblk for getting device serial numbers and can initially serve as a test for this cascade rational.