### PR TITLE
postfix smtp sender address. Fixes #970

### DIFF
--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -75,6 +75,7 @@ def update_generic(sender, revert=False):
         if (not revert):
             fo.write('@%s %s\n' % (hostname, sender))
             fo.write('@%s.localdomain %s\n' %(hostname, sender))
+            # todo need an entry here to add @<hostname>.<domain>
     os.chmod(generic_file, 0400)
     run_command([POSTMAP, generic_file])
     os.chmod('%s.db' % generic_file, 0600)

--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -63,10 +63,11 @@ def update_generic(sender, revert=False):
     """
     overrites the contents of /etc/postfix/generic with the following mapping
     @<hostname> <sender-email-address>
+    @<hostname>.localdomain <sender-email-address>
     Then sets the file permissions and runs "postmap generic" to create the db
-    The db file is then chmod 0600
+    file and change it's permissions in turn.
     :param sender: email address entered as the sender email account
-    :param revert: if True do nothing (defaults to False)
+    :param revert: if True wipe the generic_file and db (defaults to False)
     :return:
     """
     generic_file = '/etc/postfix/generic'

--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -74,6 +74,7 @@ def update_generic(sender, revert=False):
     with open(generic_file, 'w') as fo:
         if (not revert):
             fo.write('@%s %s\n' % (hostname, sender))
+            fo.write('@%s.localdomain %s\n' %(hostname, sender))
     os.chmod(generic_file, 0400)
     run_command([POSTMAP, generic_file])
     os.chmod('%s.db' % generic_file, 0600)

--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -69,12 +69,11 @@ def update_generic(sender, revert=False):
     :param revert: if True do nothing (defaults to False)
     :return:
     """
-    if (revert is True):
-        return
     generic_file = '/etc/postfix/generic'
     hostname = gethostname()
     with open(generic_file, 'w') as fo:
-        fo.write('@%s %s' % (hostname, sender))
+        if (not revert):
+            fo.write('@%s %s\n' % (hostname, sender))
     os.chmod(generic_file, 0400)
     run_command([POSTMAP, generic_file])
     os.chmod('%s.db' % generic_file, 0600)

--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -51,6 +51,7 @@ def rockstor_postfix_config(fo, smtp_server, revert):
     fo.write('smtp_tls_CAfile = /etc/ssl/certs/ca-bundle.crt\n')
     fo.write('smtp_sasl_security_options = noanonymous\n')
     fo.write('smtp_sasl_tls_security_options = noanonymous\n')
+    fo.write('smtp_generic_maps = hash:/etc/postfix/generic\n')
     fo.write('%s\n' % FOOTER)
 
 def update_forward(email, revert=False):
@@ -63,7 +64,7 @@ def update_generic(sender, revert=False):
     overrites the contents of /etc/postfix/generic with the following mapping
     @<hostname> <sender-email-address>
     Then sets the file permissions and runs "postmap generic" to create the db
-    The db file is then chmod 600 
+    The db file is then chmod 0600
     :param sender: email address entered as the sender email account
     :param revert: if True do nothing (defaults to False)
     :return:


### PR DESCRIPTION
Rewrite / remap local email to be from the sender email address so as to avoid some isp's blocking the notification  / root emails due to them not having a "real" domain.

previously for nut notifications we had:-
From nut@rockstor.localdomain To root@localhost.localdomain
now:-
From given-sender-email To root@localhost.localdomain

and for notifications re SMART error logs we have
previously
From notifications@hostname.localdomain To root@hostname.localdomain
now:-
From   given-sender-email  To given-sender-email

So not perfect but at least we now have legitimate "From" labelling so should no longer be susceptible to blocking on account of non public domains.