### PR TITLE
Refine sensing of smart self-test in progress. Fixes #1097

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -60,7 +60,8 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 		var p = c.name.indexOf("routine");
 		var short_name = c.name.substring(0, p);
 		test_capabilities[short_name] = c.capabilities;
-	    } else if (c.name == 'Self-test execution status' && c.flag != 0) {
+	    } else if (c.name == 'Self-test execution status'
+				&& c.flag > 240 && c.flag < 250) {
 		running_test = c.capabilities;
 	    }
 	});


### PR DESCRIPTION
Previously we used !=0 status test but this gives false
positives so refine to "240 < state < 250" which indicates
test in progress as other non zero states indicate other
conditions such as if the last test performed was aborted
by the host for example.

Tested on 5 different manufacturers across 7 drives including 2 mSATA and 5 SATA.
All reported state of above range whilst testing and UI performed as expected.
State is read from capabilities tab matching "Self-test execution status".
smartctl -c /dev/sda

Not that during testing the utility of a "Cancel S.M.A.R.T Self-Test" button was highlighted. I will open a separate issue for this as a feature request.