### PR TITLE
Issue#792 email typo and rewording

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
@@ -18,7 +18,7 @@
   *
   */
 </script>
-<h3>Setup E-mail for alerts</h3>
+<h3>Setup Email for alerts</h3>
 <label class="control-label"></label>
 <div class="form-box">
   <form id="email-form" name="email-form" class="form-horizontal" autocomplete="off">
@@ -72,12 +72,12 @@
     </div>
 
     <div class="form-group">
-      <label class="col-sm-2 control-label">Receipient email<span class="required"> *</span></label>
+      <label class="col-sm-2 control-label">Recipient Email<span class="required"> *</span></label>
       <div class="col-sm-3">
         <%  if(email!=null) {  %>
         <input class="form-control" type="email" id="receiver"  name="receiver" value="<%= email.get('receiver')%>" >
         <% } else { %>
-        <input class="form-control" type="email" id="receiver" name="receiver"  title="Rockstor will send email notifications to this address. eg: your personal e-mail." >
+        <input class="form-control" type="email" id="receiver" name="receiver"  title="Rockstor will send email notifications to this address. eg: your personal email." >
         <% }  %>
       </div>
     </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
@@ -40,7 +40,7 @@
         <%  if(email!=null) {  %>
         <input class="form-control" type="email" id="sender"  name="sender" value="<%= email.get('sender')%>" >
         <% } else { %>
-        <input class="form-control" type="email" id="sender" name="sender"  title="Rockstor will send email notifications from this address. For better security, We highly recommend a separate email account for this purpose." >
+        <input class="form-control" type="email" id="sender" name="sender"  title="Rockstor will send email notifications from this address / account. For better security we highly recommend using a separate dedicated email account for this purpose." >
         <% }  %>
       </div>
     </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
@@ -66,7 +66,7 @@
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-6 controls">
         <label class="radio inline">
-          <input type="radio" name="secured_connection" value="TSL" checked> Secured connection using TSL
+          <input type="radio" name="secured_connection" value="TLS" checked> Secured connection using TLS
         </label>
       </div>
     </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
@@ -34,16 +34,16 @@
       	<button type="Submit" id="Add-email-address" class="btn btn-primary">Setup E-mail for alerts</button>
         <%} else { %>
 	<div class="alert alert-warning">
-	  <p>Rockstor uses below credentials to send e-mail notifications. Any
+	  <p>Rockstor uses the credentials below to send e-mail notifications. Any
 	    system information sent to the root user results in a
-	    notification. Rockstor assumes the <b>Sender</b> account and from
-	    that account, sends e-mails to <b>Receiver</b>
-	    account. <b>Sender</b> e-mail password is stored in
+	    notification. Rockstor assumes/uses the <b>Sender</b> account and from
+	    that account sends e-mails to the <b>Receiver</b>
+	    email address. The <b>Sender</b> e-mail account password is stored in
 	    <code>/etc/postfix/sasl_passwd</code> which has restricted
-	    permissions. However, we strongly recommend against using personal
+	    permissions. However, we strongly recommend against using a personal
 	    or important e-mail account for the <b>Sender</b>. On the other
-	    hand, <b>Receiver</b> e-mail address can be anything you have
-	    access to, where notifications will arrive.
+	    hand the <b>Receiver</b> e-mail address can be anything you have
+	    access to and is simply the recipient of the notifications sent.
 	  </p>
 
 	  <p>To test if notifications are setup properly, login as root and

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
@@ -46,8 +46,9 @@
 	    access to and is simply the recipient of the notifications sent.
 	  </p>
 
-	  <p>To test if notifications are setup properly, login as root and
-	    send a test e-mail using this command: <code>echo "Hello from
+	  <p>To test if notifications are setup properly, login to Rockstor as root
+	     on a terminal or via ssh and
+	     send a test e-mail using this command: <code>echo "Hello from
 	      Rockstor" | mail -s "test message" -r <%= email.get('sender') %> <%= email.get('receiver') %></code>.
 	     If you do not receive the e-mail, you can find clues
 	    in <code>/var/log/maillog</code>.

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email_setup.jst
@@ -26,10 +26,10 @@
         <div class="controls">
 	  <div class="alert alert-warning">
 	    <p>Rockstor can push notifications to you via e-mail. We recommend
-	      creating a separate e-mail account for this purpose. Rockstor will
-	      login to this e-mail account and send notifications to another
-	      preferred e-mail address, such as your personal gmail
-	      account.</p>
+	      creating a separate dedicated e-mail account for this purpose.
+	      Rockstor will login to this e-mail account and use it to send
+	      notifications to another specified e-mail address, such as your
+	      personal gmail account.</p>
 	  </div>
       	<button type="Submit" id="Add-email-address" class="btn btn-primary">Setup E-mail for alerts</button>
         <%} else { %>


### PR DESCRIPTION
Changes "visible only text" re new email feature; typos and rewording.

I think one id was also changed so I may have upset something there but I don't think so.

I have applied these changes to 3.8-5 and all email setup functions still works, given my other pull request on core of #794 . Note this pull request relates to https://github.com/rockstor/rockstor-doc/pull/71

Ready for review and fixes #792 
