### PR TITLE
improve bios raid handling. Fixes #1151

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -769,8 +769,7 @@ def root_disk():
             fields = line.split()
             # todo does this not allow ext4 root, ie silencing no btrfs root
             # todo exception raised here otherwise?
-            if (fields[1] == '/' and
-                    (fields[2] == 'ext4' or fields[2] == 'btrfs')):
+            if (fields[1] == '/' and fields[2] == 'btrfs'):
                 disk = os.path.realpath(fields[0])
                 if (re.match('/dev/md', disk) is not None):
                     # We have an Multi Device naming scheme which is a little

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -767,8 +767,6 @@ def root_disk():
     with open('/proc/mounts') as fo:
         for line in fo.readlines():
             fields = line.split()
-            # todo does this not allow ext4 root, ie silencing no btrfs root
-            # todo exception raised here otherwise?
             if (fields[1] == '/' and fields[2] == 'btrfs'):
                 disk = os.path.realpath(fields[0])
                 if (re.match('/dev/md', disk) is not None):
@@ -798,7 +796,6 @@ def root_disk():
 
 def scan_disks(min_size):
     base_root_disk = root_disk()
-    logger.debug('root_disk returned the value of %s ', base_root_disk)
     cmd = ['/usr/bin/lsblk', '-P', '-o',
            'NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID']
     o, e, rc = run_command(cmd)
@@ -907,13 +904,10 @@ def scan_disks(min_size):
                     # we should update that base dev's entry in dnames to
                     # parted "True" as when recorded lsblk type on base device
                     # would have been disk or RAID1 (for base md device).
-                    logger.debug('prior entry for lsblk type via dnames[dname][11] = %s', dnames[dname][11])
                     # Change the 12th entry (0 indexed) of this device to True
                     # The 12 entry is the parted flag so we label
                     # our existing dnames entry as parted ie partitioned.
                     dnames[dname][11] = True
-                    logger.debug('Changed to = %s', dnames[dname][11])
-                    logger.debug('quick look at structure of dnames[dname] = %s', dnames[dname])
         if ((not is_root_disk and not is_partition) or
                 (is_partition and is_btrfs)):
             # We have a non system disk that is not a partition
@@ -938,7 +932,6 @@ def scan_disks(min_size):
                     dmap['HCTL'] = root_hctl
                     # and if we are an md device then use get_md_members string
                     # to populate our MODEL since it is otherwise unused.
-                    logger.debug('WE ARE SETTING ROOT DETIALS')
                     if (re.match('md', dmap['NAME']) is not None):
                         # cheap way to display our member drives
                         dmap['MODEL'] = get_md_members(dmap['NAME'])
@@ -994,7 +987,6 @@ def scan_disks(min_size):
     # Transfer our collected disk / dev entries of interest to the disks list.
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
-        logger.debug('disks item = %s ', Disk(*dnames[d]))
     return disks
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -879,6 +879,8 @@ def scan_disks(min_size):
         # normal partitions are of type 'part', md partitions are of type 'md'
         # normal disks are of type 'disk' md devices are of type eg 'raid1'
         # disk members of eg intel bios raid md devices fstype='isw_raid_member'
+        # Note for future re-write; when using udevadm DEVTYPE, partition and
+        # disk works for both raid and non raid partitions and devices.
         if (dmap['TYPE'] == 'part'):
             for dname in dnames.keys():
                 if (re.match(dname, dmap['NAME']) is not None):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -775,19 +775,17 @@ def root_disk():
                     # different ie 3rd partition = md126p3 on the md126 device,
                     # or md0p3 as third partition on md0 device.
                     logger.debug('root_disk found an md device')
-                    # as md devs often have 1 to 3 numerical chars we search
-                    # for them after the 5th [index 4] char to skip /dev/??
-                    # We trim off the 2 character partition designator in our
-                    # disk string to avoid matching the partition number.
+                    # As md devs often have 1 to 3 numerical chars we search
+                    # for one or more numeric characters, this assumes our dev
+                    # name has no prior numerical components ie starts /dev/md
+                    # but then we are here due to that match.
                     # Find the indexes of the device name without the partition.
-                    # ie search for where the numbers after "md" end
-                    end = re.search('\d+', disk[:-2]).end()
-                    logger.debug('disk to -2 string = %s', disk[:-2])
+                    # Search for where the numbers after "md" end.
+                    # N.B. the following will also work if root is not in a
+                    # partition ie on md126 directly.
+                    end = re.search('\d+', disk).end()
+                    logger.debug('disk string = %s', disk)
                     logger.debug('end of md numbers match = index of %s', end)
-                    # N.B. the above assumes no more than 2 numeric chars for
-                    # the partition designator but allows also for a single char
-                    # ie d2 or d11, in the second case we leave a non numeric.
-                    # todo Possible out of range if / on md126 (no partition)
                     return disk[5:end]
                 else:
                     # catch all that assumes we have eg /dev/sda3 and want "sda"

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -866,15 +866,17 @@ def scan_disks(min_size):
             root_transport = dmap['TRAN']
             root_vendor = dmap['VENDOR']
             root_hctl = dmap['HCTL']
-        if (dmap['TYPE'] == 'part'):
+        # md raid partitions are of type 'md' and raw md device is type 'raid1'
+        # normal partitions are of type 'part'
+        if (dmap['TYPE'] == 'part' or dmap['TYPE'] == 'md'):
             for dname in dnames.keys():
                 if (re.match(dname, dmap['NAME']) is not None):
                     dnames[dname][11] = True
-        if (((dmap['NAME'] != root and dmap['TYPE'] != 'part') or
-                (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'))):
+        if (((dmap['NAME'] != root and (dmap['TYPE'] != 'part' or dmap['TYPE'] != 'md')) or
+                ((dmap['TYPE'] == 'part' or dmap['TYPE'] == 'md') and dmap['FSTYPE'] == 'btrfs'))):
             dmap['parted'] = False  # part = False by default
             dmap['root'] = False
-            if (dmap['TYPE'] == 'part' and dmap['FSTYPE'] == 'btrfs'):
+            if ((dmap['TYPE'] == 'part' or dmap['TYPE'] == 'md') and dmap['FSTYPE'] == 'btrfs'):
                 # btrfs partition for root (rockstor_rockstor) pool
                 if (re.match(root, dmap['NAME']) is not None):
                     # now add the properties we stashed when looking at the root

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -891,8 +891,8 @@ def scan_disks(min_size):
         # Note for future re-write; when using udevadm DEVTYPE, partition and
         # disk works for both raid and non raid partitions and devices.
         # Begin readability variables assignment
-        # - is this a partition
-        if (dmap['TYPE'] == 'part'):
+        # - is this a partition regular or md type.
+        if (dmap['TYPE'] == 'part' or dmap['TYPE'] == 'md'):
             is_partition = True
         # - is filesystem of type btrfs
         if (dmap['FSTYPE'] == 'btrfs'):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -769,6 +769,7 @@ def root_disk():
             if (fields[1] == '/' and
                     (fields[2] == 'ext4' or fields[2] == 'btrfs')):
                 disk = os.path.realpath(fields[0])
+                logger.debug('os.path.realpath in ROOT_DISK = %s', disk)
                 return disk[5:-1]
     msg = ('root filesystem is not BTRFS. During Rockstor installation, '
            'you must select BTRFS instead of LVM and other options for '
@@ -900,6 +901,8 @@ def scan_disks(min_size):
                                     dmap['root'], ]
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
+        logger.info('disks item = %s ', Disk(*dnames[d]))
+    logger.info('root_disk returned the value of %s ', root)
     return disks
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -859,6 +859,11 @@ def scan_disks(min_size):
         # We are not interested in CD / DVD rom devices so skip to next device
         if (dmap['TYPE'] == 'rom'):
             continue
+        # We are not interested in swap partitions or devices so skip further
+        # processing and move to next device.
+        # N.B. this also facilitates a simpler mechanism of classification.
+        if (dmap['FSTYPE'] == 'swap'):
+            continue
         if (dmap['NAME'] == root):
             # Based on our root variable we are looking at the system drive.
             # Given lsblk doesn't return serial, model, transport, vendor, hctl

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -871,6 +871,9 @@ def scan_disks(min_size):
             root_transport = dmap['TRAN']
             root_vendor = dmap['VENDOR']
             root_hctl = dmap['HCTL']
+        # normal partitions are of type 'part', md partitions are of type 'md'
+        # normal disks are of type 'disk' md devices are of type eg 'raid1'
+        # disk members of eg intel bios raid md devices fstype='isw_raid_member'
         if (dmap['TYPE'] == 'part'):
             for dname in dnames.keys():
                 if (re.match(dname, dmap['NAME']) is not None):

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -154,9 +154,10 @@ class DiskMixin(object):
             # find all the not offline db entries
             if (not do.offline):
                 # We have an attached disk db entry
-                if re.match('vd', do.name):
-                    # Virtio disks (named vd*) have no smart capability.
-                    # avoids cluttering logs with exceptions on these devices.
+                if re.match('vd', do.name) or re.match('md', do.name):
+                    # Virtio disks (named vd*) and md devices (named md*) have
+                    # no smart capability so avoid cluttering logs with
+                    # exceptions on these types of devices.
                     do.smart_available = do.smart_enabled = False
                     continue
                 # try to establish smart availability and status and update db

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -66,7 +66,7 @@ class DiskMixin(object):
         # 1) scrub all device names with unique but nonsense uuid4
         # 1) mark all offline disks as such via db flag
         # 2) mark all offline disks smart available and enabled flags as False
-        logger.info('update_disk_state() Called')
+        # logger.info('update_disk_state() Called')
         for do in Disk.objects.all():
             # Replace all device names with a unique placeholder on each scan
             # N.B. do not optimize by re-using uuid index as this could lead

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -154,8 +154,10 @@ class DiskMixin(object):
             # find all the not offline db entries
             if (not do.offline):
                 # We have an attached disk db entry
-                if re.match('vd', do.name) or re.match('md', do.name):
-                    # Virtio disks (named vd*) and md devices (named md*) have
+                if re.match('vd', do.name) or re.match('md', do.name) or\
+                        re.match('mmcblk', do.name):
+                    # Virtio disks (named vd*), md devices (named md*), and
+                    # an sdcard reader that provides devs named mmcblk* have
                     # no smart capability so avoid cluttering logs with
                     # exceptions on these types of devices.
                     do.smart_available = do.smart_enabled = False

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -388,7 +388,6 @@ def get_md_members(device_name, test=None):
     example: "[2]-/dev/sda[0]-/dev/sdb[1]-raid1" = 2 devices with level info
     """
     line_fields = []
-    logger.debug('get_md_members called with device name %s' % device_name)
     # if non md device then return empty string
     if re.match('md', device_name) is None:
         return ''
@@ -413,12 +412,9 @@ def get_md_members(device_name, test=None):
         # less than 3 fields are of no use so just in case:-
         if len(line_fields) < 3:
             continue
-        logger.debug('MD UDEVADM info line as list = %s', line_fields)
-        logger.debug('value of re.match test = %s',
-                     re.match('MD_DEVICE', line_fields[1]))
+        # catch the lines that begin with MD_DEVICE or MD_LEVEL
         if re.match('MD_DEVICE', line_fields[1]) is not None or \
                 re.match('MD_LEVEL', line_fields[1]) is not None:
-            logger.debug('found a match for MD_DEVICE, adding value')
             # add this entries value (3rd column) to our string
             if len(line_fields[2]) == 1:
                 # Surround single digits with square brackets ie the number of
@@ -431,7 +427,6 @@ def get_md_members(device_name, test=None):
                 else:
                     # > 1 char value that doesn't start with /dev, so raid level
                     members_string += line_fields[2]
-    logger.debug('get_md_members returning member string = %s' % members_string)
     return members_string
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -367,6 +367,7 @@ def is_mounted(mnt_pt):
                 return True
     return False
 
+
 def get_md_members(device_name, test=None):
     """
     Returns the md members from a given device, if the given device is not an
@@ -384,6 +385,7 @@ def get_md_members(device_name, test=None):
     :param test: if test is not None then it's contents is used in lieu of
     udevadm output.
     :return: String of all members listed in udevadm info --name=device_name
+    example: "[2]-/dev/sda[0]-/dev/sdb[1]-raid1" = 2 devices with level info
     """
     line_fields = []
     logger.debug('get_md_members called with device name %s' % device_name)
@@ -412,12 +414,16 @@ def get_md_members(device_name, test=None):
         if len(line_fields) < 3:
             continue
         logger.debug('MD UDEVADM info line as list = %s', line_fields)
-        logger.debug('value of re.match test = %s', re.match('MD_DEVICE', line_fields[1]))
-        if re.match('MD_DEVICE', line_fields[1]) is not None:
+        logger.debug('value of re.match test = %s',
+                     re.match('MD_DEVICE', line_fields[1]))
+        if re.match('MD_DEVICE', line_fields[1]) is not None or \
+                re.match('MD_LEVEL', line_fields[1]) is not None:
             logger.debug('found a match for MD_DEVICE, adding value')
             # add this entries value (3rd column) to our string
-            members_string += line_fields[2]
-            members_string += '-'
+            if len(line_fields[2]) == 1:
+                members_string += '[' + line_fields[2] + ']-'
+            else:
+                members_string += line_fields[2]
     logger.debug('get_md_members returning member string = %s' % members_string)
     return members_string
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -422,7 +422,7 @@ def get_md_members(device_name, test=None):
     return members_string
 
 
-def get_disk_serial(device_name, test):
+def get_disk_serial(device_name, test=None):
     """
     Returns the serial number of device_name using udevadm to match that
     returned by lsblk. N.B. udevadm has been observed to return the following:-

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -421,9 +421,16 @@ def get_md_members(device_name, test=None):
             logger.debug('found a match for MD_DEVICE, adding value')
             # add this entries value (3rd column) to our string
             if len(line_fields[2]) == 1:
-                members_string += '[' + line_fields[2] + ']-'
+                # Surround single digits with square brackets ie the number of
+                # members and the member index (assumes max 9 md members)
+                members_string += '[' + line_fields[2] + '] '
             else:
-                members_string += line_fields[2]
+                if re.match('/dev', line_fields[2]) is not None:
+                    # We have a dev name so put it's serial in our string.
+                    members_string += get_disk_serial(line_fields[2])
+                else:
+                    # > 1 char value that doesn't start with /dev, so raid level
+                    members_string += line_fields[2]
     logger.debug('get_md_members returning member string = %s' % members_string)
     return members_string
 


### PR DESCRIPTION
I have tested this patch set on a variety of machines both real and virtual with regular installs and a single Intel bios raid install. Intel bios raid is essentially a bios level instantiation of software raid that in linux is managed as part of the standard mdadm subsystem. This allows for the bios to define a single bootable drive from say 2 and this single raid drive shows up as a bootable bios raid during the installer but isn't actually built until after the install.
Due to differences in naming the existing scan_disks and root_drive functions in btrfs were unable to identify what we had, from manual testing this looks to be resolved with no regression identified.
N.B. there is still the issue of the raid members showing up with the cog icon but this can go into another issue as we are big enough here already. Also may require a disk role that ties into other pending issues.

Minor logic changes were applied to scan_disks but only after fairly extensive readability changes and a generous about of comments to aid in this and hopefully future changes.
Of note is the exclusion of swap in a far simpler and earlier fashion than was used previously. Also the inclusion of md as a type that identifies a partition, this was confirmed in a regular md setup and the bios raid setup which were the same with regard to naming.

Please see the #1151 issue for testing prior to pr submission and more details.

Note the model field of the md root device is used to store the member disk serial numbers and their raid index as well as the total disk count.
I have also extended the get_disk_serial() function to return the md uuid as device serial to avoid having to create udev rules for md devices.

Submitting as works for me and I don't think I've done anything risky here but this is a prime candidate for careful review.

Hope it works and if there are problems then I'm happy to chip away some more.


