### PR TITLE
924 no ip address in console partially fixes #924

### DIFF
--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -27,6 +27,7 @@ import time
 from tempfile import mkstemp
 from django.conf import settings
 
+logger = logging.getLogger(__name__)
 
 SYSCTL = '/usr/bin/systemctl'
 BASE_DIR = settings.ROOT_DIR
@@ -63,6 +64,7 @@ def update_issue():
             ifo.write('\nRockstor is successfully installed.\n\n')
             ifo.write('You can access the web-ui by pointing your browser to '
                       'https://%s\n\n' % ipaddr)
+    return ipaddr
 
 
 def set_def_kernel(logger, version=settings.SUPPORTED_KERNEL_VERSION):
@@ -201,7 +203,8 @@ def main():
     shutil.copyfile('/etc/issue', '/etc/issue.rockstor')
     for i in range(30):
         try:
-            update_issue()
+            if update_issue() is None:
+                raise e
             break
         except Exception, e:
             logging.info('exception occurred while running update_issue. '

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -55,11 +55,12 @@ def update_issue():
                 ipaddr = i2.split()[1]
     with open('/etc/issue', 'w') as ifo:
         if (ipaddr is None):
-            ifo.write('The system does not have an ip address.\n\n')
-            ifo.write('Rockstor cannot be configured using the web-ui '
-                      'without an ip address.\n\n')
-            ifo.write('Login as root and configure your network to proceed '
-                      'further.\n')
+            ifo.write('The system does not yet have an ip address.\n')
+            ifo.write('Rockstor cannot be configured using the web interface '
+                        'without this.\n\n')
+            ifo.write('Press Enter to receive updated network status\n')
+            ifo.write('If this message persists login as root and configure '
+                      'your network manually to proceed further.\n')
         else:
             ifo.write('\nRockstor is successfully installed.\n\n')
             ifo.write('You can access the web-ui by pointing your browser to '

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -41,7 +41,7 @@ OPENSSL = '/usr/bin/openssl'
 GRUBBY = '/usr/sbin/grubby'
 
 
-def update_issue():
+def init_update_issue():
     default_if = None
     ipaddr = None
     o, e, c = run_command(['/usr/sbin/route'])
@@ -204,7 +204,7 @@ def main():
     shutil.copyfile('/etc/issue', '/etc/issue.rockstor')
     for i in range(30):
         try:
-            if update_issue() is None:
+            if init_update_issue() is None:
                 raise e
             break
         except Exception, e:


### PR DESCRIPTION
Recent changes have caused a regression where rockstor.py only tires once to discover the IP address, which almost always resulted in a fail as the interfaced hasn't yet got it's IP. This results in the no ip message. Patch set returns multiple tries in background function and additionally suggests on fail issue message that pressing return may yield an updated network status. Bit hacky but didn't want to put any pre-delays before /etc/issue update in until this was merged; though that may be the way to go.
Works when applied to 3.8-8.05 testing on two real machines, both using pcie mSATA as root. One single core (but multi threaded) and one dual core.
Also note that a logging related variable has been re-instated.

