### PR TITLE
no smart info on msa70. Fixes #997

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -281,10 +281,12 @@
 	  <% }); %>
 	</tbody>
       </table>
+			<pre>
       <% testlogdetail.forEach(function(detail) { %>
-      <%= detail.line %><br>
+      <%= detail.line %>
       <% }); %>
       <% } %>
+			</pre>
     </div>
   </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -167,39 +167,43 @@
       </div>
   </div>
 
-  <div id="smartcapabilities">
-    <div class="row">
-      <table id="smartcapabilites-table"
-             class="table table-condensed table-bordered table-hover table-striped tablesorter"
-             summary="Table of S.M.A.R.T capabilities">
-        <thead>
-        <tr>
-          <th>Id</th>
-          <th>Name</th>
-          <th>Flag</th>
-          <th>Capabilities</th>
-        </tr>
-        </thead>
-        <tbody>
-        <% capabilities.forEach(function(capability) { %>
-        <tr>
-          <td><%= capability.id %></td>
-          <td><%= capability.name %></td>
-          <td><%= capability.flag %></td>
-          <td><%= capability.capabilities %></td>
-        </tr>
-        <% }); %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+	<div id="smartcapabilities">
+		<div class="row">
+			<% if (capabilities.length == 0) { %>
+			<h3>No S.M.A.R.T Capabilities found (ATA/SATA only)</h3>
+			<% } else { %>
+			<table id="smartcapabilites-table"
+						 class="table table-condensed table-bordered table-hover table-striped tablesorter"
+						 summary="Table of S.M.A.R.T capabilities">
+				<thead>
+				<tr>
+					<th>Id</th>
+					<th>Name</th>
+					<th>Flag</th>
+					<th>Capabilities</th>
+				</tr>
+				</thead>
+				<tbody>
+				<% capabilities.forEach(function(capability) { %>
+				<tr>
+					<td><%= capability.id %></td>
+					<td><%= capability.name %></td>
+					<td><%= capability.flag %></td>
+					<td><%= capability.capabilities %></td>
+				</tr>
+				<% }); %> <!-- capabilities.forEach  -->
+				</tbody>
+			</table>
+			<% } %> <!-- capabilities.length -->
+		</div>
+	</div>
 
   <div id="smarterrorlogs">
     <div class="row">
       <% if (errorlogsummary.length == 0) { %>
         <% if (errorlog.length < 5) { %> <!-- No errors and empty raw log -->
           <h3>There are no errors.</h3>
-        <% } else {%> <!-- no summary but something in raw log -->
+        <% } else { %> <!-- no summary but something in raw log -->
           <h3>No error summary available, please see the raw log below</h3>
         <% } %>
       <% } else { %> <!-- we do have a summary so create and populate it -->

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -169,62 +169,76 @@
 
   <div id="smartcapabilities">
     <div class="row">
-      <table id="smartcapabilites-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="Table of S.M.A.R.T capabilities">
-	<thead>
-	  <tr>
-	    <th>Id</th>
-	    <th>Name</th>
-	    <th>Flag</th>
-	    <th>Capabilities</th>
-	  </tr>
-	</thead>
-	<tbody>
-	  <% capabilities.forEach(function(capability) { %>
-	    <tr>
-	      <td><%= capability.id %></td>
-	      <td><%= capability.name %></td>
-	      <td><%= capability.flag %></td>
-	      <td><%= capability.capabilities %></td>
-	    </tr>
-	  <% }); %>
-	</tbody>
+      <table id="smartcapabilites-table"
+             class="table table-condensed table-bordered table-hover table-striped tablesorter"
+             summary="Table of S.M.A.R.T capabilities">
+        <thead>
+        <tr>
+          <th>Id</th>
+          <th>Name</th>
+          <th>Flag</th>
+          <th>Capabilities</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% capabilities.forEach(function(capability) { %>
+        <tr>
+          <td><%= capability.id %></td>
+          <td><%= capability.name %></td>
+          <td><%= capability.flag %></td>
+          <td><%= capability.capabilities %></td>
+        </tr>
+        <% }); %>
+        </tbody>
       </table>
     </div>
   </div>
+
   <div id="smarterrorlogs">
     <div class="row">
       <% if (errorlogsummary.length == 0) { %>
-        <h3>There are no errors.</h3>
-      <% } else { %>
-        <p><%= errorlog[0].line %></p>
-	<p><%= errorlog[1].line %></p>
-      <table id="smarterrorlogsummary-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="Table of S.M.A.R.T error log summary">
-	<thead>
-	  <tr>
-	    <th>Error #</th>
-	    <th>Lifetime hours</th>
-	    <th>State</th>
-	    <th>Type</th>
-	    <th>Details</th>
-	  </tr>
-	</thead>
-	<tbody>
-	  <% errorlogsummary.forEach(function(summary) { %>
-	    <tr>
-	      <td><%= summary.error_num %></td>
-	      <td><%= summary.lifetime_hours %></td>
-	      <td><%= summary.state %></td>
-	      <td><%= summary.etype %></td>
-	      <td><%= summary.details %></td>
-	    </tr>
-	  <% }); %>
-	</tbody>
+        <% if (errorlog.length < 5) { %> <!-- No errors and empty raw log -->
+          <h3>There are no errors.</h3>
+        <% } else {%> <!-- no summary but something in raw log -->
+          <h3>No error summary available, please see the raw log below</h3>
+        <% } %>
+      <% } else { %> <!-- we do have a summary so create and populate it -->
+      <p><%= errorlog[0].line %></p>
+      <p><%= errorlog[1].line %></p>
+      <table id="smarterrorlogsummary-table"
+             class="table table-condensed table-bordered table-hover table-striped tablesorter"
+             summary="Table of S.M.A.R.T error log summary">
+        <thead>
+        <tr>
+          <th>Error #</th>
+          <th>Lifetime hours</th>
+          <th>State</th>
+          <th>Type</th>
+          <th>Details</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% errorlogsummary.forEach(function(summary) { %>
+        <tr>
+          <td><%= summary.error_num %></td>
+          <td><%= summary.lifetime_hours %></td>
+          <td><%= summary.state %></td>
+          <td><%= summary.etype %></td>
+          <td><%= summary.details %></td>
+        </tr>
+        <% }); %> <!-- errorlogsummary.forEach  -->
+        </tbody>
       </table>
-      <% errorlog.forEach(function(log) { %>
-        <%= log.line %><br>
-      <% }); %>
-      <% } %>
-    </div>
+      <% } %> <!-- (errorlogsummary.length == 0) else clause -->
+        <% if (errorlog.length > 4) { %>
+          <h3>Raw S.M.A.R.T error log</h3>
+          <pre>
+          <% errorlog.forEach(function(log) { %>
+            <%= log.line %>
+          <% }); %> <!-- errorlog.forEach -->
+          </pre>
+        <% } %> <!-- if (errorlog.length test) -->
+    </div> <!-- class="row" -->
   </div>
 
   <div id="smarttestlogs">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -130,42 +130,48 @@
     </div>
   </div>
 
-  <div id="smartattributes">
-      <div class="row">
-	<table id="smartattributes-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="List of S.M.A.R.T attributes">
-	  <thead>
-	    <tr>
-	      <th>Id</th>
-	      <th>Name</th>
-	      <th>Failed</th>
-	      <th>Norm-ed Value</th>
-	      <th>Worst</th>
-	      <th>Threshold</th>
-	      <th>Raw Value</th>
-	      <th>Type</th>
-	      <th>Updated</th>
-	      <th>Flag</th>
-	    </tr>
-	  </thead>
-	  <tbody>
-	    <% attributes.forEach(function(attribute) { %>
-	      <tr>
-		<td><%= attribute.aid %></td>
-		<td><%= attribute.name %></td>
-		<td><%= attribute.failed %></td>
-		<td><%= attribute.normed_value %></td>
-		<td><%= attribute.worst %></td>
-		<td><%= attribute.threshold %></td>
-		<td><%= attribute.raw_value %></td>
-		<td><%= attribute.atype %></td>
-		<td><%= attribute.updated %></td>
-		<td><%= attribute.flag %></td>
-	      </tr>
-	    <% }); %>
-	  </tbody>
-	</table>
-      </div>
-  </div>
+	<div id="smartattributes">
+		<div class="row">
+			<% if (attributes.length == 0) { %>
+			<h3>No S.M.A.R.T Attributes found (ATA/SATA only)</h3>
+			<% } else { %>
+			<table id="smartattributes-table"
+						 class="table table-condensed table-bordered table-hover table-striped tablesorter"
+						 summary="List of S.M.A.R.T attributes">
+				<thead>
+				<tr>
+					<th>Id</th>
+					<th>Name</th>
+					<th>Failed</th>
+					<th>Norm-ed Value</th>
+					<th>Worst</th>
+					<th>Threshold</th>
+					<th>Raw Value</th>
+					<th>Type</th>
+					<th>Updated</th>
+					<th>Flag</th>
+				</tr>
+				</thead>
+				<tbody>
+				<% attributes.forEach(function(attribute) { %>
+				<tr>
+					<td><%= attribute.aid %></td>
+					<td><%= attribute.name %></td>
+					<td><%= attribute.failed %></td>
+					<td><%= attribute.normed_value %></td>
+					<td><%= attribute.worst %></td>
+					<td><%= attribute.threshold %></td>
+					<td><%= attribute.raw_value %></td>
+					<td><%= attribute.atype %></td>
+					<td><%= attribute.updated %></td>
+					<td><%= attribute.flag %></td>
+				</tr>
+				<% }); %> <!-- attributes.forEach -->
+				</tbody>
+			</table>
+			<% } %> <!-- attributes.length -->
+		</div>
+	</div>
 
 	<div id="smartcapabilities">
 		<div class="row">

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -160,6 +160,7 @@ def error_logs(device, test_mode=TESTMODE):
     """
     # todo successfully returns log_l for lsi type output but it is interpreted
     # todo later in GUI as "There are no errors" suspect as no summary.
+    # todo ie in storageadmin/js/templates/disk/disk_details_layout.jst
     if not test_mode:
         o, e, rc = run_command([SMART, '-l', 'error', '/dev/%s' % device],
                            throw=False)

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -158,9 +158,6 @@ def error_logs(device, test_mode=TESTMODE):
     error number.
     :return: log_l: A list containing each line in turn of the error log.
     """
-    # todo successfully returns log_l for lsi type output but it is interpreted
-    # todo later in GUI as "There are no errors" suspect as no summary.
-    # todo ie in storageadmin/js/templates/disk/disk_details_layout.jst
     if not test_mode:
         o, e, rc = run_command([SMART, '-l', 'error', '/dev/%s' % device],
                            throw=False)
@@ -228,8 +225,6 @@ def error_logs(device, test_mode=TESTMODE):
                     summary[err_num] = list([lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     print ('summary_d %s' % summary)
-    logger.debug('SMART error_logs parser returned summary of %s' % summary)
-    logger.debug('SMART error_logs parser returned log_l of %s' % log_l)
     return (summary, log_l)
 
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 SMART = '/usr/sbin/smartctl'
 CAT = '/usr/bin/cat'
 # enables reading file dumps of smartctl output instead of running smartctl
-TESTMODE = True
+# currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
+# default setting = False
+TESTMODE = False
 
 
 def info(device, test_mode=TESTMODE):
@@ -114,7 +116,6 @@ def capabilities(device, test_mode=TESTMODE):
     :param test_mode: Not True causes cat from file rather than smartctl command
     :return: dictionary of smart capabilities extracted from device or test file
     """
-    # todo should these run_command calls not have throw=False on as others have
     if not test_mode:
         o, e, rc = run_command([SMART, '-c', '/dev/%s' % device])
     else:  # we are testing so use a smartctl -c file dump instead
@@ -237,7 +238,6 @@ def test_logs(device, test_mode=TESTMODE):
     :param test_mode: Not True causes cat from file rather than smartctl command
     :return: test_d as a dictionary of summarized test
     """
-    # todo need to confirm this as working on lsi controller reports
     if not test_mode:
         o, e, rc = run_command(
             [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s' % device])

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -208,10 +208,10 @@ def available(device, test_mode=False):
     a = False
     e = False
     for i in o:
-        # todo Check on matching as sometimes multiple spaces after ":" ie on lsi9207
-        if (re.match('SMART support is: Available', i) is not None):
+        # N.B. .* in pattern match to allow for multiple spaces
+        if (re.match('SMART support is:.* Available', i) is not None):
             a = True
-        if (re.match('SMART support is: Enabled', i) is not None):
+        if (re.match('SMART support is:.* Enabled', i) is not None):
             e = True
     return a, e
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -44,16 +44,13 @@ def info(device, test_mode=TESTMODE):
     else:  # we are testing so use a smartctl -H --info file dump instead
         o, e, rc = run_command([CAT, '/root/smartdumps/smart-H--info.out'], throw=False)
     res = {}
-    # todo add additional matching to account of eg some lsi formatting and name
-    # todo differences eg
-    # expected:- "SMART Health Status: OK"
-    # presented by lsi:- "SMART overall-health self-assessment test result: PASSED"
-    # Also note there are quite a few additional keys to look for here.
-    matches = ('Model Family:', 'Device Model:', 'Serial Number:',
-               'LU WWN Device Id:', 'Firmware Version:', 'User Capacity:',
-               'Sector Size:', 'Rotation Rate:', 'Device is:', 'ATA Version is:',
-               'SATA Version is:', 'Local Time is:', 'SMART support is: Available',
-               'SMART support is: Enabled', 'SMART overall-health self-assessment',)
+    # List of string matches to look for in smartctrl -H --info output.
+    # Note the "|" char allows for defining alternative matches ie A or B
+    matches = ('Model Family:|Vendor:', 'Device Model:|Product:', 'Serial Number:|Serial number:',
+               'LU WWN Device Id:|Logical Unit id:', 'Firmware Version:|Revision', 'User Capacity:',
+               'Sector Size:|Logical block size:', 'Rotation Rate:', 'Device is:', 'ATA Version is:',
+               'SATA Version is:', 'Local Time is:', 'SMART support is:.* Available',
+               'SMART support is:.* Enabled', 'SMART overall-health self-assessment|SMART Health Status:',)
     res = ['',] * len(matches)
     version = ''
     for l in o:

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -228,10 +228,22 @@ def error_logs(device, test_mode=TESTMODE):
     return (summary, log_l)
 
 
-def test_logs(device):
+def test_logs(device, test_mode=TESTMODE):
+    """
+    Retrieves information from SMART Self-Test logs held by the drive.
+    Creates a dictionary of previous test info, indexed by test number and a
+    list containing the remaining log info, each line is an item in the list.
+    :param device: disk device name
+    :param test_mode: Not True causes cat from file rather than smartctl command
+    :return: test_d as a dictionary of summarized test
+    """
     # todo need to confirm this as working on lsi controller reports
-    o, e, rc = run_command(
-        [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s' % device])
+    if not test_mode:
+        o, e, rc = run_command(
+            [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s' % device])
+    else:
+        o, e, rc = run_command(
+            [CAT, '/root/smartdumps/smart-l-selftest-l-selective.out'])
     test_d = {}
     log_l = []
     for i in range(len(o)):

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -28,6 +28,7 @@ from exceptions import CommandException
 logger = logging.getLogger(__name__)
 
 SMART = '/usr/sbin/smartctl'
+CAT = '/usr/bin/cat'
 
 
 def info(device):
@@ -192,7 +193,7 @@ def run_test(device, test):
     # start a smart test(short, long or conveyance)
     return run_command([SMART, '-t', test, '/dev/%s' % device])
 
-def available(device):
+def available(device, test_mode=False):
     """
     Returns boolean pair: true if SMART support is available on the device and
     true if SMART support is enabled.
@@ -200,7 +201,10 @@ def available(device):
     :param device:
     :return: available (boolean), enabled (boolean)
     """
-    o, e, rc = run_command([SMART, '--info', ('/dev/%s' % device)])
+    if not test_mode:
+        o, e, rc = run_command([SMART, '--info', ('/dev/%s' % device)])
+    else: # we are testing so use a smartctl --info file dump instead
+        o, e, rc = run_command([CAT, '/root/smartdumps/smart--info.out'])
     a = False
     e = False
     for i in o:


### PR DESCRIPTION
By adding a mode that reads smartctl outputs directly from file dumps of the same I was able to use @priel71 's smartctl outputs from their lsi9207-8i setup and correct some parsing issues.
The most noteworthy of which caused the existing parser to report no smart availability.
Since some smart info is not presented in a standard way I have also modified the UI presentation to dump raw output of for example Error Logs when no parsing for a summary was successful but when error info exists. Also the patch set adds info to user of no Attributes and Capabilities returned from some drives rather than just showing an empty table.
I was unable to verify Error Logs & Self-Test Logs tab function as the supplied outputs had no info on either of these. I am assuming if present this info is formatted similarly to what has worked to date.
Where logs were previously saved verbatim but not displayed as such I have via "pre" tags reproduced the original formatting as this is important for interpreting tabulated / spaced output; and in the case of error logs is the only means of viewing them. There is apparently no standard formatting on non ATA/SATA drives.

All changes have been tested with several existing drives that have error logs and test logs and drives that have neither. 

Note that main presented in the Identity / Info tab is paired with equivalents and no db / model changes were required.

Fixes #997 Although the modifications were based on a later submitter they are assumed to be equivalent. I have re-contacted the original reporter on the forum but have not heard back.

Possible simple improvements are to remove the redundant double spacing in the display of:-
Raw S.M.A.R.T error log
non summary part of Self-Test Logs
This is currently better readability wise but aesthetically challenged.
