### PR TITLE
Issue#1198 tooltip chop

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -179,6 +179,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
 	this.$('#nut-form #mode').tooltip({
 	    html: true,
 	    placement: 'right',
+	    container: 'body',
 	    title: "<strong>Nut Mode</strong> — Select the overall mode of Network UPS Tools operation. The drop-down list offers the following options:<br> \
 <ul>\
 <li><strong>Standalone</strong> — The most common and recommended mode if you have a locally connected UPS and don't wish for Rockstor to act as a NUT server to any other LAN connected machines.</li> \

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -285,7 +285,8 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
     showCompressionTooltips: function() {
 	this.$('#ph-compression-info #compression').tooltip({
 	    html: true,
-	    placement: 'bottom',
+	    placement: 'top',
+	    container: 'body',
 	    title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
 	});
 	this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -285,7 +285,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
     showCompressionTooltips: function() {
 	this.$('#ph-compression-info #compression').tooltip({
 	    html: true,
-	    placement: 'top',
+	    placement: 'bottom',
 	    title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
 	});
 	this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });


### PR DESCRIPTION
This PR solves the tooltip issue at 2 places:
a) Edit Compression Algorithm option under pool details page. 
b) Nut mode under NUT-UPS service Config

Explanation:
1) Add container = 'body' to the tooltip plugin. 
2) It appends the tooltip to the body element. 
3) Since Navbar is also under the body element, tooltip is displayed over it instead of getting chopped.