### PR TITLE
Hide sidemenu on mobile view #869

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -1514,6 +1514,15 @@ input[type="radio"].selectedRoot {
     background: #fff;
 }
 
+@media (max-width: 800px) {
+    #sidebar {
+        display: none;
+    }
+    #content {
+        left: 0px;
+    }
+}
+
 .dashboard-widget-controls {
     color: #FFFFFF;
     font-family: Roboto-Light;


### PR DESCRIPTION
Sidebar collapses at window size of 800px - 800px is when tables start to crunch