### PR TITLE
Sort shares by name in UI

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -88,7 +88,11 @@ var Share = Backbone.Model.extend({
 var ShareCollection = RockStorPaginatedCollection.extend({
     model: Share,
     baseUrl: '/api/shares',
-
+    extraParams: function() {
+        var p = this.constructor.__super__.extraParams.apply(this, arguments);
+        p['sortby'] = 'name';
+        return p;
+    } 
 });
 
 var Image = Backbone.Model.extend({

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -90,13 +90,16 @@ class ShareListView(ShareMixin, rfc.GenericView):
     def get_queryset(self, *args, **kwargs):
         with self._handle_exception(self.request):
             sort_col = self.request.query_params.get('sortby', None)
-            if (sort_col is not None and sort_col == 'usage'):
+            if (sort_col is not None):
                 reverse = self.request.query_params.get('reverse', 'no')
                 if (reverse == 'yes'):
                     reverse = True
                 else:
                     reverse = False
-                return sorted(Share.objects.all(), key=lambda u: u.rusage,
+                if (sort_col == 'usage'):
+                    sort_col = 'rusage'
+                return sorted(Share.objects.all(),
+                              key=lambda u: getattr(u, sort_col),
                               reverse=reverse)
             return Share.objects.all()
 


### PR DESCRIPTION
The share list in *Storage - Shares* or in the dropdown on *Storage - Samba* is now sorted by name per default - IMHO this gives a nicer overview. This is done by making the API (class `ShareListView`) accept any object attribute in URL parameter `sortby`.

To discuss:
If sorting is not considered a relevant overhead even for a large number of shares, we could set a default server-side sorting by attribute `name`. Currently, if `sortby` URL parameter is NOT given, no sorting takes place.