### PR TITLE
raw smart error logs missing. Fixes #1084

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -194,48 +194,52 @@
       </table>
     </div>
   </div>
-  <div id="smarterrorlogs">
-    <div class="row">
-      {{#if errorLogSummaryNull}}
-        <h3>There are no errors.</h3>
-        {{else}}
-        <p>{{errorlogZero}}</p>
-	<p>{{errorlogOne}}</p>
-      <table id="smarterrorlogsummary-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="Table of S.M.A.R.T error log summary">
-	<thead>
-	  <tr>
-	    <th>Error #</th>
-	    <th>Lifetime hours</th>
-	    <th>State</th>
-	    <th>Type</th>
-	    <th>Details</th>
-	  </tr>
-	</thead>
-	<tbody>
-	  {{#each errorlogsummary as |summary|}}
-	    <tr>
-	      <td>{{summary.error_num}}</td>
-	      <td>{{summary.lifetime_hours}}</td>
-	      <td>{{summary.state}}</td>
-	      <td>{{summary.etype}}</td>
-	      <td>{{summary.details}}</td>
-	    </tr>
-	  {{/each}}
-	</tbody>
-      </table>
-      {{#if errorlog.count}}
-      <h3>Raw S.M.A.R.T error log</h3>
-      <pre>
-	{{#each errorlog as |log|}}
-        {{log.line}}<br>
-	{{/each}}
-	{{/if}}
-      </pre>
-      {{/if}}
-    </div>
-  </div>
 
-  <div id="smarttestlogs">
+	<div id="smarterrorlogs">
+		<div class="row">
+			{{#if errorLogSummaryNull}}
+			<h3>There are no errors.</h3>
+			{{else}}
+			<p>{{errorlogZero}}</p>
+
+			<p>{{errorlogOne}}</p>
+			<table id="smarterrorlogsummary-table"
+						 class="table table-condensed table-bordered table-hover table-striped tablesorter"
+						 summary="Table of S.M.A.R.T error log summary">
+				<thead>
+				<tr>
+					<th>Error #</th>
+					<th>Lifetime hours</th>
+					<th>State</th>
+					<th>Type</th>
+					<th>Details</th>
+				</tr>
+				</thead>
+				<tbody>
+				{{#each errorlogsummary as |summary|}}
+				<tr>
+					<td>{{summary.error_num}}</td>
+					<td>{{summary.lifetime_hours}}</td>
+					<td>{{summary.state}}</td>
+					<td>{{summary.etype}}</td>
+					<td>{{summary.details}}</td>
+				</tr>
+				{{/each}}
+				</tbody>
+			</table>
+			{{#isAboveMinLength 4 errorlog}}
+			<h3>Raw S.M.A.R.T error log</h3>
+			<pre>
+				{{#each errorlog as |log|}}
+					{{log.line}}
+				{{/each}}
+			</pre>
+			{{/isAboveMinLength}}
+			{{/if}}
+		</div>
+	</div>
+
+	<div id="smarttestlogs">
     <div class="row">
       {{#if testLogNull}}
       <h3>There are no Self-Test logs.</h3>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -198,10 +198,13 @@
 	<div id="smarterrorlogs">
 		<div class="row">
 			{{#if errorLogSummaryNull}}
-			<h3>There are no errors.</h3>
+				{{#isAboveMinLength 4 errorlog}}
+					<h3>No error summary available, please see the raw log below.</h3>
+				{{else}}
+					<h3>There are no errors.</h3>
+				{{/isAboveMinLength}}
 			{{else}}
 			<p>{{errorlogZero}}</p>
-
 			<p>{{errorlogOne}}</p>
 			<table id="smarterrorlogsummary-table"
 						 class="table table-condensed table-bordered table-hover table-striped tablesorter"
@@ -227,6 +230,7 @@
 				{{/each}}
 				</tbody>
 			</table>
+			{{/if}}
 			{{#isAboveMinLength 4 errorlog}}
 			<h3>Raw S.M.A.R.T error log</h3>
 			<pre>
@@ -235,7 +239,6 @@
 				{{/each}}
 			</pre>
 			{{/isAboveMinLength}}
-			{{/if}}
 		</div>
 	</div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -273,9 +273,9 @@
 	</tbody>
       </table>
       <pre>
-	{{#each testlogdetail as |detail|}}
-	{{detail.line}}<br>
-	{{/each}}
+				{{#each testlogdetail as |detail|}}
+				{{detail.line}}
+				{{/each}}
       </pre>
       {{/if}}
     </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -36,6 +36,7 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 		this.dependencies.push(this.disk);
 		this.dependencies.push(this.smartinfo);
 		this.active_tab = 0;
+		this.initHandlebarHelpers();
 	},
 
 	events: {
@@ -66,7 +67,7 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 		var attributes = this.smartinfo.get('attributes') || [];
 		var errorlogsummary = this.smartinfo.get('errorlogsummary') || [];
 		var errorlog = this.smartinfo.get('errorlog') || [];
-		var errorlogZero, errorlogOne = null
+		var errorlogZero, errorlogOne = null;
 		if(errorlog.length != 0){
 			errorlogZero = errorlog[0].line;
 			errorlogOne = errorlog[1].line;
@@ -160,6 +161,23 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 			},
 			error: function(xhr, status, error) {
 				enableButton(button);
+			}
+		});
+	},
+
+	initHandlebarHelpers: function () {
+		Handlebars.registerHelper('isAboveMinLength', function (minValue, target, options) {
+			// check we have all the arguments we expect
+			console.log('arguments.length = ' + arguments.length);
+			if (arguments.length != 3) {
+				throw new Error("Handlerbars Helper " +
+						"'isAboveMinLength' expects exactly 2 parameter.");
+			}
+			// do our logic and return options functions appropriately.
+			if (target.length > minValue) {
+				return options.fn(this);
+			} else {
+				return options.inverse(this);
 			}
 		});
 	}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -168,7 +168,6 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 	initHandlebarHelpers: function () {
 		Handlebars.registerHelper('isAboveMinLength', function (minValue, target, options) {
 			// check we have all the arguments we expect
-			console.log('arguments.length = ' + arguments.length);
 			if (arguments.length != 3) {
 				throw new Error("Handlerbars Helper " +
 						"'isAboveMinLength' expects exactly 2 parameter.");


### PR DESCRIPTION
Corrects minor regression in display of raw smart error logs.
Created a custom handlebarsjs comparison block helper to restore simple view logic on wether to show raw logs or not.
Please see #1084 for output after patches.
Tested on a sata drive with errors and some without and on submitted smart dumps (using internal testmode) for lsi9207-8i , the same dumps used when this enhancement was originally added in #1076 .

N.B. The raw log outputs are now no longer double spaced which is nice.

Ready for review as works for me in both Chrome and Firefox.