### PR TITLE
Remove console.log preventing rockon restart

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -212,7 +212,6 @@ RockonsView = RockstorLayoutView.extend({
     },
 
     startRockon: function(rockonId) {
-	console.log(event);
 	var _this = this;
 	this.stopPolling();
 	$.ajax({


### PR DESCRIPTION
A console.log trying to log an undefined var was preventing the user to be able to restart a stopped rock-on from the web ui.