### PR TITLE
smart data collection broken Fixes #657

### DIFF
--- a/src/rockstor/system/email_util.py
+++ b/src/rockstor/system/email_util.py
@@ -24,6 +24,8 @@ from email.MIMEBase import MIMEBase
 from email.MIMEText import MIMEText
 from email.Utils import formatdate
 from email import Encoders
+from system.osi import gethostname
+
 
 def send_test_email(eco, subject):
     msg = MIMEMultipart()
@@ -45,9 +47,11 @@ def email_root(subject, message):
     :param subject: of the email
     :param message: body content of the email
     """
+    hostname = gethostname()
+
     msg = MIMEMultipart()
-    msg['From'] = 'notifications@localhost'
-    msg['To'] = 'root@localhost'
+    msg['From'] = 'notifications@%s' % hostname
+    msg['To'] = 'root@%s' % hostname
     msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = subject
     msg.attach(MIMEText(message))

--- a/src/rockstor/system/email_util.py
+++ b/src/rockstor/system/email_util.py
@@ -36,3 +36,23 @@ def send_test_email(eco, subject):
     smtp = smtplib.SMTP('localhost')
     smtp.sendmail(eco.sender, eco.receiver, msg.as_string())
     smtp.close()
+
+def email_root(subject, message):
+    """
+    Simple wrapper to email root, which generally will be forwarded to admin
+    personnel if email notifications are enabled hence acting as remote monitor
+    / notification system
+    :param subject: of the email
+    :param message: body content of the email
+    """
+    msg = MIMEMultipart()
+    msg['From'] = 'notifications@localhost'
+    msg['To'] = 'root@localhost'
+    msg['Date'] = formatdate(localtime=True)
+    msg['Subject'] = subject
+    msg.attach(MIMEText(message))
+
+    smtp = smtplib.SMTP('localhost')
+    smtp.sendmail(msg['From'], msg['To'], msg.as_string())
+    smtp.close()
+

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -92,7 +92,15 @@ def capabilities(device):
     return cap_d
 
 def error_logs(device):
-    o, e, rc = run_command([SMART, '-l', 'error', '/dev/%s' % device])
+    o, e, rc = run_command([SMART, '-l', 'error', '/dev/%s' % device],
+                           throw=False)
+    # As we mute exceptions when calling the above command we should at least
+    # examine what we have as return code (rc); 64 has been seen when the error
+    # log contains errors so we deal with it.
+    if rc == 64:
+        msg = ('Drive /dev/%s has logged SMART errors. Please view '\
+               'the Error logs tab for this device' % device)
+        logger.info(msg)
     ecode_map = {
         'ABRT' : 'Command ABoRTed',
         'AMNF' : 'Address Mark Not Found',

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -22,6 +22,8 @@ from tempfile import mkstemp
 from shutil import move
 import logging
 from system.email_util import email_root
+from exceptions import CommandException
+
 
 logger = logging.getLogger(__name__)
 
@@ -98,12 +100,20 @@ def error_logs(device):
                            throw=False)
     # As we mute exceptions when calling the above command we should at least
     # examine what we have as return code (rc); 64 has been seen when the error
-    # log contains errors so we deal with it.
+    # log contains errors but otherwise executes successfully so we catch this.
     if rc == 64:
         e_msg = 'Drive /dev/%s has logged S.M.A.R.T errors. Please view ' \
                 'the Error logs tab for this device.' % device
         logger.error(e_msg)
         email_root('S.M.A.R.T error', e_msg)
+    # In all other instances that are an error (non zero) we raise exception
+    # as normal.
+    elif rc != 0:
+        e_msg = ('non-zero code(%d) returned by command: %s -l error output: '
+                 '%s error: %s' % (rc, SMART, o, e))
+        logger.error(e_msg)
+        raise CommandException(('%s -l error /dev/%s' % (SMART, device)), o, e,
+                               rc)
     ecode_map = {
         'ABRT' : 'Command ABoRTed',
         'AMNF' : 'Address Mark Not Found',

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -21,6 +21,8 @@ from osi import run_command
 from tempfile import mkstemp
 from shutil import move
 import logging
+from system.email_util import email_root
+
 logger = logging.getLogger(__name__)
 
 SMART = '/usr/sbin/smartctl'
@@ -98,9 +100,10 @@ def error_logs(device):
     # examine what we have as return code (rc); 64 has been seen when the error
     # log contains errors so we deal with it.
     if rc == 64:
-        msg = ('Drive /dev/%s has logged SMART errors. Please view '\
-               'the Error logs tab for this device' % device)
-        logger.info(msg)
+        e_msg = 'Drive /dev/%s has logged S.M.A.R.T errors. Please view ' \
+                'the Error logs tab for this device.' % device
+        logger.error(e_msg)
+        email_root('S.M.A.R.T error', e_msg)
     ecode_map = {
         'ABRT' : 'Command ABoRTed',
         'AMNF' : 'Address Mark Not Found',


### PR DESCRIPTION
In some instances it seems that smartctl -l error returned a command line error of 64. This was correctly caught by Rockstor but interpreted as a failed command execution. In tests on several drives that displayed this wall of red text error that looked like a failure this pr produces valid smartctl error logs.
As this is an error condition I have added an email root function that is executed when this error code is encountered. N.B. if one refreshes smart data read via the web ui refresh button on a drive with S.M.A.R.T errors logged this email will be triggered. Note that I don't thing that all drives are capable of self logging.

Submitting as is for code review and further testing / analysis of my silencing an exception.

email part tested with and without email notifications enabled.