### PR TITLE
remove quota rescan on share usage collection. Fixes #950

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -567,7 +567,6 @@ def share_usage(pool, share_id):
     for now, exclusive byte count
     """
     root_pool_mnt = mount_root(pool)
-    run_command([BTRFS, 'quota', 'rescan', root_pool_mnt], throw=False)
     cmd = [BTRFS, 'qgroup', 'show', root_pool_mnt]
     out, err, rc = run_command(cmd, log=True)
     rusage = eusage = None
@@ -593,7 +592,6 @@ def shares_usage(pool, share_map, snap_map):
             break
     if (mnt_pt is None):
         mnt_pt = mount_root(pool)
-    run_command([BTRFS, 'quota', 'rescan', mnt_pt], throw=False)
     cmd = [BTRFS, 'qgroup', 'show', mnt_pt]
     out, err, rc = run_command(cmd, log=True)
     combined_map = dict(share_map, **snap_map)


### PR DESCRIPTION
In 4.1 and IIRC 4.0 kernels, we had to issue quota rescans to refresh
the qgroup size information. This was resulting in high cpu usage at
regular intervals. In 4.2.1 kernel, the current one, it doesn't seem to
be necessary to rescan all the time. So the first step is to remove
these rescans.

Recent qgroup changes that went into 4.2 still need to be fully tested
in the context of Rockstor, but removing rescans is a good step in that
direction.