### PR TITLE
remote rock-on info not updating deprecated volumes. Fixes #1294

### DIFF
--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -246,6 +246,7 @@ class RockOnView(rfc.GenericView):
             v_d = c_d.get('volumes', {})
             cur_vols = [vo.dest_dir for vo in
                         DVolume.objects.filter(container=co)]
+            logger.debug('container description volumes = %s', v_d)
             logger.debug('cur_vols _create_update_meta = %s', cur_vols)
             #cur_vols can have entries not in the config for Shares mapped post
             #install.

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -358,9 +358,11 @@ class RockOnView(rfc.GenericView):
         meta_cfg = {}
         for k,v in root.items():
             cur_meta_url = '%s/%s' % (url_root, v)
+            logger.debug('we are looking to retrieve the following url =%s', cur_meta_url)
             msg = ('Error while processing Rock-on profile at %s' % cur_meta_url)
             with self._handle_exception(self.request, msg=msg):
                 cur_res = requests.get(cur_meta_url, timeout=10)
+                logger.debug('this is the json retrieved %s', cur_res)
                 if (cur_res.status_code != 200):
                     cur_res.raise_for_status()
                 meta_cfg.update(cur_res.json())

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -246,9 +246,6 @@ class RockOnView(rfc.GenericView):
             v_d = c_d.get('volumes', {})
             cur_vols = [vo.dest_dir for vo in
                         DVolume.objects.filter(container=co)]
-            logger.debug('dealing with updating %s', co.name)
-            logger.debug('container description volumes = %s', v_d.keys())
-            logger.debug('cur_vols _create_update_meta = %s', cur_vols)
             # cur_vols can have entries not in the config for Shares mapped post
             # install.
             # If we have more volumes defined in the rock-on definition than
@@ -276,7 +273,6 @@ class RockOnView(rfc.GenericView):
                     # we have some current volumes in db that are no longer in
                     # our updated rock-on definition so remove all volumes for
                     # this rock-on so they might be updated whole sale.
-                    logger.debug('removing all volume records for container %s', co.name)
                     # Delete all volume entries for this container so that they
                     # might be created a fresh.
                     DVolume.objects.filter(container=co).delete()
@@ -389,11 +385,9 @@ class RockOnView(rfc.GenericView):
         meta_cfg = {}
         for k,v in root.items():
             cur_meta_url = '%s/%s' % (url_root, v)
-            logger.debug('we are looking to retrieve the following url =%s', cur_meta_url)
             msg = ('Error while processing Rock-on profile at %s' % cur_meta_url)
             with self._handle_exception(self.request, msg=msg):
                 cur_res = requests.get(cur_meta_url, timeout=10)
-                logger.debug('this is the json retrieved %s', cur_res)
                 if (cur_res.status_code != 200):
                     cur_res.raise_for_status()
                 meta_cfg.update(cur_res.json())

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -246,7 +246,7 @@ class RockOnView(rfc.GenericView):
             v_d = c_d.get('volumes', {})
             cur_vols = [vo.dest_dir for vo in
                         DVolume.objects.filter(container=co)]
-            logger.debug('container description volumes = %s', v_d)
+            logger.debug('container description volumes = %s', v_d.keys())
             logger.debug('cur_vols _create_update_meta = %s', cur_vols)
             #cur_vols can have entries not in the config for Shares mapped post
             #install.
@@ -258,6 +258,10 @@ class RockOnView(rfc.GenericView):
                              (co.name, ro.name))
                     handle_exception(Exception(e_msg), self.request)
                 DVolume.objects.filter(container=co).delete()
+            # maybe a similar check for cur_vols that are no longer in the
+            # container description, and if we are also in the process of
+            # installing then remove these entries from the db as they are now
+            # in error. ie cycle through them and .delete() them.
 
             for v in v_d:
                 cv_d = v_d[v]

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -246,6 +246,7 @@ class RockOnView(rfc.GenericView):
             v_d = c_d.get('volumes', {})
             cur_vols = [vo.dest_dir for vo in
                         DVolume.objects.filter(container=co)]
+            logger.debug('cur_vols _create_update_meta = %s', cur_vols)
             #cur_vols can have entries not in the config for Shares mapped post
             #install.
             if (len(set(v_d.keys()) - set(cur_vols)) != 0):


### PR DESCRIPTION
In the case of our first deprecated volume definition within a rock-on we are not successfully removing the volumes requirement locally, ie the plex rock-on was updated to require one less volume; however that deprecated volume (mapped to /transcode in the container) was still used as a prompt during Plex installs or re-installs on all systems that booted or performed a rock-on metadata update prior to April 13th and this commit:-
https://github.com/rockstor/rockon-registry/commit/dca3235dd672e63af2b0f45157fe44b61a3e0b9e
where the rock-on definition file was updated.

This pull request address this by removing all prior knowledge of volume requirements during an update but only when the associated rock-on is not installed and when the remembered volume requirements exceed in number the retrieved volume count from the rockon-registry.

I have tested this pr on a clean build and on multiple systems that booted or performed a rockon metadata update prior to the above referenced volume deprecation within the Plex rock-on. No default or additional storage volume info was affected on installed plex rock-ons but upon that rock-on being un-installed both the deprecated and the additional storage mappings were removed as intended and updated to the registry definition of volumes requirement. This is akin to prior patch behaviour except that the deprecated transcoding volume requirement was also removed. There after no prompt was issued for the transcoding volume during plex install. Existing installs that used the transcoding volume mapping were un-affected by updates after this patch, at least until that Plex Rock-on install was un-installed.

In addition to the logging included within this pr (and removed prior to pr submission) the following sql command was used to verify the db's knowledge of the required volumes:
```
select storageadmin_dvolume.container_id, storageadmin_dvolume.dest_dir, storageadmin_dcontainer.name from storageadmin_dvolume join storageadmin_dcontainer on storageadmin_dcontainer.dimage_id = storageadmin_dvolume.container_id where storageadmin_dcontainer.name like '%plex%';
```

@schakrava Pull request ready for review.
Fixes #1294 