### PR TITLE
enhance smart return code handling. Fixes #1107

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -157,8 +157,8 @@ def error_logs(device, test_mode=TESTMODE):
     error number.
     :return: log_l: A list containing each line in turn of the error log.
     """
+    smart_command = [SMART, '-l', 'error', '/dev/%s' % device]
     if not test_mode:
-        smart_command = [SMART, '-l', 'error', '/dev/%s' % device]
         o, e, rc = run_command(smart_command, throw=False)
     else:
         o, e, rc = run_command([CAT, '/root/smartdumps/smart-l-error.out'])
@@ -226,9 +226,9 @@ def test_logs(device, test_mode=TESTMODE):
     :param test_mode: Not True causes cat from file rather than smartctl command
     :return: test_d as a dictionary of summarized test
     """
+    smart_command = [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s'
+                     % device]
     if not test_mode:
-        smart_command = [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s'
-                         % device]
         o, e, rc = run_command(smart_command, throw=False)
     else:
         o, e, rc = run_command(

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -46,8 +46,7 @@ def info(device, test_mode=TESTMODE):
         o, e, rc = run_command([SMART, '-H', '--info', '/dev/%s' % device],
                                throw=False)
     else:  # we are testing so use a smartctl -H --info file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-H--info.out'],
-                               throw=False)
+        o, e, rc = run_command([CAT, '/root/smartdumps/smart-H--info.out'])
     res = {}
     # List of string matches to look for in smartctrl -H --info output.
     # Note the "|" char allows for defining alternative matches ie A or B
@@ -87,8 +86,7 @@ def extended_info(device, test_mode=TESTMODE):
     if not test_mode:
         o, e, rc = run_command([SMART, '-a', '/dev/%s' % device], throw=False)
     else:  # we are testing so use a smartctl -a file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-a.out'],
-                               throw=False)
+        o, e, rc = run_command([CAT, '/root/smartdumps/smart-a.out'])
     attributes = {}
     for i in range(len(o)):
         if (re.match('Vendor Specific SMART Attributes with Thresholds:',
@@ -163,8 +161,7 @@ def error_logs(device, test_mode=TESTMODE):
         smart_command = [SMART, '-l', 'error', '/dev/%s' % device]
         o, e, rc = run_command(smart_command, throw=False)
     else:
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-l-error.out'],
-                           throw=False)
+        o, e, rc = run_command([CAT, '/root/smartdumps/smart-l-error.out'])
     # As we mute exceptions when calling the above command we should at least
     # examine what we have as return code (rc); 64 has been seen when the error
     # log contains errors but otherwise executes successfully so we catch this.


### PR DESCRIPTION
Simple enhancement to deal with return code of 128 from the smart command used to retrieve self test logs that otherwise produced sane output. This avoids all smart data being inaccessible for drives causing this return code on this smart probe.

I have tested on a single drive that exibits this behaviour and a number of other drives that behave more normally.

Note this pull request abstracts the mechanism that was previously used to override specific return codes that was introduced in pull request #957 so future codes that we need to handle differently can be more easily incorporated.

