### PR TITLE
Fix submit button in Plex storage configuration

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -834,20 +834,18 @@ RockonSettingsComplete = RockstorWizardPage.extend({
     },
 
     save: function() {
-	var _this = this;
-	event.preventDefault();
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	return $.ajax({
-	    url: '/api/rockons/' + this.rockon.id + '/update',
-	    type: 'POST',
-	    dataType: 'json',
-	    contentType: 'application/json',
-	    data: JSON.stringify({
-		'shares': this.shares
-	    }),
-	    success: function() {}
-	});
+        var _this = this;
+       	if (document.getElementById('next-page').disabled) return false;
+        document.getElementById('next-page').disabled = true;
+        return $.ajax({
+            url: '/api/rockons/' + this.rockon.id + '/update',
+            type: 'POST',
+            dataType: 'json',
+            contentType: 'application/json',
+            data: JSON.stringify({
+               	'shares': this.shares
+            }),
+            success: function() {}
+        });
     }
 });


### PR DESCRIPTION
Old (?) code tried to process none existing `event` object to disable submit button. This is now done via `getElementById()`.