### PR TITLE
smart commands act on root partition not root device #1206 

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -74,8 +74,6 @@ def info(device, test_mode=TESTMODE):
                 # Assume all characters after colon are the result / value and
                 # strip off begin and end spaces. Limit to 64 chars for db.
                 res[i] = line[first_colon + 1:].strip()[:64]
-                logger.debug('extracted result / value of res[i] = %s', res[i])
-                logger.debug('char count of this line = %s', len(res[i]))
     # smartctl version is expected at index 14 (15th item)
     res.insert(14, version)
     return res
@@ -386,13 +384,10 @@ def get_base_device(device, test_mode=TESTMODE):
         line_fields = line.split()
         if len(line_fields) < 1:
             # skip empty lines
-            logger.debug('get_base_device skipped an empty line')
             continue
         if re.match(line_fields[0], device):
-            # We have found a device string match to our device so
-            logger.debug('get_base_device found a match in lsblk out for '
-                         'device %s in line %s' % (device, line))
+            # We have found a device string match to our device so record it.
             base_dev = line_fields[0]
             break
-    # return base_dev which should now be None or first character matches
+    # return base_dev ie None or first character matches to line start in lsblk
     return base_dev

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -69,7 +69,10 @@ def info(device, test_mode=TESTMODE):
             version = ' '.join(l.split()[1:4])
         for i in range(len(matches)):
             if (re.match(matches[i], l) is not None):
+                # TODO needs improving as loses nice info ie in SATA line
+                # due to inadvertent split by second ":" in Value fields
                 res[i] = l.split(': ')[1].strip()
+    # smartctl version is expected at index 14 (15th item)
     res.insert(14, version)
     return res
 


### PR DESCRIPTION
Introduces a smart device name pre-processor so that we can translate for example sda3 to sda.
This gives more consistent SMART behaviour and more informative results.
See Issue #1206 for examples.
Should only have an effect on partition names ie the default install of root in sda3 will now no longer call smart commands with sda3 but this sda.

Note however that in some circumstances this leads to a system device being labelled as having smart available and enabled but after this pr is applied it will be recorded as Not Supported.

This to me is correct as in the first instance although some smart Identity info and status is retrieved, nothing else is and the error message displayed (due to non zero return codes) when attempting to do a smart info refresh is not helpful. As calling on the base device is more informative we get helpful info in rockstor.log and all other calls are blocked due to no smart available returns with the wrapper in place.

An example device used in proving this fix was the SanDisk Extreme USB 3.0 which requires custom smart options. Via the manual test method of reading from smart output file dumps I was able to retrieve and present full smart status info by calling on the base device (along with the custom -d sat). Where as using the partition device name led to misinformation as to status and availability as no other smart calls would succeed without custom options.

This pr is a pre-cursor to that required for #1079 and may also help to accommodate the custom smart device names used by some 3ware controllers.

Also tested on a bios raid install and a regular mdraid install.

Additionally there is a minor Identity tab values parsing improvement.