### PR TITLE
minor regression in fake serial ui logic. Fixes#1086

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -174,7 +174,7 @@ DisksView = Backbone.View.extend({
     	Handlebars.registerHelper('display_disks_tbody', function() {
 
         var html = '',
-            warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further';
+            warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further.';
 
         this.collection.each(function(disk, index) {
           	var diskName = disk.get('name'),

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -207,7 +207,7 @@ DisksView = Backbone.View.extend({
         html += '<td>';
 	    if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
 	       html += '<div class="alert alert-danger">' +
-				   '<h4>Warning! Disk serial number or UUID is not legitimate or unique.</h4>' + warning +'</div>';
+				   '<h4>Warning! Disk serial number is not legitimate or unique.</h4>' + warning +'</div>';
        	}else{
 	       html += serial;
 	       if (serial) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -205,7 +205,7 @@ DisksView = Backbone.View.extend({
 
         html += '</td>';
         html += '<td>';
-	    if (serial == null || serial == '' || serial == diskName) {
+	    if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
 	       html += '<div class="alert alert-danger">' +
                    + '<h4>Warning! Disk serial number or UUID is not legitimate or unique.</h4>' + warning +'</div>';
        	}else{

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -207,7 +207,7 @@ DisksView = Backbone.View.extend({
         html += '<td>';
 	    if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
 	       html += '<div class="alert alert-danger">' +
-                   + '<h4>Warning! Disk serial number or UUID is not legitimate or unique.</h4>' + warning +'</div>';
+				   '<h4>Warning! Disk serial number or UUID is not legitimate or unique.</h4>' + warning +'</div>';
        	}else{
 	       html += serial;
 	       if (serial) {


### PR DESCRIPTION
Restore additional check that crept in while extensive UI updates were happening which caused a minor regression in the treatment of the new fake-serial mechanism used since #1045 .
N.B. I have also removed the reference to UUID in the serial warning message to reduce possible confusion with disk UUID as this message is only displayed when there are issues with disk serial and is not UUID related.

Fixes #1086 