### PR TITLE
drive power down interface. Issue #885

### DIFF
--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -1,0 +1,9 @@
+Description=Rockstor hdparm settings
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=
+
+[Install]
+WantedBy=suspend.target basic.target

--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -1,9 +1,13 @@
+[Unit]
 Description=Rockstor hdparm settings
 After=suspend.target
+# Rockstor-hdparm - the automated maintenance of this file requires a clear line
+# at the end of the Unit and Service sections, but no other clear lines.
+# Also requires at least one ExecStart entry in Service section with a comment
+# directly after each ExecStart entry.
 
 [Service]
 Type=oneshot
-ExecStart=
 
 [Install]
 WantedBy=suspend.target basic.target

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -46,7 +46,6 @@ DEFAULT_MNT_DIR = '/mnt2/'
 RMDIR = '/bin/rmdir'
 WIPEFS = '/usr/sbin/wipefs'
 QID = '2015'
-HDPARM = '/usr/sbin/hdparm'
 
 
 Disk = collections.namedtuple('Disk',
@@ -1073,43 +1072,6 @@ def wipe_disk(disk):
     # todo candidate for move to system/osi as not btrfs related
     disk = ('/dev/%s' % disk)
     return run_command([WIPEFS, '-a', disk])
-
-
-def get_disk_power_status(disk):
-    """
-    When given a disk name such as that stored in the db ie sda
-    we return it's current power state via hdparm -C /dev/<disk>
-    Possible states are:
-    unknown - command not supported by disk
-    active/idle - normal operation
-    standby - low power mode, ie drive motor not active ie -y will do this
-    sleeping - lowest power mode, completely shut down ie -Y will do this
-    N.B. -C shouldn't spin up a drive in standby but has been reported to wake
-    a drive from sleeping but we aren't going to invoke sleeping as pretty much
-    any request will wake a fully sleeping drive.
-    Drives in 'sleeping' mode typically require a hard or soft reset before
-    becoming available for use, the kernel does this automatically however.
-    :param device: disk name as stored in db / Disk model.
-    :return: single word sting of state as indicated by hdparm -C /dev/<disk>
-    and if we encounter an error line in the output we return unknown.
-    """
-    # todo candidate for move to system/osi as not btrfs related
-    # if we use the -C -q switches then we have only one line of output:
-    # hdparm -C -q /dev/sda
-    # drive state is:  active/idle
-    # in some instances an error can be returned even with rc=0, we ignore this
-    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
-    # We may want to ignore / return unknown when len(err) != 1
-    out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % disk],
-                               throw=False)
-    # if len(err) != 1:
-    #     logger.debug('hdparm has output to standard error of %s', err)
-    if len(out) > 0:
-        fields = out[0].split()
-        # our line of interest has 4 fields when split by spaces, see above.
-        if (len(fields) == 4):
-            return fields[3]
-    return 'unknown'
 
 
 def blink_disk(disk, total_exec, read, sleep):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1085,26 +1085,26 @@ def get_disk_power_status(disk):
     any request will wake a fully sleeping drive.
     Drives in 'sleeping' mode typically require a hard or soft reset before
     becoming available for use, the kernel does this automatically however.
-    :param device: disk name eg sda.
+    :param device: disk name as stored in db / Disk model.
     :return: single word sting of state as indicated by hdparm -C /dev/<disk>
     and if we encounter an error line in the output we return unknown.
     """
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
-    # Note however that if there is an bad/missing sense data then it will be
-    # on the first line but then we can't trust what follows anyway then.
-    hdparm_command = [HDPARM, '-C', '-q' '/dev/%s' % disk]
-    # todo consider throw=False for production
-    out, err, rc = run_command(hdparm_command)
-    # should be only one line but trawl anyway.
-    # todo once tested loose the for loop.
-    for line in out:
-        fields = line.split()
-        # our line of interest as 4 fields when split by spaces, see above.
+    # in some instances an error can be returned even with rc=0, we ignore this
+    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
+    # We may want to ignore / return unknown when len(err) != 1
+    out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % disk],
+                               throw=False)
+    # if len(err) != 1:
+    #     logger.debug('hdparm has output to standard error of %s', err)
+    if len(out) > 0:
+        fields = out[0].split()
+        # our line of interest has 4 fields when split by spaces, see above.
         if (len(fields) == 4):
             return fields[3]
-    return 'Unknown'
+    return 'unknown'
 
 
 def blink_disk(disk, total_exec, read, sleep):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -46,6 +46,7 @@ DEFAULT_MNT_DIR = '/mnt2/'
 RMDIR = '/bin/rmdir'
 WIPEFS = '/usr/sbin/wipefs'
 QID = '2015'
+HDPARM = '/usr/sbin/hdparm'
 
 
 Disk = collections.namedtuple('Disk',
@@ -1079,9 +1080,31 @@ def get_disk_power_status(disk):
     active/idle - normal operation
     standby - low power mode, ie drive motor not active ie -y will do this
     sleeping - lowest power mode, completely shut down ie -Y will do this
-    :param device: disk name
+    N.B. -C shouldn't spin up a drive in standby but has been reported to wake
+    a drive from sleeping but we aren't going to invoke sleeping as pretty much
+    any request will wake a fully sleeping drive.
+    Drives in 'sleeping' mode typically require a hard or soft reset before
+    becoming available for use, the kernel does this automatically however.
+    :param device: disk name eg sda.
     :return: single word sting of state as indicated by hdparm -C /dev/<disk>
+    and if we encounter an error line in the output we return unknown.
     """
+    # if we use the -C -q switches then we have only one line of output:
+    # hdparm -C -q /dev/sda
+    # drive state is:  active/idle
+    # Note however that if there is an bad/missing sense data then it will be
+    # on the first line but then we can't trust what follows anyway then.
+    hdparm_command = [HDPARM, '-C', '-q' '/dev/%s' % disk]
+    # todo consider throw=False for production
+    out, err, rc = run_command(hdparm_command)
+    # should be only one line but trawl anyway.
+    # todo once tested loose the for loop.
+    for line in out:
+        fields = line.split()
+        # our line of interest as 4 fields when split by spaces, see above.
+        if (len(fields) == 4):
+            return fields[3]
+    return 'Unknown'
 
 
 def blink_disk(disk, total_exec, read, sleep):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1070,6 +1070,20 @@ def wipe_disk(disk):
     return run_command([WIPEFS, '-a', disk])
 
 
+def get_disk_power_status(disk):
+    """
+    When given a disk name such as that stored in the db ie sda
+    we return it's current power state via hdparm -C /dev/<disk>
+    Possible states are:
+    unknown - command not supported by disk
+    active/idle - normal operation
+    standby - low power mode, ie drive motor not active ie -y will do this
+    sleeping - lowest power mode, completely shut down ie -Y will do this
+    :param device: disk name
+    :return: single word sting of state as indicated by hdparm -C /dev/<disk>
+    """
+
+
 def blink_disk(disk, total_exec, read, sleep):
     DD_CMD = [DD, 'if=/dev/%s' % disk, 'of=/dev/null', 'bs=512',
               'conv=noerror']

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -581,6 +581,7 @@ def update_quota(pool, qgroup, size_bytes):
 
 
 def convert_to_KiB(size):
+    # todo candidate for move to system/osi as not btrfs related
     SMAP = {
         'KiB': 1,
         'MiB': 1024,
@@ -777,6 +778,7 @@ def root_disk():
     The assumption with non md devices is that the partition number will be a
     single character.
     """
+    # todo candidate for move to system/osi as not btrfs related
     with open('/proc/mounts') as fo:
         for line in fo.readlines():
             fields = line.split()
@@ -819,6 +821,7 @@ def scan_disks(min_size):
     :param min_size: Discount all devices below this size in KB
     :return: List containing drives of interest
     """
+    # todo candidate for move to system/osi as not btrfs related
     base_root_disk = root_disk()
     cmd = ['/usr/bin/lsblk', '-P', '-o',
            'NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID']
@@ -1067,6 +1070,7 @@ def scan_disks(min_size):
 
 
 def wipe_disk(disk):
+    # todo candidate for move to system/osi as not btrfs related
     disk = ('/dev/%s' % disk)
     return run_command([WIPEFS, '-a', disk])
 
@@ -1089,6 +1093,7 @@ def get_disk_power_status(disk):
     :return: single word sting of state as indicated by hdparm -C /dev/<disk>
     and if we encounter an error line in the output we return unknown.
     """
+    # todo candidate for move to system/osi as not btrfs related
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
@@ -1108,6 +1113,7 @@ def get_disk_power_status(disk):
 
 
 def blink_disk(disk, total_exec, read, sleep):
+    # todo candidate for move to system/osi as not btrfs related
     DD_CMD = [DD, 'if=/dev/%s' % disk, 'of=/dev/null', 'bs=512',
               'conv=noerror']
     p = subprocess.Popen(DD_CMD, shell=False, stdout=subprocess.PIPE,

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.db import models
 from storageadmin.models import Pool
 from system.osi import get_disk_power_status, get_dev_byid_name, \
-    read_hdparm_setting
+    read_hdparm_setting, get_disk_APM_level
 
 
 class Disk(models.Model):
@@ -68,6 +68,13 @@ class Disk(models.Model):
     def hdparm_setting(self, *args, **kwargs):
         try:
             return read_hdparm_setting(get_dev_byid_name(self.name))
+        except:
+            return None
+
+    @property
+    def apm_level(self, *args, **kwargs):
+        try:
+            return get_disk_APM_level(str(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,7 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
-from system.osi import get_disk_power_status
+from system.osi import get_disk_power_status, get_dev_byid_name, \
+    read_hdparm_setting
 
 
 class Disk(models.Model):
@@ -60,6 +61,13 @@ class Disk(models.Model):
     def power_state(self, *args, **kwargs):
         try:
             return get_disk_power_status(str(self.name))
+        except:
+            return None
+
+    @property
+    def hdparm_setting(self, *args, **kwargs):
+        try:
+            return read_hdparm_setting(get_dev_byid_name(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
-from fs.btrfs import get_disk_power_status
+from system.osi import get_disk_power_status
 
 
 class Disk(models.Model):

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
+from fs.btrfs import get_disk_power_status
 
 
 class Disk(models.Model):
@@ -52,6 +53,13 @@ class Disk(models.Model):
     def pool_name(self, *args, **kwargs):
         try:
             return self.pool.name
+        except:
+            return None
+
+    @property
+    def power_state(self, *args, **kwargs):
+        try:
+            return get_disk_power_status(str(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -36,6 +36,7 @@ from django.contrib.auth.models import User as DjangoUser
 class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
     power_state = serializers.CharField()
+    hdparm_setting = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -35,7 +35,7 @@ from django.contrib.auth.models import User as DjangoUser
 
 class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
-
+    power_state = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -37,6 +37,7 @@ class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
     power_state = serializers.CharField()
     hdparm_setting = serializers.CharField()
+    apm_level = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -37,6 +37,7 @@ var AppRouter = Backbone.Router.extend({
 	"disks": "showDisks",
 	"disks/blink/:diskName": "blinkDrive",
 	"disks/smartcustom/:diskName": "smartcustomDrive",
+	"disks/spindown/:diskName": "spindownDrive",
 	"disks/:diskName": "showDisk",
 	"pools": "showPools",
 	"pools/:poolName": "showPool",
@@ -175,6 +176,14 @@ var AppRouter = Backbone.Router.extend({
 	this.renderSidebar('storage', 'disks');
 	this.cleanup();
 	this.currentLayout = new SmartcustomDiskView({diskName: diskName});
+	$('#maincontent').empty();
+	$('#maincontent').append(this.currentLayout.render().el);
+    },
+
+	spindownDrive: function(diskName) {
+	this.renderSidebar('storage', 'disks');
+	this.cleanup();
+	this.currentLayout = new SpindownDiskView({diskName: diskName});
 	$('#maincontent').empty();
 	$('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -9,6 +9,7 @@
     <th scope="col" abbr="Capacity">Capacity</th>
     <th scope="col" abbr="Pool">Pool</th>
     <th scope="col" abbr="SpinDown">Power Status</th>
+    <th scope="col" abbr="APM">APM</th>
     <th scope="col" abbr="Model">Model</th>
     <th scope="col" abbr="Transport">Transport</th>
     <th scope="col" abbr="Vendor">Vendor</th>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -1,24 +1,27 @@
 {{#if collectionNotEmpty}}
-  <table id="disks-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of disks">
-    <thead>
-      <tr>
-        <th scope="col" abbr="Name">Name</th>
-	<th scope="col" abbr="Serial">Serial</th>
-        <th scope="col" abbr="Capacity">Capacity</th>
-        <th scope="col" abbr="Pool">Pool</th>
-	<th scope="col" abbr="Model">Model</th>
-	<th scope="col" abbr="Transport">Transport</th>
-	<th scope="col" abbr="Vendor">Vendor</th>
-	<th scope="col" abbr="Smart">S.M.A.R.T</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{display_disks_tbody}}
-    </tbody>
-  </table>
-  <div>
+<table id="disks-table"
+       class="table table-condensed table-bordered table-hover table-striped share-table tablesorter"
+       summary="List of disks">
+  <thead>
+  <tr>
+    <th scope="col" abbr="Name">Name</th>
+    <th scope="col" abbr="Serial">Serial</th>
+    <th scope="col" abbr="Capacity">Capacity</th>
+    <th scope="col" abbr="Pool">Pool</th>
+    <th scope="col" abbr="SpinDown">Power Status</th>
+    <th scope="col" abbr="Model">Model</th>
+    <th scope="col" abbr="Transport">Transport</th>
+    <th scope="col" abbr="Vendor">Vendor</th>
+    <th scope="col" abbr="Smart">S.M.A.R.T</th>
+  </tr>
+  </thead>
+  <tbody>
+  {{display_disks_tbody}}
+  </tbody>
+</table>
+<div>
   {{pagination}}
-  </div>
+</div>
 {{else}}
-  <h4>No disks added. Click on Rescan to discover disks</h4>
+<h4>No disks added. Click on Rescan to discover disks</h4>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -64,7 +64,7 @@
           <div class="col-xs-8">
             <div id="slider" class="control-label" style="width: 400px;"></div>
             <input type="text" style="margin-top: 16px;" class="col-md-2"
-                   name="apm_value" id="apm_value"
+                   name="apm_value" id="apm_value" value="0"
                    title="Enter APM Value">
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -73,14 +73,14 @@
           <div class="col-xs-8 col-xs-offset-4">
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>
-            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be needed to
-              allow spin down on some drives
+            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be
+              required for spin down (lower power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-reclaimable"></div>
-            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) On some drives
-              these values may inhibit spin down
+            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) May
+              inhibit spin down (higher power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -1,0 +1,49 @@
+<h3>Add drive specific Spin down time</h3>
+<h4>This is the time a drive must remains <strong>Idle</strong> before
+  spinning down it's disks / platters to save on power and reduce drive noise.</h4>
+<h5>Please note that a drives <i>initial</i> response time when in
+  <strong>standby</strong> mode is typically increased by up to tens of seconds
+  as the disk motor takes time to re-energize the platters.</h5>
+<h6>The value entered here will be used by hdparm -C to set this drives Spin
+  down delay. If this delay is set to small for a specific work load then the
+  the drive will spend more time than necessary spinning up and down and have
+  an unnecessary impact on performance and wear levels. Conversely a high or
+  non existent spin down time may waste energy and cause a drive to create
+  unwanted noise and heat. For HOME or SMALL OFFICE consider values in the
+  range of 20 minutes. For larger installs consider values greater than 1 hour.
+  </h6>
+
+<div class="row">
+  <div class="col-md-8">
+    <label class="control-label"></label>
+    <div class="form-box">
+      <form class="form-horizontal" id="add-spindown-disk-form"  name="aform" >
+        <div class="messages"></div>
+
+        <!-- Form Header Info -->
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
+            <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+          </div>
+        </div>
+
+        <!-- Spindown time selection -->
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="spindown_options">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <div class="col-sm-8">
+            <input class="form-control shorten-input" type="text" name="spindown_options" id="spindown_options" title="Select Time from drop down" value="placeholder">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <a id="cancel" class="btn btn-default">Cancel</a>
+            <input type="Submit" id="spindown-disk" class="btn btn-primary" value="Submit"></input>
+          </div>
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -52,13 +52,13 @@
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
             <label class="checkbox inline">
-              <input type="checkbox" id="enable_apm"
+              <input type="checkbox" id="enable_apm" checked="true"
                      name="enable_apm"> Enable APM setting
             </label>
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" id="slider-entry">
           <label class="col-sm-4 control-label" for="apm_value">APM
             setting</label>
           <div class="col-sm-8">
@@ -69,7 +69,7 @@
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" id="slider-key">
           <div class="col-xs-8 col-xs-offset-4">
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -36,10 +36,12 @@
 
         <!-- Spindown time selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="spindownTime">Idle Time prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
-            <select class="form-control" id="spindown_time" name="spindown_time">
-            {{display_spindown_time}}
+            <select class="form-control" id="spindownTime" name="spindownTime">
+              <!-- {{display_spindown_time}} -->
+              <option value="6">30 seconds</option>
+              <option value="12">60 seconds</option>
             </select>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -39,9 +39,10 @@
           <label class="col-sm-4 control-label" for="spindownTime">Idle Time prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
             <select class="form-control" id="spindownTime" name="spindownTime">
-              <!-- {{display_spindown_time}} -->
-              <option value="6">30 seconds</option>
-              <option value="12">60 seconds</option>
+              <!--{{display_spindown_time}}-->
+              {{#each spindownTimes}}
+                <option value="{{this}}">{{@key}}</option>
+              {{/each}}
             </select>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -74,18 +74,18 @@
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>
             <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be
-              required for spin down (lower power & performance).
+              required for spin down - (lower power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-reclaimable"></div>
             <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) May
-              inhibit spin down (higher power & performance).
+              inhibit spin down - (higher power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-used"></div>
-            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM disabled
+            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM off.
             </div>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -1,9 +1,9 @@
 <h3>Add drive specific Spin down time</h3>
 <h4>This is the time a drive must remains <strong>Idle</strong> before
   spinning down it's disks / platters to save on power and reduce drive noise.
-<br>
+  <br>
   Idle periods a disk activity can be encouraged by adding <strong>Task
-  execution time windows</strong> to relevant <strong>Scheduled Tasks</strong>.
+    execution time windows</strong> to relevant <strong>Scheduled Tasks</strong>.
   <i>See System - Scheduled Tasks</i>
 </h4>
 
@@ -17,13 +17,13 @@
   non existent spin down time may waste energy and cause a drive to create
   unwanted noise and heat. For HOME or SMALL OFFICE consider values in the
   range of 20 minutes. For larger installs consider values greater than 1 hour.
-  </h6>
+</h6>
 
 <div class="row">
   <div class="col-md-8">
     <label class="control-label"></label>
     <div class="form-box">
-      <form class="form-horizontal" id="add-spindown-disk-form"  name="aform" >
+      <form class="form-horizontal" id="add-spindown-disk-form" name="aform">
         <div class="messages"></div>
 
         <!-- Form Header Info -->
@@ -36,12 +36,14 @@
 
         <!-- Spindown time selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="spindown_time">Idle Time
+            prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
-            <select class="form-control" id="spindown_time" name="spindown_time">
+            <select class="form-control" id="spindown_time"
+                    name="spindown_time">
               {{display_spindown_time}}
               <!--{{#each spindownTimes}}-->
-                <!--<option value="{{this}}">{{@key}}</option>-->
+              <!--<option value="{{this}}">{{@key}}</option>-->
               <!--{{/each}}-->
             </select>
           </div>
@@ -49,8 +51,50 @@
 
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
+            <label class="checkbox inline">
+              <input type="checkbox" id="enable_apm"
+                     name="enable_apm"> Enable Advanced APM setting
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-xs-4 control-label" for="apm_value">APM setting<span
+              class="required"> *</span></label>
+          <div class="col-xs-8">
+            <div id="slider" class="control-label" style="width: 400px;"></div>
+            <input type="text" style="margin-top: 16px;" class="col-md-2"
+                   name="apm_value" id="apm_value"
+                   title="Enter APM Value">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-xs-8 col-xs-offset-4">
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-free"></div>
+            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be needed to
+              allow spin down on some drives
+            </div>
+            <br>
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-reclaimable"></div>
+            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) On some drives
+              these values may inhibit spin down
+            </div>
+            <br>
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-used"></div>
+            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM disabled
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
             <a id="cancel" class="btn btn-default">Cancel</a>
-            <input type="Submit" id="spindown-disk" class="btn btn-primary" value="Submit"></input>
+            <input type="Submit" id="spindown-disk" class="btn btn-primary"
+                   value="Submit"></input>
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -39,10 +39,10 @@
           <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
             <select class="form-control" id="spindown_time" name="spindown_time">
-              <!--{{display_spindown_time}}-->
-              {{#each spindownTimes}}
-                <option value="{{this}}">{{@key}}</option>
-              {{/each}}
+              {{display_spindown_time}}
+              <!--{{#each spindownTimes}}-->
+                <!--<option value="{{this}}">{{@key}}</option>-->
+              <!--{{/each}}-->
             </select>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -10,7 +10,7 @@
 <h5>Please note that a drives <i>initial</i> response time when in
   <strong>standby</strong> mode is typically increased by up to tens of seconds
   as the disk motor takes time to re-energize the platters.</h5>
-<h6>The value entered here will be used by hdparm -C to set this drives Spin
+<h6>The value entered here will be used by hdparm -S to set this drives Spin
   down delay. If this delay is set too small for a specific work load then the
   the drive will spend more time than necessary spinning up and down and have
   an unnecessary impact on performance and wear levels. Conversely a high or

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -36,9 +36,9 @@
 
         <!-- Spindown time selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="spindownTime">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
-            <select class="form-control" id="spindownTime" name="spindownTime">
+            <select class="form-control" id="spindown_time" name="spindown_time">
               <!--{{display_spindown_time}}-->
               {{#each spindownTimes}}
                 <option value="{{this}}">{{@key}}</option>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -53,17 +53,17 @@
           <div class="col-sm-offset-4 col-sm-8">
             <label class="checkbox inline">
               <input type="checkbox" id="enable_apm"
-                     name="enable_apm"> Enable Advanced APM setting
+                     name="enable_apm"> Enable APM setting
             </label>
           </div>
         </div>
 
         <div class="form-group">
-          <label class="col-xs-4 control-label" for="apm_value">APM setting<span
-              class="required"> *</span></label>
-          <div class="col-xs-8">
+          <label class="col-sm-4 control-label" for="apm_value">APM
+            setting</label>
+          <div class="col-sm-8">
             <div id="slider" class="control-label" style="width: 400px;"></div>
-            <input type="text" style="margin-top: 16px;" class="col-md-2"
+            <input class="col-sm-3" type="text"
                    name="apm_value" id="apm_value" value="0"
                    title="Enter APM Value">
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -7,8 +7,8 @@
   <i>See System - Scheduled Tasks</i>
 </h4>
 
-<h5>Please note that a drives <i>initial</i> response time when in
-  <strong>standby</strong> mode is typically increased by up to tens of seconds
+<h5>Please note that a drive's <i>initial</i> response time when in
+  <strong>standby</strong> mode is typically increased by tens of seconds
   as the disk motor takes time to re-energize the platters.</h5>
 <h6>The value entered here will be used by hdparm -S to set this drives Spin
   down delay. If this delay is set too small for a specific work load then the

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -30,9 +30,11 @@
 
         <!-- Spindown time selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="spindown_options">Idle Time prior to Spin Down<span class="required"> *</span></label>
-          <div class="col-sm-8">
-            <input class="form-control shorten-input" type="text" name="spindown_options" id="spindown_options" title="Select Time from drop down" value="placeholder">
+          <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <div class="col-sm-4">
+            <select class="form-control" id="spindown_time" name="spindown_time">
+            {{display_spindown_time}}
+            </select>
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -1,11 +1,17 @@
 <h3>Add drive specific Spin down time</h3>
 <h4>This is the time a drive must remains <strong>Idle</strong> before
-  spinning down it's disks / platters to save on power and reduce drive noise.</h4>
+  spinning down it's disks / platters to save on power and reduce drive noise.
+<br>
+  Idle periods a disk activity can be encouraged by adding <strong>Task
+  execution time windows</strong> to relevant <strong>Scheduled Tasks</strong>.
+  <i>See System - Scheduled Tasks</i>
+</h4>
+
 <h5>Please note that a drives <i>initial</i> response time when in
   <strong>standby</strong> mode is typically increased by up to tens of seconds
   as the disk motor takes time to re-energize the platters.</h5>
 <h6>The value entered here will be used by hdparm -C to set this drives Spin
-  down delay. If this delay is set to small for a specific work load then the
+  down delay. If this delay is set too small for a specific work load then the
   the drive will spend more time than necessary spinning up and down and have
   an unnecessary impact on performance and wear levels. Conversely a high or
   non existent spin down time may waste energy and cause a drive to create

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -206,7 +206,7 @@ DisksView = Backbone.View.extend({
                     html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
                 } else if (btrfsUId && _.isNull(poolName)) {
                     html += '<a href="#" class="btrfs_wipe" data-disk-name="' + diskName + '" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
-                    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="' + diskName + '" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
+                    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="' + diskName + '" title="Click to automatically import data (pools, shares and snapshots) on this disk" rel="tooltip">';
                     html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
                 }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -230,7 +230,11 @@ DisksView = Backbone.View.extend({
                 }
                 html += '</td>';
                 // begin Spin Down / power column
-                html += '<td>' + 'active/idle' + '</td>';
+                html += '<td>';
+                html += 'active/idle' + ' ';
+                html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
+                html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';
                 // begin Transport column

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -31,6 +31,7 @@ DisksView = Backbone.View.extend({
         'click .delete': 'deleteDisk',
         'click .btrfs_wipe': 'btrfsWipeDisk',
         'click .btrfs_import': 'btrfsImportDisk',
+        'click .pause': 'pauseDisk',
         'switchChange.bootstrapSwitch': 'smartToggle'
     },
 
@@ -83,6 +84,27 @@ DisksView = Backbone.View.extend({
         });
     },
 
+    pauseDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to force the following device into Standby mode ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName + '/pause',
+                type: 'POST',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+
     wipeDisk: function (event) {
         var _this = this;
         if (event) event.preventDefault();
@@ -103,6 +125,7 @@ DisksView = Backbone.View.extend({
             });
         }
     },
+
     btrfsWipeDisk: function (event) {
         var _this = this;
         if (event) event.preventDefault();
@@ -233,10 +256,18 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin Spin Down / Power Status column
                 html += '<td>';
-                html += powerState + ' ';
                 if (powerState == 'unknown' || powerState == null ) {
+                    html += '<i class="glyphicon glyphicon-pause"></i>';
+                    html += powerState + ' ';
                     html += '<i class="glyphicon glyphicon-hourglass"></i>';
                 } else {
+                    if (powerState == 'active/idle') {
+                        html += '<a href="#" class="pause" data-disk-name="' + diskName + '" title="Force drive into Standby mode." rel="tooltip">';
+                        html += '<i class="glyphicon glyphicon-pause"></i></a>';
+                    } else {
+                        html += '<i class="glyphicon glyphicon-pause"></i>';
+                    }
+                    html += powerState + ' ';
                     html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                     html += '<i class="glyphicon glyphicon-hourglass"></i></a>';
                 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -190,7 +190,8 @@ DisksView = Backbone.View.extend({
                     diskParted = disk.get('parted'),
                     smartEnabled = disk.get('smart_enabled'),
                     diskRole = disk.get('role'),
-                    smartOptions = disk.get('smart_options');
+                    smartOptions = disk.get('smart_options'),
+                    powerState = disk.get('power_state');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -229,9 +230,9 @@ DisksView = Backbone.View.extend({
                     html += '<a href="#pools/' + poolName + '">' + poolName + '</a>';
                 }
                 html += '</td>';
-                // begin Spin Down / power column
+                // begin Spin Down / Power Status column
                 html += '<td>';
-                html += 'active/idle' + ' ';
+                html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                 html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -215,7 +215,8 @@ DisksView = Backbone.View.extend({
                     diskRole = disk.get('role'),
                     smartOptions = disk.get('smart_options'),
                     powerState = disk.get('power_state'),
-                    hdparmSetting = disk.get('hdparm_setting');
+                    hdparmSetting = disk.get('hdparm_setting'),
+                    apmLevel = disk.get('apm_level');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -273,6 +274,15 @@ DisksView = Backbone.View.extend({
                 }
                 if (hdparmSetting != null) {
                     html += hdparmSetting;
+                }
+                html += ' ';
+                html += '</td>';
+                // begin APM column
+                html += '<td>';
+                if (apmLevel == 'unknown' || apmLevel == null){
+                    html += '???';
+                } else {
+                    html += apmLevel;
                 }
                 html += ' ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -279,10 +279,14 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin APM column
                 html += '<td>';
-                if (apmLevel == 'unknown' || apmLevel == null){
+                if (apmLevel == 0 || apmLevel == null) {
                     html += '???';
                 } else {
-                    html += apmLevel;
+                    if (apmLevel == 255) {
+                        html += 'off';
+                    } else {
+                        html += apmLevel;
+                    }
                 }
                 html += ' ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -209,6 +209,7 @@ DisksView = Backbone.View.extend({
                 }
 
                 html += '</td>';
+                // begin Serial number column
                 html += '<td>';
                 if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
                     html += '<div class="alert alert-danger">' +
@@ -220,14 +221,21 @@ DisksView = Backbone.View.extend({
                     }
                 }
                 html += '</td>';
+                // begin Capacity column
                 html += '<td>' + diskSize + '</td>';
+                // begin Pool column
                 html += '<td>';
                 if (!_.isNull(poolName)) {
                     html += '<a href="#pools/' + poolName + '">' + poolName + '</a>';
                 }
                 html += '</td>';
+                // begin Spin Down / power column
+                html += '<td>' + 'active/idle' + '</td>';
+                // begin Model column
                 html += '<td>' + diskModel + '</td>';
+                // begin Transport column
                 html += '<td>' + diskTransport + '</td>';
+                // begin Vendor column
                 html += '<td>' + diskVendor + '</td>';
                 // begin smart table data cell contents
                 html += '<td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -234,9 +234,16 @@ DisksView = Backbone.View.extend({
                 // begin Spin Down / Power Status column
                 html += '<td>';
                 html += powerState + ' ';
-                html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
-                html += '<i class="glyphicon glyphicon-hourglass"></i></a> ';
-                html += hdparmSetting + ' ';
+                if (powerState == 'unknown' || powerState == null ) {
+                    html += '<i class="glyphicon glyphicon-hourglass"></i>';
+                } else {
+                    html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
+                    html += '<i class="glyphicon glyphicon-hourglass"></i></a>';
+                }
+                if (hdparmSetting != null) {
+                    html += hdparmSetting;
+                }
+                html += ' ';
                 html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -191,7 +191,8 @@ DisksView = Backbone.View.extend({
                     smartEnabled = disk.get('smart_enabled'),
                     diskRole = disk.get('role'),
                     smartOptions = disk.get('smart_options'),
-                    powerState = disk.get('power_state');
+                    powerState = disk.get('power_state'),
+                    hdparmSetting = disk.get('hdparm_setting');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -235,6 +236,7 @@ DisksView = Backbone.View.extend({
                 html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                 html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                html += hdparmSetting + ' ';
                 html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -235,7 +235,7 @@ DisksView = Backbone.View.extend({
                 html += '<td>';
                 html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
-                html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                html += '<i class="glyphicon glyphicon-hourglass"></i></a> ';
                 html += hdparmSetting + ' ';
                 html += '</td>';
                 // begin Model column

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -156,12 +156,17 @@ SpindownDiskView = RockstorLayoutView.extend({
             // we have a device that doesn't support APM or there was an error
             // reading it's current level so disable / hide our APM settings.
             console.log('the received value of APM =' + apmLevel);
-            // this.$('enable_apm').attr('checked','false')
+            //this.$('#enable_apm').attr('checked', 'true');
+            this.$('#enable_apm').removeAttr('checked');
+            this.$('#enable_apm').attr('disabled', 'true');
+            //this.$('#slider').hide();
+            this.$('#slider-entry').hide();
+            this.$('#slider-key').hide();
 
         }
         _this.renderSlider();
         // update the slider when the apm_value text box is changed
-        _this.$("#apm_value").change(function () {
+        _this.$('#apm_value').change(function () {
             var our_value = this.value;
             _this.slider.setValue((our_value));
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -1,0 +1,133 @@
+/*
+ *
+ * @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+
+SpindownDiskView = RockstorLayoutView.extend({
+    events: {
+        'click #cancel': 'cancel'
+    },
+
+    initialize: function () {
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.template = window.JST.disk_spindown_disks;
+        this.disks = new DiskCollection();
+        this.diskName = this.options.diskName;
+        this.dependencies.push(this.disks);
+    },
+
+    render: function () {
+        this.fetch(this.renderDisksForm, this);
+        return this;
+    },
+
+    renderDisksForm: function () {
+        if (this.$('[rel=tooltip]')) {
+            this.$("[rel=tooltip]").tooltip('hide');
+        }
+        var _this = this;
+        var disk_name = this.diskName;
+        var serialNumber = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('serial');
+
+
+        $(this.el).html(this.template({
+            diskName: this.diskName,
+            serialNumber: serialNumber
+        }));
+
+        this.$('#add-spindown-disk-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+
+        var err_msg = '';
+        var spindown_err_msg = function () {
+            return err_msg;
+        };
+
+
+        this.$('#add-spindown-disk-form').validate({
+            onfocusout: false,
+            onkeyup: false,
+            rules: {
+               // spindown_time: 'validateSpindown',
+            },
+
+            submitHandler: function () {
+                var button = $('#spindown-disk');
+                if (buttonDisabled(button)) return false;
+                disableButton(button);
+                var submitmethod = 'POST';
+                var posturl = '/api/disks/' + disk_name + '/spindown-drive';
+                $.ajax({
+                    url: posturl,
+                    type: submitmethod,
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    data: JSON.stringify(_this.$('#add-spindown-disk-form').getJSON()),
+                    success: function () {
+                        enableButton(button);
+                        _this.$('#add-spindown-disk-form :input').tooltip('hide');
+                        app_router.navigate('disks', {trigger: true});
+                    },
+
+                    error: function (xhr, status, error) {
+                        enableButton(button);
+                    }
+                });
+
+                return false;
+            }
+        });
+    },
+
+    initHandlebarHelpers: function () {
+        // helper to fill dropdown with drive spindown values
+        Handlebars.registerHelper('display_spindown_time', function () {
+            var html = '',
+                _this = this;
+            var spindownTimes = ['30 seconds', '1 minute', '5 minutes', '10 minutes', '20 minutes', '30 minutes', '1 hour', '2 hours', '3 hours', '4 hours', '6 hours', '8 hours'];
+            _.each(spindownTimes, function (timeString, index) {
+                // need to programatically retrieve current setting for previously set spindownTime ie read from systemd file
+                // note it is not possible to use smart or hdparm to read what was set previously hence read from sys file.
+                if (timeString == '20 minutes') {
+                    html += '<option value="' + timeString + '" selected="selected">';
+                    html += timeString + '</option>';
+                } else {
+                    html += '<option value="' + timeString + '">' + timeString + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
+    },
+
+    cancel: function (event) {
+        event.preventDefault();
+        this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+        app_router.navigate('disks', {trigger: true});
+    }
+
+});

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -30,6 +30,7 @@ SpindownDiskView = RockstorLayoutView.extend({
     },
 
     initialize: function () {
+        var _this = this;
         this.constructor.__super__.initialize.apply(this, arguments);
         this.template = window.JST.disk_spindown_disks;
         this.disks = new DiskCollection();
@@ -37,16 +38,22 @@ SpindownDiskView = RockstorLayoutView.extend({
         this.dependencies.push(this.disks);
         this.tickFormatter = function (d) {
             var formatter = d3.format(",.0f");
-            if (d > 254) {
-                return formatter(d) + "off";
-            } else {
-                return formatter(d);
+            if (d > 254.5) {
+                return formatter(d) + " off";
             }
+            if (d < 0.5) {
+                return "remove"
+            }
+            return formatter(d);
+        }
+        this.tickFormatterText = function (d) {
+            var formatter = d3.format(",.0f");
+            return formatter(d);
         }
         this.slider = null;
         this.sliderCallback = function (slider) {
             var value = slider.value();
-            _this.$('#apm_value').val(_this.tickFormatter(value));
+            _this.$('#apm_value').val(_this.tickFormatterText(value));
         }
         this.initHandlebarHelpers();
     },
@@ -86,7 +93,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         // retrieve local copy of current apm level
         var apmLevel = this.disks.find(function (d) {
             return (d.get('name') == disk_name);
-        }).get('apm_setting');
+        }).get('apm_level');
 
         $(this.el).html(this.template({
             diskName: this.diskName,
@@ -111,15 +118,17 @@ SpindownDiskView = RockstorLayoutView.extend({
             //$('#slide_lower_half').prop('disable', !this.checked);
             //$('#slide_upper_half').prop('disable', !this.checked);
             //$('#slide_disabled').prop('disable', !this.checked);
-            if (this.checked) {
-                _this.renderSlider();
-            }
+            //if (this.checked) {
+            //    _this.renderSlider();
+            //}
         });
 
-        if (apmLevel != 'unknown' || apmLevel != null) {
-            // don't show apm slider if we couldn't read apm value
-            _this.renderSlider();
-        }
+        //if (apmLevel != 'unknown' || apmLevel != null) {
+        //    // don't show apm slider if we couldn't read apm value
+        //    _this.renderSlider();
+        //}
+
+        _this.renderSlider();
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,
@@ -197,9 +206,8 @@ SpindownDiskView = RockstorLayoutView.extend({
         if (value == 'off') {
             value = 255;
         }
-
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(1).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -55,7 +55,8 @@ SpindownDiskView = RockstorLayoutView.extend({
 
         $(this.el).html(this.template({
             diskName: this.diskName,
-            serialNumber: serialNumber
+            serialNumber: serialNumber,
+            spindownTimes: ['30 seconds', '1 minute', '5 minutes', '10 minutes', '20 minutes', '30 minutes', '1 hour', '2 hours', '3 hours', '4 hours', '6 hours', '8 hours']
         }));
 
         this.$('#add-spindown-disk-form :input').tooltip({
@@ -69,11 +70,12 @@ SpindownDiskView = RockstorLayoutView.extend({
         };
 
 
+
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,
             onkeyup: false,
             rules: {
-               // spindown_time: 'validateSpindown',
+               spindownTime: 'required'
             },
 
             submitHandler: function () {
@@ -104,20 +106,21 @@ SpindownDiskView = RockstorLayoutView.extend({
         });
     },
 
-    initHandlebarHelpers: function () {
+    initHandlebarHelpers: function(){
         // helper to fill dropdown with drive spindown values
-        Handlebars.registerHelper('display_spindown_time', function () {
+        // eg by generating dynamicaly lines of the following
+        // <option value="20 minutes">20 minutes</option>
+        Handlebars.registerHelper('display_spindown_time', function(){
             var html = '',
-                _this = this;
-            var spindownTimes = ['30 seconds', '1 minute', '5 minutes', '10 minutes', '20 minutes', '30 minutes', '1 hour', '2 hours', '3 hours', '4 hours', '6 hours', '8 hours'];
-            _.each(spindownTimes, function (timeString, index) {
+            _this = this;
+            _.each(_this.spindownTimes, function(spindownTime, index) {
                 // need to programatically retrieve current setting for previously set spindownTime ie read from systemd file
                 // note it is not possible to use smart or hdparm to read what was set previously hence read from sys file.
-                if (timeString == '20 minutes') {
-                    html += '<option value="' + timeString + '" selected="selected">';
-                    html += timeString + '</option>';
+                if (spindownTime == '20 minutes') {
+                    html += '<option value="' + spindownTime + '" selected="selected">';
+                    html += spindownTime + '</option>';
                 } else {
-                    html += '<option value="' + timeString + '">' + timeString + '</option>';
+                    html += '<option value="' + spindownTime + '">' + spindownTime + '</option>';
                 }
             });
             return new Handlebars.SafeString(html);
@@ -126,7 +129,7 @@ SpindownDiskView = RockstorLayoutView.extend({
 
     cancel: function (event) {
         event.preventDefault();
-        this.$('#add-smartcustom-disk-form :input').tooltip('hide');
+        this.$('#add-spindown-disk-form :input').tooltip('hide');
         app_router.navigate('disks', {trigger: true});
     }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -210,7 +210,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             value = 255;
         }
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(1).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -49,7 +49,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         }
         var _this = this;
         var disk_name = this.diskName;
-        var spindownTimes = {'30 seconds': 6, '1 minute': 12, '5 minutes': 60, '10 minutes': 120, '20 minutes': 240, '30 minutes': 241, '1 hour': 242, '2 hours': 244, '4 hours': 248, 'vendor defined (8-12h)': 253};
+        var spindownTimes = {'30 seconds': 6, '1 minute': 12, '5 minutes': 60, '10 minutes': 120, '20 minutes': 240, '30 minutes': 241, '1 hour': 242, '2 hours': 244, '4 hours': 248, 'Vendor defined (8-12h)': 253, 'No spin down': 0};
         var serialNumber = this.disks.find(function (d) {
             return (d.get('name') == disk_name);
         }).get('serial');

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -188,6 +188,10 @@ SpindownDiskView = RockstorLayoutView.extend({
         // <option value="240">20 minutes</option>
         Handlebars.registerHelper('display_spindown_time', function () {
             var html = '';
+            if (this.hdparmSetting == null){
+                // if there is no previous setting then default to 20 minutes
+                this.hdparmSetting = '20 minutes';
+            }
             for (var timeString in this.spindownTimes) {
                 // Get the last setting by reading it from systemd file's
                 // comment line as neither smart or hdparm can retrieve it.

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -38,7 +38,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         this.dependencies.push(this.disks);
         this.tickFormatter = function (d) {
             var formatter = d3.format(",.0f");
-            if (d > 254.5) {
+            if (d > 254.4) {
                 return formatter(d) + " off";
             }
             if (d < 0.5) {
@@ -214,7 +214,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             value = 255;
         }
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(1).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(0.5).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -51,6 +51,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             return formatter(d);
         }
         this.slider = null;
+        // update the text box apm_value when ever the slider is moved.
         this.sliderCallback = function (slider) {
             var value = slider.value();
             _this.$('#apm_value').val(_this.tickFormatterText(value));
@@ -146,7 +147,19 @@ SpindownDiskView = RockstorLayoutView.extend({
         //    _this.renderSlider();
         //}
 
+        // apmLevel = the current sensed level from the drive
+        // apm_value = the text box and it's entered value
+        // set the text box to show the current sensed APM level
         _this.renderSlider();
+        // update the slider when the apm_value text box is changed
+        _this.$("#apm_value").change(function () {
+            var our_value = this.value;
+            _this.slider.setValue((our_value));
+        });
+        _this.$('#apm_value').val(apmLevel);
+        // now call the change event on text box apm_value to update the slider
+        _this.$('#apm_value').change();
+
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -114,15 +114,32 @@ SpindownDiskView = RockstorLayoutView.extend({
             return err_msg;
         };
 
-        this.$('#enable_apm').click(function () {
-            $('#apm_value').prop('disable', !this.checked); // disable apm text
-            //$('#slide_lower_half').prop('disable', !this.checked);
-            //$('#slide_upper_half').prop('disable', !this.checked);
-            //$('#slide_disabled').prop('disable', !this.checked);
-            //if (this.checked) {
-            //    _this.renderSlider();
-            //}
-        });
+        $.validator.addMethod('validateApmValue', function (value) {
+            var apm_value = $('#apm_value').val();
+            if (apm_value == "") {
+                err_msg = 'Please enter an APM value (1-255), or 0 to not apply an APM settings.';
+                return false;
+            }
+            if (/^[0-9\b]+$/.test(apm_value) == false) {
+                err_msg = 'Invalid APM value: please enter a number in the range 0-255.';
+                return false;
+            }
+            if (apm_value < 0 || apm_value > 255) {
+                err_msg = 'The APM setting must be between 0 (no setting) and 255 (disabled).';
+                return false;
+            }
+            return true;
+        }, spindown_err_msg);
+
+        //this.$('#enable_apm').click(function () {
+        //    $('#apm_value').prop('disable', !this.checked); // disable apm text
+        //    //$('#slide_lower_half').prop('disable', !this.checked);
+        //    //$('#slide_upper_half').prop('disable', !this.checked);
+        //    //$('#slide_disabled').prop('disable', !this.checked);
+        //    //if (this.checked) {
+        //    //    _this.renderSlider();
+        //    //}
+        //});
 
         //if (apmLevel != 'unknown' || apmLevel != null) {
         //    // don't show apm slider if we couldn't read apm value
@@ -136,10 +153,11 @@ SpindownDiskView = RockstorLayoutView.extend({
             onkeyup: false,
             rules: {
                 spindown_time: 'required',
-                slider: {
-                    required: "#enable_apm:checked" // slider required only if
-                    // APM settings tickbox enabled.
-                },
+                apm_value: 'validateApmValue',
+                //slider: {
+                //    required: "#enable_apm:checked" // slider required only if
+                //    // APM settings tickbox enabled.
+                //},
             },
 
             submitHandler: function () {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -42,7 +42,7 @@ SpindownDiskView = RockstorLayoutView.extend({
                 return formatter(d) + " off";
             }
             if (d < 0.5) {
-                return "remove"
+                return "none"
             }
             return formatter(d);
         }
@@ -150,6 +150,15 @@ SpindownDiskView = RockstorLayoutView.extend({
         // apmLevel = the current sensed level from the drive
         // apm_value = the text box and it's entered value
         // set the text box to show the current sensed APM level
+
+        // apmLevel can be 'unknown' which is displayed as
+        if (apmLevel == 0){
+            // we have a device that doesn't support APM or there was an error
+            // reading it's current level so disable / hide our APM settings.
+            console.log('the received value of APM =' + apmLevel);
+            // this.$('enable_apm').attr('checked','false')
+
+        }
         _this.renderSlider();
         // update the slider when the apm_value text box is changed
         _this.$("#apm_value").change(function () {
@@ -239,13 +248,9 @@ SpindownDiskView = RockstorLayoutView.extend({
     },
 
     renderSlider: function () {
-        var value = this.apmLevel;
-        // when queried hdparm -B returns off when set to 255 so reverse this
-        if (value == 'off') {
-            value = 255;
-        }
+        // Callback used to broadcast our changing value.
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(0.5).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(0).reclaimable(127).used(0.5).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -132,48 +132,54 @@ SpindownDiskView = RockstorLayoutView.extend({
             return true;
         }, spindown_err_msg);
 
-        //this.$('#enable_apm').click(function () {
-        //    $('#apm_value').prop('disable', !this.checked); // disable apm text
-        //    //$('#slide_lower_half').prop('disable', !this.checked);
-        //    //$('#slide_upper_half').prop('disable', !this.checked);
-        //    //$('#slide_disabled').prop('disable', !this.checked);
-        //    //if (this.checked) {
-        //    //    _this.renderSlider();
-        //    //}
-        //});
-
-        //if (apmLevel != 'unknown' || apmLevel != null) {
-        //    // don't show apm slider if we couldn't read apm value
-        //    _this.renderSlider();
-        //}
+        this.$('#enable_apm').click(function () {
+            // $('#apm_value').prop('disable', !this.checked); // disable apm text
+            //$('#slide_lower_half').prop('disable', !this.checked);
+            //$('#slide_upper_half').prop('disable', !this.checked);
+            //$('#slide_disabled').prop('disable', !this.checked);
+            if (this.checked) {
+                $('#slider-entry').show();
+                $('#slider-key').show();
+                $('#apm_value').val(apmLevel);
+            } else {
+                $('#slider-entry').hide();
+                $('#slider-key').hide();
+            }
+        });
 
         // apmLevel = the current sensed level from the drive
-        // apm_value = the text box and it's entered value
-        // set the text box to show the current sensed APM level
-
-        // apmLevel can be 'unknown' which is displayed as
-        if (apmLevel == 0){
+        if (apmLevel == 0) {
             // we have a device that doesn't support APM or there was an error
             // reading it's current level so disable / hide our APM settings.
-            console.log('the received value of APM =' + apmLevel);
             //this.$('#enable_apm').attr('checked', 'true');
             this.$('#enable_apm').removeAttr('checked');
             this.$('#enable_apm').attr('disabled', 'true');
             //this.$('#slider').hide();
             this.$('#slider-entry').hide();
             this.$('#slider-key').hide();
+        } else {
+            // we can't disable the slider this way:
+            // this.$('#slider').attr('disabled', 'true');
+            // the apm_value text box is greyed but the slider still updates it's
+            // contents.
+            // disable on the text box works a treat given the above
+            // this.$('#apm_value').attr('disabled', 'true');
 
+            _this.renderSlider();
+            // apmLevel = the current sensed level from the drive
+            // apm_value = the text box and it's entered value
+            // update the slider when the apm_value text box is changed
+            //_this.$('#apm_value').focusout(function () {
+            _this.$('#apm_value').change(function () {
+                var our_value = this.value;
+                _this.slider.setValue((our_value));
+            });
+            // set the text box to show the current sensed APM level
+            _this.$('#apm_value').val(apmLevel);
+            // now call the change event on text box apm_value to update the slider
+            _this.$('#apm_value').change();
+            //_this.$('#enable_apm').click();
         }
-        _this.renderSlider();
-        // update the slider when the apm_value text box is changed
-        _this.$('#apm_value').change(function () {
-            var our_value = this.value;
-            _this.slider.setValue((our_value));
-        });
-        _this.$('#apm_value').val(apmLevel);
-        // now call the change event on text box apm_value to update the slider
-        _this.$('#apm_value').change();
-
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,
@@ -203,6 +209,11 @@ SpindownDiskView = RockstorLayoutView.extend({
                         spindown_text = time_string;
                         break;
                     }
+                }
+                // safeguard against setting -B (APM) option if enable_apm is
+                // unticked.
+                if (data.enable_apm != true) {
+                    data.apm_value = 0;
                 }
                 data.spindown_message = spindown_text;
                 $.ajax({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -35,6 +35,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         this.disks = new DiskCollection();
         this.diskName = this.options.diskName;
         this.dependencies.push(this.disks);
+        this.initHandlebarHelpers();
     },
 
     render: function () {
@@ -48,6 +49,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         }
         var _this = this;
         var disk_name = this.diskName;
+        var spindownTimes = {'30 seconds': 6, '1 minute': 12, '5 minutes': 60, '10 minutes': 120, '20 minutes': 240, '30 minutes': 241, '1 hour': 242, '2 hours': 244, '4 hours': 248, 'vendor defined (8-12h)': 253};
         var serialNumber = this.disks.find(function (d) {
             return (d.get('name') == disk_name);
         }).get('serial');
@@ -56,7 +58,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         $(this.el).html(this.template({
             diskName: this.diskName,
             serialNumber: serialNumber,
-            spindownTimes: ['30 seconds', '1 minute', '5 minutes', '10 minutes', '20 minutes', '30 minutes', '1 hour', '2 hours', '3 hours', '4 hours', '6 hours', '8 hours']
+            spindownTimes: spindownTimes
         }));
 
         this.$('#add-spindown-disk-form :input').tooltip({
@@ -109,20 +111,23 @@ SpindownDiskView = RockstorLayoutView.extend({
     initHandlebarHelpers: function(){
         // helper to fill dropdown with drive spindown values
         // eg by generating dynamicaly lines of the following
-        // <option value="20 minutes">20 minutes</option>
+        // <option value="240">20 minutes</option>
+        // todo this helper doesnt work but I (Phil) would rather use it than
+        // todo the built in #each helper as we can then set default here.
         Handlebars.registerHelper('display_spindown_time', function(){
-            var html = '',
-            _this = this;
-            _.each(_this.spindownTimes, function(spindownTime, index) {
+            var html = '';
+            for (var timeString in this.spindownTime){
                 // need to programatically retrieve current setting for previously set spindownTime ie read from systemd file
                 // note it is not possible to use smart or hdparm to read what was set previously hence read from sys file.
-                if (spindownTime == '20 minutes') {
-                    html += '<option value="' + spindownTime + '" selected="selected">';
-                    html += spindownTime + '</option>';
+                // for now hardwire 20 mins as default (pre-selected)
+                console.log('processing timeString = ' + timeString);
+                if (timeString == '20 minutes') {
+                    html += '<option value="' + spindownTime[timeString] + '" selected="selected">';
+                    html += timeString + '</option>';
                 } else {
-                    html += '<option value="' + spindownTime + '">' + spindownTime + '</option>';
+                    html += '<option value="' + spindownTimes[timeString] + '">' + timeString+ '</option>';
                 }
-            });
+            }
             return new Handlebars.SafeString(html);
         });
     },

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -348,7 +348,7 @@ class DiskDetailView(rfc.GenericView):
     @classmethod
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
-        spindown_time = int(request.data.get('spindown_time', ''))
+        spindown_time = int(request.data.get('spindown_time', 20))
         # todo attempt to retrieve spindown_message as well and pass it along.
         spindown_message = str(
             request.data.get('spindown_message', 'message issue!'))

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -30,7 +30,7 @@ from share_helpers import (import_shares, import_snapshots)
 from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
-from system.osi import set_disk_spindown
+from system.osi import set_disk_spindown, enter_standby
 from copy import deepcopy
 import uuid
 import logging
@@ -266,10 +266,12 @@ class DiskDetailView(rfc.GenericView):
                 return self._smartcustom_drive(dname, request)
             if (command == 'spindown-drive'):
                 return self._spindown_drive(dname, request)
+            if (command == 'pause'):
+                return self._pause(dname, request)
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
                  ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
-                 ' smartcustom-drive, spindown-drive' % command)
+                 ' smartcustom-drive, spindown-drive, pause' % command)
         handle_exception(Exception(e_msg), request)
 
     @transaction.atomic
@@ -348,4 +350,10 @@ class DiskDetailView(rfc.GenericView):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
         set_disk_spindown(disk.name, spindown_time)
+        return Response()
+
+    @classmethod
+    def _pause(cls, dname, request):
+        disk = cls._validate_disk(dname, request)
+        enter_standby(disk.name)
         return Response()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -352,7 +352,8 @@ class DiskDetailView(rfc.GenericView):
         # todo attempt to retrieve spindown_message as well and pass it along.
         spindown_message = str(
             request.data.get('spindown_message', 'message issue!'))
-        set_disk_spindown(disk.name, spindown_time, spindown_message)
+        apm_value = int(request.data.get('apm_value', 0))
+        set_disk_spindown(disk.name, spindown_time, apm_value, spindown_message)
         return Response()
 
     @classmethod

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -349,7 +349,10 @@ class DiskDetailView(rfc.GenericView):
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
-        set_disk_spindown(disk.name, spindown_time)
+        # todo attempt to retrieve spindown_message as well and pass it along.
+        spindown_message = str(
+            request.data.get('spindown_message', 'message issue!'))
+        set_disk_spindown(disk.name, spindown_time, spindown_message)
         return Response()
 
     @classmethod

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -263,6 +263,8 @@ class DiskDetailView(rfc.GenericView):
                 return self._toggle_smart(dname, request)
             if (command == 'smartcustom-drive'):
                 return self._smartcustom_drive(dname, request)
+            if (command == 'spindown-drive'):
+                return self._spindown_drive(dname, request)
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
                  ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
@@ -338,4 +340,12 @@ class DiskDetailView(rfc.GenericView):
         blink_time = int(request.data.get('blink_time', 15))
         sleep_time = int(request.data.get('sleep_time', 5))
         blink_disk(disk.name, total_time, blink_time, sleep_time)
+        return Response()
+
+    @classmethod
+    def _spindown_drive(cls, dname, request):
+        disk = cls._validate_disk(dname, request)
+        spindown_time = str(
+            request.data.get('spindown_time', ''))
+        smart.set_disk_spindown(disk.name, spindown_time)
         return Response()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -269,7 +269,7 @@ class DiskDetailView(rfc.GenericView):
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
                  ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
-                 ' smartcustom-drive' % command)
+                 ' smartcustom-drive, spindown-drive' % command)
         handle_exception(Exception(e_msg), request)
 
     @transaction.atomic

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -345,7 +345,6 @@ class DiskDetailView(rfc.GenericView):
     @classmethod
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
-        spindown_time = str(
-            request.data.get('spindown_time', ''))
+        spindown_time = int(request.data.get('spindown_time', ''))
         smart.set_disk_spindown(disk.name, spindown_time)
         return Response()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -30,6 +30,7 @@ from share_helpers import (import_shares, import_snapshots)
 from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
+from system.osi import set_disk_spindown
 from copy import deepcopy
 import uuid
 import logging
@@ -346,5 +347,5 @@ class DiskDetailView(rfc.GenericView):
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
-        smart.set_disk_spindown(disk.name, spindown_time)
+        set_disk_spindown(disk.name, spindown_time)
         return Response()

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -700,6 +700,8 @@ def set_disk_spindown(device, spindown_time):
     or an error was return by the command, True otherwise.
     """
     # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
+    # but it does require a full path, ie sda3 doesn't work.
+    # Could use the new get_devname(device, true) to add the dev path.
     # todo lighten by removing base_dev
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -615,11 +615,9 @@ def is_rotational(device_name, test=None):
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
-    logger.debug('is_rotational called with the following %s', device_name)
     if test is None:
-        # todo consider changing back to throw=False for production.
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name=' + device_name[0]], throw=True)
+                                    '--name=' + device_name[0]], throw=False)
     else:
         # test mode so process test instead of udevadmin output
         out = test
@@ -713,15 +711,15 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
         return False
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
-        logger.debug('skipping hdparm -S as device not confirmed as rotational')
+        logger.info('skipping hdparm -S as device not confirmed as rotational')
         return False
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,
                       '%s' % get_dev_byid_name(base_dev[0])]
     out, err, rc = run_command(hdparm_command, throw=False)
     if rc != 0:
-        logger.error('non zero return code from hdparm command with '
-                     'error %s and return code %s' % (err, rc))
+        logger.error('non zero return code from hdparm command %s with '
+                     'error %s and return code %s' % (hdparm_command, err, rc))
         return False
     # hdparm ran without issues so attempt to edit rockstor-hdparm.service
     # with the same entry
@@ -903,9 +901,10 @@ def update_hdparm_service(hdparm_command_list, comment):
         # then this is a fresh systemd instance so enable it
         # can't use systemctrl wrapper as then circular dependency
         # return systemctl('rockstor-hdparm', 'enable')
-        # todo remember to run this and convert success (rc == 0) into True
-        # return run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
-        return True
+        logger.info('Enabling the rockstor-hdparm systemd service.')
+        out, err, rc = run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
+        if rc != 0:
+            return False
     return True
 
 
@@ -961,6 +960,4 @@ def enter_standby(device_name):
     :return: None or out, err, rc of command
     """
     hdparm_command = [HDPARM, '-q', '-y', '%s' % get_devname(device_name, True)]
-    logger.debug('enter_standby called wtih device name %s', device_name)
-    logger.debug('proposed hdparm_command = %s', hdparm_command)
     return run_command(hdparm_command)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -685,6 +685,39 @@ def get_disk_power_status(device_name):
     return 'unknown'
 
 
+def get_disk_APM_level(device_name):
+    """
+    When given a disk name such as that stored in the db ie sda
+    we return it's current APM level via hdparm -B /dev/<device_name>
+    Possible return values from the command are:
+    1 to 254 ie min to max power use
+    'off' = equivalent to 255 setting
+    If we receive an error message, can happen even with rc=0 we ignore any
+    reading and return 'unknown'
+
+    :param device_name: disk name as stored in db / Disk model eg sda
+    :return: APM setting read from the drive ie 1 - 255 or off or None if an
+    error occurred ie when APM is not supported
+    """
+    # todo - consider combining with get_disk_power_status(device_name) via
+    # todo - a switch option
+    # if we use the -B -q switches then we have only one line of output:
+    # hdparm -B -q /dev/sda
+    #  APM_level<tab>= 192
+    out, err, rc = run_command([HDPARM, '-B', '-q', '/dev/%s' % device_name],
+                               throw=False)
+    if len(err) != 1:
+        # In some instances an error can be returned even with rc=0.
+        # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ...
+        return 'unknown'  # don't trust any results in this instance
+    if len(out) > 0:
+        fields = out[0].split()
+        # our line of interest has 3 fields when split by spaces, see above.
+        if (len(fields) == 3):
+            return fields[2]
+    return 'unknown'
+
+
 def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     """
     Takes a value to be used with hdparm -S to set disk spindown time for the

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -696,25 +696,28 @@ def set_disk_spindown(device, spindown_time):
     to enact these changes in order to keep keep our drive intervention to a
     minimum.
     :param device: The name of a disk device as used in the db ie sda
-    :param spindown_time: String received from settings form ie "20 minutes"
-    :return:
+    :param spindown_time: Integer received from settings form ie 240
+    :return: True or the results from a run_command
     """
     # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
     # todo lighten by removing base_dev
+    # todo consider normalizing return values.
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
     # todo look to using system/osi get_md_members(device_name, test=None)
     # todo with md devices and then treat each in turn.
     if len(base_dev[0]) == 0:
-        return True;
+        return True
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
         logger.debug('skipping hdparm -S as device not confirmed as rotational')
-        return True;
+        return True
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time, '%s' % get_dev_byid_name(base_dev[0])]
     logger.debug('proposed hdparm command = %s', hdparm_command)
-
+    # todo - Catch this result or work in with run_command
+    # todo - ie examine rc of run_comand(hdparm_comamnd) and if all ok then
+    # todo - go on to update_hdparm_service with the same
     update_hdparm_service(hdparm_command)
 
     return run_command(hdparm_command)
@@ -847,8 +850,7 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
         update = False
     # Create our proposed temporary file based on the source file plus edits.
     with open(infile) as ino, open(npath, 'w') as outo:
-        for line in ino.readlines(): # readlines reads whole file in one go.
-            logger.debug('processing line with contents %s', line)
+        for line in ino.readlines():  # readlines reads whole file in one go.
             if do_edit and edit_done and clear_line_count != 2:
                 # We must have just edited an entry so we need to skip
                 # a line as each entry consists of an ExecStart= line and a
@@ -874,6 +876,8 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
                     do_edit = True
             if do_edit and not edit_done:
                 outo.write('ExecStart=' + ' '.join(hdparm_command_list) + '\n')
+                # todo - Currently writing raw value as debug aid but this is
+                # todo - intended to be the human message we are passed.
                 outo.write('# %s' % hdparm_command_list[-2] + '\n')
                 edit_done = True
             # mechanism to skip a line if we have just done an edit
@@ -904,6 +908,8 @@ def read_hdparm_setting(dev_byid):
     :return: comment string immediately following an entry containing the given
     device name.
     """
+    if dev_byid is None:
+        return None
     infile = '/etc/systemd/system/rockstor-hdparm.service'
     if not os.path.isfile(infile):
         return None
@@ -915,7 +921,9 @@ def read_hdparm_setting(dev_byid):
                 continue
             line_fields = line.split()
             if dev_byid_found:
-                if line_fields[0] == '#':
+                # we have already matched ExecStart line ending with dev_byid
+                # so now look for a non empty (>= 2) comment line following it.
+                if line_fields[0] == '#' and len(line_fields) >= 2:
                     # we have a comment after our target device entry so return
                     # that comment minus the #
                     return ' '.join(line_fields[1:])
@@ -928,6 +936,6 @@ def read_hdparm_setting(dev_byid):
                 # we don't do slow re.match on non candidates.
                 continue
             if re.match('ExecStart', line_fields[0]) and line_fields[-1] == dev_byid:
-                # we have a line beginnign with ExecStart and ending in dev_byid
+                # Found a line beginning with ExecStart and ending in dev_byid.
                 dev_byid_found = True
     return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -686,7 +686,7 @@ def get_disk_power_status(device_name):
     return 'unknown'
 
 
-def set_disk_spindown(device, spindown_time):
+def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     """
     Takes a value to be used with hdparm -S to set disk spindown time for the
     device specified.
@@ -696,6 +696,8 @@ def set_disk_spindown(device, spindown_time):
     minimum.
     :param device: The name of a disk device as used in the db ie sda
     :param spindown_time: Integer received from settings form ie 240
+    :param spindown_message: message received from drop down as human presented
+    selection, used later in systemd script to retrieve previous setting
     :return: False if an hdparm command was not possible ie inappropriate dev,
     or an error was return by the command, True otherwise.
     """
@@ -723,7 +725,7 @@ def set_disk_spindown(device, spindown_time):
         return False
     # hdparm ran without issues so attempt to edit rockstor-hdparm.service
     # with the same entry
-    if update_hdparm_service(hdparm_command) is not None:
+    if update_hdparm_service(hdparm_command, spindown_message) is not True:
         return False
     return True
 
@@ -827,12 +829,12 @@ def get_devname(device_name, addPath=False):
     return None
 
 
-def update_hdparm_service(hdparm_command_list, message='test_message'):
+def update_hdparm_service(hdparm_command_list, comment):
     """
     Updates or creates the /etc/systemd/system/rockstor-hdparm.service file for
     the device_name given.
     :param hdparm_command_list: list containing the hdparm command elements
-    :param message: test message to follow hdparm command on next line
+    :param comment: test message to follow hdparm command on next line
     :return: None or the result of enabling the service via run_command which is
     only done when the service is freshly installed, ie when no existing
     /etc/systemd/system/rockstor-hdparm.service file exists in the first place.
@@ -883,7 +885,9 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
                 outo.write('ExecStart=' + ' '.join(hdparm_command_list) + '\n')
                 # todo - Currently writing raw value as debug aid but this is
                 # todo - intended to be the human message we are passed.
-                outo.write('# %s' % hdparm_command_list[-2] + '\n')
+                # outo.write('# %s' % message + '\n')
+                # todo - remove this and the following line on message / comment pass issue resolution
+                outo.write('# %s' % hdparm_command_list[-2] + ' %s' % comment + '\n')
                 edit_done = True
             # mechanism to skip a line if we have just done an edit
             if not (do_edit and edit_done and clear_line_count != 2):
@@ -897,11 +901,12 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
     shutil.move(npath, '/etc/systemd/system/rockstor-hdparm.service')
     if update is not True:
         # then this is a fresh systemd instance so enable it
-        # can't use systemctrl wrapper as circular then circular dependency
+        # can't use systemctrl wrapper as then circular dependency
         # return systemctl('rockstor-hdparm', 'enable')
+        # todo remember to run this and convert success (rc == 0) into True
         # return run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
-        return None
-    return None
+        return True
+    return True
 
 
 def read_hdparm_setting(dev_byid):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -48,6 +48,7 @@ UDEVADM = '/usr/sbin/udevadm'
 GREP = '/usr/bin/grep'
 NMCLI = '/usr/bin/nmcli'
 HOSTNAMECTL = '/usr/bin/hostnamectl'
+HDPARM = '/usr/sbin/hdparm'
 
 
 def inplace_replace(of, nf, regex, nl):
@@ -607,6 +608,42 @@ def is_rotational(device_name, test=None):
                 rotational = True
                 break
     return rotational
+
+
+def get_disk_power_status(device_name):
+    """
+    When given a disk name such as that stored in the db ie sda
+    we return it's current power state via hdparm -C /dev/<disk>
+    Possible states are:
+    unknown - command not supported by disk
+    active/idle - normal operation
+    standby - low power mode, ie drive motor not active ie -y will do this
+    sleeping - lowest power mode, completely shut down ie -Y will do this
+    N.B. -C shouldn't spin up a drive in standby but has been reported to wake
+    a drive from sleeping but we aren't going to invoke sleeping as pretty much
+    any request will wake a fully sleeping drive.
+    Drives in 'sleeping' mode typically require a hard or soft reset before
+    becoming available for use, the kernel does this automatically however.
+    :param device_name: disk name as stored in db / Disk model eg sda
+    :return: single word sting of state as indicated by hdparm -C /dev/<disk>
+    and if we encounter an error line in the output we return unknown.
+    """
+    # if we use the -C -q switches then we have only one line of output:
+    # hdparm -C -q /dev/sda
+    # drive state is:  active/idle
+    # in some instances an error can be returned even with rc=0, we ignore this
+    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
+    # We may want to ignore / return unknown when len(err) != 1
+    out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % device_name],
+                               throw=False)
+    # if len(err) != 1:
+    #     logger.debug('hdparm has output to standard error of %s', err)
+    if len(out) > 0:
+        fields = out[0].split()
+        # our line of interest has 4 fields when split by spaces, see above.
+        if (len(fields) == 4):
+            return fields[3]
+    return 'unknown'
 
 
 def get_dev_byid_name(device_name):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -634,6 +634,7 @@ def get_dev_byid_name(device_name):
         throw=False)
     if len(out) > 0:
         # the output has at least one line
+        # split this line by '=' and ' ' chars
         fields = out[0].replace('=', ' ').split()
         if len(fields) > 1:
             # we have at least 2 fields in this line
@@ -641,4 +642,67 @@ def get_dev_byid_name(device_name):
                 # return the first value directly after DEVLINKS
                 return fields[1]
     # if no DEVLINKS value found or an error occurred.
+    return None
+
+def get_devname_old(device_name):
+    """
+    Depricated / prior version of get_devname()
+    Returns the value of DEVNAME as reported by udevadm when supplied with a
+    legal device name ie a full path by-id or full path by-path ie any DEVLINKS.
+    Also works when supplied with eg "sda"
+    Primarily intended to retrieve the full path device name from a full path
+    by-id name or an abbreviated DEVNAME eg sda.
+    N.B. this is a partner function to get_dev_byid_name(device_name)
+    Works by sampling the second line of udevadm and confirming it begins with
+    DEVNAME, then returning the value found after the '=' char.
+    example line:
+    DEVNAME=/dev/sda
+    :param device_name: sda, /dev/sda, full path by-id or by-path
+    :return: Full path of device name eg /dev/sda or None if error or no DEVNAME
+    found
+    """
+    out, err, rc = run_command(
+        [UDEVADM, 'info', '--query=property', '--name', str(device_name)],
+        throw=False)
+    if len(out) > 1:
+        # the output has at least two lines
+        # split the second line by the '=' char
+        fields = out[1].split('=')
+        if len(fields) > 1:
+            # we have at least 2 fields in this line
+            if fields[0] == 'DEVNAME':
+                # return the first value directly after DEVNAME
+                return fields[1]
+    # if no DEVNAME value found or an error occurred.
+    return None
+
+
+def get_devname(device_name, addPath=False):
+    """
+    Intended as a light and quicker way to retrieve a device name with or
+    without path (default) from any legal udevadm --name parameter
+    Simple wrapper around a call to:
+    udevadm info --query=name device_name
+    Works with device_name of eg sda /dev/sda /dev/disk/by-id/ and /dev/disk/
+    If a device doesn't exist then udevadm returns multi work advise so if more
+    than one word assume failure and return None.
+    N.B. if given /dev/sdc3 or equivalent DEVLINKS this method will return sdc3
+    if no path is requested.
+    :param device_name: legal device name to --name in udevadmin
+    :return: short device name ie sda (no path) or with path /dev/sda if addPath
+    is True or None if multi word response from udevadm ie "Unknown device, .."
+    """
+    out, err, rc = run_command(
+        [UDEVADM, 'info', '--query=name', '--name', str(device_name)],
+        throw=False)
+    if len(out) > 0:
+        # we have at least a single line of output
+        fields = out[0].split()
+        if len(fields) == 1:
+            # we have a single word output so return it with or without path
+            if addPath:
+                return '/dev/%s' % fields[0]
+            # return the word (device name ie sda) without added /dev/
+            return fields[0]
+    # a non one word reply was received on the first line from udevadm or
     return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -27,6 +27,8 @@ from struct import pack
 from exceptions import CommandException
 import hashlib
 import logging
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,6 +52,7 @@ NMCLI = '/usr/bin/nmcli'
 HOSTNAMECTL = '/usr/bin/hostnamectl'
 LSBLK = '/usr/bin/lsblk'
 HDPARM = '/usr/sbin/hdparm'
+SYSTEMCTL_BIN = '/usr/bin/systemctl'
 
 
 def inplace_replace(of, nf, regex, nl):
@@ -695,14 +698,11 @@ def set_disk_spindown(device, spindown_time):
     :param spindown_time: String received from settings form ie "20 minutes"
     :return:
     """
-    logger.debug('set_disk_spindown received device %s and -S value %s' % (
-    device, spindown_time))
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
     # todo look to using system/osi get_md_members(device_name, test=None)
     # todo with md devices and then treat each in turn.
     if len(base_dev[0]) == 0:
-        logger.debug('skipping hdparm -S as device = ""')
         return True;
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
@@ -710,7 +710,10 @@ def set_disk_spindown(device, spindown_time):
         return True;
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
-    logger.debug('proposed hdparm commnad = %s', hdparm_command)
+    logger.debug('proposed hdparm command = %s', hdparm_command)
+
+    # update_hdparm_service(base_dev, switches)
+
     return run_command(hdparm_command)
 
 
@@ -811,3 +814,69 @@ def get_devname(device_name, addPath=False):
             return fields[0]
     # a non one word reply was received on the first line from udevadm or
     return None
+
+
+def update_hdparm_service(device_name, switches, message='test_message'):
+    """
+    Updates or creates the /etc/systemd/system/rockstor-hdparm.service file for
+    the device_name given.
+    :param device_name: ie sda, will be converted internally to by-id
+    :param switches:
+    :param message:
+    :return:
+    """
+    edit_done = False
+    do_edit = False
+    clear_line_count = 0
+    # get our by-id device name
+    device_name_byid = get_dev_byid_name(device_name)
+    # first create a temp file to use as our output until we are done editing.
+    tfo, npath = mkstemp()
+    # if there is already a rockstor-hdparm.service file then we use that
+    # as our source file, otherwise use conf's empty template.
+    if os.path.isfile('/etc/systemd/system/rockstor-hdparm.service'):
+        infile = '/etc/systemd/system/rockstor-hdparm.service'
+        update = True
+    else:
+        infile = ('%s/rockstor-hdparm.service' % settings.CONFROOT)
+        update = False
+    with open(infile) as ino, open(npath, 'w') as outo:
+        for line in ino.readlines():
+            if (re.match('ExecStart=', line) is not None) and not edit_done:
+                # we have found a line beginning with "ExecStart="
+                if update:
+                    if device_name_byid != line.split()[-1]:
+                        # in update but device name doesn't match so continue
+                        continue
+                else:  # no update and ExecStart found so set edit flag
+                    do_edit = True
+            else:
+                if line == '':
+                    clear_line_count += 1
+                if clear_line_count == 2 and not edit_done:
+                    do_edit = True
+            if do_edit and not edit_done:
+                outo.write('/usr/sbin/hdparm %s %s' % (switches, device_name_byid))
+                outo.write('# %', message)
+                edit_done = True
+            # mechanism to skip a line if we have just done an edit
+            if do_edit and edit_done:
+                # we need to skip a line as we have just inserted 2
+                # first reset our do_edit as it's now been done
+                do_edit = False
+                # then continue rather than copy source line to target
+                # which effects a line skip
+                continue
+            else:
+                # copy source line over to temp file
+                outo.write(line)
+    # now copy our temp file over to our destination as we are done editing
+    shutil.move(npath, '/etc/systemd/system/rockstor-hdparm.service')
+    if update is not True:
+        # then this is a fresh systemd instance so enable it
+        # can't use systemctrl wrapper as circular then circular dependency
+        # return systemctl('rockstor-hdparm', 'enable')
+        return run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
+    return None
+
+

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -969,7 +969,7 @@ def read_hdparm_setting(dev_byid):
     no file or no matching entry or comment there after was found.
     :param dev_byid: full path device name of by-id type
     :return: comment string immediately following an entry containing the given
-    device name.
+    device name or None if None found or the systemd file didn't exist.
     """
     if dev_byid is None:
         return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -944,3 +944,18 @@ def read_hdparm_setting(dev_byid):
                 # Found a line beginning with ExecStart and ending in dev_byid.
                 dev_byid_found = True
     return None
+
+
+def enter_standby(device_name):
+    """
+    Simple wrapper to execute hdparm -y /dev/device_name which requests that the
+    named device enter 'standby' mode which usually means it will spin down.
+    Should only be available if he power status of the device can be
+    successfully read without errors (ui inforced)
+    :param device_name: device name as stored in db ie sda
+    :return: None or out, err, rc of command
+    """
+    hdparm_command = [HDPARM, '-q', '-y', '%s' % get_devname(device_name, True)]
+    logger.debug('enter_standby called wtih device name %s', device_name)
+    logger.debug('proposed hdparm_command = %s', hdparm_command)
+    return run_command(hdparm_command)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -608,3 +608,37 @@ def is_rotational(device_name, test=None):
                 break
     return rotational
 
+
+def get_dev_byid_name(device_name):
+    """
+    When given a standard dev name eg sda will return the /dev/disk/by-id
+    name, or None if error or no name available.
+    Works by querying udev via udevadm info --query=property --name device_name
+    The first line of which (DEVLINKS) is examined and parsed for the first
+    entry which has been found to be the /dev/disk/by-id symlink to our
+    device_name eg:
+    DEVLINKS=/dev/disk/by-id/ata-QEMU_HARDDISK_QM00005
+    /dev/disk/by-path/pci-0000:00:05.0-ata-1.0
+    In the above example we have the by-id name made from type, model and serial
+    and a second by-path entry which is not used here.
+    N.B. As the subsystem of the device is embeded in the by-id name a drive's
+    by-id path will change if for example it is plugged in via usb rather than
+    ata subsystem.
+    :param device_name: eg sda but can also be /dev/sda or even the by-id name
+    but only if the full path is specified with by-id
+    :return: None if error or no DEVLINKS entry found or the full path to this
+    given device_name.
+    """
+    out, err, rc = run_command(
+        [UDEVADM, 'info', '--query=property', '--name', str(device_name)],
+        throw=False)
+    if len(out) > 0:
+        # the output has at least one line
+        fields = out[0].replace('=', ' ').split()
+        if len(fields) > 1:
+            # we have at least 2 fields in this line
+            if fields[0] == 'DEVLINKS':
+                # return the first value directly after DEVLINKS
+                return fields[1]
+    # if no DEVLINKS value found or an error occurred.
+    return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -692,30 +692,36 @@ def get_disk_APM_level(device_name):
     Possible return values from the command are:
     1 to 254 ie min to max power use
     'off' = equivalent to 255 setting
-    If we receive an error message, can happen even with rc=0 we ignore any
-    reading and return 'unknown'
-
+    If we receive an error message, can happen even with rc=0, we ignore any
+    reading and return 0. We also translate the 'off' setting back to it's
+    number equivalent
     :param device_name: disk name as stored in db / Disk model eg sda
-    :return: APM setting read from the drive ie 1 - 255 or off or None if an
-    error occurred ie when APM is not supported
+    :return: APM setting read from the drive ie 1 - 255 (off is translated to
+    it's setting equivalent of 255. If there is an error, such as can happen
+    when APM is not supported, then we return 0.
     """
     # todo - consider combining with get_disk_power_status(device_name) via
     # todo - a switch option
     # if we use the -B -q switches then we have only one line of output:
     # hdparm -B -q /dev/sda
     #  APM_level<tab>= 192
+    #  APM_level<tab>= off
+    #  APM_level<tab>= not supported
     out, err, rc = run_command([HDPARM, '-B', '-q', '/dev/%s' % device_name],
                                throw=False)
     if len(err) != 1:
         # In some instances an error can be returned even with rc=0.
         # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ...
-        return 'unknown'  # don't trust any results in this instance
+        return 0  # don't trust any results in this instance
     if len(out) > 0:
         fields = out[0].split()
         # our line of interest has 3 fields when split by spaces, see above.
         if (len(fields) == 3):
-            return fields[2]
-    return 'unknown'
+            level = fields[2]
+            if level == 'off':
+                return 255
+            return level
+    return 0
 
 
 def set_disk_spindown(device, spindown_time, apm_value,
@@ -730,7 +736,9 @@ def set_disk_spindown(device, spindown_time, apm_value,
     :param device: The name of a disk device as used in the db ie sda
     :param spindown_time: Integer received from settings form ie 240
     :param apm_value: value to be used with hdparm's -B parameter to set the
-    drives APM level should be between 1-255 and will be ignored if not.
+    drives APM level. Should be between 1-255 and will be ignored if not. When
+    ignored there will be no hdparm -B executed and no -B switch added to the
+    relevant systemd line.
     :param spindown_message: message received from drop down as human presented
     selection, used later in systemd script to retrieve previous setting.
     :return: False if an hdparm command was not possible ie inappropriate dev,

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -641,7 +641,7 @@ def is_rotational(device_name, test=None):
                 # non zero rotation so flag and look no further
                 rotational = True
                 break
-        if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM':
+        if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM_CURRENT_VALUE':
             # we have an Automatic Acoustic Managment entry
             if line_fields[1] != '0':
                 # a non zero AAM entry so flag and look no further

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -718,7 +718,8 @@ def get_disk_APM_level(device_name):
     return 'unknown'
 
 
-def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
+def set_disk_spindown(device, spindown_time, apm_value,
+                      spindown_message='no comment'):
     """
     Takes a value to be used with hdparm -S to set disk spindown time for the
     device specified.
@@ -728,6 +729,8 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     minimum.
     :param device: The name of a disk device as used in the db ie sda
     :param spindown_time: Integer received from settings form ie 240
+    :param apm_value: value to be used with hdparm's -B parameter to set the
+    drives APM level should be between 1-255 and will be ignored if not.
     :param spindown_message: message received from drop down as human presented
     selection, used later in systemd script to retrieve previous setting.
     :return: False if an hdparm command was not possible ie inappropriate dev,
@@ -735,6 +738,9 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     """
     # hdparm -S works on for example /dev/sda3 so base_dev is not needed,
     # but it does require a full path, ie sda3 doesn't work.
+    logger.debug(
+        'set_disk_spindown() called with dev= %s spind= %s apm= %s '
+        'message= %s' % (device, spindown_time, apm_value, spindown_message))
     device_with_path = get_devname(device, True)
     # md devices arn't offered a spindown config: unknown status from hdparm -C
     # Their member disks are exposed on the Disks page so for the time being
@@ -746,14 +752,39 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
         logger.info(
             'Skipping hdparm settings: device not confirmed as rotational')
         return False
-    # setup hdparm command
-    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,
-                      '%s' % get_dev_byid_name(device_with_path)]
+    dev_byid = get_dev_byid_name(device_with_path)
+    # execute the -B hdparm command first as if it fails we can then not include
+    # it in the final command in systemd as it will trip the whole command then.
+    # todo - check if only rc != 0 throws systemd execution ie do error returns
+    # todo - also trip the script exection
+    switch_list = []
+    if apm_value > 0 and apm_value < 256:
+        apm_switch_list = ['-q', '-B%s' % apm_value]
+        logger.debug('switch list is now = %s', apm_switch_list)
+        hdparm_command = [HDPARM] + apm_switch_list + ['%s' % dev_byid]
+        logger.debug('-B hdparm command = %s', hdparm_command)
+        # try running this -B only hdparm to see if it will run without
+        # error or non zero return code.
+        out, err, rc = run_command(hdparm_command, throw=False)
+        if rc == 0 and len(err) == 1:
+            # if execution of the -B switch ran OK then add to switch list
+            switch_list += apm_switch_list
+            logger.debug('adding apm_switch_list so switch_list now = %s', switch_list)
+        else:
+            logger.error('non zero return code or error from hdparm '
+                         'command %s with error %s and return code %s'
+                         % (hdparm_command, err, rc))
+    # setup -S hdparm command
+    # todo shorten by combining -S with value when messaging sorted
+    standby_switch_list = ['-q', '-S', '%s' % spindown_time]
+    hdparm_command = [HDPARM] + standby_switch_list + ['%s' % dev_byid]
     out, err, rc = run_command(hdparm_command, throw=False)
     if rc != 0:
         logger.error('non zero return code from hdparm command %s with '
                      'error %s and return code %s' % (hdparm_command, err, rc))
         return False
+    hdparm_command = [HDPARM] + switch_list + standby_switch_list + [
+        '%s' % dev_byid]
     # hdparm ran without issues so attempt to edit rockstor-hdparm.service
     # with the same entry
     if update_hdparm_service(hdparm_command, spindown_message) is not True:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -100,6 +100,8 @@ def run_command(cmd, shell=False, stdout=subprocess.PIPE,
 
 def uptime():
     with open('/proc/uptime') as ufo:
+        # todo check on readline here as reads a character at a time
+        # todo xreadlines() reads one line at a time.
         return int(float(ufo.readline().split()[0]))
 
 
@@ -630,7 +632,6 @@ def is_rotational(device_name, test=None):
             continue
         # nonlocal line_fields
         line_fields = line.strip().split('=')
-        logger.debug('line_fields now look like this %s', line_fields)
         # example original line "ID_ATA_FEATURE_SET_AAM=1"
         # less than 2 fields are of no use so just in case:-
         if len(line_fields) < 2:
@@ -698,6 +699,8 @@ def set_disk_spindown(device, spindown_time):
     :param spindown_time: String received from settings form ie "20 minutes"
     :return:
     """
+    # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
+    # todo lighten by removing base_dev
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
     # todo look to using system/osi get_md_members(device_name, test=None)
@@ -709,10 +712,10 @@ def set_disk_spindown(device, spindown_time):
         logger.debug('skipping hdparm -S as device not confirmed as rotational')
         return True;
     # setup hdparm command
-    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
+    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time, '%s' % get_dev_byid_name(base_dev[0])]
     logger.debug('proposed hdparm command = %s', hdparm_command)
 
-    # update_hdparm_service(base_dev, switches)
+    update_hdparm_service(hdparm_command)
 
     return run_command(hdparm_command)
 
@@ -816,23 +819,22 @@ def get_devname(device_name, addPath=False):
     return None
 
 
-def update_hdparm_service(device_name, switches, message='test_message'):
+def update_hdparm_service(hdparm_command_list, message='test_message'):
     """
     Updates or creates the /etc/systemd/system/rockstor-hdparm.service file for
     the device_name given.
-    :param device_name: ie sda, will be converted internally to by-id
-    :param switches:
-    :param message:
-    :return:
+    :param hdparm_command_list: list containing the hdparm command elements
+    :param message: test message to follow hdparm command on next line
+    :return: None or
     """
     edit_done = False
     do_edit = False
     clear_line_count = 0
-    # get our by-id device name
-    device_name_byid = get_dev_byid_name(device_name)
+    # get our by-id device name by extracting the last hdparm list item
+    device_name_byid = hdparm_command_list[-1]
     # first create a temp file to use as our output until we are done editing.
     tfo, npath = mkstemp()
-    # if there is already a rockstor-hdparm.service file then we use that
+    # If there is already a rockstor-hdparm.service file then we use that
     # as our source file, otherwise use conf's empty template.
     if os.path.isfile('/etc/systemd/system/rockstor-hdparm.service'):
         infile = '/etc/systemd/system/rockstor-hdparm.service'
@@ -840,35 +842,44 @@ def update_hdparm_service(device_name, switches, message='test_message'):
     else:
         infile = ('%s/rockstor-hdparm.service' % settings.CONFROOT)
         update = False
+    # Create our proposed temporary file based on the source file plus edits.
     with open(infile) as ino, open(npath, 'w') as outo:
-        for line in ino.readlines():
+        for line in ino.readlines(): # readlines reads whole file in one go.
+            logger.debug('processing line with contents %s', line)
+            if do_edit and edit_done and clear_line_count != 2:
+                # We must have just edited an entry so we need to skip
+                # a line as each entry consists of an ExecStart= line and a
+                # remark line directly afterwards, but only if clear_line_count
+                # doesn't indicate an addition.
+                # reset our do_edit flag and continue
+                do_edit = False
+                continue
             if (re.match('ExecStart=', line) is not None) and not edit_done:
                 # we have found a line beginning with "ExecStart="
                 if update:
-                    if device_name_byid != line.split()[-1]:
-                        # in update but device name doesn't match so continue
-                        continue
+                    if device_name_byid == line.split()[-1]:
+                        # matching device name entry so set edit flat
+                        do_edit = True
                 else:  # no update and ExecStart found so set edit flag
                     do_edit = True
-            else:
-                if line == '':
+            # process all lines with the following
+            if line == '\n':  # empty line, or rather just a newline char
                     clear_line_count += 1
-                if clear_line_count == 2 and not edit_done:
+            if clear_line_count == 2 and not edit_done:
+                    # we are looking at our second empty line and haven't yet
+                    # achieved edit_done so do our edit / addition in this case.
                     do_edit = True
             if do_edit and not edit_done:
-                outo.write('/usr/sbin/hdparm %s %s' % (switches, device_name_byid))
-                outo.write('# %', message)
+                outo.write('ExecStart=' + ' '.join(hdparm_command_list) + '\n')
+                outo.write('# %s' % hdparm_command_list[-2] + '\n')
                 edit_done = True
             # mechanism to skip a line if we have just done an edit
-            if do_edit and edit_done:
-                # we need to skip a line as we have just inserted 2
-                # first reset our do_edit as it's now been done
-                do_edit = False
-                # then continue rather than copy source line to target
-                # which effects a line skip
-                continue
-            else:
-                # copy source line over to temp file
+            if not (do_edit and edit_done and clear_line_count != 2):
+                # if do-edit and edit_done are both true it means we have just
+                # done a line replacement so we skip copying the original line
+                # over to the target file, but only if clear_line_count also
+                # !=2 as this would indicate an addition where we do need to
+                # copy over the original files line.
                 outo.write(line)
     # now copy our temp file over to our destination as we are done editing
     shutil.move(npath, '/etc/systemd/system/rockstor-hdparm.service')
@@ -876,7 +887,8 @@ def update_hdparm_service(device_name, switches, message='test_message'):
         # then this is a fresh systemd instance so enable it
         # can't use systemctrl wrapper as circular then circular dependency
         # return systemctl('rockstor-hdparm', 'enable')
-        return run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
+        # return run_command([SYSTEMCTL_BIN, 'enable', 'rockstor-hdparm'])
+        return None
     return None
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -598,7 +598,6 @@ def get_base_device(device, test_mode=False):
     return base_dev
 
 
-
 def is_rotational(device_name, test=None):
     """
     When given a device_name a udevadmin lookup takes place to look for either:
@@ -611,13 +610,15 @@ def is_rotational(device_name, test=None):
     1 = rotational.
     N.B. we use --query=property and so have only 2 fields rather than 3 and
     no spaces, only '=' this simplifies the parsing required.
-    :param device: list containing device name eg ['/dev/sda']
+    :param device: string containing device name eg sda or /dev/sda, ie any
+    legal udevadm --name parameter.
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
     if test is None:
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name=' + device_name[0]], throw=False)
+                                    '--name=' + '%s' % device_name],
+                                   throw=False)
     else:
         # test mode so process test instead of udevadmin output
         out = test
@@ -695,27 +696,29 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     :param device: The name of a disk device as used in the db ie sda
     :param spindown_time: Integer received from settings form ie 240
     :param spindown_message: message received from drop down as human presented
-    selection, used later in systemd script to retrieve previous setting
+    selection, used later in systemd script to retrieve previous setting.
     :return: False if an hdparm command was not possible ie inappropriate dev,
     or an error was return by the command, True otherwise.
     """
-    # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
+    # hdparm -S works on for example /dev/sda3 so base_dev is not needed,
     # but it does require a full path, ie sda3 doesn't work.
-    # Could use the new get_devname(device, true) to add the dev path.
-    # todo lighten by removing base_dev
-    base_dev = get_base_device(device)
-    # md devices result in [''] from get_base_device so do nothing and return
-    # md devices have their member disks exposed on the Disks page so for the
-    # time being their spin down times are addressed as regular disks are.
-    if len(base_dev[0]) == 0:
+    logger.debug('set_disk_spindown called with device = %s', device)
+    device_with_path = get_devname(device, True)
+    logger.debug('get_devname returned %s', device_with_path)
+    # md devices arn't offered a spindown config: unknown status from hdparm -C
+    # Their member disks are exposed on the Disks page so for the time being
+    # their spin down times are addressed as regular disks are.
+    # todo test new arrangement with md device
+    if device_with_path is None:
+        logger.debug('set_disk_spindown found device_with_path = None')
         return False
     # Don't spin down non rotational devices, skip all and return True.
-    if is_rotational(base_dev) is not True:
+    if is_rotational(device_with_path) is not True:
         logger.info('skipping hdparm -S as device not confirmed as rotational')
         return False
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,
-                      '%s' % get_dev_byid_name(base_dev[0])]
+                      '%s' % get_dev_byid_name(device_with_path)]
     out, err, rc = run_command(hdparm_command, throw=False)
     if rc != 0:
         logger.error('non zero return code from hdparm command %s with '
@@ -745,8 +748,8 @@ def get_dev_byid_name(device_name):
     ata subsystem.
     :param device_name: eg sda but can also be /dev/sda or even the by-id name
     but only if the full path is specified with by-id
-    :return: None if error or no DEVLINKS entry found or the full path to this
-    given device_name.
+    :return: None if error or no DEVLINKS entry found or the full path by-id
+    name of the given device_name.
     """
     out, err, rc = run_command(
         [UDEVADM, 'info', '--query=property', '--name', str(device_name)],
@@ -803,7 +806,7 @@ def get_devname(device_name, addPath=False):
     Simple wrapper around a call to:
     udevadm info --query=name device_name
     Works with device_name of eg sda /dev/sda /dev/disk/by-id/ and /dev/disk/
-    If a device doesn't exist then udevadm returns multi work advise so if more
+    If a device doesn't exist then udevadm returns multi word advise so if more
     than one word assume failure and return None.
     N.B. if given /dev/sdc3 or equivalent DEVLINKS this method will return sdc3
     if no path is requested.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -48,6 +48,7 @@ UDEVADM = '/usr/sbin/udevadm'
 GREP = '/usr/bin/grep'
 NMCLI = '/usr/bin/nmcli'
 HOSTNAMECTL = '/usr/bin/hostnamectl'
+LSBLK = '/usr/bin/lsblk'
 HDPARM = '/usr/sbin/hdparm'
 
 
@@ -557,6 +558,42 @@ def md5sum(fpath):
     return md5.hexdigest()
 
 
+def get_base_device(device, test_mode=False):
+    """
+    Helper function that returns the full path of the base device of a partition
+    or if given a base device then will return it's full path,
+    ie
+    input sda3 output /dev/sda
+    input sda output /dev/sda
+    Works as a function of lsblk list order ie base devices first. So we return
+    the first start of line match to our supplied device name with the pattern
+    as the first element in lsblk's output and the match target as our device.
+    :param device: device name as per db entry, ie as returned from scan_disks
+    :param test_mode: Not True causes cat from file rather than smartctl command
+    :return: base_dev: single item list containing the root device's full path
+    ie device = sda3 the base_dev = /dev/sda or [''] if no lsblk entry was found
+    to match.
+    """
+    base_dev = ['', ]
+    if not test_mode:
+        out, e, rc = run_command([LSBLK])
+    else:
+        out, e, rc = run_command([CAT, '/root/smartdumps/lsblk.out'])
+    # now examine the output from lsblk line by line
+    for line in out:
+        line_fields = line.split()
+        if len(line_fields) < 1:
+            # skip empty lines
+            continue
+        if re.match(line_fields[0], device):
+            # We have found a device string match to our device so record it.
+            base_dev[0] = '/dev/' + line_fields[0]
+            break
+    # Return base_dev ie [''] or first character matches to line start in lsblk.
+    return base_dev
+
+
+
 def is_rotational(device_name, test=None):
     """
     When given a device_name a udevadmin lookup takes place to look for either:
@@ -644,6 +681,37 @@ def get_disk_power_status(device_name):
         if (len(fields) == 4):
             return fields[3]
     return 'unknown'
+
+
+def set_disk_spindown(device, spindown_time):
+    """
+    Takes a value to be used with hdparm -S to set disk spindown time for the
+    device specified.
+    Executes hdparm -S spindown_time and ensures the systemd script to do the
+    same on boot is also updated. Note we do not restart the systemd service
+    to enact these changes in order to keep keep our drive intervention to a
+    minimum.
+    :param device: The name of a disk device as used in the db ie sda
+    :param spindown_time: String received from settings form ie "20 minutes"
+    :return:
+    """
+    logger.debug('set_disk_spindown received device %s and -S value %s' % (
+    device, spindown_time))
+    base_dev = get_base_device(device)
+    # md devices result in [''] from get_base_device so do nothing and return
+    # todo look to using system/osi get_md_members(device_name, test=None)
+    # todo with md devices and then treat each in turn.
+    if len(base_dev[0]) == 0:
+        logger.debug('skipping hdparm -S as device = ""')
+        return True;
+    # Don't spin down non rotational devices, skip all and return True.
+    if is_rotational(base_dev) is not True:
+        logger.debug('skipping hdparm -S as device not confirmed as rotational')
+        return True;
+    # setup hdparm command
+    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
+    logger.debug('proposed hdparm commnad = %s', hdparm_command)
+    return run_command(hdparm_command)
 
 
 def get_dev_byid_name(device_name):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -637,13 +637,13 @@ def is_rotational(device_name, test=None):
             continue
         if line_fields[0] == 'ID_ATA_ROTATION_RATE_RPM':
             # we have a rotation rate entry
-            if line_fields[1] != 0:
+            if line_fields[1] != '0':
                 # non zero rotation so flag and look no further
                 rotational = True
                 break
         if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM':
             # we have an Automatic Acoustic Managment entry
-            if line_fields[1] != 0:
+            if line_fields[1] != '0':
                 # a non zero AAM entry so flag and look no further
                 rotational = True
                 break
@@ -702,19 +702,16 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     """
     # hdparm -S works on for example /dev/sda3 so base_dev is not needed,
     # but it does require a full path, ie sda3 doesn't work.
-    logger.debug('set_disk_spindown called with device = %s', device)
     device_with_path = get_devname(device, True)
-    logger.debug('get_devname returned %s', device_with_path)
     # md devices arn't offered a spindown config: unknown status from hdparm -C
     # Their member disks are exposed on the Disks page so for the time being
     # their spin down times are addressed as regular disks are.
-    # todo test new arrangement with md device
     if device_with_path is None:
-        logger.debug('set_disk_spindown found device_with_path = None')
         return False
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(device_with_path) is not True:
-        logger.info('skipping hdparm -S as device not confirmed as rotational')
+        logger.info(
+            'Skipping hdparm settings: device not confirmed as rotational')
         return False
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -672,13 +672,12 @@ def get_disk_power_status(device_name):
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
-    # in some instances an error can be returned even with rc=0, we ignore this
-    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
-    # We may want to ignore / return unknown when len(err) != 1
     out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % device_name],
                                throw=False)
-    # if len(err) != 1:
-    #     logger.debug('hdparm has output to standard error of %s', err)
+    if len(err) != 1:
+        # In some instances an error can be returned even with rc=0.
+        # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ...
+        return 'unknown'  # don't trust any results in this instance
     if len(out) > 0:
         fields = out[0].split()
         # our line of interest has 4 fields when split by spaces, see above.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -825,7 +825,9 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
     the device_name given.
     :param hdparm_command_list: list containing the hdparm command elements
     :param message: test message to follow hdparm command on next line
-    :return: None or
+    :return: None or the result of enabling the service via run_command which is
+    only done when the service is freshly installed, ie when no existing
+    /etc/systemd/system/rockstor-hdparm.service file exists in the first place.
     """
     edit_done = False
     do_edit = False
@@ -840,6 +842,7 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
         infile = '/etc/systemd/system/rockstor-hdparm.service'
         update = True
     else:
+        # todo consider checking for template file also.
         infile = ('%s/rockstor-hdparm.service' % settings.CONFROOT)
         update = False
     # Create our proposed temporary file based on the source file plus edits.
@@ -892,3 +895,39 @@ def update_hdparm_service(hdparm_command_list, message='test_message'):
     return None
 
 
+def read_hdparm_setting(dev_byid):
+    """
+    Looks through /etc/systemd/system/rockstor-hdparm service for any comment
+    following a matching device entry and returns it if found. Returns None if
+    no file or no matching entry or comment there after was found.
+    :param dev_byid: full path device name of by-id type
+    :return: comment string immediately following an entry containing the given
+    device name.
+    """
+    infile = '/etc/systemd/system/rockstor-hdparm.service'
+    if not os.path.isfile(infile):
+        return None
+    dev_byid_found = False
+    with open(infile) as ino:
+        for line in ino.readlines():
+            if line == '\n':
+                # skip empty lines
+                continue
+            line_fields = line.split()
+            if dev_byid_found:
+                if line_fields[0] == '#':
+                    # we have a comment after our target device entry so return
+                    # that comment minus the #
+                    return ' '.join(line_fields[1:])
+                else:
+                    # no comment found directly after target dev so return None
+                    return None
+            if line_fields[0] == '#' or len(line_fields) < 4:
+                # Skip comment lines not directly after our target dev_byid.
+                # Also no device line will be of interest if below 4, this way
+                # we don't do slow re.match on non candidates.
+                continue
+            if re.match('ExecStart', line_fields[0]) and line_fields[-1] == dev_byid:
+                # we have a line beginnign with ExecStart and ending in dev_byid
+                dev_byid_found = True
+    return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -697,30 +697,34 @@ def set_disk_spindown(device, spindown_time):
     minimum.
     :param device: The name of a disk device as used in the db ie sda
     :param spindown_time: Integer received from settings form ie 240
-    :return: True or the results from a run_command
+    :return: False if an hdparm command was not possible ie inappropriate dev,
+    or an error was return by the command, True otherwise.
     """
     # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
     # todo lighten by removing base_dev
-    # todo consider normalizing return values.
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
-    # todo look to using system/osi get_md_members(device_name, test=None)
-    # todo with md devices and then treat each in turn.
+    # md devices have their member disks exposed on the Disks page so for the
+    # time being their spin down times are addressed as regular disks are.
     if len(base_dev[0]) == 0:
-        return True
+        return False
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
         logger.debug('skipping hdparm -S as device not confirmed as rotational')
-        return True
+        return False
     # setup hdparm command
-    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time, '%s' % get_dev_byid_name(base_dev[0])]
-    logger.debug('proposed hdparm command = %s', hdparm_command)
-    # todo - Catch this result or work in with run_command
-    # todo - ie examine rc of run_comand(hdparm_comamnd) and if all ok then
-    # todo - go on to update_hdparm_service with the same
-    update_hdparm_service(hdparm_command)
-
-    return run_command(hdparm_command)
+    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,
+                      '%s' % get_dev_byid_name(base_dev[0])]
+    out, err, rc = run_command(hdparm_command, throw=False)
+    if rc != 0:
+        logger.error('non zero return code from hdparm command with '
+                     'error %s and return code %s' % (err, rc))
+        return False
+    # hdparm ran without issues so attempt to edit rockstor-hdparm.service
+    # with the same entry
+    if update_hdparm_service(hdparm_command) is not None:
+        return False
+    return True
 
 
 def get_dev_byid_name(device_name):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -572,21 +572,24 @@ def is_rotational(device_name, test=None):
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
+    logger.debug('is_rotational called with the following %s', device_name)
     if test is None:
+        # todo consider changing back to throw=False for production.
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name='] + device_name, throw=False)
+                                    '--name=' + device_name[0]], throw=True)
     else:
         # test mode so process test instead of udevadmin output
         out = test
         rc = 0
     if rc != 0:  # if return code is an error return False
         return False
-    # search output of udevadmin to find
+    # search output of udevadm to find signs of rotational media
     for line in out:
         if line == '':
             continue
         # nonlocal line_fields
         line_fields = line.strip().split('=')
+        logger.debug('line_fields now look like this %s', line_fields)
         # example original line "ID_ATA_FEATURE_SET_AAM=1"
         # less than 2 fields are of no use so just in case:-
         if len(line_fields) < 2:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -554,3 +554,54 @@ def md5sum(fpath):
         for l in tfo.readlines():
             md5.update(l)
     return md5.hexdigest()
+
+
+def is_rotational(device_name, test=None):
+    """
+    When given a device_name a udevadmin lookup takes place to look for either:
+    E: ID_ATA_ROTATION_RATE_RPM non zero or ID_ATA_FEATURE_SET_AAM
+    AAM = Automatic Acoustic Mamanement - ie head speed / noise tradeoff
+    If neither is found for then the device is assumed to be non
+    rotational. This method appears more reliable than
+    "cat /sys/block/sda/queue/rotational"
+    and "lsblk -d -o name,rota" which will both often report usb sticks as
+    1 = rotational.
+    N.B. we use --query=property and so have only 2 fields rather than 3 and
+    no spaces, only '=' this simplifies the parsing required.
+    :param device:
+    :return: True if rotational, false if error or unknown.
+    """
+    rotational = False  # until we find otherwise
+    if test is None:
+        out, err, rc = run_command([UDEVADM, 'info', '--query=property',
+                                    '--name=' + device_name], throw=False)
+    else:
+        # test mode so process test instead of udevadmin output
+        out = test
+        rc = 0
+    if rc != 0:  # if return code is an error return False
+        return False
+    # search output of udevadmin to find
+    for line in out:
+        if line == '':
+            continue
+        # nonlocal line_fields
+        line_fields = line.strip().split('=')
+        # example original line "ID_ATA_FEATURE_SET_AAM=1"
+        # less than 2 fields are of no use so just in case:-
+        if len(line_fields) < 2:
+            continue
+        if line_fields[0] == 'ID_ATA_ROTATION_RATE_RPM':
+            # we have a rotation rate entry
+            if line_fields[1] != 0:
+                # non zero rotation so flag and look no further
+                rotational = True
+                break
+        if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM':
+            # we have an Automatic Acoustic Managment entry
+            if line_fields[1] != 0:
+                # a non zero AAM entry so flag and look no further
+                rotational = True
+                break
+    return rotational
+

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -449,7 +449,7 @@ def get_disk_serial(device_name, test=None):
     ---------
     Additional personality added for md devices ie md0p1 or md126, these devices
     have no serial so we search for their MD_UUID and use that instead.
-    :param device_name:
+    :param device_name: eg sda
     :param test:
     :return: 12345678901234567890
     """
@@ -515,7 +515,7 @@ def get_virtio_disk_serial(device_name):
     Returns the serial number of device_name virtio disk eg /dev/vda
     Returns empty string if cat /sys/block/vda/serial command fails
     Note no serial entry in /sys/block/sda/ for real or KVM sata drives
-    :param device_name: vda
+    :param device_name: eg vda
     :return: 12345678901234567890
 
     Note maximum length of serial number reported = 20 chars
@@ -524,7 +524,7 @@ def get_virtio_disk_serial(device_name):
     https://github.com/qemu/qemu/blob/
     a9392bc93c8615ad1983047e9f91ee3fa8aae75f/include/standard-headers/
     linux/virtio_blk.h
-    #define VIRTIO_BLK_ID_BYTES	20	/* ID string length */
+    #define VIRTIO_BLK_ID_BYTES 20  /* ID string length */
 
     This process may not deal well with spaces in the serial number
     but VMM does not allow this.
@@ -568,13 +568,13 @@ def is_rotational(device_name, test=None):
     1 = rotational.
     N.B. we use --query=property and so have only 2 fields rather than 3 and
     no spaces, only '=' this simplifies the parsing required.
-    :param device:
+    :param device: list containing device name eg ['/dev/sda']
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
     if test is None:
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name=' + device_name], throw=False)
+                                    '--name='] + device_name, throw=False)
     else:
         # test mode so process test instead of udevadmin output
         out = test

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -467,6 +467,8 @@ def get_dev_options(device, custom_options=''):
         dev_options = get_base_device(device)
     else:
         # Convert string of custom options into a list ready for run_command
+        # todo think this ascii should be utf-8 as that's kernel standard
+        # todo or just use str(custom_options).split()
         dev_options = custom_options.encode('ascii').split()
         # If our custom options don't contain a raid controller target then add
         # the full path to our base device as our last device specific option.

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -333,18 +333,15 @@ def toggle_smart(device, custom_options='', enable=False):
 
 def set_disk_spindown(device, spindown_time):
     """
-    Takes a human readable string of the form "20 minutes" and applies the
-    appropriate -S parameter of hdparm to the passed device to set spindown
-    time for that device.
+    Takes a value to be used with hdparm -S to set disk spindown time for the
+    device specified.
+    Executes hdparm -S spindown_time and ensures the systemd script to do the
+    same is also updated.
     :param disk: The name of a disk device as used in the db ie sda
     :param spindown_time: String received from settings form ie "20 minutes"
     :return:
     """
-    time_fields = spindown_time.split()
-    if len(time_fields) == 2:
-        time = time_fields[0]
-        time_units = time_fields[1]
-    # todo mechanism to translate time sting into appropriate hdparm -S value
+    logger.debug('set_disk_spindown received device %s and -S value %s' % (device, spindown_time))
 
 
 def update_config(config):

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -349,12 +349,14 @@ def set_disk_spindown(device, spindown_time):
     # todo look to using system/osi get_md_members(device_name, test=None)
     # todo with md devices and then treat each in turn.
     if len(base_dev[0]) == 0:
+        logger.debug('skipping hdparm -S as device = ""')
         return True;
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
+        logger.debug('skipping hdparm -S as device not confirmed as rotational')
         return True;
     # setup hdparm command
-    hdparm_command = [HDPARM, '-C', spindown_time] + base_dev
+    hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
 
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -331,6 +331,7 @@ def toggle_smart(device, custom_options='', enable=False):
         [SMART, '--smart=%s' % switch] + get_dev_options(device,
                                                          custom_options))
 
+
 def set_disk_spindown(device, spindown_time):
     """
     Takes a value to be used with hdparm -S to set disk spindown time for the
@@ -343,7 +344,8 @@ def set_disk_spindown(device, spindown_time):
     :param spindown_time: String received from settings form ie "20 minutes"
     :return:
     """
-    logger.debug('set_disk_spindown received device %s and -S value %s' % (device, spindown_time))
+    logger.debug('set_disk_spindown received device %s and -S value %s' % (
+    device, spindown_time))
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
     # todo look to using system/osi get_md_members(device_name, test=None)
@@ -358,7 +360,7 @@ def set_disk_spindown(device, spindown_time):
     # setup hdparm command
     hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
-
+    return run_command(hdparm_command)
 
 
 def update_config(config):

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import re
-from osi import run_command, is_rotational
+from osi import run_command, get_base_device
 from tempfile import mkstemp
 from shutil import move
 import logging
@@ -28,8 +28,6 @@ logger = logging.getLogger(__name__)
 
 SMART = '/usr/sbin/smartctl'
 CAT = '/usr/bin/cat'
-LSBLK = '/usr/bin/lsblk'
-HDPARM = '/usr/sbin/hdparm'
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
@@ -332,37 +330,6 @@ def toggle_smart(device, custom_options='', enable=False):
                                                          custom_options))
 
 
-def set_disk_spindown(device, spindown_time):
-    """
-    Takes a value to be used with hdparm -S to set disk spindown time for the
-    device specified.
-    Executes hdparm -S spindown_time and ensures the systemd script to do the
-    same on boot is also updated. Note we do not restart the systemd service
-    to enact these changes in order to keep keep our drive intervention to a
-    minimum.
-    :param disk: The name of a disk device as used in the db ie sda
-    :param spindown_time: String received from settings form ie "20 minutes"
-    :return:
-    """
-    logger.debug('set_disk_spindown received device %s and -S value %s' % (
-    device, spindown_time))
-    base_dev = get_base_device(device)
-    # md devices result in [''] from get_base_device so do nothing and return
-    # todo look to using system/osi get_md_members(device_name, test=None)
-    # todo with md devices and then treat each in turn.
-    if len(base_dev[0]) == 0:
-        logger.debug('skipping hdparm -S as device = ""')
-        return True;
-    # Don't spin down non rotational devices, skip all and return True.
-    if is_rotational(base_dev) is not True:
-        logger.debug('skipping hdparm -S as device not confirmed as rotational')
-        return True;
-    # setup hdparm command
-    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
-    logger.debug('proposed hdparm commnad = %s', hdparm_command)
-    return run_command(hdparm_command)
-
-
 def update_config(config):
     SMARTD_CONFIG = '/etc/smartmontools/smartd.conf'
     ROCKSTOR_HEADER = '###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###'
@@ -411,41 +378,6 @@ def screen_return_codes(msg_on_hit, return_code_target, o, e, rc, command):
         raise CommandException(('%s' % command), o, e, rc)
 
 
-def get_base_device(device, test_mode=TESTMODE):
-    """
-    Helper function that returns the full path of the base device of a partition
-    or if given a base device then will return it's full path,
-    ie
-    input sda3 output /dev/sda
-    input sda output /dev/sda
-    Works as a function of lsblk list order ie base devices first. So we return
-    the first start of line match to our supplied device name with the pattern
-    as the first element in lsblk's output and the match target as our device.
-    :param device: device name as per db entry, ie as returned from scan_disks
-    :param test_mode: Not True causes cat from file rather than smartctl command
-    :return: base_dev: single item list containing the root device's full path
-    ie device = sda3 the base_dev = /dev/sda or [''] if no lsblk entry was found
-    to match.
-    """
-    base_dev = ['', ]
-    if not test_mode:
-        out, e, rc = run_command([LSBLK])
-    else:
-        out, e, rc = run_command([CAT, '/root/smartdumps/lsblk.out'])
-    # now examine the output from lsblk line by line
-    for line in out:
-        line_fields = line.split()
-        if len(line_fields) < 1:
-            # skip empty lines
-            continue
-        if re.match(line_fields[0], device):
-            # We have found a device string match to our device so record it.
-            base_dev[0] = '/dev/' + line_fields[0]
-            break
-    # Return base_dev ie [''] or first character matches to line start in lsblk.
-    return base_dev
-
-
 def get_dev_options(device, custom_options=''):
     """
     Returns device specific options for all smartctl commands.
@@ -464,7 +396,7 @@ def get_dev_options(device, custom_options=''):
     if custom_options is None or custom_options == '':
         # Empty custom_options or they have never been set so just return
         # full path to base device as nothing else to do.
-        dev_options = get_base_device(device)
+        dev_options = get_base_device(device, TESTMODE)
     else:
         # Convert string of custom options into a list ready for run_command
         # todo think this ascii should be utf-8 as that's kernel standard
@@ -474,7 +406,7 @@ def get_dev_options(device, custom_options=''):
         # the full path to our base device as our last device specific option.
         if (re.search('/dev/tw|/dev/cciss/c|/dev/sg', custom_options) is None):
             # add full path to our custom options as we see no raid target dev
-            dev_options += get_base_device(device)
+            dev_options += get_base_device(device, TESTMODE)
     # Note on raid controller target devices.
     # /dev/twe#, or /dev/twa#, or /dev/twl# are 3ware controller targets devs
     # respectively 3x-xxxx, 3w-9xxx, and t2-sas (3ware/LSI 9750) drivers for

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -358,7 +358,7 @@ def set_disk_spindown(device, spindown_time):
         logger.debug('skipping hdparm -S as device not confirmed as rotational')
         return True;
     # setup hdparm command
-    hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
+    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
     return run_command(hdparm_command)
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 SMART = '/usr/sbin/smartctl'
 CAT = '/usr/bin/cat'
 LSBLK = '/usr/bin/lsblk'
+HDPARM = '/usr/sbin/hdparm'
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
@@ -329,6 +330,21 @@ def toggle_smart(device, custom_options='', enable=False):
     return run_command(
         [SMART, '--smart=%s' % switch] + get_dev_options(device,
                                                          custom_options))
+
+def set_disk_spindown(device, spindown_time):
+    """
+    Takes a human readable string of the form "20 minutes" and applies the
+    appropriate -S parameter of hdparm to the passed device to set spindown
+    time for that device.
+    :param disk: The name of a disk device as used in the db ie sda
+    :param spindown_time: String received from settings form ie "20 minutes"
+    :return:
+    """
+    time_fields = spindown_time.split()
+    if len(time_fields) == 2:
+        time = time_fields[0]
+        time_units = time_fields[1]
+    # todo mechanism to translate time sting into appropriate hdparm -S value
 
 
 def update_config(config):


### PR DESCRIPTION
Opening this pull request to aid in collaboration.

The last issue I'm having problems with in this pr is the passing of an additional value 'spindown_message' from:

storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
and it's associated js in
storageadmin/static/storageadmin/js/views/spindown_disks.js

The value is the index in the js object "spindownTimes" in spindown_disks.js that the 'display_spindown_time' handlebar helper in the same file uses to populate the form drop down named spindown_time.

So I want to pass as an additional value the text (key in js object) used to populate that drop down.
The selected value is already passed successfully I'm just stuck on adding the text of the selected key as an additional element.

The receiving  method in:
storageadmin/views/disk.py
def _spindown_drive(cls, dname, request):
has in place a request.data.get('spindown_message', 'message issue!'))
and passes this on to:
set_disk_spindown(disk.name, spindown_time, spindown_message)

So stuck on presenting the js object key as spindown_message.

Everything else is currently working as intended.

Sorry if this is a silly one it's just the last hurdle and I'm drawing a blank.
