### PR TITLE
#1301 AD tweak: less checking on NTP

### DIFF
--- a/src/rockstor/smart_manager/views/active_directory.py
+++ b/src/rockstor/smart_manager/views/active_directory.py
@@ -156,10 +156,7 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
                 #1. Name resolution check
                 self._resolve_check(config.get('domain'), request)
 
-                #2. ntp check
-                self._ntp_check(request)
-
-                #3. realm discover check?
+                #2. realm discover check?
                 #@todo: phase our realm and just use net?
                 domain = config.get('domain')
                 try:


### PR DESCRIPTION
Only check for NTP service when enabling AD - not before being allowed to configure it.
Unlike some other services, AD is only enabled when you choose to enable it - rather than automatically after configuring it.