### PR TITLE
AD_switch_on_in_error. Fixes #1029

### DIFF
--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -158,7 +158,8 @@ def service_status(service_name, config=None):
             for l in o:
                 if (l == config['domain']):
                     return '', '', 0
-        return '', '', -1
+        # bootstrap switch subsystem interprets -1 as ON so returning 1 instead
+        return '', '', 1
 
     return init_service_op(service_name, 'status', throw=False)
 


### PR DESCRIPTION
I'm afraid I have yet to setup my FreeIPA system to test Rocktor's sssd registration system but with the supplied patch the new bootstrap switch is now OFF by default and responds appropriately and as far as I can tell as it did prior to this issue arising. 

Note this may well be a work around rather than a fix, please see #1027 for a related issue.

Awaiting more informed review.

Patch notes:-
The new bootstrap switch subsystem reads the -1 rc as
ON state which results in inability to switch AD on as the
subsystem believes it is already ON, leading to a catch 22.