### PR TITLE
mend share permissions edit in testing channel. Fixes #1100

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
@@ -492,21 +492,21 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
 			if (this.permStr[0] == "1") { 
 				html += '<input type="checkbox" name="perms[]" value="owner-r" checked="true">';
 			} else { 
-				html += '<input type="checkbox">'; 
+				html += '<input type="checkbox" name="perms[]" value="owner-r">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[3] == "1") { 
 				html += '<input type="checkbox" name="perms[]" value="group-r" checked="true">';
 			} else { 
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="group-r">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[6] == "1") { 
 				html += '<input type="checkbox" name="perms[]" value="other-r" checked="true">';
 			} else {  
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="other-r">';
 			}
 			html += '</td>';
 			return new Handlebars.SafeString(html);
@@ -516,23 +516,23 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
 			var html = '';
 			html += '<td>';
 			if (this.permStr[1] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="owner-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="owner-w" checked="true">';
 			} else { 
-				html += '<input type="checkbox">'; 
+				html += '<input type="checkbox" name="perms[]" value="owner-w">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[4] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="group-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="group-w" checked="true">';
 			} else { 
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="group-w">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[7] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="other-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="other-w" checked="true">';
 			} else {  
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="other-w">';
 			}
 			html += '</td>';
 			return new Handlebars.SafeString(html);
@@ -542,23 +542,23 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
 			var html = '';
 			html += '<td>';
 			if (this.permStr[2] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="owner-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="owner-x" checked="true">';
 			} else { 
-				html += '<input type="checkbox">'; 
+				html += '<input type="checkbox" name="perms[]" value="owner-x">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[5] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="group-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="group-x" checked="true">';
 			} else { 
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="group-x">';
 			} 
 			html += '</td>';
 			html += '<td>';
 			if (this.permStr[8] == "1") { 
-				html += '<input type="checkbox" name="perms[]" value="other-r" checked="true">';
+				html += '<input type="checkbox" name="perms[]" value="other-x" checked="true">';
 			} else {  
-				html += '<input type="checkbox">';
+				html += '<input type="checkbox" name="perms[]" value="other-x">';
 			}
 			html += '</td>';
 			return new Handlebars.SafeString(html);


### PR DESCRIPTION
As reported in #1100 by @parker1c share permission edits would result in 444 access writes irrespective of selection. Turned out to be minor omission in recent massive UI overall.

I have tested this commit when applied to 3.8-10.17 and the share permissions both edit and view behaved as expected. Owner and Group fields were also tested for edit and display and all 9 tick boxes responded as expected. ie Owner Group Other for Read Write and Execute permission. Verification was carried out via:-
```
watch -d ls -la /mnt2
```
while saving edits and viewing edits on a number of shares.

Fixes #1100 .

@schakrava Ready for review and submitting as tested via the above method.
