### PR TITLE
nut config ownership and config screen fix. Fixes #1073. Fixes #1094

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
@@ -28,7 +28,7 @@
 
         <!-- NUT mode -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="mode">Nut Mode<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="mode">NUT Mode<span class="required"> *</span></label>
           <div class="col-sm-4">
             <select class="form-control" id="mode" name="mode">
             {{display_nutMode_options}}
@@ -83,7 +83,7 @@
 
         <!-- nut server name / ip -->
         <div class="form-group" id="nut-server">
-          <label class="col-sm-4 control-label" for="nutserver">Nut Server <span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="nutserver">NUT Server <span class="required"> *</span></label>
           <div class="col-sm-4">
             <input class="form-control" type="text" id="nutserver" name="nutserver" value="{{config.nutserver}}" placeholder="hostname or ip of nutserver">
           </div>
@@ -91,7 +91,7 @@
 
         <!-- nut user name -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="nutuser">Nut User<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="nutuser">NUT User<span class="required"> *</span></label>
           <div class="col-sm-4">
             <input class="form-control" type="text" id="nutuser" name="nutuser" value="{{config.nutuser}}" placeholder="NUT username eg 'monuser'">
           </div>
@@ -99,7 +99,7 @@
 
         <!-- nut user password (no spaces)-->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="password">Nut User Password<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="password">NUT User Password<span class="required"> *</span></label>
           <div class="col-sm-4">
             <input class="form-control" type="text" id="password" name="password" value="{{config.password}}" placeholder="NUT user password">
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -377,7 +377,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
 			_this = this;
 			var nutDriverTypes = ['apcsmart','apcsmart-old','apcupsd-ups','bcmxcp','bcmxcp_usb','belkin','belkinunv','bestfcom','bestfortress','bestuferrups','bestups','blazer_ser','blazer_usb','dummy-ups','etapro','everups','gamatronic','genericups','isbmex','ivtscd','liebert','liebert-esp2','masterguard','metasys','mge-shut','mge-utalk','microdowell','nutclient','nutdrv_qx','oldmge-shut','oneac','optiups','powercom','powerpanel','rhino','richcomm_usb','riello_ser','riello_usb','safenet','skel','snmp-ups','solis','tripplite','tripplite_usb','tripplitesu','upscode2','usbhid-ups','victronups'];
 			_.each(nutDriverTypes, function(driver, index) { 
-				if (driver == _this.config.nutdriver) { 
+				if (driver == _this.config.driver) {
 					html += '<option value="' + driver + '" selected="selected">';
 					html += driver + '</option>';
 				} else { 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -347,7 +347,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
 			_this = this;
 			var nutModeTypes = ['standalone','netserver','netclient']; 
 			_.each(nutModeTypes, function(mode, index) { 
-				if (mode == _this.config.nutmode) {
+				if (mode == _this.config.mode) {
 					html += '<option value="' + mode + '" selected="selected">';
 					html += mode + '</option>';
 				} else {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -378,7 +378,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
 			var nutDriverTypes = ['apcsmart','apcsmart-old','apcupsd-ups','bcmxcp','bcmxcp_usb','belkin','belkinunv','bestfcom','bestfortress','bestuferrups','bestups','blazer_ser','blazer_usb','dummy-ups','etapro','everups','gamatronic','genericups','isbmex','ivtscd','liebert','liebert-esp2','masterguard','metasys','mge-shut','mge-utalk','microdowell','nutclient','nutdrv_qx','oldmge-shut','oneac','optiups','powercom','powerpanel','rhino','richcomm_usb','riello_ser','riello_usb','safenet','skel','snmp-ups','solis','tripplite','tripplite_usb','tripplitesu','upscode2','usbhid-ups','victronups'];
 			_.each(nutDriverTypes, function(driver, index) { 
 				if (driver == _this.config.nutdriver) { 
-					htm += '<option value="' + driver + '" selected="selected">';
+					html += '<option value="' + driver + '" selected="selected">';
 					html += driver + '</option>';
 				} else { 
 					html += '<option value="' + driver + '">' + driver + '</option>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -363,7 +363,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
 			var nutMonitorTypes = ['master','slave'];
 			_.each(nutMonitorTypes, function(upsmon, index) { 
 				if (upsmon == _this.config.upsmon) { 
-					htm += '<option value="' + upsmon + '" selected="selected">';
+					html += '<option value="' + upsmon + '" selected="selected">';
 					html += upsmon + '</option>';
 				} else { 
 					html += '<option value="' + upsmon + '">' + upsmon + '</option>';

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -195,10 +195,18 @@ def configure_nut(config):
         # nut-client installs upsmon.conf and upssched.conf
         # ups.conf must be readable by upsdrvctl and any drivers and upsd
         # all nut config files by default in a CentOS install are 640 but our
-        # file editing process creates a temp file and copies it over as root
-        # the files as is are left as root.nut owner group so:-
-        # os.chmod(config_file, 0644)
+        # file editing process creates a temp file and copies it over as root.
+        # The files used to be left as root.nut owner group so previously we
+        # only had to chmod but note the following comment re the chown addition
+        # after our existing chmod:-
         run_command([CHMOD, '640', config_file])
+        # N.B. as of around Dec 2015 an os update changed the behaviour of
+        # the mechanism used here such that root.root became the owner group.
+        # This takes effect once we instantiate a fresh config which then
+        # results is a non working nut subsystems as nut the user no longer has
+        # read access. Fixed by chown root.nut on all files we edit as a matter
+        # of course.
+        run_command([CHOWN, 'root.nut', config_file])
     config_upssched()
 
 


### PR DESCRIPTION
#1073 
In certain circumstances the config files of nut became root.root which broke nut as the nut user couldn't access it's own config. This was tricky to reproduce and seems to depend on OS updates that changed default mask behaviour but on a machine where I did reproduce the included patch returned the file rights to the expected and previous default of root.nut.
#1094 
Typo corrections and some variable name corrections to reverse regression in NUT config screen.
NUT config screen now appears and functions as it did prior to 3.8-10.15 / 3.8-10.16.
Also corrected an inconsistency in use of NUT rather than Nut.

Tested on vm with dummy driver (standalone and netserver mode) and with real hardware with USB riello_usb driver and dummy driver (standalone and netserver mode) as well as netclient modes on both platforms.