### PR TITLE
Change ipv4 address key

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -279,7 +279,7 @@ def net_config_helper(name):
 
             elif (config['method'] == 'manual'):
                 #manual
-                if (re.match('IP4.ADDRESS', l) is not None):
+                if (re.match('ipv4.addresses', l) is not None):
                     kv_split = l.split(':')
                     if (len(kv_split) > 1):
                         vsplit = kv_split[1].split('/')


### PR DESCRIPTION
Changed the key from which the ipv4 address is read (old: IP4.ADRESS[1], new: ipv4.addresses)

With the old key one could not use ip-address aliases on interfaces.

It would be a nice feature to be able to handle them (the aliases in rockstor gui, or at least se them) but as the first step I thought I could prevent rockstor from using the wrong ip-address.

Output from nmcli -t c show enp2s0 (in my case) 

ip a add 192.168.0.14/24 dev enp2s0
(creates a non-persistent alias on the interface)

[nmcli_single_ip_output.txt](https://github.com/rockstor/rockstor-core/files/160031/nmcli_single_ip_output.txt)

[nmcli_with_ip_alias_output.txt](https://github.com/rockstor/rockstor-core/files/160032/nmcli_with_ip_alias_output.txt)
