### PR TITLE
improve root not in partition behaviour and mdraid member labeling. Fixes #1164

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -795,6 +795,17 @@ def root_disk():
 
 
 def scan_disks(min_size):
+    """
+    Using lsblk we scan all attached disks and categorize them according to
+    if they are partitioned, their file system, if the drive hosts our / mount
+    point etc. The result of this scan is used by:-
+    view/disk.py _update_disk_state
+    for further analysis / categorization.
+    N.B. if a device (partition or whole dev) hosts swap or is of no interest
+    then it is ignored.
+    :param min_size: Discount all devices below this size in KB
+    :return: List containing drives of interest
+    """
     base_root_disk = root_disk()
     logger.debug('root_disk returned the value of %s ', base_root_disk)
     cmd = ['/usr/bin/lsblk', '-P', '-o',

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -940,10 +940,19 @@ def scan_disks(min_size):
                     # finding this partition on that base_root_disk
                     # N.B. Assumes base dev is listed before it's partitions
                     # The 13th item in dnames entries is root so index = 12
-                    # todo keyerror when called with base_root_disk of md125
-                    # todo which is otherwise correct as it's our root
-                    dnames[base_root_disk][12] = False
-                    # And update this partition on base_root_disk as real root
+                    # todo make these comments more consistent with new behaviour re root on base dev
+                    # todo test to make sure we have no regressions on existing drive categorization
+                    # only update our base_root_disk if it exists in our scaned
+                    # disks as this may be the first time we are seeing it.
+                    # search to see if we already have an entry for the
+                    # the base_root_disk which may be us or our base dev if we
+                    # are a partition
+                    for dname in dnames.keys():
+                        if (dname == base_root_disk):
+                            dnames[base_root_disk][12] = False
+                    # And update this device as real root
+                    # Note we may be looking at the base_root_disk or one of
+                    # it's partitions there after.
                     dmap['root'] = True
                     # If we are an md device then use get_md_members string
                     # to populate our MODEL since it is otherwise unused.

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -909,22 +909,22 @@ def scan_disks(min_size):
                     # Given we have found a partition on an existing base dev
                     # we should update that base dev's entry in dnames to
                     # parted "True" as when recorded lsblk type on base device
-                    # would have been disk or RAID1 (for base md device).
+                    # would have been disk or RAID1 or raid1 (for base md dev).
                     # Change the 12th entry (0 indexed) of this device to True
                     # The 12 entry is the parted flag so we label
                     # our existing dnames entry as parted ie partitioned.
                     dnames[dname][11] = True
         if ((not is_root_disk and not is_partition) or
-                (is_partition and is_btrfs)):
+                (is_btrfs)):
             # We have a non system disk that is not a partition
             # or
-            # We have a partition that is btrfs formatted
+            # We have a device that is btrfs formatted
             # In the case of a btrfs partition we override the parted flag.
             # Or we may just be a non system disk without partitions.
             dmap['parted'] = False
             dmap['root'] = False  # until we establish otherwise as we might be.
-            if is_partition and is_btrfs:
-                # a btrfs partition
+            if is_btrfs:
+                # a btrfs file system
                 if (re.match(base_root_disk, dmap['NAME']) is not None):
                     # We are assuming that a partition with a btrfs fs on is our
                     # root if it's name begins with our base system disk name.
@@ -940,6 +940,8 @@ def scan_disks(min_size):
                     # finding this partition on that base_root_disk
                     # N.B. Assumes base dev is listed before it's partitions
                     # The 13th item in dnames entries is root so index = 12
+                    # todo keyerror when called with base_root_disk of md125
+                    # todo which is otherwise correct as it's our root
                     dnames[base_root_disk][12] = False
                     # And update this partition on base_root_disk as real root
                     dmap['root'] = True

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -901,7 +901,9 @@ def scan_disks(min_size):
             is_btrfs = True
         # End readability variables assignment
         if is_partition:
-            # search our working dictionary of already scanned devices by name
+            # Search our working dictionary of already scanned devices by name
+            # We are assuming base devices are listed first and if of interest
+            # we have recorded it and can now back port it's partitioned status.
             for dname in dnames.keys():
                 if (re.match(dname, dmap['NAME']) is not None):
                     # Our device name has a base device entry of interest saved:
@@ -921,7 +923,7 @@ def scan_disks(min_size):
             # We have a device that is btrfs formatted
             # In the case of a btrfs partition we override the parted flag.
             # Or we may just be a non system disk without partitions.
-            dmap['parted'] = False
+            dmap['parted'] = False  # could be corrected later
             dmap['root'] = False  # until we establish otherwise as we might be.
             if is_btrfs:
                 # a btrfs file system
@@ -948,7 +950,7 @@ def scan_disks(min_size):
                     # the base_root_disk which may be us or our base dev if we
                     # are a partition
                     for dname in dnames.keys():
-                        if (dname == base_root_disk):
+                        if dname == base_root_disk:
                             dnames[base_root_disk][12] = False
                     # And update this device as real root
                     # Note we may be looking at the base_root_disk or one of
@@ -960,6 +962,7 @@ def scan_disks(min_size):
                         # cheap way to display our member drives
                         dmap['MODEL'] = get_md_members(dmap['NAME'])
                 else:
+                    logger.debug('Skipping the following attached disk as not of interest - %s', dmap)
                     # ignore btrfs partitions that are not on our system disk.
                     continue
             # convert size into KB

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -973,9 +973,16 @@ def scan_disks(min_size):
                         # cheap way to display our member drives
                         dmap['MODEL'] = get_md_members(dmap['NAME'])
                 else:
-                    logger.debug('Skipping the following attached disk as not of interest - %s', dmap)
-                    # ignore btrfs partitions that are not on our system disk.
-                    continue
+                    # We have a non system disk btrfs filesystem.
+                    # Ie we are a whole disk or a partition with btrfs on but
+                    # NOT on the system disk.
+                    # Most likely a current btrfs data drive or one we could
+                    # import.
+                    # As we don't understand / support btrfs in partitions
+                    # then ignore / skip this btrfs device if it's a partition
+                    if is_partition:
+                        logger.debug('Skipping the following attached disk as not of interest - %s', dmap)
+                        continue
             # convert size into KB
             size_str = dmap['SIZE']
             if (size_str[-1] == 'G'):

--- a/src/rockstor/storageadmin/migrations/0042_auto__add_field_disk_smart_options__add_field_disk_role.py
+++ b/src/rockstor/storageadmin/migrations/0042_auto__add_field_disk_smart_options__add_field_disk_role.py
@@ -1,0 +1,556 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Disk.smart_options'
+        db.add_column(u'storageadmin_disk', 'smart_options',
+                      self.gf('django.db.models.fields.CharField')(max_length=64, null=True),
+                      keep_default=False)
+
+        # Adding field 'Disk.role'
+        db.add_column(u'storageadmin_disk', 'role',
+                      self.gf('django.db.models.fields.CharField')(max_length=256, null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Disk.smart_options'
+        db.delete_column(u'storageadmin_disk', 'smart_options')
+
+        # Deleting field 'Disk.role'
+        db.delete_column(u'storageadmin_disk', 'role')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'oauth2_provider.application': {
+            'Meta': {'object_name': 'Application'},
+            'authorization_grant_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'client_id': ('django.db.models.fields.CharField', [], {'default': "u'nCNEVJIQss2nsOZya0mRdhfww3e2ZOzEGKgU7P2O'", 'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'client_secret': ('django.db.models.fields.CharField', [], {'default': "u'Z9gWIkixAxJiY3w7iz3ECiY3yaAKpcLRKNbNSKM5S5dfAOk57f5KRzErTk8QPFpEg39H1oYzkxYCIcAAjYBsWzKQqjS8X7mbUtXWUC3bCNcH5470LnGjCoeskXccvxyx'", 'max_length': '255', 'db_index': 'True', 'blank': 'True'}),
+            'client_type': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'redirect_uris': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'skip_authorization': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'oauth2_provider_application'", 'to': u"orm['auth.User']"})
+        },
+        'storageadmin.advancednfsexport': {
+            'Meta': {'object_name': 'AdvancedNFSExport'},
+            'export_str': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'storageadmin.apikeys': {
+            'Meta': {'object_name': 'APIKeys'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '8'})
+        },
+        'storageadmin.appliance': {
+            'Meta': {'object_name': 'Appliance'},
+            'client_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'client_secret': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'current_appliance': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'default': "'Rockstor'", 'max_length': '128'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'mgmt_port': ('django.db.models.fields.IntegerField', [], {'default': '443'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'})
+        },
+        'storageadmin.configbackup': {
+            'Meta': {'object_name': 'ConfigBackup'},
+            'config_backup': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'md5sum': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'storageadmin.containeroption': {
+            'Meta': {'object_name': 'ContainerOption'},
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.DContainer']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'val': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'})
+        },
+        'storageadmin.dashboardconfig': {
+            'Meta': {'object_name': 'DashboardConfig'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True'}),
+            'widgets': ('django.db.models.fields.CharField', [], {'max_length': '4096'})
+        },
+        'storageadmin.dcontainer': {
+            'Meta': {'object_name': 'DContainer'},
+            'dimage': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.DImage']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'launch_order': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1024'}),
+            'rockon': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.RockOn']"}),
+            'uid': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'storageadmin.dcontainerenv': {
+            'Meta': {'unique_together': "(('container', 'key'),)", 'object_name': 'DContainerEnv'},
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.DContainer']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'val': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'})
+        },
+        'storageadmin.dcontainerlink': {
+            'Meta': {'unique_together': "(('destination', 'name'),)", 'object_name': 'DContainerLink'},
+            'destination': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'destination_container'", 'to': "orm['storageadmin.DContainer']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'source': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['storageadmin.DContainer']", 'unique': 'True'})
+        },
+        'storageadmin.dcustomconfig': {
+            'Meta': {'unique_together': "(('rockon', 'key'),)", 'object_name': 'DCustomConfig'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'rockon': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.RockOn']"}),
+            'val': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'})
+        },
+        'storageadmin.dimage': {
+            'Meta': {'object_name': 'DImage'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'repo': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'tag': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        },
+        'storageadmin.disk': {
+            'Meta': {'object_name': 'Disk'},
+            'btrfs_uuid': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'offline': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'parted': ('django.db.models.fields.BooleanField', [], {}),
+            'pool': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Pool']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True'}),
+            'serial': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'smart_available': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'smart_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'smart_options': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'transport': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'vendor': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'})
+        },
+        'storageadmin.dport': {
+            'Meta': {'unique_together': "(('container', 'containerp'),)", 'object_name': 'DPort'},
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.DContainer']"}),
+            'containerp': ('django.db.models.fields.IntegerField', [], {}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'hostp': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'hostp_default': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'protocol': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'uiport': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'storageadmin.dvolume': {
+            'Meta': {'unique_together': "(('container', 'dest_dir'),)", 'object_name': 'DVolume'},
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.DContainer']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'dest_dir': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'min_size': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Share']", 'null': 'True'}),
+            'uservol': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'storageadmin.emailclient': {
+            'Meta': {'object_name': 'EmailClient'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1024'}),
+            'receiver': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'sender': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'smtp_server': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        },
+        'storageadmin.group': {
+            'Meta': {'object_name': 'Group'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'gid': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'groupname': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'storageadmin.installedplugin': {
+            'Meta': {'object_name': 'InstalledPlugin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'install_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'plugin_meta': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Plugin']"})
+        },
+        'storageadmin.iscsitarget': {
+            'Meta': {'object_name': 'IscsiTarget'},
+            'dev_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'dev_size': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Share']"}),
+            'tid': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'tname': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'})
+        },
+        'storageadmin.netatalkshare': {
+            'Meta': {'object_name': 'NetatalkShare'},
+            'description': ('django.db.models.fields.CharField', [], {'default': "'afp on rockstor'", 'max_length': '1024'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'share': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'netatalkshare'", 'unique': 'True', 'to': "orm['storageadmin.Share']"}),
+            'time_machine': ('django.db.models.fields.CharField', [], {'default': "'yes'", 'max_length': '3'})
+        },
+        'storageadmin.networkinterface': {
+            'Meta': {'object_name': 'NetworkInterface'},
+            'autoconnect': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True'}),
+            'ctype': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'dname': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'dns_servers': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'dspeed': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'dtype': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'gateway': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ipaddr': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'itype': ('django.db.models.fields.CharField', [], {'default': "'io'", 'max_length': '100'}),
+            'mac': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'netmask': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'})
+        },
+        'storageadmin.nfsexport': {
+            'Meta': {'object_name': 'NFSExport'},
+            'export_group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.NFSExportGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mount': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Share']"})
+        },
+        'storageadmin.nfsexportgroup': {
+            'Meta': {'object_name': 'NFSExportGroup'},
+            'admin_host': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'editable': ('django.db.models.fields.CharField', [], {'default': "'rw'", 'max_length': '2'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'host_str': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mount_security': ('django.db.models.fields.CharField', [], {'default': "'insecure'", 'max_length': '8'}),
+            'nohide': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'syncable': ('django.db.models.fields.CharField', [], {'default': "'async'", 'max_length': '5'})
+        },
+        'storageadmin.oauthapp': {
+            'Meta': {'object_name': 'OauthApp'},
+            'application': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['oauth2_provider.Application']", 'unique': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.User']"})
+        },
+        'storageadmin.plugin': {
+            'Meta': {'object_name': 'Plugin'},
+            'css_file_name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'description': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4096'}),
+            'display_name': ('django.db.models.fields.CharField', [], {'default': "''", 'unique': 'True', 'max_length': '4096'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'js_file_name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'})
+        },
+        'storageadmin.pool': {
+            'Meta': {'object_name': 'Pool'},
+            'compression': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mnt_options': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'raid': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True'}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'toc': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'})
+        },
+        'storageadmin.poolbalance': {
+            'Meta': {'object_name': 'PoolBalance'},
+            'end_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'percent_done': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pool': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Pool']"}),
+            'start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'started'", 'max_length': '10'}),
+            'tid': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True'})
+        },
+        'storageadmin.poolscrub': {
+            'Meta': {'object_name': 'PoolScrub'},
+            'corrected_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'csum_discards': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'csum_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'data_extents_scrubbed': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'end_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kb_scrubbed': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'last_physical': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'malloc_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'no_csum': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pid': ('django.db.models.fields.IntegerField', [], {}),
+            'pool': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Pool']"}),
+            'read_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'started'", 'max_length': '10'}),
+            'super_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'tree_bytes_scrubbed': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'tree_extents_scrubbed': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'uncorrectable_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'unverified_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'verify_errors': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'storageadmin.posixacls': {
+            'Meta': {'object_name': 'PosixACLs'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'perms': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'smb_share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SambaShare']"})
+        },
+        'storageadmin.rockon': {
+            'Meta': {'object_name': 'RockOn'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'https': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'icon': ('django.db.models.fields.URLField', [], {'max_length': '1024', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'more_info': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'ui': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'volume_add_support': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'website': ('django.db.models.fields.CharField', [], {'max_length': '2048', 'null': 'True'})
+        },
+        'storageadmin.sambacustomconfig': {
+            'Meta': {'object_name': 'SambaCustomConfig'},
+            'custom_config': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'smb_share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SambaShare']"})
+        },
+        'storageadmin.sambashare': {
+            'Meta': {'object_name': 'SambaShare'},
+            'browsable': ('django.db.models.fields.CharField', [], {'default': "'yes'", 'max_length': '3'}),
+            'comment': ('django.db.models.fields.CharField', [], {'default': "'foo bar'", 'max_length': '100'}),
+            'guest_ok': ('django.db.models.fields.CharField', [], {'default': "'no'", 'max_length': '3'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'read_only': ('django.db.models.fields.CharField', [], {'default': "'no'", 'max_length': '3'}),
+            'shadow_copy': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'share': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'sambashare'", 'unique': 'True', 'to': "orm['storageadmin.Share']"}),
+            'snapshot_prefix': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'})
+        },
+        'storageadmin.setup': {
+            'Meta': {'object_name': 'Setup'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'setup_disks': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'setup_network': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'setup_system': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'setup_user': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'storageadmin.sftp': {
+            'Meta': {'object_name': 'SFTP'},
+            'editable': ('django.db.models.fields.CharField', [], {'default': "'ro'", 'max_length': '2'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'share': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['storageadmin.Share']", 'unique': 'True'})
+        },
+        'storageadmin.share': {
+            'Meta': {'object_name': 'Share'},
+            'compression_algo': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'eusage': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'group': ('django.db.models.fields.CharField', [], {'default': "'root'", 'max_length': '4096'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096'}),
+            'owner': ('django.db.models.fields.CharField', [], {'default': "'root'", 'max_length': '4096'}),
+            'perms': ('django.db.models.fields.CharField', [], {'default': "'755'", 'max_length': '9'}),
+            'pool': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Pool']"}),
+            'pqgroup': ('django.db.models.fields.CharField', [], {'default': "'-1/-1'", 'max_length': '32'}),
+            'qgroup': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'replica': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rusage': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'subvol_name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'toc': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'})
+        },
+        'storageadmin.smartattribute': {
+            'Meta': {'object_name': 'SMARTAttribute'},
+            'aid': ('django.db.models.fields.IntegerField', [], {}),
+            'atype': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'failed': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'flag': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'normed_value': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'raw_value': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'threshold': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'updated': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'worst': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'storageadmin.smartcapability': {
+            'Meta': {'object_name': 'SMARTCapability'},
+            'capabilities': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'flag': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        },
+        'storageadmin.smarterrorlog': {
+            'Meta': {'object_name': 'SMARTErrorLog'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'line': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'storageadmin.smarterrorlogsummary': {
+            'Meta': {'object_name': 'SMARTErrorLogSummary'},
+            'details': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'error_num': ('django.db.models.fields.IntegerField', [], {}),
+            'etype': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'lifetime_hours': ('django.db.models.fields.IntegerField', [], {}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'storageadmin.smartidentity': {
+            'Meta': {'object_name': 'SMARTIdentity'},
+            'assessment': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'ata_version': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'capacity': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'device_model': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'enabled': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'firmware_version': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_smartdb': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'model_family': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'rotation_rate': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'sata_version': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'scanned_on': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'sector_size': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'serial_number': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'supported': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'world_wide_name': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'storageadmin.smartinfo': {
+            'Meta': {'object_name': 'SMARTInfo'},
+            'disk': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Disk']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'toc': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        'storageadmin.smarttestlog': {
+            'Meta': {'object_name': 'SMARTTestLog'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'lba_of_first_error': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'lifetime_hours': ('django.db.models.fields.IntegerField', [], {}),
+            'pct_completed': ('django.db.models.fields.IntegerField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'test_num': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'storageadmin.smarttestlogdetail': {
+            'Meta': {'object_name': 'SMARTTestLogDetail'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'info': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.SMARTInfo']"}),
+            'line': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'storageadmin.snapshot': {
+            'Meta': {'unique_together': "(('share', 'name'),)", 'object_name': 'Snapshot'},
+            'eusage': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'qgroup': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'real_name': ('django.db.models.fields.CharField', [], {'default': "'unknownsnap'", 'max_length': '4096'}),
+            'rusage': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'share': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Share']"}),
+            'size': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'snap_type': ('django.db.models.fields.CharField', [], {'default': "'admin'", 'max_length': '64'}),
+            'toc': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'uvisible': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'writable': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'storageadmin.supportcase': {
+            'Meta': {'object_name': 'SupportCase'},
+            'case_type': ('django.db.models.fields.CharField', [], {'max_length': '6'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '9'}),
+            'zipped_log': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'storageadmin.tlscertificate': {
+            'Meta': {'object_name': 'TLSCertificate'},
+            'certificate': ('django.db.models.fields.CharField', [], {'max_length': '12288', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '12288', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1024'})
+        },
+        'storageadmin.updatesubscription': {
+            'Meta': {'object_name': 'UpdateSubscription'},
+            'appliance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Appliance']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '512'})
+        },
+        'storageadmin.user': {
+            'Meta': {'object_name': 'User'},
+            'admin': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'gid': ('django.db.models.fields.IntegerField', [], {'default': '5000'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['storageadmin.Group']", 'null': 'True', 'blank': 'True'}),
+            'homedir': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True', 'blank': 'True'}),
+            'shell': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'smb_shares': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'admin_users'", 'null': 'True', 'to': "orm['storageadmin.SambaShare']"}),
+            'uid': ('django.db.models.fields.IntegerField', [], {'default': '5000'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'blank': 'True', 'related_name': "'suser'", 'unique': 'True', 'null': 'True', 'to': u"orm['auth.User']"}),
+            'username': ('django.db.models.fields.CharField', [], {'default': "''", 'unique': 'True', 'max_length': '4096'})
+        }
+    }
+
+    complete_apps = ['storageadmin']

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -40,6 +40,13 @@ class Disk(models.Model):
     vendor = models.CharField(max_length=1024, null=True)
     smart_available = models.BooleanField(default=False)
     smart_enabled = models.BooleanField(default=False)
+    """custom smart options for drive, ie for USB bridges / enclosures"""
+    """eg "-d usbjmicron,p" or "-s on -d 3ware,0"."""
+    smart_options = models.CharField(max_length=64, null=True)
+    """drive role ie "isw_raid_member" or "linux_raid_member"."""
+    """could also be "import" or "backup" for temp external drive connection."""
+    """role is aux info to flag special use disks"""
+    role = models.CharField(max_length=256, null=True)
 
     @property
     def pool_name(self, *args, **kwargs):

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -189,14 +189,18 @@ DisksView = Backbone.View.extend({
                	btrfsUId = disk.get('btrfs_uuid'),
                	diskParted = disk.get('parted'),
                	smartEnabled = disk.get('smart_enabled');
+				diskRole = disk.get('role');
 
         html += '<tr>';
         html += '<td><a href="#disks/' + diskName +' "><i class="glyphicon glyphicon-hdd"></i> '+ diskName +'</a>&nbsp';
         if (diskOffline) {
            html += '<a href="#" class="delete" data-disk-name="'+ diskName +'" title="Disk is unusable because it is offline.Click to delete it from the system" rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>';
-        } else if (diskParted) {
+        } else if (diskRole == 'isw_raid_member' || diskRole == 'linux_raid_member') {
+		   html += '<a href="#" class="raid_member" data-disk-name="'+ diskName +'" title="Disk is a mdraid member." rel="tooltip">';
+		   html += '<i class="glyphicon glyphicon-info-sign"></i></a>';
+		} else if (diskParted) {
            html += '<a href="#" class="wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has some other filesystem on it.';
-           html+= 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
+           html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
         } else if (btrfsUId && _.isNull(poolName)) {
            html += '<a href="#" class="btrfs_wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
            html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="'+ diskName +'" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -118,7 +118,7 @@ class DiskMixin(object):
             # If attached disk has an fs and it isn't btrfs
             if (d.fstype is not None and d.fstype != 'btrfs'):
                 dob.btrfs_uuid = None
-                dob.parted = True
+                dob.parted = True  # overload use of parted as non btrfs flag.
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -123,18 +123,18 @@ class DiskMixin(object):
                 # of the Disk.role field.
                 if d.fstype == 'isw_raid_member' \
                         or d.fstype == 'linux_raid_member':
-                    logger.debug('Found scan_disks indicator of raid member '
-                                 'so updating dob role accordingly dev = %s',
-                                 d.name)
                     # transfer fstype raid member indicator to role field
                     dob.role = d.fstype
                 else:
-                    # no identified role from scan_disks() fstype indicator so
+                    # No identified role from scan_disks() fstype indicator so
                     # set as None to update db of new drive role. If we don't
                     # do this then the same drive when re-deployed will inherit
                     # it's previous role in the db which may be desired but in
-                    # the case of these raid member indicator from scan_disks()
+                    # the case of these raid member indicators from scan_disks()
                     # we have the current truth provided.
+                    # N.B. this if else could be expanded to accommodate other
+                    # roles based on the fs found and also take heed of an
+                    # existing devices db role entry prior to overwriting.
                     dob.role = None
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -119,6 +119,23 @@ class DiskMixin(object):
             if (d.fstype is not None and d.fstype != 'btrfs'):
                 dob.btrfs_uuid = None
                 dob.parted = True  # overload use of parted as non btrfs flag.
+                # N.B. this overload use may become redundant with the addition
+                # of the Disk.role field.
+                if d.fstype == 'isw_raid_member' \
+                        or d.fstype == 'linux_raid_member':
+                    logger.debug('Found scan_disks indicator of raid member '
+                                 'so updating dob role accordingly dev = %s',
+                                 d.name)
+                    # transfer fstype raid member indicator to role field
+                    dob.role = d.fstype
+                else:
+                    # no identified role from scan_disks() fstype indicator so
+                    # set as None to update db of new drive role. If we don't
+                    # do this then the same drive when re-deployed will inherit
+                    # it's previous role in the db which may be desired but in
+                    # the case of these raid member indicator from scan_disks()
+                    # we have the current truth provided.
+                    dob.role = None
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.


### PR DESCRIPTION
@schakrava  Please see #1164 for development details and testing.

Appears to maintain existing functionality whilst allowing for / on an md device directly rather than in a partition. Mdraid disk members, both intel bios raid and pure software mdraid, are now labelled as such and no longer have the "wipe me" invite flag.

Changes outside the remit of this issue:-
I have added a smart_options to the Disk model for the proposed custom smart options per disk. This I thought would cut down on the number of db migrations and ease the associated development on that issue.

As this patch set alters the categorization logic of scan_disks() it requires careful review, also this is the first model change I've made so please advise if I need to do more than I have anticipated.

Submitting as works for me.

N.B. I see the disk role field as also serving future flagging of such things as temp externally connected usb drives used for backup or import, where their once labelled 'role' will be maintained in the db against their serial number as long as their entry is not deleted from disk.
