### PR TITLE
mdraid member status not updated and transition to multi use Disk.role field. Fixes #1214

### DIFF
--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -42,12 +42,16 @@ class Disk(models.Model):
     vendor = models.CharField(max_length=1024, null=True)
     smart_available = models.BooleanField(default=False)
     smart_enabled = models.BooleanField(default=False)
-    """custom smart options for drive, ie for USB bridges / enclosures"""
-    """eg "-d usbjmicron,p" or "-s on -d 3ware,0"."""
+    """custom smart options for drive, ie for USB bridges / enclosures
+    eg "-d usbjmicron,p" or "-s on -d 3ware,0".
+    """
     smart_options = models.CharField(max_length=64, null=True)
-    """drive role ie "isw_raid_member" or "linux_raid_member"."""
-    """could also be "import" or "backup" for temp external drive connection."""
-    """role is aux info to flag special use disks"""
+    """role is json formatted aux info to flag special use disks
+    ie "import" or "backup" flags for temp external drive connection.
+    Also flags mdraid status eg {"mdraid": "isw_raid_member"} or
+    {"mdraid": "linux_raid_member"}.
+    role can be Null if no flags are in use.
+    """
     role = models.CharField(max_length=256, null=True)
 
     @property

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -232,12 +232,36 @@ DisksView = Backbone.View.extend({
             }
             return false;
         });
-    	Handlebars.registerHelper('displayInfo', function (role) {
-    	    if(role == 'isw_raid_member' || role == 'linux_raid_member'){
-    		return true;
-    	    }
-    	    return false;
-    	});
+        Handlebars.registerHelper('displayInfo', function (role) {
+            // check for the legacy / pre json formatted role field contents.
+            if (role == 'isw_raid_member' || role == 'linux_raid_member') {
+                return true;
+            }
+            // now check if our role is null = db default of None
+            if (role == null) {
+                console.log('role = null returning false')
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // todo not sure if this is redundant?
+            try {
+                var roleAsJson = JSON.parse(role);
+            } catch (e) {
+                console.log('exception in JSON.parse(role) returning false')
+                return false;
+            }
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('mdraid')) {
+                // in the case of an mdraid property we are assured it is an
+                // mdraid member, the specific type is not important here.
+                // Non mdraid members will have no mdraid property.
+                console.log('confirmed to have mdraid property in role')
+                return true;
+            }
+            // In all other cases return false.
+            console.log('defaulting to return false')
+            return false;
+        });
 
     	Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
     	    if(btrfsUid && _.isNull(poolName)){

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -237,9 +237,8 @@ DisksView = Backbone.View.extend({
             if (role == 'isw_raid_member' || role == 'linux_raid_member') {
                 return true;
             }
-            // now check if our role is null = db default of None
+            // now check if our role is null = db default
             if (role == null) {
-                console.log('role = null returning false')
                 return false;
             }
             // try json conversion and return false if it fails
@@ -247,7 +246,6 @@ DisksView = Backbone.View.extend({
             try {
                 var roleAsJson = JSON.parse(role);
             } catch (e) {
-                console.log('exception in JSON.parse(role) returning false')
                 return false;
             }
             // We have a json string ie non legacy role info so we can examine:
@@ -255,11 +253,9 @@ DisksView = Backbone.View.extend({
                 // in the case of an mdraid property we are assured it is an
                 // mdraid member, the specific type is not important here.
                 // Non mdraid members will have no mdraid property.
-                console.log('confirmed to have mdraid property in role')
                 return true;
             }
             // In all other cases return false.
-            console.log('defaulting to return false')
             return false;
         });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -259,24 +259,23 @@ DisksView = Backbone.View.extend({
             return false;
         });
 
-    	Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
-    	    if(btrfsUid && _.isNull(poolName)){
-    		return true;
-    	    }
-    	    return false;
-    	});
+        Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
+            if (btrfsUid && _.isNull(poolName)) {
+                return true;
+            }
+            return false;
+        });
 
-    	Handlebars.registerHelper('checkSerialStatus', function (serial, diskName, opts) {
-    	    if(serial == null || serial == '' || serial == diskName || serial.length == 48){
-    		return opts.fn(this);
-    	    }
-    	    return opts.inverse(this);
-    	});
-    	
+        Handlebars.registerHelper('checkSerialStatus', function (serial, diskName, opts) {
+            if (serial == null || serial == '' || serial == diskName || serial.length == 48) {
+                return opts.fn(this);
+            }
+            return opts.inverse(this);
+        });
 
-    	Handlebars.registerHelper('humanReadableSize', function (size) {
-    	    return humanize.filesize(size * 1024);
-    	});
+        Handlebars.registerHelper('humanReadableSize', function (size) {
+            return humanize.filesize(size * 1024);
+        });
     },
 
     smartToggle: function (event, state) {

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -137,7 +137,7 @@ class DiskMixin(object):
                 # format for the db role field we stored one of 2 strings.
                 # if these 2 strings are found then ignore them as we then
                 # overwrite with our current finding and in the new json format.
-                # ie non None could also be a legacy entry so follow overwrite
+                # I.e. non None could also be a legacy entry so follow overwrite
                 # path when legacy entry found by treating as a None entry.
                 # todo - When we reset migrations the following need only check
                 # todo - "dob.role is not None"
@@ -152,8 +152,8 @@ class DiskMixin(object):
                     # return updated dict to json format and store in db object
                     dob.role = json.dumps(known_roles)
                     logger.debug('known_roles now = %s', known_roles)
-                else:  # we have a None dob.role so just insert our new role.
-                    # also applies to legacy pre json role entries.
+                else:  # We have a dob.role = None so just insert our new role.
+                    # Also applies to legacy pre json role entries.
                     dob.role = '{"mdraid": "' + d.fstype + '"}'  # json string
                     logger.debug('setting db role for %s', dob.name)
                     logger.debug('to role = %s', dob.role)
@@ -169,8 +169,16 @@ class DiskMixin(object):
                     # which should now only be in json format
                     known_roles = json.loads(dob.role)
                     if 'mdraid' in known_roles:
-                        del known_roles['mdraid']
-                        dob.role = json.dumps(known_roles)
+                        if len(known_roles) > 1:
+                            # mdraid is not the only entry so we have to pull
+                            # out only mdraid from dict and convert back to json
+                            del known_roles['mdraid']
+                            dob.role = json.dumps(known_roles)
+                        else:
+                            # mdraid was the only entry so we need not bother
+                            # with dict edit and json conversion only to end up
+                            # with an empty json {} so revert to default 'None'.
+                            dob.role = None
                         logger.debug('setting db role to %s', dob.role)
                 else:  # Empty or legacy role entry.
                     # We have either None or a legacy mdraid role when this disk

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -129,7 +129,6 @@ class DiskMixin(object):
             # current truth provided so update the db role status accordingly.
             # N.B. this if else could be expanded to accommodate other
             # roles based on the fs found
-            logger.debug('looking at disk named %s', dob.name)
             if d.fstype == 'isw_raid_member' or d.fstype == 'linux_raid_member':
                 # We have an indicator of mdraid membership so update existing
                 # role info if any.
@@ -141,22 +140,17 @@ class DiskMixin(object):
                 # path when legacy entry found by treating as a None entry.
                 # todo - When we reset migrations the following need only check
                 # todo - "dob.role is not None"
-                logger.debug('processing dob.role of %s', dob.role)
                 if dob.role is not None and dob.role != 'isw_raid_member' \
                         and dob.role != 'linux_raid_member':
                     # get our known roles into a dictionary
-                    logger.debug('Non None dob.role about to be updated')
                     known_roles = json.loads(dob.role)
                     # create or update an mdraid dictionary entry
                     known_roles['mdraid'] = str(d.fstype)
                     # return updated dict to json format and store in db object
                     dob.role = json.dumps(known_roles)
-                    logger.debug('known_roles now = %s', known_roles)
                 else:  # We have a dob.role = None so just insert our new role.
                     # Also applies to legacy pre json role entries.
                     dob.role = '{"mdraid": "' + d.fstype + '"}'  # json string
-                    logger.debug('setting db role for %s', dob.name)
-                    logger.debug('to role = %s', dob.role)
             else:  # We know this disk is not an mdraid raid member.
                 # No identified role from scan_disks() fstype value (mdraid
                 # only for now )so we preserve any prior known roles not
@@ -179,12 +173,10 @@ class DiskMixin(object):
                             # with dict edit and json conversion only to end up
                             # with an empty json {} so revert to default 'None'.
                             dob.role = None
-                        logger.debug('setting db role to %s', dob.role)
                 else:  # Empty or legacy role entry.
                     # We have either None or a legacy mdraid role when this disk
                     # is no longer an mdraid member. We can now assert None.
                     dob.role = None
-                    logger.debug('setting db role to None for %s', dob.name)
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -124,7 +124,12 @@ class DiskMixin(object):
                 # N.B. this overload use may become redundant with the addition
                 # of the Disk.role field.
             # Update the role field with scan_disks findings, currently only
-            # mdraid membership type based on fstype info.
+            # mdraid membership type based on fstype info. In the case of
+            # these raid member indicators from scan_disks() we have the
+            # current truth provided so update the db role status accordingly.
+            # N.B. this if else could be expanded to accommodate other
+            # roles based on the fs found
+            logger.debug('looking at disk named %s', dob.name)
             if d.fstype == 'isw_raid_member' or d.fstype == 'linux_raid_member':
                 # We have an indicator of mdraid membership so update existing
                 # role info if any.
@@ -142,6 +147,7 @@ class DiskMixin(object):
                     # get our known roles into a dictionary
                     logger.debug('Non None dob.role about to be updated')
                     known_roles = json.loads(dob.role)
+                    # create or update an mdraid dictionary entry
                     known_roles['mdraid'] = str(d.fstype)
                     # return updated dict to json format and store in db object
                     dob.role = json.dumps(known_roles)
@@ -151,20 +157,26 @@ class DiskMixin(object):
                     dob.role = '{"mdraid": "' + d.fstype + '"}'  # json string
                     logger.debug('setting db role for %s', dob.name)
                     logger.debug('to role = %s', dob.role)
-            else:
-                # No identified role from scan_disks() fstype indicator so
-                # set as None to update db of new drive role. If we don't
-                # do this then the same drive when re-deployed will inherit
-                # it's previous role in the db which may be desired but in
-                # the case of these raid member indicators from scan_disks()
-                # we have the current truth provided.
-                # N.B. this if else could be expanded to accommodate other
-                # roles based on the fs found and also take heed of an
-                # existing devices db role entry prior to overwriting.
-                # todo account for other role types than mdraid as the following
-                # todo overwrites all that is found otherwise.
-                dob.role = None
-                logger.debug('setting db role to None for %s', dob.name)
+            else:  # We know this disk is not an mdraid raid member.
+                # No identified role from scan_disks() fstype value (mdraid
+                # only for now )so we preserve any prior known roles not
+                # exposed by scan_disks but remove the mdraid role if found.
+                # todo - When we reset migrations the following need only check
+                # todo - "dob.role is not None"
+                if dob.role is not None and dob.role != 'isw_raid_member' \
+                        and dob.role != 'linux_raid_member':
+                    # remove mdraid role if found but preserve prior roles
+                    # which should now only be in json format
+                    known_roles = json.loads(dob.role)
+                    if 'mdraid' in known_roles:
+                        del known_roles['mdraid']
+                        dob.role = json.dumps(known_roles)
+                        logger.debug('setting db role to %s', dob.role)
+                else:  # Empty or legacy role entry.
+                    # We have either None or a legacy mdraid role when this disk
+                    # is no longer an mdraid member. We can now assert None.
+                    dob.role = None
+                    logger.debug('setting db role to None for %s', dob.name)
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -122,21 +122,20 @@ class DiskMixin(object):
                 dob.parted = True  # overload use of parted as non btrfs flag.
                 # N.B. this overload use may become redundant with the addition
                 # of the Disk.role field.
-                if d.fstype == 'isw_raid_member' \
-                        or d.fstype == 'linux_raid_member':
-                    # transfer fstype raid member indicator to role field
-                    dob.role = d.fstype
-                else:
-                    # No identified role from scan_disks() fstype indicator so
-                    # set as None to update db of new drive role. If we don't
-                    # do this then the same drive when re-deployed will inherit
-                    # it's previous role in the db which may be desired but in
-                    # the case of these raid member indicators from scan_disks()
-                    # we have the current truth provided.
-                    # N.B. this if else could be expanded to accommodate other
-                    # roles based on the fs found and also take heed of an
-                    # existing devices db role entry prior to overwriting.
-                    dob.role = None
+            if d.fstype == 'isw_raid_member' or d.fstype == 'linux_raid_member':
+                # transfer fstype raid member indicator to role field
+                dob.role = d.fstype
+            else:
+                # No identified role from scan_disks() fstype indicator so
+                # set as None to update db of new drive role. If we don't
+                # do this then the same drive when re-deployed will inherit
+                # it's previous role in the db which may be desired but in
+                # the case of these raid member indicators from scan_disks()
+                # we have the current truth provided.
+                # N.B. this if else could be expanded to accommodate other
+                # roles based on the fs found and also take heed of an
+                # existing devices db role entry prior to overwriting.
+                dob.role = None
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -125,6 +125,8 @@ class DiskMixin(object):
             if d.fstype == 'isw_raid_member' or d.fstype == 'linux_raid_member':
                 # transfer fstype raid member indicator to role field
                 dob.role = d.fstype
+                logger.debug('setting db role for %s', dob.name)
+                logger.debug('to role = %s', dob.role)
             else:
                 # No identified role from scan_disks() fstype indicator so
                 # set as None to update db of new drive role. If we don't
@@ -136,6 +138,7 @@ class DiskMixin(object):
                 # roles based on the fs found and also take heed of an
                 # existing devices db role entry prior to overwriting.
                 dob.role = None
+                logger.debug('setting db role to None for %s', dob.name)
             # If our existing Pool db knows of this disk's pool via it's label:
             if (Pool.objects.filter(name=d.label).exists()):
                 # update the disk db object's pool field accordingly.


### PR DESCRIPTION
The initial commit in this pr addresses the issue of prior mdraid member's db entries being updated once they are no longer mdraid members. The rest of the pr is concerned with migrating the 'role' Disk field in the db to use the json format and to open it up to alternative purposes than simply as an mdraid member labelling systems.. Previously it was expected to contain either null  (db default) or one of the following strings 'isw_raid_member' and 'linux_raid_member'. This pr prepares the role field for future use such as labelling drives for special purposes eg as backup or import devices where a role will be needed to label devices appropriately. So far the mdraid member status is fully maintained as this can be assessed via the current (and unchanged) scan_disks method by way of it's FSTYPE probe but provision has been made to preserve existing role entries, along side those of mdraid, over re-scans and device disconnect / reconnect cycles.

I will specify the testing employed to prove this mechanism in a separate post on this pr.