### PR TITLE
toggle sftp service. Fixes #1027

### DIFF
--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -51,7 +51,7 @@ class SFTPServiceView(BaseServiceDetailView):
                 if (command == 'start'):
                     toggle_sftp_service()
                 else:
-                    e_msg = 'non config and non start so assuming stop in sftpserviceview'
+                    e_msg = 'non config and non start so assuming stop in sftpserviceview, received %s' % command
                     logger.error(e_msg)
                     toggle_sftp_service(switch=False)
             except Exception, e:

--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -51,6 +51,8 @@ class SFTPServiceView(BaseServiceDetailView):
                 if (command == 'start'):
                     toggle_sftp_service()
                 else:
+                    e_msg = 'non config and non start so assuming stop in sftpserviceview'
+                    logger.error(e_msg)
                     toggle_sftp_service(switch=False)
             except Exception, e:
                 logger.exception(e)

--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -51,8 +51,6 @@ class SFTPServiceView(BaseServiceDetailView):
                 if (command == 'start'):
                     toggle_sftp_service()
                 else:
-                    e_msg = 'non config and non start so assuming stop in sftpserviceview, received %s' % command
-                    logger.error(e_msg)
                     toggle_sftp_service(switch=False)
             except Exception, e:
                 logger.exception(e)

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
@@ -102,9 +102,11 @@ ServicesView = Backbone.View.extend({
     switchStatus: function(event,state){
       var serviceName = $(event.target).attr('data-service-name');
         if (state){
-          this.startService(serviceName);
+			console.log('switchStatus startService called on ', serviceName,  state);
+			this.startService(serviceName);
         }else {
-          this.stopService(serviceName);
+			console.log('switchStatus stopService called on ', serviceName, state);
+			this.stopService(serviceName);
         }
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
@@ -102,9 +102,9 @@ ServicesView = Backbone.View.extend({
     switchStatus: function(event,state){
       var serviceName = $(event.target).attr('data-service-name');
         if (state){
-			this.startService(serviceName);
+		  this.startService(serviceName);
         }else {
-			this.stopService(serviceName);
+		  this.stopService(serviceName);
         }
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
@@ -102,10 +102,8 @@ ServicesView = Backbone.View.extend({
     switchStatus: function(event,state){
       var serviceName = $(event.target).attr('data-service-name');
         if (state){
-			console.log('switchStatus startService called on ', serviceName,  state);
 			this.startService(serviceName);
         }else {
-			console.log('switchStatus stopService called on ', serviceName, state);
 			this.stopService(serviceName);
         }
     },

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -129,8 +129,11 @@ def service_status(service_name, config=None):
         return init_service_op('nslcd', 'status', throw=False)
     elif (service_name == 'sftp'):
         out, err, rc = init_service_op('sshd', 'status', throw=False)
+        # initial check on sshd status: 0 = OK 3 = stopped
         if (rc != 0):
             return out, err, rc
+        # sshd has sftp subsystem so we check for it's config line which is
+        # inserted or deleted to enable or disable the sftp service.
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
                 if (re.match("Subsystem\s+sftp", line) is not
@@ -138,6 +141,7 @@ def service_status(service_name, config=None):
                     return out, err, rc
             # -1 not appropriate as inconsistent with bash return codes
             # Returning 1 as Catchall for general errors.
+            # the calling system interprets -1 as enabled, 1 works for disabled.
             return out, err, 1
     elif (service_name == 'replication' or
           service_name == 'data-collector'):

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -24,8 +24,7 @@ import shutil
 from tempfile import mkstemp
 import os
 from shutil import move
-import logging
-logger = logging.getLogger(__name__)
+
 
 CHKCONFIG_BIN = '/sbin/chkconfig'
 AUTHCONFIG = '/usr/sbin/authconfig'
@@ -130,18 +129,13 @@ def service_status(service_name, config=None):
         return init_service_op('nslcd', 'status', throw=False)
     elif (service_name == 'sftp'):
         out, err, rc = init_service_op('sshd', 'status', throw=False)
-        logger.debug('service_status called for sftp')
-        logger.debug('return code from systemctl sshd status = %s' % rc)
         if (rc != 0):
-            logger.debug('rc != 0 so returning all results')
             return out, err, rc
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
                 if (re.match("Subsystem\s+sftp", line) is not
                         None):
-                    logger.debug('sftp Subsystem string found returning rc as is')
                     return out, err, rc
-            logger.debug('sftp Subsystem string not found returning rc as 1')
             # -1 not appropriate as inconsistent with bash return codes
             # Returning 1 as Catchall for general errors.
             return out, err, 1

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -137,7 +137,7 @@ def service_status(service_name, config=None):
             return out, err, rc
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
-                if (re.match("Subsystem\tsftp\tinternal-sftp", line) is not
+                if (re.match("Subsystem\s+sftp", line) is not
                         None):
                     logger.debug('sftp Subsystem string found returning rc as is')
                     return out, err, rc

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -24,6 +24,8 @@ import shutil
 from tempfile import mkstemp
 import os
 from shutil import move
+import logging
+logger = logging.getLogger(__name__)
 
 CHKCONFIG_BIN = '/sbin/chkconfig'
 AUTHCONFIG = '/usr/sbin/authconfig'
@@ -128,14 +130,21 @@ def service_status(service_name, config=None):
         return init_service_op('nslcd', 'status', throw=False)
     elif (service_name == 'sftp'):
         out, err, rc = init_service_op('sshd', 'status', throw=False)
+        logger.debug('service_status called for sftp')
+        logger.debug('return code from systemctl sshd status = %s' % rc)
         if (rc != 0):
+            logger.debug('rc != 0 so returning all results')
             return out, err, rc
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
                 if (re.match("Subsystem\tsftp\tinternal-sftp", line) is not
                         None):
+                    logger.debug('sftp Subsystem string found returning rc as is')
                     return out, err, rc
-            return out, err, -1
+            logger.debug('sftp Subsystem string not found returning rc as 1')
+            # -1 not appropriate as inconsistent with bash return codes
+            # Returning 1 as Catchall for general errors.
+            return out, err, 1
     elif (service_name == 'replication' or
           service_name == 'data-collector'):
         return superctl(service_name, 'status')

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -24,6 +24,10 @@ from system.osi import run_command
 import os
 from django.conf import settings
 
+import logging
+logger = logging.getLogger(__name__)
+
+
 SSHD_CONFIG = '/etc/ssh/sshd_config'
 MKDIR = '/bin/mkdir'
 MOUNT = '/bin/mount'
@@ -58,6 +62,8 @@ def update_sftp_config(input_map):
 
 
 def toggle_sftp_service(switch=True):
+    e_msg = 'toggle_sftp_service called with %s' % switch
+    logger.error(e_msg)
     fo, npath = mkstemp()
     written = False
     with open(SSHD_CONFIG) as sfo, open(npath, 'w') as tfo:

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -24,9 +24,6 @@ from system.osi import run_command
 import os
 from django.conf import settings
 
-import logging
-logger = logging.getLogger(__name__)
-
 
 SSHD_CONFIG = '/etc/ssh/sshd_config'
 MKDIR = '/bin/mkdir'
@@ -62,8 +59,6 @@ def update_sftp_config(input_map):
 
 
 def toggle_sftp_service(switch=True):
-    e_msg = 'toggle_sftp_service called with %s' % switch
-    logger.error(e_msg)
     fo, npath = mkstemp()
     written = False
     with open(SSHD_CONFIG) as sfo, open(npath, 'w') as tfo:

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -59,6 +59,7 @@ def update_sftp_config(input_map):
 
 
 def toggle_sftp_service(switch=True):
+    # TODO add Subsystem sftp line below Rockstor header rather than above
     fo, npath = mkstemp()
     written = False
     with open(SSHD_CONFIG) as sfo, open(npath, 'w') as tfo:


### PR DESCRIPTION
On install sftp was indicated as ON but on switching OFF the switch would return almost immediately to indicate sftp was ON however the off function was executed and so no sftp service was then active.  But as the switch was then in an ON position it could only send OFF signals, there by blocking activation of Rockstor initiated sftp service (as opposed to that enabled by the default config).

Problem was interpretation of the return code of -1 by the new switch subsystem as ON, fixed by returning 1 in the sftp disabled state ie where no line in sshd_config matches "Subsystem\s+sftp".

Also brought service_status check in system/services.py in-line with previously improved ssh.py check.for sftp substring. This avoids false negatives on initial install.

sftp checked via:-

-disabled behaviour-
sftp root@rockstor.local
subsystem request failed on channel 0
Couldn't read packet: Connection reset by peer

-enabled behaviour-
sftp root@rockstor.local
Connected to rockstor.local.
sftp> 

Tested with clean build and default sshd_config and then again with Rockstor generated config as slightly different sftp substrings.
