### PR TITLE
Issue #1263 rfc2307 active directory

### DIFF
--- a/src/rockstor/smart_manager/views/active_directory.py
+++ b/src/rockstor/smart_manager/views/active_directory.py
@@ -220,7 +220,7 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
                     cmd += ['--update', '--enablelocauthorize',]
                     run_command(cmd)
                 workgroup = self._domain_workgroup(domain, method=method)
-                update_global_config(workgroup, domain, config.get('idmap_range'))
+                update_global_config(workgroup, domain, config.get('idmap_range'), config.get('rfc2307'))
                 self._join_domain(config, method=method)
                 if (method == 'sssd' and config.get('enumerate') is True):
                     self._update_sssd(domain)

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
@@ -58,6 +58,14 @@
           </div>
         </div>
 
+    <div class="form-group">
+      <div class="col-sm-offset-4 col-sm-8">
+        <label class="checkbox inline">
+          <input type="checkbox" id="rfc2307" name="rfc2307" {{#if config.rfc2307}}checked{{/if}}> Enable RFC2307 and use UIDS and homes/shells AD DC values
+        </label>
+      </div>
+    </div>
+
         <!-- Submit -->
         <div class="form-group">
           <div class="col-sm-8 col-sm-offset-4">

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -110,13 +110,17 @@ def update_global_config(workgroup=None, realm=None, idmap_range=None, rfc2307=F
             tfo.write('    winbind enum groups = yes\n')
             tfo.write('    idmap config * : backend = tdb\n')
             tfo.write('    idmap config * : range = %s\n' % default_range)
+            #enable rfc2307 schema and collect UIDS from AD DC
+            #we assume if rfc2307 then winbind nss info too - collects AD DC home and shell for each user 
             if (rfc2307):
                 tfo.write('    idmap config %s : backend = ad\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, idmap_range))
                 tfo.write('    idmap config %s : schema_mode = rfc2307\n' % workgroup)
+                tfo.write('    winbind nss info = rfc2307')
             else:
                 tfo.write('    idmap config %s : backend = rid\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, idmap_range))
+
         #@todo: remove log level once AD integration is working well for users.
         tfo.write('    log level = 3\n')
         tfo.write('    load printers = no\n')

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -116,11 +116,10 @@ def update_global_config(workgroup=None, realm=None, idmap_range=None, rfc2307=F
                 tfo.write('    idmap config %s : backend = ad\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, idmap_range))
                 tfo.write('    idmap config %s : schema_mode = rfc2307\n' % workgroup)
-                tfo.write('    winbind nss info = rfc2307')
+                tfo.write('    winbind nss info = rfc2307\n')
             else:
                 tfo.write('    idmap config %s : backend = rid\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, idmap_range))
-
         #@todo: remove log level once AD integration is working well for users.
         tfo.write('    log level = 3\n')
         tfo.write('    load printers = no\n')


### PR DESCRIPTION
PR on issue #1263
To @schakrava : tested on my AD and easily switched between Rockstor default and RFC2307 and viceversa

Not able to check rfc2307 grabbing UIDS shells and homes because my AD hasn't been provisioned with rfc2307 (and i can't modify it on the fly, my AD serves 50+ working users - not a test env)

Maybe @ScarabMonkey can give it a try :wink: 

Apart from that, i can safely say that with rfc2307 enabled and AD missing rfc2307, Rockstor still get users and groups providing valid uids without generating any kind of error

Flyer