### PR TITLE
drive power down interface. Fixes #885

### DIFF
--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -1,0 +1,9 @@
+Description=Rockstor hdparm settings
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=
+
+[Install]
+WantedBy=suspend.target basic.target

--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -3,8 +3,11 @@ Description=Rockstor hdparm settings
 After=suspend.target
 # Rockstor-hdparm - the automated maintenance of this file requires a clear line
 # at the end of both the Unit and Service sections, but no other clear lines.
-# It should also be exactly 13 lines long including these comments but not
-# including the ExecStart lines and their obligatory following one line comment.
+# The line count of the template file in <rockstorroot>/conf is used to evaluate
+# if an 'all entries removed' scenario has been reached. If any modification are
+# made to the template file please also delete the generated file,
+# /etc/systemd/system/rockstor-hdparm.service, and recreate any existing
+# configuration via Rockstor's WebUI.
 
 [Service]
 Type=oneshot

--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -1,9 +1,13 @@
+[Unit]
 Description=Rockstor hdparm settings
 After=suspend.target
+# Rockstor-hdparm - the automated maintenance of this file requires a clear line
+# at the end of the Unit and Service sections, but no other clear lines.
+# Also requires at least one ExecStart entry in Service section with a comment
+# directly after each ExecStart entry.
 
 [Service]
 Type=oneshot
-ExecStart=
 
 [Install]
 WantedBy=suspend.target basic.target

--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -3,8 +3,8 @@ Description=Rockstor hdparm settings
 After=suspend.target
 # Rockstor-hdparm - the automated maintenance of this file requires a clear line
 # at the end of the Unit and Service sections, but no other clear lines.
-# Also requires at least one ExecStart entry in Service section with a comment
-# directly after each ExecStart entry.
+# It should also be exactly 13 lines long including these comments but not
+# including the ExecStart lines and their obligatory following one line comment.
 
 [Service]
 Type=oneshot

--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -2,7 +2,7 @@
 Description=Rockstor hdparm settings
 After=suspend.target
 # Rockstor-hdparm - the automated maintenance of this file requires a clear line
-# at the end of the Unit and Service sections, but no other clear lines.
+# at the end of both the Unit and Service sections, but no other clear lines.
 # It should also be exactly 13 lines long including these comments but not
 # including the ExecStart lines and their obligatory following one line comment.
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1115,26 +1115,26 @@ def get_disk_power_status(disk):
     any request will wake a fully sleeping drive.
     Drives in 'sleeping' mode typically require a hard or soft reset before
     becoming available for use, the kernel does this automatically however.
-    :param device: disk name eg sda.
+    :param device: disk name as stored in db / Disk model.
     :return: single word sting of state as indicated by hdparm -C /dev/<disk>
     and if we encounter an error line in the output we return unknown.
     """
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
-    # Note however that if there is an bad/missing sense data then it will be
-    # on the first line but then we can't trust what follows anyway then.
-    hdparm_command = [HDPARM, '-C', '-q' '/dev/%s' % disk]
-    # todo consider throw=False for production
-    out, err, rc = run_command(hdparm_command)
-    # should be only one line but trawl anyway.
-    # todo once tested loose the for loop.
-    for line in out:
-        fields = line.split()
-        # our line of interest as 4 fields when split by spaces, see above.
+    # in some instances an error can be returned even with rc=0, we ignore this
+    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
+    # We may want to ignore / return unknown when len(err) != 1
+    out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % disk],
+                               throw=False)
+    # if len(err) != 1:
+    #     logger.debug('hdparm has output to standard error of %s', err)
+    if len(out) > 0:
+        fields = out[0].split()
+        # our line of interest has 4 fields when split by spaces, see above.
         if (len(fields) == 4):
             return fields[3]
-    return 'Unknown'
+    return 'unknown'
 
 
 def blink_disk(disk, total_exec, read, sleep):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1100,6 +1100,20 @@ def wipe_disk(disk):
     return run_command([WIPEFS, '-a', disk])
 
 
+def get_disk_power_status(disk):
+    """
+    When given a disk name such as that stored in the db ie sda
+    we return it's current power state via hdparm -C /dev/<disk>
+    Possible states are:
+    unknown - command not supported by disk
+    active/idle - normal operation
+    standby - low power mode, ie drive motor not active ie -y will do this
+    sleeping - lowest power mode, completely shut down ie -Y will do this
+    :param device: disk name
+    :return: single word sting of state as indicated by hdparm -C /dev/<disk>
+    """
+
+
 def blink_disk(disk, total_exec, read, sleep):
     DD_CMD = [DD, 'if=/dev/%s' % disk, 'of=/dev/null', 'bs=512',
               'conv=noerror']

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -46,7 +46,6 @@ DEFAULT_MNT_DIR = '/mnt2/'
 RMDIR = '/bin/rmdir'
 WIPEFS = '/usr/sbin/wipefs'
 QID = '2015'
-HDPARM = '/usr/sbin/hdparm'
 
 
 Disk = collections.namedtuple('Disk',
@@ -1103,43 +1102,6 @@ def wipe_disk(disk):
     # todo candidate for move to system/osi as not btrfs related
     disk = ('/dev/%s' % disk)
     return run_command([WIPEFS, '-a', disk])
-
-
-def get_disk_power_status(disk):
-    """
-    When given a disk name such as that stored in the db ie sda
-    we return it's current power state via hdparm -C /dev/<disk>
-    Possible states are:
-    unknown - command not supported by disk
-    active/idle - normal operation
-    standby - low power mode, ie drive motor not active ie -y will do this
-    sleeping - lowest power mode, completely shut down ie -Y will do this
-    N.B. -C shouldn't spin up a drive in standby but has been reported to wake
-    a drive from sleeping but we aren't going to invoke sleeping as pretty much
-    any request will wake a fully sleeping drive.
-    Drives in 'sleeping' mode typically require a hard or soft reset before
-    becoming available for use, the kernel does this automatically however.
-    :param device: disk name as stored in db / Disk model.
-    :return: single word sting of state as indicated by hdparm -C /dev/<disk>
-    and if we encounter an error line in the output we return unknown.
-    """
-    # todo candidate for move to system/osi as not btrfs related
-    # if we use the -C -q switches then we have only one line of output:
-    # hdparm -C -q /dev/sda
-    # drive state is:  active/idle
-    # in some instances an error can be returned even with rc=0, we ignore this
-    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
-    # We may want to ignore / return unknown when len(err) != 1
-    out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % disk],
-                               throw=False)
-    # if len(err) != 1:
-    #     logger.debug('hdparm has output to standard error of %s', err)
-    if len(out) > 0:
-        fields = out[0].split()
-        # our line of interest has 4 fields when split by spaces, see above.
-        if (len(fields) == 4):
-            return fields[3]
-    return 'unknown'
 
 
 def blink_disk(disk, total_exec, read, sleep):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -611,6 +611,7 @@ def update_quota(pool, qgroup, size_bytes):
 
 
 def convert_to_KiB(size):
+    # todo candidate for move to system/osi as not btrfs related
     SMAP = {
         'KiB': 1,
         'MiB': 1024,
@@ -807,6 +808,7 @@ def root_disk():
     The assumption with non md devices is that the partition number will be a
     single character.
     """
+    # todo candidate for move to system/osi as not btrfs related
     with open('/proc/mounts') as fo:
         for line in fo.readlines():
             fields = line.split()
@@ -849,6 +851,7 @@ def scan_disks(min_size):
     :param min_size: Discount all devices below this size in KB
     :return: List containing drives of interest
     """
+    # todo candidate for move to system/osi as not btrfs related
     base_root_disk = root_disk()
     cmd = ['/usr/bin/lsblk', '-P', '-o',
            'NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID']
@@ -1097,6 +1100,7 @@ def scan_disks(min_size):
 
 
 def wipe_disk(disk):
+    # todo candidate for move to system/osi as not btrfs related
     disk = ('/dev/%s' % disk)
     return run_command([WIPEFS, '-a', disk])
 
@@ -1119,6 +1123,7 @@ def get_disk_power_status(disk):
     :return: single word sting of state as indicated by hdparm -C /dev/<disk>
     and if we encounter an error line in the output we return unknown.
     """
+    # todo candidate for move to system/osi as not btrfs related
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
@@ -1138,6 +1143,7 @@ def get_disk_power_status(disk):
 
 
 def blink_disk(disk, total_exec, read, sleep):
+    # todo candidate for move to system/osi as not btrfs related
     DD_CMD = [DD, 'if=/dev/%s' % disk, 'of=/dev/null', 'bs=512',
               'conv=noerror']
     p = subprocess.Popen(DD_CMD, shell=False, stdout=subprocess.PIPE,

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.db import models
 from storageadmin.models import Pool
 from system.osi import get_disk_power_status, get_dev_byid_name, \
-    read_hdparm_setting
+    read_hdparm_setting, get_disk_APM_level
 
 
 class Disk(models.Model):
@@ -68,6 +68,13 @@ class Disk(models.Model):
     def hdparm_setting(self, *args, **kwargs):
         try:
             return read_hdparm_setting(get_dev_byid_name(self.name))
+        except:
+            return None
+
+    @property
+    def apm_level(self, *args, **kwargs):
+        try:
+            return get_disk_APM_level(str(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,7 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
-from system.osi import get_disk_power_status
+from system.osi import get_disk_power_status, get_dev_byid_name, \
+    read_hdparm_setting
 
 
 class Disk(models.Model):
@@ -60,6 +61,13 @@ class Disk(models.Model):
     def power_state(self, *args, **kwargs):
         try:
             return get_disk_power_status(str(self.name))
+        except:
+            return None
+
+    @property
+    def hdparm_setting(self, *args, **kwargs):
+        try:
+            return read_hdparm_setting(get_dev_byid_name(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
-from fs.btrfs import get_disk_power_status
+from system.osi import get_disk_power_status
 
 
 class Disk(models.Model):

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from storageadmin.models import Pool
+from fs.btrfs import get_disk_power_status
 
 
 class Disk(models.Model):
@@ -52,6 +53,13 @@ class Disk(models.Model):
     def pool_name(self, *args, **kwargs):
         try:
             return self.pool.name
+        except:
+            return None
+
+    @property
+    def power_state(self, *args, **kwargs):
+        try:
+            return get_disk_power_status(str(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -36,6 +36,7 @@ from django.contrib.auth.models import User as DjangoUser
 class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
     power_state = serializers.CharField()
+    hdparm_setting = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -35,7 +35,7 @@ from django.contrib.auth.models import User as DjangoUser
 
 class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
-
+    power_state = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -37,6 +37,7 @@ class DiskInfoSerializer(serializers.ModelSerializer):
     pool_name = serializers.CharField()
     power_state = serializers.CharField()
     hdparm_setting = serializers.CharField()
+    apm_level = serializers.CharField()
     class Meta:
         model = Disk
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -9,6 +9,7 @@
     <th scope="col" abbr="Capacity">Capacity</th>
     <th scope="col" abbr="Pool">Pool</th>
     <th scope="col" abbr="SpinDown">Power Status</th>
+    <th scope="col" abbr="APM">APM</th>
     <th scope="col" abbr="Model">Model</th>
     <th scope="col" abbr="Transport">Transport</th>
     <th scope="col" abbr="Vendor">Vendor</th>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -64,7 +64,7 @@
           <div class="col-xs-8">
             <div id="slider" class="control-label" style="width: 400px;"></div>
             <input type="text" style="margin-top: 16px;" class="col-md-2"
-                   name="apm_value" id="apm_value"
+                   name="apm_value" id="apm_value" value="0"
                    title="Enter APM Value">
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -73,14 +73,14 @@
           <div class="col-xs-8 col-xs-offset-4">
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>
-            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be needed to
-              allow spin down on some drives
+            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be
+              required for spin down (lower power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-reclaimable"></div>
-            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) On some drives
-              these values may inhibit spin down
+            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) May
+              inhibit spin down (higher power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -52,13 +52,13 @@
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
             <label class="checkbox inline">
-              <input type="checkbox" id="enable_apm"
+              <input type="checkbox" id="enable_apm" checked="true"
                      name="enable_apm"> Enable APM setting
             </label>
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" id="slider-entry">
           <label class="col-sm-4 control-label" for="apm_value">APM
             setting</label>
           <div class="col-sm-8">
@@ -69,7 +69,7 @@
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" id="slider-key">
           <div class="col-xs-8 col-xs-offset-4">
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -74,18 +74,18 @@
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-free"></div>
             <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be
-              required for spin down (lower power & performance).
+              required for spin down - (lower power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-reclaimable"></div>
             <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) May
-              inhibit spin down (higher power & performance).
+              inhibit spin down - (higher power & performance).
             </div>
             <br>
             <div style="width: 15px; height: 15px; float: left"
                  class="slider-legend-used"></div>
-            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM disabled
+            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM off.
             </div>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -1,9 +1,9 @@
 <h3>Add drive specific Spin down time</h3>
 <h4>This is the time a drive must remains <strong>Idle</strong> before
   spinning down it's disks / platters to save on power and reduce drive noise.
-<br>
+  <br>
   Idle periods a disk activity can be encouraged by adding <strong>Task
-  execution time windows</strong> to relevant <strong>Scheduled Tasks</strong>.
+    execution time windows</strong> to relevant <strong>Scheduled Tasks</strong>.
   <i>See System - Scheduled Tasks</i>
 </h4>
 
@@ -17,13 +17,13 @@
   non existent spin down time may waste energy and cause a drive to create
   unwanted noise and heat. For HOME or SMALL OFFICE consider values in the
   range of 20 minutes. For larger installs consider values greater than 1 hour.
-  </h6>
+</h6>
 
 <div class="row">
   <div class="col-md-8">
     <label class="control-label"></label>
     <div class="form-box">
-      <form class="form-horizontal" id="add-spindown-disk-form"  name="aform" >
+      <form class="form-horizontal" id="add-spindown-disk-form" name="aform">
         <div class="messages"></div>
 
         <!-- Form Header Info -->
@@ -36,12 +36,14 @@
 
         <!-- Spindown time selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="spindown_time">Idle Time
+            prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
-            <select class="form-control" id="spindown_time" name="spindown_time">
+            <select class="form-control" id="spindown_time"
+                    name="spindown_time">
               {{display_spindown_time}}
               <!--{{#each spindownTimes}}-->
-                <!--<option value="{{this}}">{{@key}}</option>-->
+              <!--<option value="{{this}}">{{@key}}</option>-->
               <!--{{/each}}-->
             </select>
           </div>
@@ -49,8 +51,50 @@
 
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
+            <label class="checkbox inline">
+              <input type="checkbox" id="enable_apm"
+                     name="enable_apm"> Enable Advanced APM setting
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-xs-4 control-label" for="apm_value">APM setting<span
+              class="required"> *</span></label>
+          <div class="col-xs-8">
+            <div id="slider" class="control-label" style="width: 400px;"></div>
+            <input type="text" style="margin-top: 16px;" class="col-md-2"
+                   name="apm_value" id="apm_value"
+                   title="Enter APM Value">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-xs-8 col-xs-offset-4">
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-free"></div>
+            <div>&nbsp;<span id="slide_lower_half"></span>&nbsp;(1-127) May be needed to
+              allow spin down on some drives
+            </div>
+            <br>
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-reclaimable"></div>
+            <div>&nbsp;<span id="slide_upper_half"></span>&nbsp;(128-254) On some drives
+              these values may inhibit spin down
+            </div>
+            <br>
+            <div style="width: 15px; height: 15px; float: left"
+                 class="slider-legend-used"></div>
+            <div>&nbsp;<span id="slide_disabled"></span>&nbsp;(255) APM disabled
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
             <a id="cancel" class="btn btn-default">Cancel</a>
-            <input type="Submit" id="spindown-disk" class="btn btn-primary" value="Submit"></input>
+            <input type="Submit" id="spindown-disk" class="btn btn-primary"
+                   value="Submit"></input>
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -39,10 +39,10 @@
           <label class="col-sm-4 control-label" for="spindown_time">Idle Time prior to Spin Down<span class="required"> *</span></label>
           <div class="col-sm-4">
             <select class="form-control" id="spindown_time" name="spindown_time">
-              <!--{{display_spindown_time}}-->
-              {{#each spindownTimes}}
-                <option value="{{this}}">{{@key}}</option>
-              {{/each}}
+              {{display_spindown_time}}
+              <!--{{#each spindownTimes}}-->
+                <!--<option value="{{this}}">{{@key}}</option>-->
+              <!--{{/each}}-->
             </select>
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -10,7 +10,7 @@
 <h5>Please note that a drives <i>initial</i> response time when in
   <strong>standby</strong> mode is typically increased by up to tens of seconds
   as the disk motor takes time to re-energize the platters.</h5>
-<h6>The value entered here will be used by hdparm -C to set this drives Spin
+<h6>The value entered here will be used by hdparm -S to set this drives Spin
   down delay. If this delay is set too small for a specific work load then the
   the drive will spend more time than necessary spinning up and down and have
   an unnecessary impact on performance and wear levels. Conversely a high or

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -53,17 +53,17 @@
           <div class="col-sm-offset-4 col-sm-8">
             <label class="checkbox inline">
               <input type="checkbox" id="enable_apm"
-                     name="enable_apm"> Enable Advanced APM setting
+                     name="enable_apm"> Enable APM setting
             </label>
           </div>
         </div>
 
         <div class="form-group">
-          <label class="col-xs-4 control-label" for="apm_value">APM setting<span
-              class="required"> *</span></label>
-          <div class="col-xs-8">
+          <label class="col-sm-4 control-label" for="apm_value">APM
+            setting</label>
+          <div class="col-sm-8">
             <div id="slider" class="control-label" style="width: 400px;"></div>
-            <input type="text" style="margin-top: 16px;" class="col-md-2"
+            <input class="col-sm-3" type="text"
                    name="apm_value" id="apm_value" value="0"
                    title="Enter APM Value">
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -42,13 +42,11 @@
             <select class="form-control" id="spindown_time"
                     name="spindown_time">
               {{display_spindown_time}}
-              <!--{{#each spindownTimes}}-->
-              <!--<option value="{{this}}">{{@key}}</option>-->
-              <!--{{/each}}-->
             </select>
           </div>
         </div>
 
+        <!-- Enable APM setting checkbox -->
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
             <label class="checkbox inline">
@@ -58,6 +56,7 @@
           </div>
         </div>
 
+        <!-- APM setting group of Slider + Text box for value  -->
         <div class="form-group" id="slider-entry">
           <label class="col-sm-4 control-label" for="apm_value">APM
             setting</label>
@@ -69,6 +68,7 @@
           </div>
         </div>
 
+        <!-- APM slider key group -->
         <div class="form-group" id="slider-key">
           <div class="col-xs-8 col-xs-offset-4">
             <div style="width: 15px; height: 15px; float: left"

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/spindown_disks.jst
@@ -7,8 +7,8 @@
   <i>See System - Scheduled Tasks</i>
 </h4>
 
-<h5>Please note that a drives <i>initial</i> response time when in
-  <strong>standby</strong> mode is typically increased by up to tens of seconds
+<h5>Please note that a drive's <i>initial</i> response time when in
+  <strong>standby</strong> mode is typically increased by tens of seconds
   as the disk motor takes time to re-energize the platters.</h5>
 <h6>The value entered here will be used by hdparm -S to set this drives Spin
   down delay. If this delay is set too small for a specific work load then the

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -275,7 +275,6 @@ DisksView = Backbone.View.extend({
                 if (hdparmSetting != null) {
                     html += hdparmSetting;
                 }
-                html += ' ';
                 html += '</td>';
                 // begin APM column
                 html += '<td>';
@@ -288,7 +287,6 @@ DisksView = Backbone.View.extend({
                         html += apmLevel;
                     }
                 }
-                html += ' ';
                 html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -206,7 +206,7 @@ DisksView = Backbone.View.extend({
                     html += 'Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>';
                 } else if (btrfsUId && _.isNull(poolName)) {
                     html += '<a href="#" class="btrfs_wipe" data-disk-name="' + diskName + '" title="Disk is unusable because it has BTRFS filesystem(s) on it.Click to wipe it clean." rel="tooltip">';
-                    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="' + diskName + '" title="Click to import data(pools, shares and snapshots) on this disk automatically" rel="tooltip">';
+                    html += '<i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="' + diskName + '" title="Click to automatically import data (pools, shares and snapshots) on this disk" rel="tooltip">';
                     html += '<i class="glyphicon glyphicon-circle-arrow-down"></i></a>';
                 }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -278,6 +278,7 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin APM column
                 html += '<td>';
+                // pre-made handlebar helper for this section below
                 if (apmLevel == 0 || apmLevel == null) {
                     html += '???';
                 } else {
@@ -316,6 +317,23 @@ DisksView = Backbone.View.extend({
                 html += '</tr>';
             });
             return new Handlebars.SafeString(html);
+        });
+        // Helper to display APM value after merger with upstream changes
+        // where the above helper is replaced by many smaller ones like this.
+        // N.B. untested. Presumably we do {{humanReadableAPM this.apm_level}}
+        // in upstream disks_table.jst
+        Handlebars.registerHelper('humanReadableAPM', function (apm) {
+            var apmhtml = '';
+            if (apm == 0 || apm == null) {
+                apmhtml = '???';
+            } else {
+                if (apm == 255) {
+                    apmhtml = 'off';
+                } else {
+                    apmhtml = apm;
+                }
+            }
+            return new Handlebars.SafeString(apmhtml);
         });
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -31,6 +31,7 @@ DisksView = Backbone.View.extend({
         'click .delete': 'deleteDisk',
         'click .btrfs_wipe': 'btrfsWipeDisk',
         'click .btrfs_import': 'btrfsImportDisk',
+        'click .pause': 'pauseDisk',
         'switchChange.bootstrapSwitch': 'smartToggle'
     },
 
@@ -83,6 +84,27 @@ DisksView = Backbone.View.extend({
         });
     },
 
+    pauseDisk: function (event) {
+        var _this = this;
+        if (event) event.preventDefault();
+        var button = $(event.currentTarget);
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        var diskName = button.data('disk-name');
+        if (confirm('Are you sure you want to force the following device into Standby mode ' + diskName + '?')) {
+            $.ajax({
+                url: '/api/disks/' + diskName + '/pause',
+                type: 'POST',
+                success: function (data, status, xhr) {
+                    _this.render();
+                },
+                error: function (xhr, status, error) {
+                    enableButton(button);
+                }
+            });
+        }
+    },
+
     wipeDisk: function (event) {
         var _this = this;
         if (event) event.preventDefault();
@@ -103,6 +125,7 @@ DisksView = Backbone.View.extend({
             });
         }
     },
+
     btrfsWipeDisk: function (event) {
         var _this = this;
         if (event) event.preventDefault();
@@ -233,10 +256,18 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin Spin Down / Power Status column
                 html += '<td>';
-                html += powerState + ' ';
                 if (powerState == 'unknown' || powerState == null ) {
+                    html += '<i class="glyphicon glyphicon-pause"></i>';
+                    html += powerState + ' ';
                     html += '<i class="glyphicon glyphicon-hourglass"></i>';
                 } else {
+                    if (powerState == 'active/idle') {
+                        html += '<a href="#" class="pause" data-disk-name="' + diskName + '" title="Force drive into Standby mode." rel="tooltip">';
+                        html += '<i class="glyphicon glyphicon-pause"></i></a>';
+                    } else {
+                        html += '<i class="glyphicon glyphicon-pause"></i>';
+                    }
+                    html += powerState + ' ';
                     html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                     html += '<i class="glyphicon glyphicon-hourglass"></i></a>';
                 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -190,7 +190,8 @@ DisksView = Backbone.View.extend({
                     diskParted = disk.get('parted'),
                     smartEnabled = disk.get('smart_enabled'),
                     diskRole = disk.get('role'),
-                    smartOptions = disk.get('smart_options');
+                    smartOptions = disk.get('smart_options'),
+                    powerState = disk.get('power_state');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -229,9 +230,9 @@ DisksView = Backbone.View.extend({
                     html += '<a href="#pools/' + poolName + '">' + poolName + '</a>';
                 }
                 html += '</td>';
-                // begin Spin Down / power column
+                // begin Spin Down / Power Status column
                 html += '<td>';
-                html += 'active/idle' + ' ';
+                html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                 html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -215,7 +215,8 @@ DisksView = Backbone.View.extend({
                     diskRole = disk.get('role'),
                     smartOptions = disk.get('smart_options'),
                     powerState = disk.get('power_state'),
-                    hdparmSetting = disk.get('hdparm_setting');
+                    hdparmSetting = disk.get('hdparm_setting'),
+                    apmLevel = disk.get('apm_level');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -273,6 +274,15 @@ DisksView = Backbone.View.extend({
                 }
                 if (hdparmSetting != null) {
                     html += hdparmSetting;
+                }
+                html += ' ';
+                html += '</td>';
+                // begin APM column
+                html += '<td>';
+                if (apmLevel == 'unknown' || apmLevel == null){
+                    html += '???';
+                } else {
+                    html += apmLevel;
                 }
                 html += ' ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -279,10 +279,14 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin APM column
                 html += '<td>';
-                if (apmLevel == 'unknown' || apmLevel == null){
+                if (apmLevel == 0 || apmLevel == null) {
                     html += '???';
                 } else {
-                    html += apmLevel;
+                    if (apmLevel == 255) {
+                        html += 'off';
+                    } else {
+                        html += apmLevel;
+                    }
                 }
                 html += ' ';
                 html += '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -257,11 +257,13 @@ DisksView = Backbone.View.extend({
                 html += '</td>';
                 // begin Spin Down / Power Status column
                 html += '<td>';
+                // pre-made handlebar helper for this conditional included below
                 if (powerState == 'unknown' || powerState == null ) {
                     html += '<i class="glyphicon glyphicon-pause"></i>';
                     html += powerState + ' ';
                     html += '<i class="glyphicon glyphicon-hourglass"></i>';
                 } else {
+                    // pre-made handlebar helper for this conditional included below
                     if (powerState == 'active/idle') {
                         html += '<a href="#" class="pause" data-disk-name="' + diskName + '" title="Force drive into Standby mode." rel="tooltip">';
                         html += '<i class="glyphicon glyphicon-pause"></i></a>';
@@ -334,6 +336,26 @@ DisksView = Backbone.View.extend({
                 }
             }
             return new Handlebars.SafeString(apmhtml);
+        });
+        // Simple helper to return true / false on powerState = null or unknown
+        // Untested. Presumably we do:
+        // {{#if (powerstateNullorUnknown this.power_state)}}
+        // in upstream disks_table.jst
+        Handlebars.registerHelper('powerStateNullorUnknown', function (pstate) {
+            if (pstate == 'unknown' || pstate == null ) {
+                return true;
+            }
+            return false;
+        });
+        // Simple helper to return true / false on powerState = active/idle
+        // Untested. Presumably we do:
+        // {{#if (powerStateActiveIdle this.power_state)}}
+        // in upstream disks_table.jst
+        Handlebars.registerHelper('powerStateActiveIdle', function (pstate) {
+            if (pstate == 'active/idle') {
+                return true;
+            }
+            return false;
         });
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -234,9 +234,16 @@ DisksView = Backbone.View.extend({
                 // begin Spin Down / Power Status column
                 html += '<td>';
                 html += powerState + ' ';
-                html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
-                html += '<i class="glyphicon glyphicon-hourglass"></i></a> ';
-                html += hdparmSetting + ' ';
+                if (powerState == 'unknown' || powerState == null ) {
+                    html += '<i class="glyphicon glyphicon-hourglass"></i>';
+                } else {
+                    html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
+                    html += '<i class="glyphicon glyphicon-hourglass"></i></a>';
+                }
+                if (hdparmSetting != null) {
+                    html += hdparmSetting;
+                }
+                html += ' ';
                 html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -191,7 +191,8 @@ DisksView = Backbone.View.extend({
                     smartEnabled = disk.get('smart_enabled'),
                     diskRole = disk.get('role'),
                     smartOptions = disk.get('smart_options'),
-                    powerState = disk.get('power_state');
+                    powerState = disk.get('power_state'),
+                    hdparmSetting = disk.get('hdparm_setting');
 
                 html += '<tr>';
                 html += '<td><a href="#disks/' + diskName + ' "><i class="glyphicon glyphicon-hdd"></i> ' + diskName + '</a>&nbsp';
@@ -235,6 +236,7 @@ DisksView = Backbone.View.extend({
                 html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
                 html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                html += hdparmSetting + ' ';
                 html += '</td>';
                 // begin Model column
                 html += '<td>' + diskModel + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -235,7 +235,7 @@ DisksView = Backbone.View.extend({
                 html += '<td>';
                 html += powerState + ' ';
                 html += '<a href="#disks/spindown/' + diskName + '" title="Click to configure Spin Down." rel="tooltip">';
-                html += '<i class="glyphicon glyphicon-pencil"></i></a> ';
+                html += '<i class="glyphicon glyphicon-hourglass"></i></a> ';
                 html += hdparmSetting + ' ';
                 html += '</td>';
                 // begin Model column

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -156,12 +156,17 @@ SpindownDiskView = RockstorLayoutView.extend({
             // we have a device that doesn't support APM or there was an error
             // reading it's current level so disable / hide our APM settings.
             console.log('the received value of APM =' + apmLevel);
-            // this.$('enable_apm').attr('checked','false')
+            //this.$('#enable_apm').attr('checked', 'true');
+            this.$('#enable_apm').removeAttr('checked');
+            this.$('#enable_apm').attr('disabled', 'true');
+            //this.$('#slider').hide();
+            this.$('#slider-entry').hide();
+            this.$('#slider-key').hide();
 
         }
         _this.renderSlider();
         // update the slider when the apm_value text box is changed
-        _this.$("#apm_value").change(function () {
+        _this.$('#apm_value').change(function () {
             var our_value = this.value;
             _this.slider.setValue((our_value));
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -30,6 +30,7 @@ SpindownDiskView = RockstorLayoutView.extend({
     },
 
     initialize: function () {
+        var _this = this;
         this.constructor.__super__.initialize.apply(this, arguments);
         this.template = window.JST.disk_spindown_disks;
         this.disks = new DiskCollection();
@@ -37,16 +38,22 @@ SpindownDiskView = RockstorLayoutView.extend({
         this.dependencies.push(this.disks);
         this.tickFormatter = function (d) {
             var formatter = d3.format(",.0f");
-            if (d > 254) {
-                return formatter(d) + "off";
-            } else {
-                return formatter(d);
+            if (d > 254.5) {
+                return formatter(d) + " off";
             }
+            if (d < 0.5) {
+                return "remove"
+            }
+            return formatter(d);
+        }
+        this.tickFormatterText = function (d) {
+            var formatter = d3.format(",.0f");
+            return formatter(d);
         }
         this.slider = null;
         this.sliderCallback = function (slider) {
             var value = slider.value();
-            _this.$('#apm_value').val(_this.tickFormatter(value));
+            _this.$('#apm_value').val(_this.tickFormatterText(value));
         }
         this.initHandlebarHelpers();
     },
@@ -86,7 +93,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         // retrieve local copy of current apm level
         var apmLevel = this.disks.find(function (d) {
             return (d.get('name') == disk_name);
-        }).get('apm_setting');
+        }).get('apm_level');
 
         $(this.el).html(this.template({
             diskName: this.diskName,
@@ -111,15 +118,17 @@ SpindownDiskView = RockstorLayoutView.extend({
             //$('#slide_lower_half').prop('disable', !this.checked);
             //$('#slide_upper_half').prop('disable', !this.checked);
             //$('#slide_disabled').prop('disable', !this.checked);
-            if (this.checked) {
-                _this.renderSlider();
-            }
+            //if (this.checked) {
+            //    _this.renderSlider();
+            //}
         });
 
-        if (apmLevel != 'unknown' || apmLevel != null) {
-            // don't show apm slider if we couldn't read apm value
-            _this.renderSlider();
-        }
+        //if (apmLevel != 'unknown' || apmLevel != null) {
+        //    // don't show apm slider if we couldn't read apm value
+        //    _this.renderSlider();
+        //}
+
+        _this.renderSlider();
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,
@@ -197,9 +206,8 @@ SpindownDiskView = RockstorLayoutView.extend({
         if (value == 'off') {
             value = 255;
         }
-
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(1).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -173,7 +173,11 @@ SpindownDiskView = RockstorLayoutView.extend({
             //_this.$('#apm_value').focusout(function () {
             _this.$('#apm_value').change(function () {
                 var our_value = this.value;
-                _this.slider.setValue((our_value));
+                // avoid passing NaN value to slider, leaving them to be
+                // validated by our forms validateApmValue
+                if (!isNaN(our_value)) {
+                    _this.slider.setValue((our_value));
+                }
             });
             // set the text box to show the current sensed APM level
             _this.$('#apm_value').val(apmLevel);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -210,7 +210,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             value = 255;
         }
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(1).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -49,7 +49,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         }
         var _this = this;
         var disk_name = this.diskName;
-        var spindownTimes = {'30 seconds': 6, '1 minute': 12, '5 minutes': 60, '10 minutes': 120, '20 minutes': 240, '30 minutes': 241, '1 hour': 242, '2 hours': 244, '4 hours': 248, 'vendor defined (8-12h)': 253};
+        var spindownTimes = {'30 seconds': 6, '1 minute': 12, '5 minutes': 60, '10 minutes': 120, '20 minutes': 240, '30 minutes': 241, '1 hour': 242, '2 hours': 244, '4 hours': 248, 'Vendor defined (8-12h)': 253, 'No spin down': 0};
         var serialNumber = this.disks.find(function (d) {
             return (d.get('name') == disk_name);
         }).get('serial');

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -188,6 +188,10 @@ SpindownDiskView = RockstorLayoutView.extend({
         // <option value="240">20 minutes</option>
         Handlebars.registerHelper('display_spindown_time', function () {
             var html = '';
+            if (this.hdparmSetting == null){
+                // if there is no previous setting then default to 20 minutes
+                this.hdparmSetting = '20 minutes';
+            }
             for (var timeString in this.spindownTimes) {
                 // Get the last setting by reading it from systemd file's
                 // comment line as neither smart or hdparm can retrieve it.

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -38,7 +38,7 @@ SpindownDiskView = RockstorLayoutView.extend({
         this.dependencies.push(this.disks);
         this.tickFormatter = function (d) {
             var formatter = d3.format(",.0f");
-            if (d > 254.5) {
+            if (d > 254.4) {
                 return formatter(d) + " off";
             }
             if (d < 0.5) {
@@ -214,7 +214,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             value = 255;
         }
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(1).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(0.5).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -51,6 +51,7 @@ SpindownDiskView = RockstorLayoutView.extend({
             return formatter(d);
         }
         this.slider = null;
+        // update the text box apm_value when ever the slider is moved.
         this.sliderCallback = function (slider) {
             var value = slider.value();
             _this.$('#apm_value').val(_this.tickFormatterText(value));
@@ -146,7 +147,19 @@ SpindownDiskView = RockstorLayoutView.extend({
         //    _this.renderSlider();
         //}
 
+        // apmLevel = the current sensed level from the drive
+        // apm_value = the text box and it's entered value
+        // set the text box to show the current sensed APM level
         _this.renderSlider();
+        // update the slider when the apm_value text box is changed
+        _this.$("#apm_value").change(function () {
+            var our_value = this.value;
+            _this.slider.setValue((our_value));
+        });
+        _this.$('#apm_value').val(apmLevel);
+        // now call the change event on text box apm_value to update the slider
+        _this.$('#apm_value').change();
+
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -114,15 +114,32 @@ SpindownDiskView = RockstorLayoutView.extend({
             return err_msg;
         };
 
-        this.$('#enable_apm').click(function () {
-            $('#apm_value').prop('disable', !this.checked); // disable apm text
-            //$('#slide_lower_half').prop('disable', !this.checked);
-            //$('#slide_upper_half').prop('disable', !this.checked);
-            //$('#slide_disabled').prop('disable', !this.checked);
-            //if (this.checked) {
-            //    _this.renderSlider();
-            //}
-        });
+        $.validator.addMethod('validateApmValue', function (value) {
+            var apm_value = $('#apm_value').val();
+            if (apm_value == "") {
+                err_msg = 'Please enter an APM value (1-255), or 0 to not apply an APM settings.';
+                return false;
+            }
+            if (/^[0-9\b]+$/.test(apm_value) == false) {
+                err_msg = 'Invalid APM value: please enter a number in the range 0-255.';
+                return false;
+            }
+            if (apm_value < 0 || apm_value > 255) {
+                err_msg = 'The APM setting must be between 0 (no setting) and 255 (disabled).';
+                return false;
+            }
+            return true;
+        }, spindown_err_msg);
+
+        //this.$('#enable_apm').click(function () {
+        //    $('#apm_value').prop('disable', !this.checked); // disable apm text
+        //    //$('#slide_lower_half').prop('disable', !this.checked);
+        //    //$('#slide_upper_half').prop('disable', !this.checked);
+        //    //$('#slide_disabled').prop('disable', !this.checked);
+        //    //if (this.checked) {
+        //    //    _this.renderSlider();
+        //    //}
+        //});
 
         //if (apmLevel != 'unknown' || apmLevel != null) {
         //    // don't show apm slider if we couldn't read apm value
@@ -136,10 +153,11 @@ SpindownDiskView = RockstorLayoutView.extend({
             onkeyup: false,
             rules: {
                 spindown_time: 'required',
-                slider: {
-                    required: "#enable_apm:checked" // slider required only if
-                    // APM settings tickbox enabled.
-                },
+                apm_value: 'validateApmValue',
+                //slider: {
+                //    required: "#enable_apm:checked" // slider required only if
+                //    // APM settings tickbox enabled.
+                //},
             },
 
             submitHandler: function () {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -42,7 +42,7 @@ SpindownDiskView = RockstorLayoutView.extend({
                 return formatter(d) + " off";
             }
             if (d < 0.5) {
-                return "remove"
+                return "none"
             }
             return formatter(d);
         }
@@ -150,6 +150,15 @@ SpindownDiskView = RockstorLayoutView.extend({
         // apmLevel = the current sensed level from the drive
         // apm_value = the text box and it's entered value
         // set the text box to show the current sensed APM level
+
+        // apmLevel can be 'unknown' which is displayed as
+        if (apmLevel == 0){
+            // we have a device that doesn't support APM or there was an error
+            // reading it's current level so disable / hide our APM settings.
+            console.log('the received value of APM =' + apmLevel);
+            // this.$('enable_apm').attr('checked','false')
+
+        }
         _this.renderSlider();
         // update the slider when the apm_value text box is changed
         _this.$("#apm_value").change(function () {
@@ -239,13 +248,9 @@ SpindownDiskView = RockstorLayoutView.extend({
     },
 
     renderSlider: function () {
-        var value = this.apmLevel;
-        // when queried hdparm -B returns off when set to 255 so reverse this
-        if (value == 'off') {
-            value = 255;
-        }
+        // Callback used to broadcast our changing value.
         this.$('#slider').empty();
-        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(value).reclaimable(127).used(0.5).callback(this.sliderCallback);
+        this.slider = d3.slider2().min(0).max(255).ticks(10).tickFormat(this.tickFormatter).value(0).reclaimable(127).used(0.5).callback(this.sliderCallback);
         d3.select('#slider').call(this.slider);
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -81,7 +81,8 @@ SpindownDiskView = RockstorLayoutView.extend({
             '2 hours': 244,
             '4 hours': 248,
             'Vendor defined (8-12h)': 253,
-            'No spin down': 0
+            'No spin down': 0,
+            'Remove config': -1
         };
         _this.spindownTimes = spindownTimes;
         // retrieve local copy of disk serial number

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -132,48 +132,54 @@ SpindownDiskView = RockstorLayoutView.extend({
             return true;
         }, spindown_err_msg);
 
-        //this.$('#enable_apm').click(function () {
-        //    $('#apm_value').prop('disable', !this.checked); // disable apm text
-        //    //$('#slide_lower_half').prop('disable', !this.checked);
-        //    //$('#slide_upper_half').prop('disable', !this.checked);
-        //    //$('#slide_disabled').prop('disable', !this.checked);
-        //    //if (this.checked) {
-        //    //    _this.renderSlider();
-        //    //}
-        //});
-
-        //if (apmLevel != 'unknown' || apmLevel != null) {
-        //    // don't show apm slider if we couldn't read apm value
-        //    _this.renderSlider();
-        //}
+        this.$('#enable_apm').click(function () {
+            // $('#apm_value').prop('disable', !this.checked); // disable apm text
+            //$('#slide_lower_half').prop('disable', !this.checked);
+            //$('#slide_upper_half').prop('disable', !this.checked);
+            //$('#slide_disabled').prop('disable', !this.checked);
+            if (this.checked) {
+                $('#slider-entry').show();
+                $('#slider-key').show();
+                $('#apm_value').val(apmLevel);
+            } else {
+                $('#slider-entry').hide();
+                $('#slider-key').hide();
+            }
+        });
 
         // apmLevel = the current sensed level from the drive
-        // apm_value = the text box and it's entered value
-        // set the text box to show the current sensed APM level
-
-        // apmLevel can be 'unknown' which is displayed as
-        if (apmLevel == 0){
+        if (apmLevel == 0) {
             // we have a device that doesn't support APM or there was an error
             // reading it's current level so disable / hide our APM settings.
-            console.log('the received value of APM =' + apmLevel);
             //this.$('#enable_apm').attr('checked', 'true');
             this.$('#enable_apm').removeAttr('checked');
             this.$('#enable_apm').attr('disabled', 'true');
             //this.$('#slider').hide();
             this.$('#slider-entry').hide();
             this.$('#slider-key').hide();
+        } else {
+            // we can't disable the slider this way:
+            // this.$('#slider').attr('disabled', 'true');
+            // the apm_value text box is greyed but the slider still updates it's
+            // contents.
+            // disable on the text box works a treat given the above
+            // this.$('#apm_value').attr('disabled', 'true');
 
+            _this.renderSlider();
+            // apmLevel = the current sensed level from the drive
+            // apm_value = the text box and it's entered value
+            // update the slider when the apm_value text box is changed
+            //_this.$('#apm_value').focusout(function () {
+            _this.$('#apm_value').change(function () {
+                var our_value = this.value;
+                _this.slider.setValue((our_value));
+            });
+            // set the text box to show the current sensed APM level
+            _this.$('#apm_value').val(apmLevel);
+            // now call the change event on text box apm_value to update the slider
+            _this.$('#apm_value').change();
+            //_this.$('#enable_apm').click();
         }
-        _this.renderSlider();
-        // update the slider when the apm_value text box is changed
-        _this.$('#apm_value').change(function () {
-            var our_value = this.value;
-            _this.slider.setValue((our_value));
-        });
-        _this.$('#apm_value').val(apmLevel);
-        // now call the change event on text box apm_value to update the slider
-        _this.$('#apm_value').change();
-
 
         this.$('#add-spindown-disk-form').validate({
             onfocusout: false,
@@ -203,6 +209,11 @@ SpindownDiskView = RockstorLayoutView.extend({
                         spindown_text = time_string;
                         break;
                     }
+                }
+                // safeguard against setting -B (APM) option if enable_apm is
+                // unticked.
+                if (data.enable_apm != true) {
+                    data.apm_value = 0;
                 }
                 data.spindown_message = spindown_text;
                 $.ajax({

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -348,7 +348,7 @@ class DiskDetailView(rfc.GenericView):
     @classmethod
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
-        spindown_time = int(request.data.get('spindown_time', ''))
+        spindown_time = int(request.data.get('spindown_time', 20))
         # todo attempt to retrieve spindown_message as well and pass it along.
         spindown_message = str(
             request.data.get('spindown_message', 'message issue!'))

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -30,7 +30,7 @@ from share_helpers import (import_shares, import_snapshots)
 from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
-from system.osi import set_disk_spindown
+from system.osi import set_disk_spindown, enter_standby
 from copy import deepcopy
 import uuid
 import logging
@@ -266,10 +266,12 @@ class DiskDetailView(rfc.GenericView):
                 return self._smartcustom_drive(dname, request)
             if (command == 'spindown-drive'):
                 return self._spindown_drive(dname, request)
+            if (command == 'pause'):
+                return self._pause(dname, request)
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
                  ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
-                 ' smartcustom-drive, spindown-drive' % command)
+                 ' smartcustom-drive, spindown-drive, pause' % command)
         handle_exception(Exception(e_msg), request)
 
     @transaction.atomic
@@ -348,4 +350,10 @@ class DiskDetailView(rfc.GenericView):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
         set_disk_spindown(disk.name, spindown_time)
+        return Response()
+
+    @classmethod
+    def _pause(cls, dname, request):
+        disk = cls._validate_disk(dname, request)
+        enter_standby(disk.name)
         return Response()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -352,7 +352,8 @@ class DiskDetailView(rfc.GenericView):
         # todo attempt to retrieve spindown_message as well and pass it along.
         spindown_message = str(
             request.data.get('spindown_message', 'message issue!'))
-        set_disk_spindown(disk.name, spindown_time, spindown_message)
+        apm_value = int(request.data.get('apm_value', 0))
+        set_disk_spindown(disk.name, spindown_time, apm_value, spindown_message)
         return Response()
 
     @classmethod

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -349,7 +349,10 @@ class DiskDetailView(rfc.GenericView):
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
-        set_disk_spindown(disk.name, spindown_time)
+        # todo attempt to retrieve spindown_message as well and pass it along.
+        spindown_message = str(
+            request.data.get('spindown_message', 'message issue!'))
+        set_disk_spindown(disk.name, spindown_time, spindown_message)
         return Response()
 
     @classmethod

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -269,7 +269,7 @@ class DiskDetailView(rfc.GenericView):
 
         e_msg = ('Unsupported command(%s). Valid commands are wipe, btrfs-wipe,'
                  ' btrfs-disk-import, blink-drive, enable-smart, disable-smart,'
-                 ' smartcustom-drive' % command)
+                 ' smartcustom-drive, spindown-drive' % command)
         handle_exception(Exception(e_msg), request)
 
     @transaction.atomic

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -349,7 +349,6 @@ class DiskDetailView(rfc.GenericView):
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', 20))
-        # todo attempt to retrieve spindown_message as well and pass it along.
         spindown_message = str(
             request.data.get('spindown_message', 'message issue!'))
         apm_value = int(request.data.get('apm_value', 0))

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -30,6 +30,7 @@ from share_helpers import (import_shares, import_snapshots)
 from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
+from system.osi import set_disk_spindown
 from copy import deepcopy
 import uuid
 import logging
@@ -346,5 +347,5 @@ class DiskDetailView(rfc.GenericView):
     def _spindown_drive(cls, dname, request):
         disk = cls._validate_disk(dname, request)
         spindown_time = int(request.data.get('spindown_time', ''))
-        smart.set_disk_spindown(disk.name, spindown_time)
+        set_disk_spindown(disk.name, spindown_time)
         return Response()

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -644,7 +644,7 @@ def is_rotational(device_name, test=None):
                 # non zero rotation so flag and look no further
                 rotational = True
                 break
-        if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM':
+        if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM_CURRENT_VALUE':
             # we have an Automatic Acoustic Managment entry
             if line_fields[1] != '0':
                 # a non zero AAM entry so flag and look no further

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -575,21 +575,24 @@ def is_rotational(device_name, test=None):
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
+    logger.debug('is_rotational called with the following %s', device_name)
     if test is None:
+        # todo consider changing back to throw=False for production.
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name='] + device_name, throw=False)
+                                    '--name=' + device_name[0]], throw=True)
     else:
         # test mode so process test instead of udevadmin output
         out = test
         rc = 0
     if rc != 0:  # if return code is an error return False
         return False
-    # search output of udevadmin to find
+    # search output of udevadm to find signs of rotational media
     for line in out:
         if line == '':
             continue
         # nonlocal line_fields
         line_fields = line.strip().split('=')
+        logger.debug('line_fields now look like this %s', line_fields)
         # example original line "ID_ATA_FEATURE_SET_AAM=1"
         # less than 2 fields are of no use so just in case:-
         if len(line_fields) < 2:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -452,7 +452,7 @@ def get_disk_serial(device_name, test=None):
     ---------
     Additional personality added for md devices ie md0p1 or md126, these devices
     have no serial so we search for their MD_UUID and use that instead.
-    :param device_name:
+    :param device_name: eg sda
     :param test:
     :return: 12345678901234567890
     """
@@ -518,7 +518,7 @@ def get_virtio_disk_serial(device_name):
     Returns the serial number of device_name virtio disk eg /dev/vda
     Returns empty string if cat /sys/block/vda/serial command fails
     Note no serial entry in /sys/block/sda/ for real or KVM sata drives
-    :param device_name: vda
+    :param device_name: eg vda
     :return: 12345678901234567890
 
     Note maximum length of serial number reported = 20 chars
@@ -527,7 +527,7 @@ def get_virtio_disk_serial(device_name):
     https://github.com/qemu/qemu/blob/
     a9392bc93c8615ad1983047e9f91ee3fa8aae75f/include/standard-headers/
     linux/virtio_blk.h
-    #define VIRTIO_BLK_ID_BYTES	20	/* ID string length */
+    #define VIRTIO_BLK_ID_BYTES 20  /* ID string length */
 
     This process may not deal well with spaces in the serial number
     but VMM does not allow this.
@@ -571,13 +571,13 @@ def is_rotational(device_name, test=None):
     1 = rotational.
     N.B. we use --query=property and so have only 2 fields rather than 3 and
     no spaces, only '=' this simplifies the parsing required.
-    :param device:
+    :param device: list containing device name eg ['/dev/sda']
     :return: True if rotational, false if error or unknown.
     """
     rotational = False  # until we find otherwise
     if test is None:
         out, err, rc = run_command([UDEVADM, 'info', '--query=property',
-                                    '--name=' + device_name], throw=False)
+                                    '--name='] + device_name, throw=False)
     else:
         # test mode so process test instead of udevadmin output
         out = test

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -964,18 +964,19 @@ def update_hdparm_service(hdparm_command_list, comment):
                     do_edit = True
             # process all lines with the following
             if line == '\n':  # empty line, or rather just a newline char
-                    clear_line_count += 1
+                clear_line_count += 1
             if clear_line_count == 2 and not edit_done:
-                    # we are looking at our second empty line and haven't yet
-                    # achieved edit_done so do our edit / addition in this case.
-                    do_edit = True
+                # we are looking at our second empty line and haven't yet
+                # achieved edit_done so do our edit / addition in this case.
+                do_edit = True
             if do_edit and not edit_done:
                 # We are due to either add or overwrite our 2 line entry but
                 # only if we are not in remove_entry mode.
                 # When remove_entry = True our writes are skipped which equates
                 # to an removal or in the case of a new addition, nothing added.
                 if not remove_entry:
-                    outo.write('ExecStart=' + ' '.join(hdparm_command_list) + '\n')
+                    outo.write(
+                        'ExecStart=' + ' '.join(hdparm_command_list) + '\n')
                     outo.write('# %s' % comment + '\n')
                 edit_done = True
             # mechanism to skip a line if we have just done an edit
@@ -999,7 +1000,8 @@ def update_hdparm_service(hdparm_command_list, comment):
         # our proposed systemd file is the same length as our template and so
         # contains no ExecStart lines so we disable the rockstor-hdparm service.
         logger.info('Disabling the rockstor-hdparm systemd service.')
-        out, err, rc = run_command([SYSTEMCTL_BIN, 'disable', 'rockstor-hdparm'])
+        out, err, rc = run_command(
+            [SYSTEMCTL_BIN, 'disable', 'rockstor-hdparm'])
         if rc != 0:
             return False
         # and remove our rockstor-hdparm.service file as it's absence indicates

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -916,9 +916,14 @@ def update_hdparm_service(hdparm_command_list, comment):
     remove_entry = False
     # Establish our systemd_template, needed when no previous config exists.
     systemd_template = ('%s/rockstor-hdparm.service' % settings.CONFROOT)
+    # Check for the existence of this systemd template file.
+    if not os.path.isfile(systemd_template):
+        # We have no template file so log the error and return False.
+        logger.error('Skipping hdparm settings: no rockstor-hdparm.service '
+                     'template file found.')
+        return False
     # Get the line count of our systemd_template, for use in recognizing when we
     # have removed all existing config entries.
-    # todo check for this files existence before we try and open it.
     with open(systemd_template) as ino:
         systemd_template_line_count = len(ino.readlines())
     # get our by-id device name by extracting the last hdparm list item
@@ -935,7 +940,7 @@ def update_hdparm_service(hdparm_command_list, comment):
         infile = '/etc/systemd/system/rockstor-hdparm.service'
         update = True
     else:
-        # todo consider checking for template file also.
+        # We have already checked for the existence of our template file.
         infile = systemd_template
         update = False
     # Create our proposed temporary file based on the source file plus edits.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -741,9 +741,6 @@ def set_disk_spindown(device, spindown_time, apm_value,
     """
     # hdparm -S works on for example /dev/sda3 so base_dev is not needed,
     # but it does require a full path, ie sda3 doesn't work.
-    logger.debug(
-        'set_disk_spindown() called with dev= %s spind= %s apm= %s '
-        'message= %s' % (device, spindown_time, apm_value, spindown_message))
     device_with_path = get_devname(device, True)
     # md devices arn't offered a spindown config: unknown status from hdparm -C
     # Their member disks are exposed on the Disks page so for the time being
@@ -758,28 +755,25 @@ def set_disk_spindown(device, spindown_time, apm_value,
     dev_byid = get_dev_byid_name(device_with_path)
     # execute the -B hdparm command first as if it fails we can then not include
     # it in the final command in systemd as it will trip the whole command then.
-    # todo - check if only rc != 0 throws systemd execution ie do error returns
-    # todo - also trip the script exection
+    # todo - Check if only rc != 0 throws systemd execution ie do error returns
+    # todo - also trip the script execution.
     switch_list = []
     if apm_value > 0 and apm_value < 256:
         apm_switch_list = ['-q', '-B%s' % apm_value]
-        logger.debug('switch list is now = %s', apm_switch_list)
         hdparm_command = [HDPARM] + apm_switch_list + ['%s' % dev_byid]
-        logger.debug('-B hdparm command = %s', hdparm_command)
         # try running this -B only hdparm to see if it will run without
         # error or non zero return code.
         out, err, rc = run_command(hdparm_command, throw=False)
         if rc == 0 and len(err) == 1:
             # if execution of the -B switch ran OK then add to switch list
             switch_list += apm_switch_list
-            logger.debug('adding apm_switch_list so switch_list now = %s', switch_list)
         else:
             logger.error('non zero return code or error from hdparm '
                          'command %s with error %s and return code %s'
                          % (hdparm_command, err, rc))
     # setup -S hdparm command
     # todo shorten by combining -S with value when messaging sorted
-    standby_switch_list = ['-q', '-S', '%s' % spindown_time]
+    standby_switch_list = ['-q', '-S%s' % spindown_time]
     hdparm_command = [HDPARM] + standby_switch_list + ['%s' % dev_byid]
     out, err, rc = run_command(hdparm_command, throw=False)
     if rc != 0:
@@ -948,11 +942,7 @@ def update_hdparm_service(hdparm_command_list, comment):
                     do_edit = True
             if do_edit and not edit_done:
                 outo.write('ExecStart=' + ' '.join(hdparm_command_list) + '\n')
-                # todo - Currently writing raw value as debug aid but this is
-                # todo - intended to be the human message we are passed.
-                # outo.write('# %s' % message + '\n')
-                # todo - remove this and the following line on message / comment pass issue resolution
-                outo.write('# %s' % hdparm_command_list[-2] + ' %s' % comment + '\n')
+                outo.write('# %s' % comment + '\n')
                 edit_done = True
             # mechanism to skip a line if we have just done an edit
             if not (do_edit and edit_done and clear_line_count != 2):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -703,8 +703,6 @@ def get_disk_APM_level(device_name):
     it's setting equivalent of 255. If there is an error, such as can happen
     when APM is not supported, then we return 0.
     """
-    # todo - consider combining with get_disk_power_status(device_name) via
-    # todo - a switch option
     # if we use the -B -q switches then we have only one line of output:
     # hdparm -B -q /dev/sda
     #  APM_level<tab>= 192

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -947,3 +947,18 @@ def read_hdparm_setting(dev_byid):
                 # Found a line beginning with ExecStart and ending in dev_byid.
                 dev_byid_found = True
     return None
+
+
+def enter_standby(device_name):
+    """
+    Simple wrapper to execute hdparm -y /dev/device_name which requests that the
+    named device enter 'standby' mode which usually means it will spin down.
+    Should only be available if he power status of the device can be
+    successfully read without errors (ui inforced)
+    :param device_name: device name as stored in db ie sda
+    :return: None or out, err, rc of command
+    """
+    hdparm_command = [HDPARM, '-q', '-y', '%s' % get_devname(device_name, True)]
+    logger.debug('enter_standby called wtih device name %s', device_name)
+    logger.debug('proposed hdparm_command = %s', hdparm_command)
+    return run_command(hdparm_command)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -972,7 +972,7 @@ def read_hdparm_setting(dev_byid):
     no file or no matching entry or comment there after was found.
     :param dev_byid: full path device name of by-id type
     :return: comment string immediately following an entry containing the given
-    device name.
+    device name or None if None found or the systemd file didn't exist.
     """
     if dev_byid is None:
         return None

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -675,13 +675,12 @@ def get_disk_power_status(device_name):
     # if we use the -C -q switches then we have only one line of output:
     # hdparm -C -q /dev/sda
     # drive state is:  active/idle
-    # in some instances an error can be returned even with rc=0, we ignore this
-    # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ......
-    # We may want to ignore / return unknown when len(err) != 1
     out, err, rc = run_command([HDPARM, '-C', '-q', '/dev/%s' % device_name],
                                throw=False)
-    # if len(err) != 1:
-    #     logger.debug('hdparm has output to standard error of %s', err)
+    if len(err) != 1:
+        # In some instances an error can be returned even with rc=0.
+        # ie SG_IO: bad/missing sense data, sb[]:  70 00 05 00 00 00 00 0a ...
+        return 'unknown'  # don't trust any results in this instance
     if len(out) > 0:
         fields = out[0].split()
         # our line of interest has 4 fields when split by spaces, see above.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -703,6 +703,8 @@ def set_disk_spindown(device, spindown_time):
     or an error was return by the command, True otherwise.
     """
     # hdparm -S work on for example /dev/sda3 so base_dev may be redundant.
+    # but it does require a full path, ie sda3 doesn't work.
+    # Could use the new get_devname(device, true) to add the dev path.
     # todo lighten by removing base_dev
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -640,13 +640,13 @@ def is_rotational(device_name, test=None):
             continue
         if line_fields[0] == 'ID_ATA_ROTATION_RATE_RPM':
             # we have a rotation rate entry
-            if line_fields[1] != 0:
+            if line_fields[1] != '0':
                 # non zero rotation so flag and look no further
                 rotational = True
                 break
         if line_fields[0] == 'ID_ATA_FEATURE_SET_AAM':
             # we have an Automatic Acoustic Managment entry
-            if line_fields[1] != 0:
+            if line_fields[1] != '0':
                 # a non zero AAM entry so flag and look no further
                 rotational = True
                 break
@@ -705,19 +705,16 @@ def set_disk_spindown(device, spindown_time, spindown_message='no comment'):
     """
     # hdparm -S works on for example /dev/sda3 so base_dev is not needed,
     # but it does require a full path, ie sda3 doesn't work.
-    logger.debug('set_disk_spindown called with device = %s', device)
     device_with_path = get_devname(device, True)
-    logger.debug('get_devname returned %s', device_with_path)
     # md devices arn't offered a spindown config: unknown status from hdparm -C
     # Their member disks are exposed on the Disks page so for the time being
     # their spin down times are addressed as regular disks are.
-    # todo test new arrangement with md device
     if device_with_path is None:
-        logger.debug('set_disk_spindown found device_with_path = None')
         return False
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(device_with_path) is not True:
-        logger.info('skipping hdparm -S as device not confirmed as rotational')
+        logger.info(
+            'Skipping hdparm settings: device not confirmed as rotational')
         return False
     # setup hdparm command
     hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time,

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -467,6 +467,8 @@ def get_dev_options(device, custom_options=''):
         dev_options = get_base_device(device)
     else:
         # Convert string of custom options into a list ready for run_command
+        # todo think this ascii should be utf-8 as that's kernel standard
+        # todo or just use str(custom_options).split()
         dev_options = custom_options.encode('ascii').split()
         # If our custom options don't contain a raid controller target then add
         # the full path to our base device as our last device specific option.

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -349,12 +349,14 @@ def set_disk_spindown(device, spindown_time):
     # todo look to using system/osi get_md_members(device_name, test=None)
     # todo with md devices and then treat each in turn.
     if len(base_dev[0]) == 0:
+        logger.debug('skipping hdparm -S as device = ""')
         return True;
     # Don't spin down non rotational devices, skip all and return True.
     if is_rotational(base_dev) is not True:
+        logger.debug('skipping hdparm -S as device not confirmed as rotational')
         return True;
     # setup hdparm command
-    hdparm_command = [HDPARM, '-C', spindown_time] + base_dev
+    hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
 
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -331,6 +331,7 @@ def toggle_smart(device, custom_options='', enable=False):
         [SMART, '--smart=%s' % switch] + get_dev_options(device,
                                                          custom_options))
 
+
 def set_disk_spindown(device, spindown_time):
     """
     Takes a value to be used with hdparm -S to set disk spindown time for the
@@ -343,7 +344,8 @@ def set_disk_spindown(device, spindown_time):
     :param spindown_time: String received from settings form ie "20 minutes"
     :return:
     """
-    logger.debug('set_disk_spindown received device %s and -S value %s' % (device, spindown_time))
+    logger.debug('set_disk_spindown received device %s and -S value %s' % (
+    device, spindown_time))
     base_dev = get_base_device(device)
     # md devices result in [''] from get_base_device so do nothing and return
     # todo look to using system/osi get_md_members(device_name, test=None)
@@ -358,7 +360,7 @@ def set_disk_spindown(device, spindown_time):
     # setup hdparm command
     hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
-
+    return run_command(hdparm_command)
 
 
 def update_config(config):

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import re
-from osi import run_command, is_rotational
+from osi import run_command, get_base_device
 from tempfile import mkstemp
 from shutil import move
 import logging
@@ -28,8 +28,6 @@ logger = logging.getLogger(__name__)
 
 SMART = '/usr/sbin/smartctl'
 CAT = '/usr/bin/cat'
-LSBLK = '/usr/bin/lsblk'
-HDPARM = '/usr/sbin/hdparm'
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
@@ -332,37 +330,6 @@ def toggle_smart(device, custom_options='', enable=False):
                                                          custom_options))
 
 
-def set_disk_spindown(device, spindown_time):
-    """
-    Takes a value to be used with hdparm -S to set disk spindown time for the
-    device specified.
-    Executes hdparm -S spindown_time and ensures the systemd script to do the
-    same on boot is also updated. Note we do not restart the systemd service
-    to enact these changes in order to keep keep our drive intervention to a
-    minimum.
-    :param disk: The name of a disk device as used in the db ie sda
-    :param spindown_time: String received from settings form ie "20 minutes"
-    :return:
-    """
-    logger.debug('set_disk_spindown received device %s and -S value %s' % (
-    device, spindown_time))
-    base_dev = get_base_device(device)
-    # md devices result in [''] from get_base_device so do nothing and return
-    # todo look to using system/osi get_md_members(device_name, test=None)
-    # todo with md devices and then treat each in turn.
-    if len(base_dev[0]) == 0:
-        logger.debug('skipping hdparm -S as device = ""')
-        return True;
-    # Don't spin down non rotational devices, skip all and return True.
-    if is_rotational(base_dev) is not True:
-        logger.debug('skipping hdparm -S as device not confirmed as rotational')
-        return True;
-    # setup hdparm command
-    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
-    logger.debug('proposed hdparm commnad = %s', hdparm_command)
-    return run_command(hdparm_command)
-
-
 def update_config(config):
     SMARTD_CONFIG = '/etc/smartmontools/smartd.conf'
     ROCKSTOR_HEADER = '###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###'
@@ -411,41 +378,6 @@ def screen_return_codes(msg_on_hit, return_code_target, o, e, rc, command):
         raise CommandException(('%s' % command), o, e, rc)
 
 
-def get_base_device(device, test_mode=TESTMODE):
-    """
-    Helper function that returns the full path of the base device of a partition
-    or if given a base device then will return it's full path,
-    ie
-    input sda3 output /dev/sda
-    input sda output /dev/sda
-    Works as a function of lsblk list order ie base devices first. So we return
-    the first start of line match to our supplied device name with the pattern
-    as the first element in lsblk's output and the match target as our device.
-    :param device: device name as per db entry, ie as returned from scan_disks
-    :param test_mode: Not True causes cat from file rather than smartctl command
-    :return: base_dev: single item list containing the root device's full path
-    ie device = sda3 the base_dev = /dev/sda or [''] if no lsblk entry was found
-    to match.
-    """
-    base_dev = ['', ]
-    if not test_mode:
-        out, e, rc = run_command([LSBLK])
-    else:
-        out, e, rc = run_command([CAT, '/root/smartdumps/lsblk.out'])
-    # now examine the output from lsblk line by line
-    for line in out:
-        line_fields = line.split()
-        if len(line_fields) < 1:
-            # skip empty lines
-            continue
-        if re.match(line_fields[0], device):
-            # We have found a device string match to our device so record it.
-            base_dev[0] = '/dev/' + line_fields[0]
-            break
-    # Return base_dev ie [''] or first character matches to line start in lsblk.
-    return base_dev
-
-
 def get_dev_options(device, custom_options=''):
     """
     Returns device specific options for all smartctl commands.
@@ -464,7 +396,7 @@ def get_dev_options(device, custom_options=''):
     if custom_options is None or custom_options == '':
         # Empty custom_options or they have never been set so just return
         # full path to base device as nothing else to do.
-        dev_options = get_base_device(device)
+        dev_options = get_base_device(device, TESTMODE)
     else:
         # Convert string of custom options into a list ready for run_command
         # todo think this ascii should be utf-8 as that's kernel standard
@@ -474,7 +406,7 @@ def get_dev_options(device, custom_options=''):
         # the full path to our base device as our last device specific option.
         if (re.search('/dev/tw|/dev/cciss/c|/dev/sg', custom_options) is None):
             # add full path to our custom options as we see no raid target dev
-            dev_options += get_base_device(device)
+            dev_options += get_base_device(device, TESTMODE)
     # Note on raid controller target devices.
     # /dev/twe#, or /dev/twa#, or /dev/twl# are 3ware controller targets devs
     # respectively 3x-xxxx, 3w-9xxx, and t2-sas (3ware/LSI 9750) drivers for

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -358,7 +358,7 @@ def set_disk_spindown(device, spindown_time):
         logger.debug('skipping hdparm -S as device not confirmed as rotational')
         return True;
     # setup hdparm command
-    hdparm_command = [HDPARM, '-S', '%s' % spindown_time] + base_dev
+    hdparm_command = [HDPARM, '-q', '-S', '%s' % spindown_time] + base_dev
     logger.debug('proposed hdparm commnad = %s', hdparm_command)
     return run_command(hdparm_command)
 


### PR DESCRIPTION
Adds a per drive power down interface / feature based on idle time using the standard hdparm parameters. Given this is closely related to a drive's Advanced Power Management (APM) setting a display of the current setting and an option to change this setting is also included in the disks table and on the same configuration page. Care has been taken to graphically associate the APM setting with the Power Status (spin down) setting by grouping these columns one after the other and maintaining this relationship on the settings page also.

Hdparm is itself an interface to the kernel's own drive control subsystem so we are sticking to core linux utilities for this feature.

The hdparm switches used are -C to set idle spin down time and -B to read and set APM level.
N.B. It is not possible to read a drives current setting for -C (idle spin down) which complicates matters, the meaning for these values can also vary between drives. The settings used are drawn from man hdparm and are apparently more reliable for newer drives.

Hdparm settings are maintained over a reboot but not over a power cycle. To address this a new stand alone rockstor systemd service is introduced (rockstor-hdparm.service). It does not depend on any other rockstor systemd service and no other rockstor service depends on it. The service is used simply to execute the tested hdparm commands that are otherwise executed on demand via the WebUI. That is if no error message and no non zero return code is received from a proposed (via user config entry) hdparm command then that same command is placed in this systemd service unit to be applied on the next boot to address the power cycle loss of these settings otherwise.

As idle time / spin down is associated with rotational media we do not apply any setting to a device if it fails an included is_rotational test. This test is based on a drives udevadm info readings for rpm and Automatic Acoustic Management (AAM) readings. The kernels own proc reading of rotation has been frequently reported as currently unreliable hence establishing our own mechanism for this. This function (in system/osi) is considered as conservative and will err on the "not confirmed as rotational" side. If the is_rotational function returns false no setting is applied and user confirmation of this is simply to not update our disk table with any requested settings. This could be improved upon but may benefit from future enhancements in a notification system. As is the following info level message is logged:-
"Skipping hdparm settings: device not confirmed as rotational"
This should soon be more readily available by improvement in WebUI log view functionality.

The core of this feature's function is several light weight property extensions to the disk model that provide the power status, hdparm -C setting, and current APM level to the disks page by way of the additional 2 columns. There is also included a pause function that simply executes hdparm -y to request a drive immediately enters standby mode. No full sleep mode is activated by the included mechanisms (ie hdparm -Y) as such a state requires that a drives interface be re-set and was considered overly heavy handed and potentially more problematic. The active settings change path takes the users input and tests it for sanity then attempt to run the proposed hdparm command one switch at a time; starting with the -B setting as this is more often problematic due to some drives not supporting this APM level set option. If any errors or non zero return codes are received then this setting is not included in the final systemd entry. The -C switch is then also tested in isolation and again if any errors or non zero return codes are encountered then at this stage no entry will be submitted to the systemd file. This means in some circumstances we may have only -C settings for a device but if the -B setting passed our tests then it is by default included; often simply re-affirming the default setting unless the user has specified otherwise. The core method to update the systemd service is implemented in update_hdparm_service which is utilized only by set_disk_spindown that tests the viability of the proposed hdparm switches.

To facilitate the option to not include a -B setting we use the 0 value for that switch. This is a symmetrical arrangement in that if an hdparm -B reading fails or returns 'not supported' the reading mechanism conflates these responses into the 0 value (see get_disk_APM_level). This is otherwise an unused APM value (ie 1-255) and so we can maintain a simple interger for this value. This way we avoid applying any -B option to a drive that has otherwise failed to cleanly respond to our -B request or has done so but with a 'not supported' response. Like wise the mechanism is employed to remove any existing -B entry by passing zero as the requested value. The same reading mechanism translates the off reading to 255 which requires our interface logic to translate this back to 'off' but this was considered a cleaner system than dealing with the raw values of 0 (our flag) or 1-255 (written values) or 'off' which represents a reading of the the written value 255. This way we maintain symmetry with reading (using our low level reader) and writing and only translate in the UI for readability. On the UI front the APM settings are disabled by way of their tickbox option and the tick box is also disabled when an APM read of 0 (error or not supported) is encountered.

Note that all hdparm commands use the dev by-id names to maintain correct targets over system reboots. Several general purpose mechanism have been included in this pr to facilitate translating the currently db drive.names of sda / sdb to these more stable by-id drive names which are created by the udev subsystem and represent simple symbolic links to their associated sda / sdb type names. It is intended that these translation functions be employed on a wider basis going forward.

By default we offer a 20 minute idle spin down time if a prior setting is not found. Given prior settings cannot be established using system calls we establish the single point of truth to be direct reading from the device and the systemd file where reading from the device is not possible (ie with -C settings). This avoids using the django db and was intended to keep the whole hdparm feature as light as possible. If the systemd file does not exist it is created from the empty template held in /opt/rockstor/conf/rockstor-hdparm.service. When newly established the service is also enabled but not started as the associated commands have already been executed by way of the tests prior to their entry in the systemd file. The service being enabled is sufficient to ensure that they will be run on next boot which is all that is needed. If on the other hand no entries are found in an existing /etc/systemd/system/rockstor-hdparm.service file, ie by way of UI instigated edits, then the service is disabled and the service file removed in order to prepare for new settings and the re enabling of the service in that instance.

In light of issue #1275 and it's associated pr #1287 which re-factors the disks table creation code modified in this pr I have prepared some handlebar helpers and included them in this pull request, they are however untested as they rely on what is as yet un-merged UI code.

Testing of the supplied spin-down values has been mostly successful with values of 20 minutes and less as higher values are less reliable to non functional. It was also found that with no WebUI open the drives are much more reliably suspended, however opening the WebUI and viewing the disks page after drives have entered standy mode and even refreshing this view via browser or via use of the "Rescan" button doesn't then wake the drives that have entered standby. So there appears to be some command active that inhibit the drives entering standby (while the WebUI is open) but doesn't then activate these drives once they are in standby mode. This was a hard one find. Also note that even with the WebUI open multiple drives did successfully enter standby when set to 30 seconds or 1 minute but no longer. However 20 mins and below seem to work find when the WebUI isn't active. This has mostly been tested when viewing the disks page and is quite a time consuming business. Hence the submission of this pr at the beginning of a testing cycle.

Reference in the user interface is also made to the recently merged "Task execution time windows" feature.

Note: This pr submission text is also intended as the basis of a wiki entry upon successful review and merge. The wiki entry can then serve as a technical manual on this subsystem.