### PR TITLE
populate disk info for system disk. Fixes #1116

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -757,7 +757,11 @@ def btrfs_importable(disk):
 
 def root_disk():
     """
-    returns the partition(s) used for /. Typically it's sda.
+    Returns the drive device name where / mount point is found.
+    Works by parsing /proc/mounts. Eg if the root entry was as follows:
+    /dev/sdc3 / btrfs rw,noatime,ssd,space_cache,subvolid=258,subvol=/root 0 0
+    the returned value is sdc
+    The assumption is that the partition number will be a single character.
     """
     with open('/proc/mounts') as fo:
         for line in fo.readlines():
@@ -896,6 +900,7 @@ def scan_disks(min_size):
                                     dmap['root'], ]
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
+    logger.info('root_disk returned the value of %s ', root)
     return disks
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -900,7 +900,6 @@ def scan_disks(min_size):
                                     dmap['root'], ]
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
-    logger.info('root_disk returned the value of %s ', root)
     return disks
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -896,7 +896,6 @@ def scan_disks(min_size):
                                     dmap['root'], ]
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
-        logger.info('disks item = %s ', Disk(*dnames[d]))
     return disks
 
 


### PR DESCRIPTION
Relatively non invasive additions that extends the existing mechanism that populates the root partition's serial entry to also populate its model, transport, vendor, and hctl entries.

Tested on a couple of real machines and all looks fine. These values would have previously been attributed the None value.

Corrected and improved some comments in the same area.

Fixes #1116