### PR TITLE
remove 1m reboot and shutdown delay. Fixes #943

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/reboot.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/reboot.js
@@ -31,7 +31,7 @@ RebootView = RockstorLayoutView.extend({
     this.constructor.__super__.initialize.apply(this, arguments);
    this.template = window.JST.common_navbar;
     this.paginationTemplate = window.JST.common_pagination;
-    this.timeLeft = 600;
+    this.timeLeft = 300;
     this.isStopped=false;
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shutdown.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shutdown.js
@@ -31,7 +31,7 @@ ShutdownView = RockstorLayoutView.extend({
     this.constructor.__super__.initialize.apply(this, arguments);
    this.template = window.JST.common_navbar;
     this.paginationTemplate = window.JST.common_pagination;
-    this.timeLeft = 300;
+    this.timeLeft = 180;
   },
 
  render: function() {

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -195,7 +195,7 @@ class CommandView(NFSExportMixin, APIView):
                 return Response(msg)
 
         if (command == 'shutdown'):
-            msg = ('The system will be shutdown after 1 minute')
+            msg = ('The system will now be shutdown')
             try:
                 request.session.flush()
                 system_shutdown()
@@ -208,7 +208,7 @@ class CommandView(NFSExportMixin, APIView):
                 return Response(msg)
 
         if (command == 'reboot'):
-            msg = ('The system will reboot after 1 minute')
+            msg = ('The system will now reboot')
             try:
                 request.session.flush()
                 system_reboot()

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -455,11 +455,11 @@ def get_virtio_disk_serial(device_name):
 
 
 def system_shutdown():
-    return run_command([SHUTDOWN, '-h'])
+    return run_command([SHUTDOWN, '-h', 'now'])
 
 
 def system_reboot():
-    return run_command([SHUTDOWN, '-r'])
+    return run_command([SHUTDOWN, '-r', 'now'])
 
 
 def md5sum(fpath):


### PR DESCRIPTION
Removes the default of 1m delay before reboot or shutdown and uses "now" instead, also addresses associated aesthetics. 

I have also lowered the js timer / dialog monitor feature that confirms the requested action.
I found there was a problem in reducing shutdown confirmation below 180 seconds so have left at this.
A closer look would be needed to reduce it further.
