### PR TITLE
smart selftest log parsing error. Fixes #1207

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -255,6 +255,8 @@ def test_logs(device, test_mode=TESTMODE):
                     for j in range(i + 2, len(o)):
                         if (re.match('# ', o[j]) is not None):
                             fields = re.split(r'\s\s+', o[j].strip()[2:])
+                            logger.debug('fields extracted are as follows %s', fields)
+                            logger.debug('problematic field 3 = %s', fields[3])
                             fields[3] = 100 - int(fields[3][:-1])
                             test_d[fields[0]] = fields[1:]
                         else:

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -256,7 +256,6 @@ def test_logs(device, test_mode=TESTMODE):
                         if (re.match('# ', o[j]) is not None):
                             # slit the line into fields using 2 or more spaces
                             fields = re.split(r'\s\s+', o[j].strip()[2:])
-                            logger.debug('fields extracted are as follows %s', fields)
                             # Some Seagate drives add an ongoing test progress
                             # report to the top of this log but there is then
                             # only one space delimiter and we loose a column.
@@ -278,7 +277,6 @@ def test_logs(device, test_mode=TESTMODE):
                             # and change % Remaining to % Completed.
                             fields[3] = 100 - int(fields[3][:-1])
                             test_d[fields[0]] = fields[1:]
-                            logger.debug('post processed fields = ------- %s', fields)
                         else:
                             log_l.append(o[j])
     return (test_d, log_l)


### PR DESCRIPTION
Introduce a specialized parser to account for in-progress Self-Test log entries.
Tested normal operation on a number of both well and ill drives and specialized parsing on trigger drives of Seagate ST3000VN000 both in first 9 hours of life (by editing smart out file dumps and using test mode) and in post 10 hour life where initial error was no longer generated but parsing was still faulty.

All parsing and behaviour, error wise, is now as expected with existing and trigger drives.

@schakrava Ready for review.

Fixes #1207 
