### PR TITLE
#1296 Add control to pool_scrub and snapshot to avoid missing cwindow…

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
+++ b/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
@@ -46,7 +46,7 @@ def update_state(t, pool, aw):
 
 def main():
     tid = int(sys.argv[1])
-    cwindow = sys.argv[2]
+    cwindow = sys.argv[2] if len(sys.argv) > 1 else '*-*-*-*-*-*'
     if (crontabwindow.crontab_range(cwindow)): #Performance note: immediately check task execution time/day window range to avoid other calls
         tdo = TaskDefinition.objects.get(id=tid)
         if (tdo.task_type != 'scrub'):

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -74,7 +74,7 @@ def delete(aw, share, snap_type, prefix, max_count):
 
 def main():
     tid = int(sys.argv[1])
-    cwindow = sys.argv[2]
+    cwindow = sys.argv[2] if len(sys.argv) > 1 else '*-*-*-*-*-*'
     if (crontabwindow.crontab_range(cwindow)): #Performance note: immediately check task execution time/day window range to avoid other calls
         tdo = TaskDefinition.objects.get(id=tid)
         stype = 'task_scheduler'


### PR DESCRIPTION
To @schakrava  #1296 Patch to avoid errors on missing sys.argvs - set execution window to default "always"

To users: Before patch merged and avail on rockstor release please edit your task and just submit again (that will auto generate missing arguments)

