### PR TITLE
Disable Add storage button when Rock-on is ON. Fixes #1178

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -959,6 +959,15 @@ RockonSettingsWizardView = WizardView.extend({
 	    this.$('#next-page').html('Add Storage');
 	    if (!this.rockon.get('volume_add_support')) {
 		this.$('#next-page').hide();
+	    }else{
+	    	 if(this.rockon.get('status') == "started") { 
+	    		 var _this = this;
+	    		 this.$('#next-page').click(function(){
+	    			//disabling the button so that the backbone event is not triggered after the alert click.
+	    			 _this.$('#next-page').prop("disabled",true); 
+	    			 alert("Rock-on must be turned off to add storage.");
+	    		 });
+	    	}
 	    }
 	} else if (this.currentPageNum == (this.pages.length - 2)) {
 	    this.$('#prev-page').html('Add Storage');


### PR DESCRIPTION
Add a alert message that storage can be added to Rock-on only when it's
turned off and then disable the add storage button to prevent any other
events from triggering.