### PR TITLE
add custom smart parameter option. Fixes #1079

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -36,6 +36,7 @@ var AppRouter = Backbone.Router.extend({
 	"home": "showHome",
 	"disks": "showDisks",
 	"disks/blink/:diskName": "blinkDrive",
+	"disks/smartcustom/:diskName": "smartcustomDrive",
 	"disks/:diskName": "showDisk",
 	"pools": "showPools",
 	"pools/:poolName": "showPool",
@@ -166,6 +167,14 @@ var AppRouter = Backbone.Router.extend({
 	this.renderSidebar('storage', 'disks');
 	this.cleanup();
 	this.currentLayout = new BlinkDiskView({diskName: diskName});
+	$('#maincontent').empty();
+	$('#maincontent').append(this.currentLayout.render().el);
+    },
+
+	smartcustomDrive: function(diskName) {
+	this.renderSidebar('storage', 'disks');
+	this.cleanup();
+	this.currentLayout = new SmartcustomDiskView({diskName: diskName});
 	$('#maincontent').empty();
 	$('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -22,13 +22,17 @@
 <div class="messages"></div>
 <!-- page heading -->
 
-{{#if diskSmartNotAvaialble}}
+{{#if diskSmartNotAvailable}}
 <div class="alert alert-danger">
-  <h4>S.M.A.R.T support is not available for this disk ({{diskName}})</h4>
+  <h4>S.M.A.R.T support is not available for this disk ({{diskName}}).<br>
+	Please see the S.M.A.R.T column entry for this disk on the Storage - Disks
+	page; custom options may be required.</h4>
 </div>
 {{else if diskSmartNotEnabled}}
 <div class="alert alert-warning">
-  <h4>Warning! S.M.A.R.T support is not enabled for this disk ({{diskName}}).<br>If available, You can enable it in the Storage screen.</h4>
+  <h4>Warning! S.M.A.R.T support is not enabled for this disk ({{diskName}}).
+	<br>If available it can be enabled in the S.M.A.R.T column entry for this disk
+	on the Storage - Disks page.</h4>
 </div>
 {{else}}
 <div class="pull-right">
@@ -285,15 +289,15 @@
     <div class="row">
       {{#if smartNotAvailableEnabled}}
       <div class="alert alert-danger">
-	<h4>Tests cannot be run because S.M.A.R.T support is either unavailable or disabled</h4>
+	<h4>Tests cannot be run because S.M.A.R.T support is either unavailable or
+		disabled.</h4>
       </div>
       {{else}}
       <p>
 	Self-tests are built-in tests within the drive designed to recognize
 	drive fault conditions. All self-tests are safe to user data. The tests
 	can be performed during normal system operation, but will take longer
-	to complete if the drive is not idle. You will not be able to access
-	the drive's SMART data while a test is in progress.
+	to complete if the drive is not idle.
       </p>
       <div class="col-md-8">
 	<label class="control-label"></label>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
@@ -25,11 +25,11 @@ tolerance. Internally Rockstor already uses -a, --info, -H, -c, -l, -t, and -s.<
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
             <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
-	          <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+            <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
           </div>
         </div>
 
-       <!-- Custom SMART options -->
+        <!-- Custom SMART options -->
         <div class="form-group">
           <label class="col-sm-4 control-label" for="smartcustom_options">Custom Options<span class="required"> *</span></label>
           <div class="col-sm-8">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
@@ -1,0 +1,50 @@
+<h3>Add drive specific custom S.M.A.R.T options</h3>
+<h4>Please see the <a href="https://www.smartmontools.org/" target="_blank">Smartmontools</a> manual page for <a
+    href="https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in" target="_blank"> smartctl</a>
+    for possible custom options.</h4>
+<h5>For smartmontools supported USB attached devices, ie USB to SATA adapters, please see: <a
+    href="https://www.smartmontools.org/wiki/Supported_USB-Devices" target="_blank">USB Device Support</a>.
+</h5>
+<h5>For smartmontools supported RAID controllers please see: <a
+    href="https://www.smartmontools.org/wiki/Supported_RAID-Controllers" target="_blank">Checking disks behind RAID controllers</a>.
+</h5>
+<h5><i>This is an advanced option that is only required in specific circumstances.<br>
+ Please follow the above links to understand any options you choose to enter.</i></h5>
+<h6>Supported smart options are <strong>-d</strong> to specify special devices and <strong>-T</strong> to set
+tolerance. Internally Rockstor already uses -a, --info, -H, -c, -l, -t, and -s.</h6>
+<h6>The custom options entered here will be added to these existing internal options.</h6>
+
+<div class="row">
+  <div class="col-md-8">
+    <label class="control-label"></label>
+    <div class="form-box">
+      <form class="form-horizontal" id="add-smartcustom-disk-form"  name="aform" >
+        <div class="messages"></div>
+
+        <!-- Form Header Info (need link to web help in here)-->
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
+	          <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+          </div>
+        </div>
+
+       <!-- Custom SMART options -->
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="smartcustom_options">Custom Options<span class="required"> *</span></label>
+          <div class="col-sm-8">
+            <input class="form-control shorten-input" type="text" name="smartcustom_options" id="smartcustom_options" title="Custom S.M.A.R.T options required to enable or enhance this drives smart responses. Submit empty for no options." value="{{ currentSmartCustom }}">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <a id="cancel" class="btn btn-default">Cancel</a>
+            <input type="Submit" id="smartcustom-disk" class="btn btn-primary" value="Submit"></input>
+          </div>
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -26,160 +26,160 @@
 
 DiskDetailsLayoutView = RockstorLayoutView.extend({
 
-    initialize: function() {
-	// call initialize of base
-	this.constructor.__super__.initialize.apply(this, arguments);
-	this.diskName = this.options.diskName;
-	this.template = window.JST.disk_disk_details_layout;
-	this.disk = new Disk({diskName: this.diskName});
-	this.smartinfo = new SmartInfo({diskName: this.diskName});
-	this.dependencies.push(this.disk);
-	this.dependencies.push(this.smartinfo);
-	this.active_tab = 0;
-	this.initHandlebarHelpers();
+    initialize: function () {
+        // call initialize of base
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.diskName = this.options.diskName;
+        this.template = window.JST.disk_disk_details_layout;
+        this.disk = new Disk({diskName: this.diskName});
+        this.smartinfo = new SmartInfo({diskName: this.diskName});
+        this.dependencies.push(this.disk);
+        this.dependencies.push(this.smartinfo);
+        this.active_tab = 0;
+        this.initHandlebarHelpers();
     },
 
     events: {
-	'click #smartinfo': 'refreshInfo',
-	'click #test-start': 'startTest'
+        'click #smartinfo': 'refreshInfo',
+        'click #test-start': 'startTest'
     },
 
-    render: function() {
-	this.fetch(this.renderSubViews, this);
-	return this;
+    render: function () {
+        this.fetch(this.renderSubViews, this);
+        return this;
     },
 
-    renderSubViews: function() {
-	var capabilities = this.smartinfo.get('capabilities') || [];
-	var test_capabilities = {};
-	var running_test = null;
-	capabilities.forEach(function(c) {
-	    if ((c.name == 'Short self-test routine recommended polling time') ||
-		(c.name == 'Extended self-test routine recommended polling time') ||
-		(c.name == 'Conveyance self-test routine recommended polling time')) {
-		var p = c.name.indexOf("routine");
-		var short_name = c.name.substring(0, p);
-		test_capabilities[short_name] = c.capabilities;
-	    } else if (c.name == 'Self-test execution status'
-				&& c.flag > 240 && c.flag < 250) {
-		running_test = c.capabilities;
-	    }
-	});
-	var attributes = this.smartinfo.get('attributes') || [];
-	var errorlogsummary = this.smartinfo.get('errorlogsummary') || [];
-	var errorlog = this.smartinfo.get('errorlog') || [];
-	var errorlogZero, errorlogOne = null;
-	if(errorlog.length != 0){
-	    errorlogZero = errorlog[0].line;
-	    errorlogOne = errorlog[1].line;
-	}
-	var testlog = this.smartinfo.get('testlog') || [];
-	var testlogLength = testlog.length;
-	var testlogdetail = this.smartinfo.get('testlogdetail') || [];
-	var identity = this.smartinfo.get('identity') || [];
-	var diskSmartNotAvailable = !this.disk.get('smart_available');
-	var diskSmartNotEnabled = !this.disk.get('smart_enabled');
-	var diskName = this.disk.get('name');
-	var errorLogSummaryNull,
-	    testLogNull,
-	    notRunningTest,
-	    smartNotAvailableEnabled = false;
-	if(errorlogsummary.length == 0){
-	    errorLogSummaryNull = true;
-	}
-	if(testlogLength == 0){
-	    testLogNull = true;
-	}
-	if (diskSmartNotAvailable || diskSmartNotEnabled){
-	    smartNotAvailableEnabled = true;
-	}
-	if(!running_test){
-	    notRunningTest = true;
-	}
+    renderSubViews: function () {
+        var capabilities = this.smartinfo.get('capabilities') || [];
+        var test_capabilities = {};
+        var running_test = null;
+        capabilities.forEach(function (c) {
+            if ((c.name == 'Short self-test routine recommended polling time') ||
+                (c.name == 'Extended self-test routine recommended polling time') ||
+                (c.name == 'Conveyance self-test routine recommended polling time')) {
+                var p = c.name.indexOf("routine");
+                var short_name = c.name.substring(0, p);
+                test_capabilities[short_name] = c.capabilities;
+            } else if (c.name == 'Self-test execution status'
+                && c.flag > 240 && c.flag < 250) {
+                running_test = c.capabilities;
+            }
+        });
+        var attributes = this.smartinfo.get('attributes') || [];
+        var errorlogsummary = this.smartinfo.get('errorlogsummary') || [];
+        var errorlog = this.smartinfo.get('errorlog') || [];
+        var errorlogZero, errorlogOne = null;
+        if (errorlog.length != 0) {
+            errorlogZero = errorlog[0].line;
+            errorlogOne = errorlog[1].line;
+        }
+        var testlog = this.smartinfo.get('testlog') || [];
+        var testlogLength = testlog.length;
+        var testlogdetail = this.smartinfo.get('testlogdetail') || [];
+        var identity = this.smartinfo.get('identity') || [];
+        var diskSmartNotAvailable = !this.disk.get('smart_available');
+        var diskSmartNotEnabled = !this.disk.get('smart_enabled');
+        var diskName = this.disk.get('name');
+        var errorLogSummaryNull,
+            testLogNull,
+            notRunningTest,
+            smartNotAvailableEnabled = false;
+        if (errorlogsummary.length == 0) {
+            errorLogSummaryNull = true;
+        }
+        if (testlogLength == 0) {
+            testLogNull = true;
+        }
+        if (diskSmartNotAvailable || diskSmartNotEnabled) {
+            smartNotAvailableEnabled = true;
+        }
+        if (!running_test) {
+            notRunningTest = true;
+        }
 
-	$(this.el).html(this.template({
-	    disk: this.disk,
-	    diskSmartNotAvailable: diskSmartNotAvailable,
-	    diskSmartNotEnabled: diskSmartNotEnabled,
-		smartNotAvailableEnabled: smartNotAvailableEnabled,
-	    diskName: diskName,
-	    attributes: attributes,
-	    capabilities: capabilities,
-	    errorlogsummary: errorlogsummary,
-	    errorLogSummaryNull: errorLogSummaryNull,
-	    errorlog: errorlog,
-	    errorlogZero: errorlogZero,
-	    errorlogOne: errorlogOne,
-	    testlog: testlog,
-	    testLogNull: testLogNull,
-	    testlogdetail: testlogdetail,
-	    smartinfo: this.smartinfo,
-	    tests: test_capabilities,
-	    running_test: running_test,
-	    notRunningTest: notRunningTest,
-	    identity: identity
-	}));
-	this.$('input.smart-status').simpleSlider({
-	    "theme": "volume",
-	    allowedValues: [0,1],
-	    snap: true
-	});
-	this.$("ul.nav.nav-tabs").tabs("div.css-panes > div");
-	this.$("ul.nav.nav-tabs").data("tabs").click(this.active_tab);
-	this.active_tab = 0;
+        $(this.el).html(this.template({
+            disk: this.disk,
+            diskSmartNotAvailable: diskSmartNotAvailable,
+            diskSmartNotEnabled: diskSmartNotEnabled,
+            smartNotAvailableEnabled: smartNotAvailableEnabled,
+            diskName: diskName,
+            attributes: attributes,
+            capabilities: capabilities,
+            errorlogsummary: errorlogsummary,
+            errorLogSummaryNull: errorLogSummaryNull,
+            errorlog: errorlog,
+            errorlogZero: errorlogZero,
+            errorlogOne: errorlogOne,
+            testlog: testlog,
+            testLogNull: testLogNull,
+            testlogdetail: testlogdetail,
+            smartinfo: this.smartinfo,
+            tests: test_capabilities,
+            running_test: running_test,
+            notRunningTest: notRunningTest,
+            identity: identity
+        }));
+        this.$('input.smart-status').simpleSlider({
+            "theme": "volume",
+            allowedValues: [0, 1],
+            snap: true
+        });
+        this.$("ul.nav.nav-tabs").tabs("div.css-panes > div");
+        this.$("ul.nav.nav-tabs").data("tabs").click(this.active_tab);
+        this.active_tab = 0;
     },
 
-    refreshInfo: function(event) {
-	var _this = this;
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	$.ajax({
-	    url: '/api/disks/smart/info/' + _this.diskName,
-	    type: 'POST',
-	    success: function(data, status, xhr) {
-		_this.render();
-	    },
-	    error: function(xhr, status, error) {
-		enableButton(button);
-	    }
-	});
+    refreshInfo: function (event) {
+        var _this = this;
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        $.ajax({
+            url: '/api/disks/smart/info/' + _this.diskName,
+            type: 'POST',
+            success: function (data, status, xhr) {
+                _this.render();
+            },
+            error: function (xhr, status, error) {
+                enableButton(button);
+            }
+        });
     },
 
-    startTest: function(event) {
-	var _this = this;
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	var test_type = $('#test_name').val();
-	$.ajax({
-	    url: '/api/disks/smart/test/' + _this.diskName,
-	    type: 'POST',
-	    dataType: 'json',
-	    data: {'test_type': test_type},
-	    success: function(data, status, xhr) {
-		_this.render();
-		_this.active_tab = 5;
-	    },
-	    error: function(xhr, status, error) {
-		enableButton(button);
-	    }
-	});
+    startTest: function (event) {
+        var _this = this;
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var test_type = $('#test_name').val();
+        $.ajax({
+            url: '/api/disks/smart/test/' + _this.diskName,
+            type: 'POST',
+            dataType: 'json',
+            data: {'test_type': test_type},
+            success: function (data, status, xhr) {
+                _this.render();
+                _this.active_tab = 5;
+            },
+            error: function (xhr, status, error) {
+                enableButton(button);
+            }
+        });
     },
 
     initHandlebarHelpers: function () {
-	Handlebars.registerHelper('isAboveMinLength', function (minValue, target, options) {
-	    // check we have all the arguments we expect
-	    if (arguments.length != 3) {
-		throw new Error("Handlerbars Helper " +
-				"'isAboveMinLength' expects exactly 2 parameter.");
-	    }
-	    // do our logic and return options functions appropriately.
-	    if (target.length > minValue) {
-		return options.fn(this);
-	    } else {
-		return options.inverse(this);
-	    }
-	});
+        Handlebars.registerHelper('isAboveMinLength', function (minValue, target, options) {
+            // check we have all the arguments we expect
+            if (arguments.length != 3) {
+                throw new Error("Handlerbars Helper " +
+                    "'isAboveMinLength' expects exactly 2 parameter.");
+            }
+            // do our logic and return options functions appropriately.
+            if (target.length > minValue) {
+                return options.fn(this);
+            } else {
+                return options.inverse(this);
+            }
+        });
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -101,6 +101,7 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
 	    disk: this.disk,
 	    diskSmartNotAvailable: diskSmartNotAvailable,
 	    diskSmartNotEnabled: diskSmartNotEnabled,
+		smartNotAvailableEnabled: smartNotAvailableEnabled,
 	    diskName: diskName,
 	    attributes: attributes,
 	    capabilities: capabilities,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -64,10 +64,10 @@ DisksView = Backbone.View.extend({
 	    container: '#disks-table'
 	});
 
-  //initialize bootstrap switch
-  this.$("[type='checkbox']").bootstrapSwitch();
-  this.$("[type='checkbox']").bootstrapSwitch('onColor','success'); //left side text color
-  this.$("[type='checkbox']").bootstrapSwitch('offColor','danger'); //right side text color
+	//initialize bootstrap switch
+	this.$("[type='checkbox']").bootstrapSwitch();
+	this.$("[type='checkbox']").bootstrapSwitch('onColor','success'); //left side text color
+	this.$("[type='checkbox']").bootstrapSwitch('offColor','danger'); //right side text color
 
     },
 
@@ -173,94 +173,94 @@ DisksView = Backbone.View.extend({
     initHandlebarHelpers: function(){
     	Handlebars.registerHelper('display_disks_tbody', function() {
 
-        var html = '',
-            warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further.';
+            var html = '',
+		warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further.';
 
-        this.collection.each(function(disk, index) {
+            this.collection.each(function(disk, index) {
           	var diskName = disk.get('name'),
-               	diskOffline = disk.get('offline'),
-               	diskSize = humanize.filesize(disk.get('size') * 1024),
-               	diskModel = disk.get('model'),
-               	diskTransport = disk.get('transport'),
-               	diskVendor = disk.get('vendor'),
-               	smartAvailable = disk.get('smart_available'),
-               	poolName = disk.get('pool_name'),
-               	serial = disk.get('serial'),
-               	btrfsUId = disk.get('btrfs_uuid'),
-               	diskParted = disk.get('parted'),
-               	smartEnabled = disk.get('smart_enabled'),
-				diskRole = disk.get('role'),
-				smartOptions = disk.get('smart_options');
+               	    diskOffline = disk.get('offline'),
+               	    diskSize = humanize.filesize(disk.get('size') * 1024),
+               	    diskModel = disk.get('model'),
+               	    diskTransport = disk.get('transport'),
+               	    diskVendor = disk.get('vendor'),
+               	    smartAvailable = disk.get('smart_available'),
+               	    poolName = disk.get('pool_name'),
+               	    serial = disk.get('serial'),
+               	    btrfsUId = disk.get('btrfs_uuid'),
+               	    diskParted = disk.get('parted'),
+               	    smartEnabled = disk.get('smart_enabled'),
+		    diskRole = disk.get('role'),
+		    smartOptions = disk.get('smart_options');
 
-        html += '<tr>';
-        html += '<td><a href="#disks/' + diskName +' "><i class="glyphicon glyphicon-hdd"></i> '+ diskName +'</a>&nbsp';
-        if (diskOffline) {
-           html += '<a href="#" class="delete" data-disk-name="'+ diskName +'" title="Disk is unusable because it is offline.Click to delete it from the system" rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>';
-        } else if (diskRole == 'isw_raid_member' || diskRole == 'linux_raid_member') {
-		   html += '<a href="#" class="raid_member" data-disk-name="'+ diskName +'" title="Disk is a mdraid member." rel="tooltip">';
-		   html += '<i class="glyphicon glyphicon-info-sign"></i></a>';
+		html += '<tr>';
+		html += '<td><a href="#disks/' + diskName +' "><i class="glyphicon glyphicon-hdd"></i> '+ diskName +'</a>&nbsp';
+		if (diskOffline) {
+		    html += '<a href="#" class="delete" data-disk-name="'+ diskName +'" title="Disk is unusable because it is offline.Click to delete it from the system" rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>';
+		} else if (diskRole == 'isw_raid_member' || diskRole == 'linux_raid_member') {
+		    html += '<a href="#" class="raid_member" data-disk-name="'+ diskName +'" title="Disk is a mdraid member." rel="tooltip">';
+		    html += '<i class="glyphicon glyphicon-info-sign"></i></a>';
 		} else if (diskParted) {
-           html += '<a href="#" class="wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has some other filesystem on it.';
-           html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
-        } else if (btrfsUId && _.isNull(poolName)) {
-           html += '<a href="#" class="btrfs_wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
-           html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="'+ diskName +'" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
-           html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
-        }
+		    html += '<a href="#" class="wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has some other filesystem on it.';
+		    html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
+		} else if (btrfsUId && _.isNull(poolName)) {
+		    html += '<a href="#" class="btrfs_wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
+		    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="'+ diskName +'" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
+		    html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
+		}
 
-        html += '</td>';
-        html += '<td>';
-	    if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
-	       html += '<div class="alert alert-danger">' +
-				   '<h4>Warning! Disk serial number is not legitimate or unique.</h4>' + warning +'</div>';
-       	}else{
-	       html += serial;
-	       if (serial) {
-	          html += '&nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/'+ diskName +'" title="A tool to physically identify the hard drive with this serial number" rel="tooltip"><i class="fa fa-lightbulb-o fa-lg"></i></a>&nbsp';
-           }
-	    }
-        html += '</td>';
-        html += '<td>'+diskSize+'</td>';
-        html += '<td>';
-        if (!_.isNull(poolName)) {
-           html += '<a href="#pools/'+ poolName +'">'+ poolName + '</a>';
-        }
-        html += '</td>';
-        html += '<td>'+diskModel+'</td>';
-        html += '<td>'+diskTransport+'</td>';
-        html += '<td>'+diskVendor+'</td>';
+		html += '</td>';
+		html += '<td>';
+		if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
+		    html += '<div class="alert alert-danger">' +
+			'<h4>Warning! Disk serial number is not legitimate or unique.</h4>' + warning +'</div>';
+       		}else{
+		    html += serial;
+		    if (serial) {
+			html += '&nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/'+ diskName +'" title="A tool to physically identify the hard drive with this serial number" rel="tooltip"><i class="fa fa-lightbulb-o fa-lg"></i></a>&nbsp';
+		    }
+		}
+		html += '</td>';
+		html += '<td>'+diskSize+'</td>';
+		html += '<td>';
+		if (!_.isNull(poolName)) {
+		    html += '<a href="#pools/'+ poolName +'">'+ poolName + '</a>';
+		}
+		html += '</td>';
+		html += '<td>'+diskModel+'</td>';
+		html += '<td>'+diskTransport+'</td>';
+		html += '<td>'+diskVendor+'</td>';
 		// begin smart table data cell contents
 		html += '<td>';
 		if (smartOptions != null) {
-			html += smartOptions + ' ';
+		    html += smartOptions + ' ';
 		}else{
-			html += ' ';
+		    html += ' ';
 		}
 		html += '<a href="#disks/smartcustom/'+ diskName +'" title="Click to add/edit Custom SMART options. Rescan to Apply." rel="tooltip">';
 		html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
-        if (!smartAvailable) {
-           html +='Not Supported</td>';
-        }else{
-            if (smartEnabled) {
-		html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini" checked></input>';
-	    	} else {
-		html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini"></input>';
-	    }
-	    html += '</td>';
-        }
-        html += '</tr>';
-        });
+		if (!smartAvailable) {
+		    html +='Not Supported</td>';
+		}else{
+		    if (smartEnabled) {
+			html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini" checked></input>';
+	    	    } else {
+			html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini"></input>';
+		    }
+		    html += '</td>';
+		}
+		html += '</tr>';
+            });
 	    return new Handlebars.SafeString(html);
         });
-     },
+    },
 
     smartToggle: function(event, state){
-      var disk_name = $(event.target).attr('data-disk-name');
-      if(state){
-        this.smartOn(disk_name);
-      }else{
-        this.smartOff(disk_name);
-      }
+	var disk_name = $(event.target).attr('data-disk-name');
+	if(state){
+            this.smartOn(disk_name);
+	}else{
+            this.smartOff(disk_name);
+	}
     },
 
     smartOff: function(disk_name) {
@@ -283,7 +283,7 @@ DisksView = Backbone.View.extend({
     		_this.render();
     	    }
     	});
-    },
+    }
 });
 
 // Add pagination

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -188,8 +188,9 @@ DisksView = Backbone.View.extend({
                	serial = disk.get('serial'),
                	btrfsUId = disk.get('btrfs_uuid'),
                	diskParted = disk.get('parted'),
-               	smartEnabled = disk.get('smart_enabled');
-				diskRole = disk.get('role');
+               	smartEnabled = disk.get('smart_enabled'),
+				diskRole = disk.get('role'),
+				smartOptions = disk.get('smart_options');
 
         html += '<tr>';
         html += '<td><a href="#disks/' + diskName +' "><i class="glyphicon glyphicon-hdd"></i> '+ diskName +'</a>&nbsp';
@@ -228,13 +229,21 @@ DisksView = Backbone.View.extend({
         html += '<td>'+diskModel+'</td>';
         html += '<td>'+diskTransport+'</td>';
         html += '<td>'+diskVendor+'</td>';
+		// begin smart table data cell contents
+		html += '<td>';
+		if (smartOptions != null) {
+			html += smartOptions + ' ';
+		}else{
+			html += ' ';
+		}
+		html += '<a href="#disks/smartcustom/'+ diskName +'" title="Click to add/edit Custom SMART options. Rescan to Apply." rel="tooltip">';
+		html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
         if (!smartAvailable) {
-           html +='<td>Not Supported</td>';
+           html +='Not Supported</td>';
         }else{
-            html += '<td>';
             if (smartEnabled) {
 		html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini" checked></input>';
-	    } else {
+	    	} else {
 		html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini"></input>';
 	    }
 	    html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -26,263 +26,263 @@
 
 DisksView = Backbone.View.extend({
     events: {
-	"click #setup": "setupDisks",
-	'click .wipe': 'wipeDisk',
-	'click .delete': 'deleteDisk',
-	'click .btrfs_wipe': 'btrfsWipeDisk',
-	'click .btrfs_import': 'btrfsImportDisk',
-	'switchChange.bootstrapSwitch': 'smartToggle'
+        "click #setup": "setupDisks",
+        'click .wipe': 'wipeDisk',
+        'click .delete': 'deleteDisk',
+        'click .btrfs_wipe': 'btrfsWipeDisk',
+        'click .btrfs_import': 'btrfsImportDisk',
+        'switchChange.bootstrapSwitch': 'smartToggle'
     },
 
-    initialize: function() {
-	this.template = window.JST.disk_disks;
-	this.disks_table_template = window.JST.disk_disks_table;
-	this.collection = new DiskCollection;
-	this.collection.on("reset", this.renderDisks, this);
-	this.initHandlebarHelpers();
+    initialize: function () {
+        this.template = window.JST.disk_disks;
+        this.disks_table_template = window.JST.disk_disks_table;
+        this.collection = new DiskCollection;
+        this.collection.on("reset", this.renderDisks, this);
+        this.initHandlebarHelpers();
     },
 
-    render: function() {
-	this.collection.fetch();
-	return this;
+    render: function () {
+        this.collection.fetch();
+        return this;
     },
 
-    renderDisks: function() {
-	// remove existing tooltips
-	if (this.$('[rel=tooltip]')) {
-	    this.$("[rel=tooltip]").tooltip('hide');
-	}
-	$(this.el).html(this.template({ collection: this.collection }));
-	this.$("#disks-table-ph").html(this.disks_table_template({
-	    collection: this.collection,
-	    collectionNotEmpty: !this.collection.isEmpty()
-	}));
+    renderDisks: function () {
+        // remove existing tooltips
+        if (this.$('[rel=tooltip]')) {
+            this.$("[rel=tooltip]").tooltip('hide');
+        }
+        $(this.el).html(this.template({collection: this.collection}));
+        this.$("#disks-table-ph").html(this.disks_table_template({
+            collection: this.collection,
+            collectionNotEmpty: !this.collection.isEmpty()
+        }));
 
-	this.$("#disks-table").tablesorter();
-	this.$("[rel=tooltip]").tooltip({
-	    placement: "right",
-	    container: '#disks-table'
-	});
+        this.$("#disks-table").tablesorter();
+        this.$("[rel=tooltip]").tooltip({
+            placement: "right",
+            container: '#disks-table'
+        });
 
-	//initialize bootstrap switch
-	this.$("[type='checkbox']").bootstrapSwitch();
-	this.$("[type='checkbox']").bootstrapSwitch('onColor','success'); //left side text color
-	this.$("[type='checkbox']").bootstrapSwitch('offColor','danger'); //right side text color
+        //initialize bootstrap switch
+        this.$("[type='checkbox']").bootstrapSwitch();
+        this.$("[type='checkbox']").bootstrapSwitch('onColor', 'success'); //left side text color
+        this.$("[type='checkbox']").bootstrapSwitch('offColor', 'danger'); //right side text color
 
     },
 
-    setupDisks: function() {
-	var _this = this;
-	$.ajax({
-	    url: "/api/disks/scan",
-	    type: "POST"
-	}).done(function() {
-	    // reset the current page
-	    _this.collection.page = 1;
-	    _this.collection.fetch();
-	});
-    },
-
-    wipeDisk: function(event) {
-	var _this = this;
-	if (event) event.preventDefault();
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	var diskName = button.data('disk-name');
-	if (confirm('Are you sure you want to completely delete all data on the disk ' + diskName + '?')) {
-	    $.ajax({
-		url: '/api/disks/' + diskName + '/wipe',
-		type: 'POST',
-		success: function(data, status, xhr) {
-		    _this.render();
-		},
-		error: function(xhr, status, error) {
-		    enableButton(button);
-		}
-	    });
-	}
-    },
-    btrfsWipeDisk: function(event) {
-	var _this = this;
-	if (event) event.preventDefault();
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	var diskName = button.data('disk-name');
-	if (confirm('Are you sure you want to erase BTRFS filesystem(s) on the disk ' + diskName + '?')) {
-	    $.ajax({
-		url: '/api/disks/' + diskName + '/btrfs-wipe',
-		type: 'POST',
-		success: function(data, status, xhr) {
-		    _this.render();
-		},
-		error: function(xhr, status, error) {
-		    enableButton(button);
-		}
-	    });
-	}
-    },
-
-    btrfsImportDisk: function(event) {
-	var _this = this;
-	if (event) event.preventDefault();
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	var diskName = button.data('disk-name');
-	if (confirm('Are you sure you want to automatically import pools, shares and snapshots that may be on the disk ' + diskName + '?')) {
-	    $.ajax({
-		url: '/api/disks/' + diskName + '/btrfs-disk-import',
-		type: 'POST',
-		success: function(data, status, xhr) {
-		    _this.render();
-		},
-		error: function(xhr, status, error) {
-		    enableButton(button);
-		}
-	    });
-	}
-    },
-
-    deleteDisk: function(event) {
-	var _this = this;
-	if (event) event.preventDefault();
-	var button = $(event.currentTarget);
-	if (buttonDisabled(button)) return false;
-	disableButton(button);
-	var diskName = button.data('disk-name');
-	if (confirm('Are you sure you want to delete the disk ' + diskName + '?')) {
-	    $.ajax({
-		url: '/api/disks/' + diskName,
-		type: 'DELETE',
-		success: function(data, status, xhr) {
-		    _this.render();
-		},
-		error: function(xhr, status, error) {
-		    enableButton(button);
-		}
-	    });
-	}
-    },
-
-    cleanup: function() {
-	this.$("[rel='tooltip']").tooltip('hide');
-    },
-
-    initHandlebarHelpers: function(){
-    	Handlebars.registerHelper('display_disks_tbody', function() {
-
-            var html = '',
-		warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further.';
-
-            this.collection.each(function(disk, index) {
-          	var diskName = disk.get('name'),
-               	    diskOffline = disk.get('offline'),
-               	    diskSize = humanize.filesize(disk.get('size') * 1024),
-               	    diskModel = disk.get('model'),
-               	    diskTransport = disk.get('transport'),
-               	    diskVendor = disk.get('vendor'),
-               	    smartAvailable = disk.get('smart_available'),
-               	    poolName = disk.get('pool_name'),
-               	    serial = disk.get('serial'),
-               	    btrfsUId = disk.get('btrfs_uuid'),
-               	    diskParted = disk.get('parted'),
-               	    smartEnabled = disk.get('smart_enabled'),
-		    diskRole = disk.get('role'),
-		    smartOptions = disk.get('smart_options');
-
-		html += '<tr>';
-		html += '<td><a href="#disks/' + diskName +' "><i class="glyphicon glyphicon-hdd"></i> '+ diskName +'</a>&nbsp';
-		if (diskOffline) {
-		    html += '<a href="#" class="delete" data-disk-name="'+ diskName +'" title="Disk is unusable because it is offline.Click to delete it from the system" rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>';
-		} else if (diskRole == 'isw_raid_member' || diskRole == 'linux_raid_member') {
-		    html += '<a href="#" class="raid_member" data-disk-name="'+ diskName +'" title="Disk is a mdraid member." rel="tooltip">';
-		    html += '<i class="glyphicon glyphicon-info-sign"></i></a>';
-		} else if (diskParted) {
-		    html += '<a href="#" class="wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has some other filesystem on it.';
-		    html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
-		} else if (btrfsUId && _.isNull(poolName)) {
-		    html += '<a href="#" class="btrfs_wipe" data-disk-name="'+ diskName +'" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
-		    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="'+ diskName +'" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
-		    html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
-		}
-
-		html += '</td>';
-		html += '<td>';
-		if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
-		    html += '<div class="alert alert-danger">' +
-			'<h4>Warning! Disk serial number is not legitimate or unique.</h4>' + warning +'</div>';
-       		}else{
-		    html += serial;
-		    if (serial) {
-			html += '&nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/'+ diskName +'" title="A tool to physically identify the hard drive with this serial number" rel="tooltip"><i class="fa fa-lightbulb-o fa-lg"></i></a>&nbsp';
-		    }
-		}
-		html += '</td>';
-		html += '<td>'+diskSize+'</td>';
-		html += '<td>';
-		if (!_.isNull(poolName)) {
-		    html += '<a href="#pools/'+ poolName +'">'+ poolName + '</a>';
-		}
-		html += '</td>';
-		html += '<td>'+diskModel+'</td>';
-		html += '<td>'+diskTransport+'</td>';
-		html += '<td>'+diskVendor+'</td>';
-		// begin smart table data cell contents
-		html += '<td>';
-		if (smartOptions != null) {
-		    html += smartOptions + ' ';
-		}else{
-		    html += ' ';
-		}
-		html += '<a href="#disks/smartcustom/'+ diskName +'" title="Click to add/edit Custom SMART options. Rescan to Apply." rel="tooltip">';
-		html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
-		if (!smartAvailable) {
-		    html +='Not Supported</td>';
-		}else{
-		    if (smartEnabled) {
-			html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini" checked></input>';
-	    	    } else {
-			html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini"></input>';
-		    }
-		    html += '</td>';
-		}
-		html += '</tr>';
-            });
-	    return new Handlebars.SafeString(html);
+    setupDisks: function () {
+        var _this = this;
+        $.ajax({
+            url: "/api/disks/scan",
+            type: "POST"
+        }).done(function () {
+            // reset the current page
+            _this.collection.page = 1;
+            _this.collection.fetch();
         });
     },
 
-    smartToggle: function(event, state){
-	var disk_name = $(event.target).attr('data-disk-name');
-	if(state){
+    wipeDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to completely delete all data on the disk ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName + '/wipe',
+                type: 'POST',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+    btrfsWipeDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to erase BTRFS filesystem(s) on the disk ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName + '/btrfs-wipe',
+                type: 'POST',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+
+    btrfsImportDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to automatically import pools, shares and snapshots that may be on the disk ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName + '/btrfs-disk-import',
+                type: 'POST',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+
+    deleteDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to delete the disk ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName,
+                type: 'DELETE',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+
+    cleanup: function () {
+        this.$("[rel='tooltip']").tooltip('hide');
+    },
+
+    initHandlebarHelpers: function () {
+        Handlebars.registerHelper('display_disks_tbody', function () {
+
+            var html = '',
+                warning = 'Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN. Please ensure that disks are provided with unique serial numbers before proceeding further.';
+
+            this.collection.each(function (disk, index) {
+                var diskName = disk.get('name'),
+                    diskOffline = disk.get('offline'),
+                    diskSize = humanize.filesize(disk.get('size') * 1024),
+                    diskModel = disk.get('model'),
+                    diskTransport = disk.get('transport'),
+                    diskVendor = disk.get('vendor'),
+                    smartAvailable = disk.get('smart_available'),
+                    poolName = disk.get('pool_name'),
+                    serial = disk.get('serial'),
+                    btrfsUId = disk.get('btrfs_uuid'),
+                    diskParted = disk.get('parted'),
+                    smartEnabled = disk.get('smart_enabled'),
+                    diskRole = disk.get('role'),
+                    smartOptions = disk.get('smart_options');
+
+                html += '<tr>';
+                html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
+                if (diskOffline) {
+                    html += '<a href="#" class="delete" data-disk-name="' + diskName + '" title="Disk is unusable because it is offline.Click to delete it from the system" rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>';
+                } else if (diskRole == 'isw_raid_member' || diskRole == 'linux_raid_member') {
+                    html += '<a href="#" class="raid_member" data-disk-name="' + diskName + '" title="Disk is a mdraid member." rel="tooltip">';
+                    html += '<i class="glyphicon glyphicon-info-sign"></i></a>';
+                } else if (diskParted) {
+                    html += '<a href="#" class="wipe" data-disk-name="' + diskName + '" title="Disk is unusable because it has some other filesystem on it.';
+                    html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
+                } else if (btrfsUId && _.isNull(poolName)) {
+                    html += '<a href="#" class="btrfs_wipe" data-disk-name="' + diskName + '" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
+                    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="' + diskName + '" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
+                    html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
+                }
+
+                html += '</td>';
+                html += '<td>';
+                if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
+                    html += '<div class="alert alert-danger">' +
+                        '<h4>Warning! Disk serial number is not legitimate or unique.</h4>' + warning + '</div>';
+                } else {
+                    html += serial;
+                    if (serial) {
+                        html += '&nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/' + diskName + '" title="A tool to physically identify the hard drive with this serial number" rel="tooltip"><i class="fa fa-lightbulb-o fa-lg"></i></a>&nbsp';
+                    }
+                }
+                html += '</td>';
+                html += '<td>' + diskSize + '</td>';
+                html += '<td>';
+                if (!_.isNull(poolName)) {
+                    html += '<a href="#pools/' + poolName + '">' + poolName + '</a>';
+                }
+                html += '</td>';
+                html += '<td>' + diskModel + '</td>';
+                html += '<td>' + diskTransport + '</td>';
+                html += '<td>' + diskVendor + '</td>';
+                // begin smart table data cell contents
+                html += '<td>';
+                if (smartOptions != null) {
+                    html += smartOptions + ' ';
+                } else {
+                    html += ' ';
+                }
+                html += '<a href="#disks/smartcustom/' + diskName + '" title="Click to add/edit Custom SMART options. Rescan to Apply." rel="tooltip">';
+                html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                if (!smartAvailable) {
+                    html += 'Not Supported</td>';
+                } else {
+                    if (smartEnabled) {
+                        html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini" checked></input>';
+                    } else {
+                        html += '<input type="checkbox" data-disk-name="' + diskName + '" data-size="mini"></input>';
+                    }
+                    html += '</td>';
+                }
+                html += '</tr>';
+            });
+            return new Handlebars.SafeString(html);
+        });
+    },
+
+    smartToggle: function (event, state) {
+        var disk_name = $(event.target).attr('data-disk-name');
+        if (state) {
             this.smartOn(disk_name);
-	}else{
+        } else {
             this.smartOff(disk_name);
-	}
+        }
     },
 
-    smartOff: function(disk_name) {
-    	var _this = this;
-    	$.ajax({
-    	    url: '/api/disks/' + disk_name + '/disable-smart',
-    	    type: 'POST',
-    	    success: function(data, status, xhr) {
-    		_this.render();
-    	    }
-    	});
+    smartOff: function (disk_name) {
+        var _this = this;
+        $.ajax({
+            url: '/api/disks/' + disk_name + '/disable-smart',
+            type: 'POST',
+            success: function (data, status, xhr) {
+                _this.render();
+            }
+        });
     },
 
-    smartOn: function(disk_name) {
-    	var _this = this;
-    	$.ajax({
-    	    url: '/api/disks/' + disk_name + '/enable-smart',
-    	    type: 'POST',
-    	    success: function(data, status, xhr) {
-    		_this.render();
-    	    }
-    	});
+    smartOn: function (disk_name) {
+        var _this = this;
+        $.ajax({
+            url: '/api/disks/' + disk_name + '/enable-smart',
+            type: 'POST',
+            success: function (data, status, xhr) {
+                _this.render();
+            }
+        });
     }
 });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -25,269 +25,271 @@
  */
 
 SmartcustomDiskView = RockstorLayoutView.extend({
-  events: {
-    'click #cancel': 'cancel'
-  },
+    events: {
+	'click #cancel': 'cancel'
+    },
 
-  initialize: function() {
-    this.constructor.__super__.initialize.apply(this, arguments);
-    this.template = window.JST.disk_smartcustom_disks;
-    this.disks = new DiskCollection();
-    this.diskName = this.options.diskName;
-    this.dependencies.push(this.disks);
-  },
+    initialize: function() {
+	this.constructor.__super__.initialize.apply(this, arguments);
+	this.template = window.JST.disk_smartcustom_disks;
+	this.disks = new DiskCollection();
+	this.diskName = this.options.diskName;
+	this.dependencies.push(this.disks);
+    },
 
- render: function() {
-    this.fetch(this.renderDisksForm, this);
-    return this;
-  },
+    render: function() {
+	this.fetch(this.renderDisksForm, this);
+	return this;
+    },
 
-  renderDisksForm: function() {
-    if (this.$('[rel=tooltip]')) {
-      this.$("[rel=tooltip]").tooltip('hide');
+    renderDisksForm: function() {
+	if (this.$('[rel=tooltip]')) {
+	    this.$("[rel=tooltip]").tooltip('hide');
+	}
+	var _this = this;
+	var disk_name = this.diskName;
+	var serialNumber = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('serial');
+	var currentSmartCustom = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('smart_options');
+
+	$(this.el).html(this.template({
+	    diskName: this.diskName,
+	    serialNumber: serialNumber,
+	    currentSmartCustom: currentSmartCustom
+	}));
+
+	this.$('#add-smartcustom-disk-form :input').tooltip({
+	    html: true,
+	    placement: 'right'
+	});
+
+	var err_msg = '';
+	var smartcustom_err_msg = function() {
+            return err_msg;
+	};
+
+	$.validator.addMethod('validateSmartCustom', function(value) {
+            var smartcustom_options = $('#smartcustom_options').val().trim();
+            var devOptions = ["auto", "test", "ata", "scsi", "sat", "sat,12", "sat,16", "sat,auto", "usbprolific", "usbjmicron", "usbjmicron,0", "usbjmicron,p", "usbjmicron,x", "usbjmicron,x,1", "usbcypress", "usbsunplus"];
+            var devOptionsRaid = ["3ware", "areca", "hpt", "cciss", "megaraid", "aacraid"];
+            var toleranceOptions = ["normal", "conservative", "permissive", "verypermissive"];
+            // RegExp patters for the following RAID target devices:
+            // 3ware /dev/twe, /dev/twa, /dev/twl followed by 0-15
+            // Areca sata /dev/sg[2-9] but for hpahcisr and hpsa drivers /dev/sg[0-9]* (lsscsi -g to help)
+            // so we still have an issue there.
+            // HP Smart array with cciss driver uses /dev/cciss/c[0-9]d0
+            var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/];
+            // Initial cascade of syntactic checks.
+            if (smartcustom_options.length == 0) {
+		// allow zero length (empty) entry to remove existing options
+		return true;
+            }
+
+	    if (/^[A-Za-z0-9,-/ ]+$/.test(smartcustom_options) == false) {
+		err_msg = 'Invalid character found, expecting only letters, numbers, and \'-\',\'/\' and \'space.\'';
+		return false;
+            }
+
+	    if((!smartcustom_options.includes("-d ")) && (!smartcustom_options.includes("-T "))){
+		err_msg = 'Must contain either -d or -T options or both.';
+		return false;
+	    }
+
+	    if(smartcustom_options.length > 64) {
+		err_msg = 'S.M.A.R.T options must not exceed 64 characters.';
+		return false;
+	    }
+
+	    // By now we have valid characters that include "-d " and or "-T " and
+	    // less than 64 of them (including spaces) - the max db field length.
+	    // Move to repeat and semantic checks
+	    //
+	    // Check for only one instance of "-d ".
+	    var first_d_option =  smartcustom_options.indexOf("-d ");
+	    if (first_d_option != -1 && smartcustom_options.lastIndexOf("-d") != first_d_option) {
+		err_msg = 'Only one occurrence of the -d switch is permitted.';
+		return false;
+	    }
+
+	    // Note that multiple instances of -T are valid.
+	    // Validate each option.
+	    // Find elements of given options via split by space.
+	    var option_array = smartcustom_options.split(" ");
+	    if ((option_array[0] != "-d") && (option_array[0] != "-T")) {
+		err_msg = 'Please begin with either \'-d \' or \'-T \'';
+		return false;
+	    }
+	    // true if option is Device switch "-d"
+	    function isDevSwitch(option) {
+		return (option == "-d");
+	    }
+	    // true if option is Tolerance switch ie "-T"
+	    function isToleranceSwitch(option) {
+		return (option == "-T");
+	    }
+	    // true if not recognized as a dev option (non Raid)
+	    function isNotDevOption(option) {
+		return (devOptions.indexOf(option) == -1);
+	    }
+	    // true if not recognized as a type option
+	    function isNotToleranceOption(option) {
+		return (toleranceOptions.indexOf(option) == -1);
+	    }
+	    // true if not recognized as a RAID option
+	    // Consider improving to use string.match(regexp) to match whole option.
+	    // Currently only validates pre ',' in for example 3ware,5
+	    function isNotRaidOption(option) {
+		var without_values = option.substring(0, option.indexOf(","));
+		return (devOptionsRaid.indexOf(without_values) == -1);
+	    }
+	    // true if not recognized as a RAID target device
+	    function isNotRaidTarget(option) {
+		// assumed not a raid controller target until found otherwise
+		target_found = false;
+		// for (var pattern of raidTargetRegExp) { // possible js version ?
+		for (index = 0; index < raidTargetRegExp.length; index++) {
+		    var pattern = raidTargetRegExp[index]; // more compatible.
+		    if (pattern.test(option) == true) {
+			target_found = true;
+			// match found so look no further.
+			break;
+		    }
+		}
+		return !target_found;
+	    }
+	    // rogue spaces are empty array elements after split so test for them
+	    function  isRogueSpace(option) {
+		return (option.toString() == "");
+	    }
+	    // test for any rogue spaces
+	    if (option_array.filter(isRogueSpace).length != 0) {
+		err_msg = 'One or more rouge spaces found, please re-check input';
+		return false;
+	    }
+	    // Categorize all entered options individually, forEach is order safe.
+	    var dev_options_found = [];
+	    var tol_options_found = [];
+	    var unknown_options_found = [];
+	    var option_type = '';
+	    var unknown_switches_found = [];
+	    var dev_switch_found = false;
+	    var tol_switch_found = false;
+	    option_array.forEach(function(option) {
+		// filter our various options before assessing them as valid.
+		if (option.charAt(0) == "-") { // option is a switch
+		    if (isDevSwitch(option)) {
+			option_type = "dev";
+			dev_switch_found = true;
+		    } else if (isToleranceSwitch(option)) {
+			option_type = "tol";
+			tol_switch_found = true;
+		    } else { // unknown switch
+			option_type = "unknown";
+			unknown_switches_found.push(option);
+		    }
+		} else if (option_type == "dev") {
+		    // collect all options proceeded by a -d option
+		    dev_options_found.push(option);
+		} else if (option_type == "tol") {
+		    // collect all options proceeded by a -T option
+		    tol_options_found.push(option);
+		} else {
+		    // collect all other options proceeded by an unknown switch.
+		    unknown_options_found.push(option);
+		}
+	    });
+	    // Report any unknown switches.
+	    if (unknown_switches_found != "" ) {
+		err_msg = 'One or more unknown switches found: \'' + unknown_switches_found.toString() + '\', supported switches are \'-d\' and \'-T\'';
+		return false;
+	    }
+	    // Report any options of unknown type.
+	    // Note this should never trigger as the last unknown_switches_found
+	    // should trigger first. We have a later one to catch unknown options
+	    // after known triggers.
+	    if (unknown_options_found != "") {
+		err_msg = 'The following options of an unknown type were entered:' +
+		    ' \'' + unknown_options_found.toString() + '\', supported ' +
+		    'options are ' + devOptions.toString() + '\n' +
+		    devOptionsRaid.toString() + toleranceOptions.toString();
+		return false;
+	    }
+	    // Filter out unknown options on known switches ie "-d notanoption"
+	    // Filter our dev options first by absolute known / allowed options
+	    // filter the resulting array by the less strict known raid options
+	    var unknown_dev_options_found = dev_options_found.filter(isNotDevOption).filter(isNotRaidOption).filter(isNotRaidTarget);
+	    if (unknown_dev_options_found != "") {
+		err_msg = 'The following unknown \'-d\' options were found \'' +
+		    unknown_dev_options_found.toString() + '\'';
+		return false;
+	    }
+	    // Filter out unknown Tolerance options
+	    var unknown_tol_options_found = tol_options_found.filter(isNotToleranceOption);
+	    if (unknown_tol_options_found != "") {
+		err_msg = 'The following unknown \'-T\' options were found \'' +
+		    unknown_tol_options_found.toString() + '\'. Available options' +
+		    ' are ' + toleranceOptions.toString();
+		return false;
+	    }
+	    // Check we have at least one Tolerance option
+	    if (tol_switch_found && tol_options_found.length < 1){
+		// no Tolerance options found
+		err_msg = 'Tolerance switch \'-T\' found without valid options';
+		return false;
+	    }
+	    // Finally check if more than one -d option is given
+	    if (dev_options_found.length > 1) {
+		// only legitimate -d option with 2 parameters is raid + raid target
+		if (dev_options_found.length == 2) {
+		    if ((!isNotRaidOption(dev_options_found[0])) && (!isNotRaidTarget(dev_options_found[1]))) {
+			// we have a raid option followed by a raid target dev
+			return true
+		    }
+		}
+		err_msg = 'Only one \'-d\' option is supported';
+		return false;
+	    }
+	    // not otherwise found to be invalid or valid so assume valid by now.
+	    return true;
+	}, smartcustom_err_msg);
+
+	this.$('#add-smartcustom-disk-form').validate({
+	    onfocusout: false,
+	    onkeyup: false,
+	    rules: {
+		smartcustom_options: 'validateSmartCustom',
+	    },
+
+	    submitHandler: function() {
+		var button = $('#smartcustom-disk');
+		if (buttonDisabled(button)) return false;
+		disableButton(button);
+		var submitmethod = 'POST';
+		var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
+		$.ajax({
+		    url: posturl,
+		    type: submitmethod,
+		    dataType: 'json',
+		    contentType: 'application/json',
+		    data: JSON.stringify(_this.$('#add-smartcustom-disk-form').getJSON()),
+		    success: function() {
+			enableButton(button);
+			_this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+			app_router.navigate('disks', {trigger: true});
+		    },
+		    error: function(xhr, status, error) {
+			enableButton(button);
+		    }
+		});
+
+		return false;
+	    }
+	});
+    },
+
+    cancel: function(event) {
+	event.preventDefault();
+	this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+	app_router.navigate('disks', {trigger: true});
     }
-    var _this = this;
-    var disk_name = this.diskName;
-    var serialNumber = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('serial');
-    var currentSmartCustom = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('smart_options');
-
-    $(this.el).html(this.template({
-	diskName: this.diskName,
-	serialNumber: serialNumber,
-    currentSmartCustom: currentSmartCustom
-    }));
-
-    this.$('#add-smartcustom-disk-form :input').tooltip({
-      html: true,
-      placement: 'right'
-    });
-
-    var err_msg = '';
-      var smartcustom_err_msg = function() {
-          return err_msg;
-      }
-
-    $.validator.addMethod('validateSmartCustom', function(value) {
-        var smartcustom_options = $('#smartcustom_options').val().trim();
-        var devOptions = ["auto", "test", "ata", "scsi", "sat", "sat,12", "sat,16", "sat,auto", "usbprolific", "usbjmicron", "usbjmicron,0", "usbjmicron,p", "usbjmicron,x", "usbjmicron,x,1", "usbcypress", "usbsunplus"];
-        var devOptionsRaid = ["3ware", "areca", "hpt", "cciss", "megaraid", "aacraid"];
-        var toleranceOptions = ["normal", "conservative", "permissive", "verypermissive"];
-        // RegExp patters for the following RAID target devices:
-        // 3ware /dev/twe, /dev/twa, /dev/twl followed by 0-15
-        // Areca sata /dev/sg[2-9] but for hpahcisr and hpsa drivers /dev/sg[0-9]* (lsscsi -g to help)
-        // so we still have an issue there.
-        // HP Smart array with cciss driver uses /dev/cciss/c[0-9]d0
-        var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/];
-        // Initial cascade of syntactic checks.
-        if (smartcustom_options.length == 0) {
-            // allow zero length (empty) entry to remove existing options
-            return true;
-        }
-        else
-            if (/^[A-Za-z0-9,-/ ]+$/.test(smartcustom_options) == false) {
-			    err_msg = 'Invalid character found, expecting only letters, numbers, and \'-\',\'/\' and \'space.\'';
-			    return false;
-        }
-        else
-            if((!smartcustom_options.includes("-d ")) && (!smartcustom_options.includes("-T "))){
-                err_msg = 'Must contain either -d or -T options or both.';
-                return false;
-            }
-        else
-            if(smartcustom_options.length > 64) {
-            err_msg = 'S.M.A.R.T options must not exceed 64 characters.';
-            return false;
-        }
-        // By now we have valid characters that include "-d " and or "-T " and
-        // less than 64 of them (including spaces) - the max db field length.
-        // Move to repeat and semantic checks
-        //
-        // Check for only one instance of "-d ".
-        var first_d_option =  smartcustom_options.indexOf("-d ")
-        if (first_d_option != -1 && smartcustom_options.lastIndexOf("-d") != first_d_option) {
-            err_msg = 'Only one occurrence of the -d switch is permitted.';
-            return false;
-        }
-        // Note that multiple instances of -T are valid.
-        // Validate each option.
-        // Find elements of given options via split by space.
-        var option_array = smartcustom_options.split(" ");
-        if ((option_array[0] != "-d") && (option_array[0] != "-T")) {
-            err_msg = 'Please begin with either \'-d \' or \'-T \'';
-            return false;
-        }
-        // true if option is Device switch "-d"
-        function isDevSwitch(option) {
-            return (option == "-d");
-        }
-        // true if option is Tolerance switch ie "-T"
-        function isToleranceSwitch(option) {
-            return (option == "-T");
-        }
-        // true if not recognized as a dev option (non Raid)
-        function isNotDevOption(option) {
-            return (devOptions.indexOf(option) == -1);
-        }
-        // true if not recognized as a type option
-        function isNotToleranceOption(option) {
-            return (toleranceOptions.indexOf(option) == -1);
-        }
-        // true if not recognized as a RAID option
-        // Consider improving to use string.match(regexp) to match whole option.
-        // Currently only validates pre ',' in for example 3ware,5
-        function isNotRaidOption(option) {
-            var without_values = option.substring(0, option.indexOf(","));
-            return (devOptionsRaid.indexOf(without_values) == -1);
-        }
-        // true if not recognized as a RAID target device
-        function isNotRaidTarget(option) {
-            // assumed not a raid controller target until found otherwise
-            target_found = false;
-            // for (var pattern of raidTargetRegExp) { // possible js version ?
-            for (index = 0; index < raidTargetRegExp.length; index++) {
-                var pattern = raidTargetRegExp[index]; // more compatible.
-                if (pattern.test(option) == true) {
-                    target_found = true;
-                    // match found so look no further.
-                    break;
-                }
-            }
-            return !target_found
-        }
-        // rogue spaces are empty array elements after split so test for them
-        function  isRogueSpace(option) {
-            return (option.toString() == "");
-        }
-        // test for any rogue spaces
-        if (option_array.filter(isRogueSpace).length != 0) {
-            err_msg = 'One or more rouge spaces found, please re-check input';
-            return false;
-        }
-        // Categorize all entered options individually, forEach is order safe.
-        var dev_options_found = [];
-        var tol_options_found = [];
-        var unknown_options_found = [];
-        var option_type = '';
-        var unknown_switches_found = [];
-        var dev_switch_found = false;
-        var tol_switch_found = false;
-        option_array.forEach(function(option) {
-            // filter our various options before assessing them as valid.
-            if (option.charAt(0) == "-") { // option is a switch
-                if (isDevSwitch(option)) {
-                    option_type = "dev";
-                    dev_switch_found = true;
-                } else if (isToleranceSwitch(option)) {
-                    option_type = "tol";
-                    tol_switch_found = true;
-                } else { // unknown switch
-                    option_type = "unknown";
-                    unknown_switches_found.push(option);
-                }
-            } else if (option_type == "dev") {
-                // collect all options proceeded by a -d option
-                dev_options_found.push(option);
-            } else if (option_type == "tol") {
-                // collect all options proceeded by a -T option
-                tol_options_found.push(option);
-            } else {
-                // collect all other options proceeded by an unknown switch.
-                unknown_options_found.push(option);
-            }
-        });
-        // Report any unknown switches.
-        if (unknown_switches_found != "" ) {
-            err_msg = 'One or more unknown switches found: \'' + unknown_switches_found.toString() + '\', supported switches are \'-d\' and \'-T\'';
-            return false;
-        }
-        // Report any options of unknown type.
-        // Note this should never trigger as the last unknown_switches_found
-        // should trigger first. We have a later one to catch unknown options
-        // after known triggers.
-        if (unknown_options_found != "") {
-            err_msg = 'The following options of an unknown type were entered:' +
-                ' \'' + unknown_options_found.toString() + '\', supported ' +
-                'options are ' + devOptions.toString() + '\n' +
-                devOptionsRaid.toString() + toleranceOptions.toString();
-            return false;
-        }
-        // Filter out unknown options on known switches ie "-d notanoption"
-        // Filter our dev options first by absolute known / allowed options
-        // filter the resulting array by the less strict known raid options
-        var unknown_dev_options_found = dev_options_found.filter(isNotDevOption).filter(isNotRaidOption).filter(isNotRaidTarget);
-        if (unknown_dev_options_found != "") {
-            err_msg = 'The following unknown \'-d\' options were found \'' +
-                unknown_dev_options_found.toString() + '\'';
-            return false;
-        }
-        // Filter out unknown Tolerance options
-        var unknown_tol_options_found = tol_options_found.filter(isNotToleranceOption);
-        if (unknown_tol_options_found != "") {
-            err_msg = 'The following unknown \'-T\' options were found \'' +
-                unknown_tol_options_found.toString() + '\'. Available options' +
-                ' are ' + toleranceOptions.toString();
-            return false;
-        }
-        // Check we have at least one Tolerance option
-        if (tol_switch_found && tol_options_found.length < 1){
-            // no Tolerance options found
-            err_msg = 'Tolerance switch \'-T\' found without valid options';
-            return false;
-        }
-        // Finally check if more than one -d option is given
-        if (dev_options_found.length > 1) {
-            // only legitimate -d option with 2 parameters is raid + raid target
-            if (dev_options_found.length == 2) {
-                if ((!isNotRaidOption(dev_options_found[0])) && (!isNotRaidTarget(dev_options_found[1]))) {
-                    // we have a raid option followed by a raid target dev
-                    return true
-                }
-            }
-            err_msg = 'Only one \'-d\' option is supported';
-            return false;
-        }
-        // not otherwise found to be invalid or valid so assume valid by now.
-        return true;
-    }, smartcustom_err_msg);
-
-    this.$('#add-smartcustom-disk-form').validate({
-      onfocusout: false,
-      onkeyup: false,
-      rules: {
-	  smartcustom_options: 'validateSmartCustom',
-      },
-
-      submitHandler: function() {
-	    var button = $('#smartcustom-disk');
-        if (buttonDisabled(button)) return false;
-        disableButton(button);
-        var submitmethod = 'POST';
-        var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
-        $.ajax({
-          url: posturl,
-          type: submitmethod,
-          dataType: 'json',
-          contentType: 'application/json',
-          data: JSON.stringify(_this.$('#add-smartcustom-disk-form').getJSON()),
-          success: function() {
-           enableButton(button);
-            _this.$('#add-smartcustom-disk-form :input').tooltip('hide');
-            app_router.navigate('disks', {trigger: true});
-          },
-          error: function(xhr, status, error) {
-            enableButton(button);
-          }
-        });
-
-        return false;
-      }
-    });
-  },
-
-  cancel: function(event) {
-    event.preventDefault();
-    this.$('#add-smartcustom-disk-form :input').tooltip('hide');
-    app_router.navigate('disks', {trigger: true});
-  }
 
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -26,48 +26,52 @@
 
 SmartcustomDiskView = RockstorLayoutView.extend({
     events: {
-	'click #cancel': 'cancel'
+        'click #cancel': 'cancel'
     },
 
-    initialize: function() {
-	this.constructor.__super__.initialize.apply(this, arguments);
-	this.template = window.JST.disk_smartcustom_disks;
-	this.disks = new DiskCollection();
-	this.diskName = this.options.diskName;
-	this.dependencies.push(this.disks);
+    initialize: function () {
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.template = window.JST.disk_smartcustom_disks;
+        this.disks = new DiskCollection();
+        this.diskName = this.options.diskName;
+        this.dependencies.push(this.disks);
     },
 
-    render: function() {
-	this.fetch(this.renderDisksForm, this);
-	return this;
+    render: function () {
+        this.fetch(this.renderDisksForm, this);
+        return this;
     },
 
-    renderDisksForm: function() {
-	if (this.$('[rel=tooltip]')) {
-	    this.$("[rel=tooltip]").tooltip('hide');
-	}
-	var _this = this;
-	var disk_name = this.diskName;
-	var serialNumber = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('serial');
-	var currentSmartCustom = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('smart_options');
+    renderDisksForm: function () {
+        if (this.$('[rel=tooltip]')) {
+            this.$("[rel=tooltip]").tooltip('hide');
+        }
+        var _this = this;
+        var disk_name = this.diskName;
+        var serialNumber = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('serial');
+        var currentSmartCustom = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('smart_options');
 
-	$(this.el).html(this.template({
-	    diskName: this.diskName,
-	    serialNumber: serialNumber,
-	    currentSmartCustom: currentSmartCustom
-	}));
+        $(this.el).html(this.template({
+            diskName: this.diskName,
+            serialNumber: serialNumber,
+            currentSmartCustom: currentSmartCustom
+        }));
 
-	this.$('#add-smartcustom-disk-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
+        this.$('#add-smartcustom-disk-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
 
-	var err_msg = '';
-	var smartcustom_err_msg = function() {
+        var err_msg = '';
+        var smartcustom_err_msg = function () {
             return err_msg;
-	};
+        };
 
-	$.validator.addMethod('validateSmartCustom', function(value) {
+        $.validator.addMethod('validateSmartCustom', function (value) {
             var smartcustom_options = $('#smartcustom_options').val().trim();
             var devOptions = ["auto", "test", "ata", "scsi", "sat", "sat,12", "sat,16", "sat,auto", "usbprolific", "usbjmicron", "usbjmicron,0", "usbjmicron,p", "usbjmicron,x", "usbjmicron,x,1", "usbcypress", "usbsunplus"];
             var devOptionsRaid = ["3ware", "areca", "hpt", "cciss", "megaraid", "aacraid"];
@@ -80,216 +84,219 @@ SmartcustomDiskView = RockstorLayoutView.extend({
             var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/];
             // Initial cascade of syntactic checks.
             if (smartcustom_options.length == 0) {
-		// allow zero length (empty) entry to remove existing options
-		return true;
+                // allow zero length (empty) entry to remove existing options
+                return true;
+            }
+            if (/^[A-Za-z0-9,-/ ]+$/.test(smartcustom_options) == false) {
+                err_msg = 'Invalid character found, expecting only letters, numbers, and \'-\',\'/\' and \'space.\'';
+                return false;
+            }
+            if ((!smartcustom_options.includes("-d ")) && (!smartcustom_options.includes("-T "))) {
+                err_msg = 'Must contain either -d or -T options or both.';
+                return false;
+            }
+            if (smartcustom_options.length > 64) {
+                err_msg = 'S.M.A.R.T options must not exceed 64 characters.';
+                return false;
+            }
+            // By now we have valid characters that include "-d " and or "-T " and
+            // less than 64 of them (including spaces) - the max db field length.
+            // Move to repeat and semantic checks
+            //
+            // Check for only one instance of "-d ".
+            var first_d_option = smartcustom_options.indexOf("-d ");
+            if (first_d_option != -1 && smartcustom_options.lastIndexOf("-d") != first_d_option) {
+                err_msg = 'Only one occurrence of the -d switch is permitted.';
+                return false;
+            }
+            // Note that multiple instances of -T are valid.
+            // Validate each option.
+            // Find elements of given options via split by space.
+            var option_array = smartcustom_options.split(" ");
+            if ((option_array[0] != "-d") && (option_array[0] != "-T")) {
+                err_msg = 'Please begin with either \'-d \' or \'-T \'';
+                return false;
+            }
+            // true if option is Device switch "-d"
+            function isDevSwitch(option) {
+                return (option == "-d");
             }
 
-	    if (/^[A-Za-z0-9,-/ ]+$/.test(smartcustom_options) == false) {
-		err_msg = 'Invalid character found, expecting only letters, numbers, and \'-\',\'/\' and \'space.\'';
-		return false;
+            // true if option is Tolerance switch ie "-T"
+            function isToleranceSwitch(option) {
+                return (option == "-T");
             }
 
-	    if((!smartcustom_options.includes("-d ")) && (!smartcustom_options.includes("-T "))){
-		err_msg = 'Must contain either -d or -T options or both.';
-		return false;
-	    }
+            // true if not recognized as a dev option (non Raid)
+            function isNotDevOption(option) {
+                return (devOptions.indexOf(option) == -1);
+            }
 
-	    if(smartcustom_options.length > 64) {
-		err_msg = 'S.M.A.R.T options must not exceed 64 characters.';
-		return false;
-	    }
+            // true if not recognized as a type option
+            function isNotToleranceOption(option) {
+                return (toleranceOptions.indexOf(option) == -1);
+            }
 
-	    // By now we have valid characters that include "-d " and or "-T " and
-	    // less than 64 of them (including spaces) - the max db field length.
-	    // Move to repeat and semantic checks
-	    //
-	    // Check for only one instance of "-d ".
-	    var first_d_option =  smartcustom_options.indexOf("-d ");
-	    if (first_d_option != -1 && smartcustom_options.lastIndexOf("-d") != first_d_option) {
-		err_msg = 'Only one occurrence of the -d switch is permitted.';
-		return false;
-	    }
+            // true if not recognized as a RAID option
+            // Consider improving to use string.match(regexp) to match whole option.
+            // Currently only validates pre ',' in for example 3ware,5
+            function isNotRaidOption(option) {
+                var without_values = option.substring(0, option.indexOf(","));
+                return (devOptionsRaid.indexOf(without_values) == -1);
+            }
 
-	    // Note that multiple instances of -T are valid.
-	    // Validate each option.
-	    // Find elements of given options via split by space.
-	    var option_array = smartcustom_options.split(" ");
-	    if ((option_array[0] != "-d") && (option_array[0] != "-T")) {
-		err_msg = 'Please begin with either \'-d \' or \'-T \'';
-		return false;
-	    }
-	    // true if option is Device switch "-d"
-	    function isDevSwitch(option) {
-		return (option == "-d");
-	    }
-	    // true if option is Tolerance switch ie "-T"
-	    function isToleranceSwitch(option) {
-		return (option == "-T");
-	    }
-	    // true if not recognized as a dev option (non Raid)
-	    function isNotDevOption(option) {
-		return (devOptions.indexOf(option) == -1);
-	    }
-	    // true if not recognized as a type option
-	    function isNotToleranceOption(option) {
-		return (toleranceOptions.indexOf(option) == -1);
-	    }
-	    // true if not recognized as a RAID option
-	    // Consider improving to use string.match(regexp) to match whole option.
-	    // Currently only validates pre ',' in for example 3ware,5
-	    function isNotRaidOption(option) {
-		var without_values = option.substring(0, option.indexOf(","));
-		return (devOptionsRaid.indexOf(without_values) == -1);
-	    }
-	    // true if not recognized as a RAID target device
-	    function isNotRaidTarget(option) {
-		// assumed not a raid controller target until found otherwise
-		target_found = false;
-		// for (var pattern of raidTargetRegExp) { // possible js version ?
-		for (index = 0; index < raidTargetRegExp.length; index++) {
-		    var pattern = raidTargetRegExp[index]; // more compatible.
-		    if (pattern.test(option) == true) {
-			target_found = true;
-			// match found so look no further.
-			break;
-		    }
-		}
-		return !target_found;
-	    }
-	    // rogue spaces are empty array elements after split so test for them
-	    function  isRogueSpace(option) {
-		return (option.toString() == "");
-	    }
-	    // test for any rogue spaces
-	    if (option_array.filter(isRogueSpace).length != 0) {
-		err_msg = 'One or more rouge spaces found, please re-check input';
-		return false;
-	    }
-	    // Categorize all entered options individually, forEach is order safe.
-	    var dev_options_found = [];
-	    var tol_options_found = [];
-	    var unknown_options_found = [];
-	    var option_type = '';
-	    var unknown_switches_found = [];
-	    var dev_switch_found = false;
-	    var tol_switch_found = false;
-	    option_array.forEach(function(option) {
-		// filter our various options before assessing them as valid.
-		if (option.charAt(0) == "-") { // option is a switch
-		    if (isDevSwitch(option)) {
-			option_type = "dev";
-			dev_switch_found = true;
-		    } else if (isToleranceSwitch(option)) {
-			option_type = "tol";
-			tol_switch_found = true;
-		    } else { // unknown switch
-			option_type = "unknown";
-			unknown_switches_found.push(option);
-		    }
-		} else if (option_type == "dev") {
-		    // collect all options proceeded by a -d option
-		    dev_options_found.push(option);
-		} else if (option_type == "tol") {
-		    // collect all options proceeded by a -T option
-		    tol_options_found.push(option);
-		} else {
-		    // collect all other options proceeded by an unknown switch.
-		    unknown_options_found.push(option);
-		}
-	    });
-	    // Report any unknown switches.
-	    if (unknown_switches_found != "" ) {
-		err_msg = 'One or more unknown switches found: \'' + unknown_switches_found.toString() + '\', supported switches are \'-d\' and \'-T\'';
-		return false;
-	    }
-	    // Report any options of unknown type.
-	    // Note this should never trigger as the last unknown_switches_found
-	    // should trigger first. We have a later one to catch unknown options
-	    // after known triggers.
-	    if (unknown_options_found != "") {
-		err_msg = 'The following options of an unknown type were entered:' +
-		    ' \'' + unknown_options_found.toString() + '\', supported ' +
-		    'options are ' + devOptions.toString() + '\n' +
-		    devOptionsRaid.toString() + toleranceOptions.toString();
-		return false;
-	    }
-	    // Filter out unknown options on known switches ie "-d notanoption"
-	    // Filter our dev options first by absolute known / allowed options
-	    // filter the resulting array by the less strict known raid options
-	    var unknown_dev_options_found = dev_options_found.filter(isNotDevOption).filter(isNotRaidOption).filter(isNotRaidTarget);
-	    if (unknown_dev_options_found != "") {
-		err_msg = 'The following unknown \'-d\' options were found \'' +
-		    unknown_dev_options_found.toString() + '\'';
-		return false;
-	    }
-	    // Filter out unknown Tolerance options
-	    var unknown_tol_options_found = tol_options_found.filter(isNotToleranceOption);
-	    if (unknown_tol_options_found != "") {
-		err_msg = 'The following unknown \'-T\' options were found \'' +
-		    unknown_tol_options_found.toString() + '\'. Available options' +
-		    ' are ' + toleranceOptions.toString();
-		return false;
-	    }
-	    // Check we have at least one Tolerance option
-	    if (tol_switch_found && tol_options_found.length < 1){
-		// no Tolerance options found
-		err_msg = 'Tolerance switch \'-T\' found without valid options';
-		return false;
-	    }
-	    // Finally check if more than one -d option is given
-	    if (dev_options_found.length > 1) {
-		// only legitimate -d option with 2 parameters is raid + raid target
-		if (dev_options_found.length == 2) {
-		    if ((!isNotRaidOption(dev_options_found[0])) && (!isNotRaidTarget(dev_options_found[1]))) {
-			// we have a raid option followed by a raid target dev
-			return true
-		    }
-		}
-		err_msg = 'Only one \'-d\' option is supported';
-		return false;
-	    }
-	    // not otherwise found to be invalid or valid so assume valid by now.
-	    return true;
-	}, smartcustom_err_msg);
+            // true if not recognized as a RAID target device
+            function isNotRaidTarget(option) {
+                // assumed not a raid controller target until found otherwise
+                target_found = false;
+                // for (var pattern of raidTargetRegExp) { // possible js version ?
+                for (index = 0; index < raidTargetRegExp.length; index++) {
+                    var pattern = raidTargetRegExp[index]; // more compatible.
+                    if (pattern.test(option) == true) {
+                        target_found = true;
+                        // match found so look no further.
+                        break;
+                    }
+                }
+                return !target_found;
+            }
 
-	this.$('#add-smartcustom-disk-form').validate({
-	    onfocusout: false,
-	    onkeyup: false,
-	    rules: {
-		smartcustom_options: 'validateSmartCustom',
-	    },
+            // rogue spaces are empty array elements after split so test for them
+            function isRogueSpace(option) {
+                return (option.toString() == "");
+            }
 
-	    submitHandler: function() {
-		var button = $('#smartcustom-disk');
-		if (buttonDisabled(button)) return false;
-		disableButton(button);
-		var submitmethod = 'POST';
-		var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
-		$.ajax({
-		    url: posturl,
-		    type: submitmethod,
-		    dataType: 'json',
-		    contentType: 'application/json',
-		    data: JSON.stringify(_this.$('#add-smartcustom-disk-form').getJSON()),
-		    success: function() {
-			enableButton(button);
-			_this.$('#add-smartcustom-disk-form :input').tooltip('hide');
-			app_router.navigate('disks', {trigger: true});
-		    },
-		    error: function(xhr, status, error) {
-			enableButton(button);
-		    }
-		});
+            // test for any rogue spaces
+            if (option_array.filter(isRogueSpace).length != 0) {
+                err_msg = 'One or more rouge spaces found, please re-check input';
+                return false;
+            }
+            // Categorize all entered options individually, forEach is order safe.
+            var dev_options_found = [];
+            var tol_options_found = [];
+            var unknown_options_found = [];
+            var option_type = '';
+            var unknown_switches_found = [];
+            var dev_switch_found = false;
+            var tol_switch_found = false;
+            option_array.forEach(function (option) {
+                // filter our various options before assessing them as valid.
+                if (option.charAt(0) == "-") { // option is a switch
+                    if (isDevSwitch(option)) {
+                        option_type = "dev";
+                        dev_switch_found = true;
+                    } else if (isToleranceSwitch(option)) {
+                        option_type = "tol";
+                        tol_switch_found = true;
+                    } else { // unknown switch
+                        option_type = "unknown";
+                        unknown_switches_found.push(option);
+                    }
+                } else if (option_type == "dev") {
+                    // collect all options proceeded by a -d option
+                    dev_options_found.push(option);
+                } else if (option_type == "tol") {
+                    // collect all options proceeded by a -T option
+                    tol_options_found.push(option);
+                } else {
+                    // collect all other options proceeded by an unknown switch.
+                    unknown_options_found.push(option);
+                }
+            });
+            // Report any unknown switches.
+            if (unknown_switches_found != "") {
+                err_msg = 'One or more unknown switches found: \'' + unknown_switches_found.toString() + '\', supported switches are \'-d\' and \'-T\'';
+                return false;
+            }
+            // Report any options of unknown type.
+            // Note this should never trigger as the last unknown_switches_found
+            // should trigger first. We have a later one to catch unknown options
+            // after known triggers.
+            if (unknown_options_found != "") {
+                err_msg = 'The following options of an unknown type were entered:' +
+                    ' \'' + unknown_options_found.toString() + '\', supported ' +
+                    'options are ' + devOptions.toString() + '\n' +
+                    devOptionsRaid.toString() + toleranceOptions.toString();
+                return false;
+            }
+            // Filter out unknown options on known switches ie "-d notanoption"
+            // Filter our dev options first by absolute known / allowed options
+            // filter the resulting array by the less strict known raid options
+            var unknown_dev_options_found = dev_options_found.filter(isNotDevOption).filter(isNotRaidOption).filter(isNotRaidTarget);
+            if (unknown_dev_options_found != "") {
+                err_msg = 'The following unknown \'-d\' options were found \'' +
+                    unknown_dev_options_found.toString() + '\'';
+                return false;
+            }
+            // Filter out unknown Tolerance options
+            var unknown_tol_options_found = tol_options_found.filter(isNotToleranceOption);
+            if (unknown_tol_options_found != "") {
+                err_msg = 'The following unknown \'-T\' options were found \'' +
+                    unknown_tol_options_found.toString() + '\'. Available options' +
+                    ' are ' + toleranceOptions.toString();
+                return false;
+            }
+            // Check we have at least one Tolerance option
+            if (tol_switch_found && tol_options_found.length < 1) {
+                // no Tolerance options found
+                err_msg = 'Tolerance switch \'-T\' found without valid options';
+                return false;
+            }
+            // Finally check if more than one -d option is given
+            if (dev_options_found.length > 1) {
+                // only legitimate -d option with 2 parameters is raid + raid target
+                if (dev_options_found.length == 2) {
+                    if ((!isNotRaidOption(dev_options_found[0])) && (!isNotRaidTarget(dev_options_found[1]))) {
+                        // we have a raid option followed by a raid target dev
+                        return true
+                    }
+                }
+                err_msg = 'Only one \'-d\' option is supported';
+                return false;
+            }
+            // not otherwise found to be invalid or valid so assume valid by now.
+            return true;
+        }, smartcustom_err_msg);
 
-		return false;
-	    }
-	});
+        this.$('#add-smartcustom-disk-form').validate({
+            onfocusout: false,
+            onkeyup: false,
+            rules: {
+                smartcustom_options: 'validateSmartCustom',
+            },
+
+            submitHandler: function () {
+                var button = $('#smartcustom-disk');
+                if (buttonDisabled(button)) return false;
+                disableButton(button);
+                var submitmethod = 'POST';
+                var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
+                $.ajax({
+                    url: posturl,
+                    type: submitmethod,
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    data: JSON.stringify(_this.$('#add-smartcustom-disk-form').getJSON()),
+                    success: function () {
+                        enableButton(button);
+                        _this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+                        app_router.navigate('disks', {trigger: true});
+                    },
+
+                    error: function (xhr, status, error) {
+                        enableButton(button);
+                    }
+                });
+
+                return false;
+            }
+        });
     },
 
-    cancel: function(event) {
-	event.preventDefault();
-	this.$('#add-smartcustom-disk-form :input').tooltip('hide');
-	app_router.navigate('disks', {trigger: true});
+    cancel: function (event) {
+        event.preventDefault();
+        this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+        app_router.navigate('disks', {trigger: true});
     }
 
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -1,0 +1,293 @@
+/*
+ *
+ * @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+
+SmartcustomDiskView = RockstorLayoutView.extend({
+  events: {
+    'click #cancel': 'cancel'
+  },
+
+  initialize: function() {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    this.template = window.JST.disk_smartcustom_disks;
+    this.disks = new DiskCollection();
+    this.diskName = this.options.diskName;
+    this.dependencies.push(this.disks);
+  },
+
+ render: function() {
+    this.fetch(this.renderDisksForm, this);
+    return this;
+  },
+
+  renderDisksForm: function() {
+    if (this.$('[rel=tooltip]')) {
+      this.$("[rel=tooltip]").tooltip('hide');
+    }
+    var _this = this;
+    var disk_name = this.diskName;
+    var serialNumber = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('serial');
+    var currentSmartCustom = this.disks.find(function(d){ return (d.get('name') == disk_name);}).get('smart_options');
+
+    $(this.el).html(this.template({
+	diskName: this.diskName,
+	serialNumber: serialNumber,
+    currentSmartCustom: currentSmartCustom
+    }));
+
+    this.$('#add-smartcustom-disk-form :input').tooltip({
+      html: true,
+      placement: 'right'
+    });
+
+    var err_msg = '';
+      var smartcustom_err_msg = function() {
+          return err_msg;
+      }
+
+    $.validator.addMethod('validateSmartCustom', function(value) {
+        var smartcustom_options = $('#smartcustom_options').val().trim();
+        var devOptions = ["auto", "test", "ata", "scsi", "sat", "sat,12", "sat,16", "sat,auto", "usbprolific", "usbjmicron", "usbjmicron,0", "usbjmicron,p", "usbjmicron,x", "usbjmicron,x,1", "usbcypress", "usbsunplus"];
+        var devOptionsRaid = ["3ware", "areca", "hpt", "cciss", "megaraid", "aacraid"];
+        var toleranceOptions = ["normal", "conservative", "permissive", "verypermissive"];
+        // RegExp patters for the following RAID target devices:
+        // 3ware /dev/twe, /dev/twa, /dev/twl followed by 0-15
+        // Areca sata /dev/sg[2-9] but for hpahcisr and hpsa drivers /dev/sg[0-9]* (lsscsi -g to help)
+        // so we still have an issue there.
+        // HP Smart array with cciss driver uses /dev/cciss/c[0-9]d0
+        var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/];
+        // Initial cascade of syntactic checks.
+        if (smartcustom_options.length == 0) {
+            // allow zero length (empty) entry to remove existing options
+            return true;
+        }
+        else
+            if (/^[A-Za-z0-9,-/ ]+$/.test(smartcustom_options) == false) {
+			    err_msg = 'Invalid character found, expecting only letters, numbers, and \'-\',\'/\' and \'space.\'';
+			    return false;
+        }
+        else
+            if((!smartcustom_options.includes("-d ")) && (!smartcustom_options.includes("-T "))){
+                err_msg = 'Must contain either -d or -T options or both.';
+                return false;
+            }
+        else
+            if(smartcustom_options.length > 64) {
+            err_msg = 'S.M.A.R.T options must not exceed 64 characters.';
+            return false;
+        }
+        // By now we have valid characters that include "-d " and or "-T " and
+        // less than 64 of them (including spaces) - the max db field length.
+        // Move to repeat and semantic checks
+        //
+        // Check for only one instance of "-d ".
+        var first_d_option =  smartcustom_options.indexOf("-d ")
+        if (first_d_option != -1 && smartcustom_options.lastIndexOf("-d") != first_d_option) {
+            err_msg = 'Only one occurrence of the -d switch is permitted.';
+            return false;
+        }
+        // Note that multiple instances of -T are valid.
+        // Validate each option.
+        // Find elements of given options via split by space.
+        var option_array = smartcustom_options.split(" ");
+        if ((option_array[0] != "-d") && (option_array[0] != "-T")) {
+            err_msg = 'Please begin with either \'-d \' or \'-T \'';
+            return false;
+        }
+        // true if option is Device switch "-d"
+        function isDevSwitch(option) {
+            return (option == "-d");
+        }
+        // true if option is Tolerance switch ie "-T"
+        function isToleranceSwitch(option) {
+            return (option == "-T");
+        }
+        // true if not recognized as a dev option (non Raid)
+        function isNotDevOption(option) {
+            return (devOptions.indexOf(option) == -1);
+        }
+        // true if not recognized as a type option
+        function isNotToleranceOption(option) {
+            return (toleranceOptions.indexOf(option) == -1);
+        }
+        // true if not recognized as a RAID option
+        // Consider improving to use string.match(regexp) to match whole option.
+        // Currently only validates pre ',' in for example 3ware,5
+        function isNotRaidOption(option) {
+            var without_values = option.substring(0, option.indexOf(","));
+            return (devOptionsRaid.indexOf(without_values) == -1);
+        }
+        // true if not recognized as a RAID target device
+        function isNotRaidTarget(option) {
+            // assumed not a raid controller target until found otherwise
+            target_found = false;
+            // for (var pattern of raidTargetRegExp) { // possible js version ?
+            for (index = 0; index < raidTargetRegExp.length; index++) {
+                var pattern = raidTargetRegExp[index]; // more compatible.
+                if (pattern.test(option) == true) {
+                    target_found = true;
+                    // match found so look no further.
+                    break;
+                }
+            }
+            return !target_found
+        }
+        // rogue spaces are empty array elements after split so test for them
+        function  isRogueSpace(option) {
+            return (option.toString() == "");
+        }
+        // test for any rogue spaces
+        if (option_array.filter(isRogueSpace).length != 0) {
+            err_msg = 'One or more rouge spaces found, please re-check input';
+            return false;
+        }
+        // Categorize all entered options individually, forEach is order safe.
+        var dev_options_found = [];
+        var tol_options_found = [];
+        var unknown_options_found = [];
+        var option_type = '';
+        var unknown_switches_found = [];
+        var dev_switch_found = false;
+        var tol_switch_found = false;
+        option_array.forEach(function(option) {
+            // filter our various options before assessing them as valid.
+            if (option.charAt(0) == "-") { // option is a switch
+                if (isDevSwitch(option)) {
+                    option_type = "dev";
+                    dev_switch_found = true;
+                } else if (isToleranceSwitch(option)) {
+                    option_type = "tol";
+                    tol_switch_found = true;
+                } else { // unknown switch
+                    option_type = "unknown";
+                    unknown_switches_found.push(option);
+                }
+            } else if (option_type == "dev") {
+                // collect all options proceeded by a -d option
+                dev_options_found.push(option);
+            } else if (option_type == "tol") {
+                // collect all options proceeded by a -T option
+                tol_options_found.push(option);
+            } else {
+                // collect all other options proceeded by an unknown switch.
+                unknown_options_found.push(option);
+            }
+        });
+        // Report any unknown switches.
+        if (unknown_switches_found != "" ) {
+            err_msg = 'One or more unknown switches found: \'' + unknown_switches_found.toString() + '\', supported switches are \'-d\' and \'-T\'';
+            return false;
+        }
+        // Report any options of unknown type.
+        // Note this should never trigger as the last unknown_switches_found
+        // should trigger first. We have a later one to catch unknown options
+        // after known triggers.
+        if (unknown_options_found != "") {
+            err_msg = 'The following options of an unknown type were entered:' +
+                ' \'' + unknown_options_found.toString() + '\', supported ' +
+                'options are ' + devOptions.toString() + '\n' +
+                devOptionsRaid.toString() + toleranceOptions.toString();
+            return false;
+        }
+        // Filter out unknown options on known switches ie "-d notanoption"
+        // Filter our dev options first by absolute known / allowed options
+        // filter the resulting array by the less strict known raid options
+        var unknown_dev_options_found = dev_options_found.filter(isNotDevOption).filter(isNotRaidOption).filter(isNotRaidTarget);
+        if (unknown_dev_options_found != "") {
+            err_msg = 'The following unknown \'-d\' options were found \'' +
+                unknown_dev_options_found.toString() + '\'';
+            return false;
+        }
+        // Filter out unknown Tolerance options
+        var unknown_tol_options_found = tol_options_found.filter(isNotToleranceOption);
+        if (unknown_tol_options_found != "") {
+            err_msg = 'The following unknown \'-T\' options were found \'' +
+                unknown_tol_options_found.toString() + '\'. Available options' +
+                ' are ' + toleranceOptions.toString();
+            return false;
+        }
+        // Check we have at least one Tolerance option
+        if (tol_switch_found && tol_options_found.length < 1){
+            // no Tolerance options found
+            err_msg = 'Tolerance switch \'-T\' found without valid options';
+            return false;
+        }
+        // Finally check if more than one -d option is given
+        if (dev_options_found.length > 1) {
+            // only legitimate -d option with 2 parameters is raid + raid target
+            if (dev_options_found.length == 2) {
+                if ((!isNotRaidOption(dev_options_found[0])) && (!isNotRaidTarget(dev_options_found[1]))) {
+                    // we have a raid option followed by a raid target dev
+                    return true
+                }
+            }
+            err_msg = 'Only one \'-d\' option is supported';
+            return false;
+        }
+        // not otherwise found to be invalid or valid so assume valid by now.
+        return true;
+    }, smartcustom_err_msg);
+
+    this.$('#add-smartcustom-disk-form').validate({
+      onfocusout: false,
+      onkeyup: false,
+      rules: {
+	  smartcustom_options: 'validateSmartCustom',
+      },
+
+      submitHandler: function() {
+	    var button = $('#smartcustom-disk');
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var submitmethod = 'POST';
+        var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
+        $.ajax({
+          url: posturl,
+          type: submitmethod,
+          dataType: 'json',
+          contentType: 'application/json',
+          data: JSON.stringify(_this.$('#add-smartcustom-disk-form').getJSON()),
+          success: function() {
+           enableButton(button);
+            _this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+            app_router.navigate('disks', {trigger: true});
+          },
+          error: function(xhr, status, error) {
+            enableButton(button);
+          }
+        });
+
+        return false;
+      }
+    });
+  },
+
+  cancel: function(event) {
+    event.preventDefault();
+    this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+    app_router.navigate('disks', {trigger: true});
+  }
+
+});

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -181,7 +181,8 @@ class DiskMixin(object):
                 # try to establish smart availability and status and update db
                 try:
                     # for non ata/sata drives
-                    do.smart_available, do.smart_enabled = smart.available(do.name)
+                    do.smart_available, do.smart_enabled = smart.available(
+                        do.name, do.smart_options)
                 except Exception, e:
                     logger.exception(e)
                     do.smart_available = do.smart_enabled = False
@@ -260,9 +261,12 @@ class DiskDetailView(rfc.GenericView):
                 return self._toggle_smart(dname, request, enable=True)
             if (command == 'disable-smart'):
                 return self._toggle_smart(dname, request)
+            if (command == 'smartcustom-drive'):
+                return self._smartcustom_drive(dname, request)
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
-                 ' btrfs-disk-import, blink-drive, enable-smart, disable-smart' % command)
+                 ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
+                 ' smartcustom-drive' % command)
         handle_exception(Exception(e_msg), request)
 
     @transaction.atomic
@@ -273,6 +277,18 @@ class DiskDetailView(rfc.GenericView):
         disk.btrfs_uuid = None
         disk.save()
         return Response(DiskInfoSerializer(disk).data)
+
+    @transaction.atomic
+    def _smartcustom_drive(self, dname, request):
+        disk = self._validate_disk(dname, request)
+        # todo Check on None, null, or '' for default in next command
+        custom_smart_options = str(
+            request.data.get('smartcustom_options', ''))
+        # strip leading and trailing white space chars before entry in db
+        disk.smart_options = custom_smart_options.strip()
+        disk.save()
+        return Response(DiskInfoSerializer(disk).data)
+
 
     @transaction.atomic
     def _btrfs_disk_import(self, dname, request):
@@ -310,7 +326,7 @@ class DiskDetailView(rfc.GenericView):
         if (not disk.smart_available):
             e_msg = ('S.M.A.R.T support is not available on this Disk(%s)' % dname)
             handle_exception(Exception(e_msg), request)
-        smart.toggle_smart(disk.name, enable)
+        smart.toggle_smart(disk.name, disk.smart_options, enable)
         disk.smart_enabled = enable
         disk.save()
         return Response(DiskInfoSerializer(disk).data)

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -66,11 +66,11 @@ class DiskSMARTDetailView(rfc.GenericView):
     @staticmethod
     @transaction.atomic
     def _info(disk):
-        attributes = extended_info(disk.name)
-        cap = capabilities(disk.name)
-        e_summary, e_lines = error_logs(disk.name)
-        smartid = info(disk.name)
-        test_d, log_lines = test_logs(disk.name)
+        attributes = extended_info(disk.name, disk.smart_options)
+        cap = capabilities(disk.name, disk.smart_options)
+        e_summary, e_lines = error_logs(disk.name, disk.smart_options)
+        smartid = info(disk.name, disk.smart_options)
+        test_d, log_lines = test_logs(disk.name, disk.smart_options)
         ts = datetime.utcnow().replace(tzinfo=utc)
         si = SMARTInfo(disk=disk, toc=ts)
         si.save()
@@ -131,7 +131,7 @@ class DiskSMARTDetailView(rfc.GenericView):
                     test_type = 'conveyance'
                 else:
                     raise Exception('Unsupported Self-Test: %s' % test_type)
-                run_test(disk.name, test_type)
+                run_test(disk.name, test_type, disk.smart_options)
                 return self._info(disk)
 
             e_msg = ('Unknown command: %s. Only valid commands are info and '

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -35,7 +35,7 @@ LSBLK = '/usr/bin/lsblk'
 TESTMODE = False
 
 
-def info(device, test_mode=TESTMODE):
+def info(device, custom_options='', test_mode=TESTMODE):
     """
     Retrieve matching properties found in smartctl -H --info output.
     Used to populate the Identity / general info tab by views/disk_smart.py
@@ -45,7 +45,7 @@ def info(device, test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '-H', '--info', '/dev/%s' % get_base_device(device)],
+            [SMART, '-H', '--info'] + get_dev_options(device, custom_options),
             throw=False)
     else:  # we are testing so use a smartctl -H --info file dump instead
         o, e, rc = run_command([CAT, '/root/smartdumps/smart-H--info.out'])
@@ -79,7 +79,7 @@ def info(device, test_mode=TESTMODE):
     return res
 
 
-def extended_info(device, test_mode=TESTMODE):
+def extended_info(device, custom_options='', test_mode=TESTMODE):
     """
     Retrieves a list of SMART attributes found from parsing smartctl -a output
     Mostly ATA / SATA as SCSI uses a free form syntax for this.
@@ -92,7 +92,8 @@ def extended_info(device, test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '-a', '/dev/%s' % get_base_device(device)], throw=False)
+            [SMART, '-a'] + get_dev_options(device, custom_options),
+            throw=False)
     else:  # we are testing so use a smartctl -a file dump instead
         o, e, rc = run_command([CAT, '/root/smartdumps/smart-a.out'])
     attributes = {}
@@ -111,7 +112,7 @@ def extended_info(device, test_mode=TESTMODE):
     return attributes
 
 
-def capabilities(device, test_mode=TESTMODE):
+def capabilities(device, custom_options='', test_mode=TESTMODE):
     """
     Retrieves a list of SMART capabilities found from parsing smartctl -c output
     ATA / SATA only.
@@ -124,7 +125,7 @@ def capabilities(device, test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '-c', '/dev/%s' % get_base_device(device)])
+            [SMART, '-c'] + get_dev_options(device, custom_options))
     else:  # we are testing so use a smartctl -c file dump instead
         o, e, rc = run_command([CAT, '/root/smartdumps/smart-c.out'])
     cap_d = {}
@@ -156,7 +157,7 @@ def capabilities(device, test_mode=TESTMODE):
     return cap_d
 
 
-def error_logs(device, test_mode=TESTMODE):
+def error_logs(device, custom_options='', test_mode=TESTMODE):
     """
     Retrieves a parsed list of SMART errors from the output of smartctl -l error
     May be empty if no errors, also returns a raw output of the error log itself
@@ -166,8 +167,8 @@ def error_logs(device, test_mode=TESTMODE):
     error number.
     :return: log_l: A list containing each line in turn of the error log.
     """
-    local_base_dev = get_base_device(device)
-    smart_command = [SMART, '-l', 'error', '/dev/%s' % local_base_dev]
+    local_base_dev = get_dev_options(device, custom_options)
+    smart_command = [SMART, '-l', 'error'] + local_base_dev
     if not test_mode:
         o, e, rc = run_command(smart_command, throw=False)
     else:
@@ -176,7 +177,7 @@ def error_logs(device, test_mode=TESTMODE):
     # examine what we have as return code (rc); 64 has been seen when the error
     # log contains errors but otherwise executes successfully so we catch this.
     overide_rc = 64
-    e_msg = 'Drive /dev/%s has logged S.M.A.R.T errors. Please view ' \
+    e_msg = 'Drive %s has logged S.M.A.R.T errors. Please view ' \
                  'the Error logs tab for this device.' % local_base_dev
     screen_return_codes(e_msg, overide_rc, o, e, rc, smart_command)
     ecode_map = {
@@ -227,7 +228,7 @@ def error_logs(device, test_mode=TESTMODE):
     return (summary, log_l)
 
 
-def test_logs(device, test_mode=TESTMODE):
+def test_logs(device, custom_options='', test_mode=TESTMODE):
     """
     Retrieves information from SMART Self-Test logs held by the drive.
     Creates a dictionary of previous test info, indexed by test number and a
@@ -236,8 +237,8 @@ def test_logs(device, test_mode=TESTMODE):
     :param test_mode: Not True causes cat from file rather than smartctl command
     :return: test_d as a dictionary of summarized test
     """
-    smart_command = [SMART, '-l', 'selftest', '-l', 'selective', '/dev/%s'
-                     % get_base_device(device)]
+    smart_command = [SMART, '-l', 'selftest', '-l',
+                     'selective'] + get_dev_options(device, custom_options)
     if not test_mode:
         o, e, rc = run_command(smart_command, throw=False)
     else:
@@ -292,12 +293,13 @@ def test_logs(device, test_mode=TESTMODE):
     return (test_d, log_l)
 
 
-def run_test(device, test):
+def run_test(device, test, custom_options=''):
     # start a smart test(short, long or conveyance)
-    return run_command([SMART, '-t', test, '/dev/%s' % get_base_device(device)])
+    return run_command(
+        [SMART, '-t', test] + get_dev_options(device, custom_options))
 
 
-def available(device, test_mode=TESTMODE):
+def available(device, custom_options='', test_mode=TESTMODE):
     """
     Returns boolean pair: true if SMART support is available on the device and
     true if SMART support is enabled.
@@ -307,7 +309,7 @@ def available(device, test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '--info', ('/dev/%s' % get_base_device(device))])
+            [SMART, '--info'] + get_dev_options(device, custom_options))
     else:  # we are testing so use a smartctl --info file dump instead
         o, e, rc = run_command([CAT, '/root/smartdumps/smart--info.out'])
     a = False
@@ -321,11 +323,12 @@ def available(device, test_mode=TESTMODE):
     return a, e
 
 
-def toggle_smart(device, enable=False):
+def toggle_smart(device, custom_options='', enable=False):
     switch = 'on' if (enable) else 'off'
     # enable SMART support of the device
     return run_command(
-        [SMART, '--smart=%s' % switch, '/dev/%s' % get_base_device(device)])
+        [SMART, '--smart=%s' % switch] + get_dev_options(device,
+                                                         custom_options))
 
 
 def update_config(config):
@@ -361,6 +364,7 @@ def screen_return_codes(msg_on_hit, return_code_target, o, e, rc, command):
     :param o: the output from the command when it was run
     :param e: the error from the command when it was run
     :param rc: the return code from running the command
+    :param command: the command that produced the previous o, e, and rc params.
     """
     # if our return code is our target then log with our message and email root
     # with the same.
@@ -377,24 +381,21 @@ def screen_return_codes(msg_on_hit, return_code_target, o, e, rc, command):
 
 def get_base_device(device, test_mode=TESTMODE):
     """
-    Helper function that returns the base device of a partition or if given
-    a base device then will return it as is;
+    Helper function that returns the full path of the base device of a partition
+    or if given a base device then will return it's full path,
     ie
-    input sda3 output sda
-    input sda output sda
+    input sda3 output /dev/sda
+    input sda output /dev/sda
     Works as a function of lsblk list order ie base devices first. So we return
     the first start of line match to our supplied device name with the pattern
     as the first element in lsblk's output and the match target as our device.
-    N.B. this function may well be a candidate to provide more advanced smart
-    device name mapping such as is required by some 3Ware raid controllers ie
-    to redirect smart commands from sd* to twl* device names. A live mapping
-    system will be required for this but could be incorporated here since we
-    are already translating at least partition names to their base dev names.
     :param device: device name as per db entry, ie as returned from scan_disks
-    :return: base_dev: the root device ie device = sda3 base_dev = sda or None
-    if no lsblk entry was found to match.
+    :param test_mode: Not True causes cat from file rather than smartctl command
+    :return: base_dev: single item list containing the root device's full path
+    ie device = sda3 the base_dev = /dev/sda or [''] if no lsblk entry was found
+    to match.
     """
-    base_dev = None
+    base_dev = ['', ]
     if not test_mode:
         out, e, rc = run_command([LSBLK])
     else:
@@ -407,7 +408,46 @@ def get_base_device(device, test_mode=TESTMODE):
             continue
         if re.match(line_fields[0], device):
             # We have found a device string match to our device so record it.
-            base_dev = line_fields[0]
+            base_dev[0] = '/dev/' + line_fields[0]
             break
-    # return base_dev ie None or first character matches to line start in lsblk
+    # Return base_dev ie [''] or first character matches to line start in lsblk.
     return base_dev
+
+
+def get_dev_options(device, custom_options=''):
+    """
+    Returns device specific options for all smartctl commands.
+    Note that in most cases this requires looking up the base device via
+    get_base_device but in some instances this is not required as in the case
+    of devices behind some raid controllers. If custom_options contains known
+    raid controller smartctl targets then these will be substituted for device
+    name.
+    :param device:  device name as per db entry, ie as returned from scan_disks
+    :param custom_options: string of user entered custom smart options.
+    :return: dev_options: list containing the device specific smart options and
+    the appropriate smart device target.
+    """
+    # Initially our custom_options parameter may be None, ie db default prior
+    # to any changes having been made. Deal with this by adding a guard.
+    if custom_options is None or custom_options == '':
+        # Empty custom_options or they have never been set so just return
+        # full path to base device as nothing else to do.
+        dev_options = get_base_device(device)
+    else:
+        # Convert string of custom options into a list ready for run_command
+        dev_options = custom_options.encode('ascii').split()
+        # If our custom options don't contain a raid controller target then add
+        # the full path to our base device as our last device specific option.
+        if (re.search('/dev/tw|/dev/cciss/c|/dev/sg', custom_options) is None):
+            # add full path to our custom options as we see no raid target dev
+            dev_options += get_base_device(device)
+    # Note on raid controller target devices.
+    # /dev/twe#, or /dev/twa#, or /dev/twl# are 3ware controller targets devs
+    # respectively 3x-xxxx, 3w-9xxx, and t2-sas (3ware/LSI 9750) drivers for
+    # respectively 6000, 7000, 8000 or 9000 or 3ware/LSI 9750 controllers.
+    # /dev/cciss/c0d0 is the first HP/Compaq Smart Array Controller using the
+    # deprecated cciss driver
+    # /dev/sg0 is the first hpsa or hpahcisr driver device for the same adapter.
+    # This same target device is also used by the Areca SATA RAID controller
+    # except that the first device is /dev/sg2.
+    return dev_options


### PR DESCRIPTION
Adds per disk custom S.M.A.R.T capabilities via simple specialized input page which includes links to upstream docs for smartmontools. All entered config is displayed on the Disks page and can be removed by submitting an empty entry in the same config page. The new config area is indicated as for advanced use only and a Disks page Rescan is required to apply the entered configuration; this allows for a before and after feedback; most often an update from "Not Supported" to the smart Switch appearing in the On state.

Of note this that this pr depends on the disk.smart_options db field added in pr #1166 in commit:
https://github.com/rockstor/rockstor-core/pull/1166/commits/cc7cfc1750cafa43b3a7c8192faa1bdce5c22f10

Custom per disk smartctl switches are limited (via input validation) to -d (device) and -T (tolerance) and an explanation is offered to inform the user that these are in addition to the usual internally used already -a --info etc switches.

Non rudimentary Input validation is included but not complete (especially in raid controller -d options and associated targets). The validation mechanism used is easily extensible to allow for future acceptance of as yet unknown options for these switches or if need be additional switches.

In the case of a raid -d option I have left the option to specify a specialized raid device target as optional. With disks behind some raid controllers the format of the smartctl command changes so that one changes the end device from for example the disk device (which of course may be a compound / raid device now) to the controller raid device. The raid -d option is then used to stipulate the port / wire that the disk of interest is attached to.
non raid syntax:
smartctl -a /dev/sda
raid syntax:
smartctl -a -d 3ware,0 /dev/twl0
This means the first raid controller /dev/twl0 and the first port/drive ie the ",0" bit.
This currently is a manual mapping but at least we now have the facility to accommodate this. The optional nature of adding this raid controller dev target is to allow for alternative controllers (some controllers don't use the alternative syntax) and to allow for diagnosing issues as the output from the two formats on controllers that support both is very different. Usually a great deal more info is available using the specialized syntax and very little using the non raid syntax.

Thanks to @kcomer on the forum for his assistance and testing of raid specific smartctl command syntax. 
https://forum.rockstor.com/t/s-m-a-r-t-support-is-not-available-for-this-disk/830/24?u=phillxnet

I have tested this patch set on several real and virtual machines and no regressions were found to other S.M.A.R.T function. (Rockstor versions from 3.8-11.20 to 3.8-12.03)

Included is a couple of minor fixes found while adding enhanced user feedback in the case of disabled or unavailable S.M.A.R.T info.

@schakrava Apologies in advance for:
1: my js code. :) (a little inconsistent but it does work and is commented and readable).
2: duplication of many commits in this pr (it's smaller than it looks on commit count). Bit of a git hiccup on my part I'm afraid.

This patch set builds on pr #1212 as it modifies and augments it's abstraction layer for device name preprocessing. But given #1212 has now been merged I am assuming this should not cause any problems.

Images to follow of UI changes.