### PR TITLE
Issue#741 smartd.conf update

### DIFF
--- a/src/rockstor/smart_manager/views/smartd_service.py
+++ b/src/rockstor/smart_manager/views/smartd_service.py
@@ -52,8 +52,8 @@ class SMARTDServiceView(BaseServiceDetailView):
                 config = request.DATA.get('config', {})
                 logger.debug('config = %s' % config)
                 self._save_config(service, config)
-                if ('smartd_config' in config):
-                    config = config['smartd_config']
+                if ('custom_config' in config):
+                    config = config['custom_config']
                 else:
                     config = ''
                 smart.update_config(config)

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
@@ -32,7 +32,7 @@
 	  <% if (config.smartd_config){ %>
           <textarea style="width: 50%" class="form-control" id="smartd_config" name="custom_config" rows="10"><%= config.smartd_config %></textarea>
 	  <% } else { %>
-          <textarea style="width: 80"class="form-control" id="smartd__config" name="custom_config" rows="10"></textarea>
+          <textarea style="width: 80"class="form-control" id="smartd_config" name="custom_config" rows="10"></textarea>
 	  <%  } %>
 	</div>
 	<div class="row">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
@@ -29,8 +29,8 @@
 
 	<div class="form-group">
 	  <label for="custom_config">configuration lines will be saved to the ROCKSTOR section in /etc/smartmontools/smartd.conf</label>
-	  <% if (config.smartd_config){ %>
-          <textarea style="width: 50%" class="form-control" id="smartd_config" name="custom_config" rows="10"><%= config.smartd_config %></textarea>
+	  <% if (config.custom_config){ %>
+          <textarea style="width: 50%" class="form-control" id="smartd_config" name="custom_config" rows="10"><%= config.custom_config %></textarea>
 	  <% } else { %>
           <textarea style="width: 80"class="form-control" id="smartd_config" name="custom_config" rows="10"></textarea>
 	  <%  } %>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -98,6 +98,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
 	}
 	console.log('configobj', configObj);
 	console.log('smartd_config', configObj.smartd_config);
+	console.log('custom_config', configObj.custom_config);
 	$(this.el).html(this.template({service: this.service, config: configObj, shares: this.shares}));
 
 	this.$('#nis-form :input').tooltip({

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -20,6 +20,8 @@ import re
 from osi import run_command
 from tempfile import mkstemp
 from shutil import move
+import logging
+logger = logging.getLogger(__name__)
 
 SMART = '/usr/sbin/smartctl'
 
@@ -179,6 +181,7 @@ def toggle_smart(device, enable=False):
     return run_command([SMART, '--smart=%s' % switch, '/dev/%s' % device])
 
 def update_config(config):
+    logger.debug("smart.udate_config received %s" % config)
     SMARTD_CONFIG = '/etc/smartmontools/smartd.conf'
     ROCKSTOR_HEADER = '###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###'
     fo, npath = mkstemp()


### PR DESCRIPTION
This corrects the smartd.conf update mechanism and repairs the mouseover tooltip on the associated custom smartd config form. The form now correctly displays previous custom entries as well.
I intended to based my branch on 3.8-4 to help at my end with dev but looks like enough has changed that it can't auto merge.  Let me know if you need me to re-submit, the changes are actually only small; I just made a meal of it.
N.B. I am unsure if I've gone about this correctly but the result is things working as intended and I have left additional logging in place in case I've missed / caused a scope issue.