### PR TITLE
update to ssl in menu items #trivial. Fixes #938

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -36,7 +36,7 @@
       <li><a href="#scheduled-tasks"><i class="glyphicon glyphicon-tasks"></i> Scheduled Tasks</a></li>
       <li><a href="#version"><i class="glyphicon glyphicon-arrow-up"></i> Software Update</a></li>
       <li><a href="#appliances"><i class="fa fa-desktop"></i> Appliances</a></li>
-      <li><a href="#update-certificate"><i class="fa fa-certificate"></i> Update Certificate</a></li>
+      <li><a href="#update-certificate"><i class="fa fa-certificate"></i> SSL Certificate</a></li>
       <li><a href="#config-backup"><i class="glyphicon glyphicon-floppy-save"></i> Config Backups</a></li>
       <li><a href="#email"><i class="fa fa-envelope"></i> Email Alerts</a></li>
     </ul>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/sidenav_system.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/sidenav_system.jst
@@ -49,9 +49,9 @@
 <li><a href="#appliances"><i class="fa fa-desktop"></i> Appliances</span></a></li>
 <% } %>
 <% if (selected == "update-certificate") { %>
-<li><a href="#update-certificate" class="selected"><i class="fa fa-certificate"></i> Update Certificate</span></a></li>
+<li><a href="#update-certificate" class="selected"><i class="fa fa-certificate"></i> SSL Certificate</span></a></li>
 <% } else { %>
-<li><a href="#update-certificate"><i class="fa fa-certificate"></i> Update Certificate</span></a></li>
+<li><a href="#update-certificate"><i class="fa fa-certificate"></i> SSL Certificate</span></a></li>
 <% } %>
 <% if (selected == "config-backup") { %>
 <li><a href="#config-backup" class="selected"><i class="glyphicon glyphicon-floppy-save"></i> Config Backups</span></a></li>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/setup/certificate_desc.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/setup/certificate_desc.jst
@@ -30,7 +30,7 @@
         </div>
         <br>
         <div class="controls">
-      	<button type="Submit" id="update-certificate" class="btn btn-primary">Update Certificate</button>
+      	<button type="Submit" id="update-certificate" class="btn btn-primary">Update SSL Certificate</button>
         </div>
   </div>
 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/setup/update_certificate.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/setup/update_certificate.jst
@@ -21,7 +21,7 @@
 <div class="row">
   <div class="col-md-8">
     <div class="panel panel-default">
-    <div class="panel-heading">Update Certificate</div>
+    <div class="panel-heading">Update SSL Certificate</div>
     <div class="panel-body">
       <form id="update-certificate-form" name="update-certificate-form" class="form-horizontal" >
         <div class="messages"></div>


### PR DESCRIPTION
To avoid confusion with the newly added update channels, overtly state certificate user facing text as pertaining to SSL.
Should remove concerns over invalidating a system for it's update channel.
"Update" next to certificate is not longer displayed in top level menus re ssl but button has "Update SSL Certificate" on so we should be good. Also shorter text in nav elements so neater.

Formatting tested in Chrome and Firefox.
