### PR TITLE
Issue#1302 issue#1289 broken network widget

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -445,9 +445,10 @@ class NetworkWidgetNamespace(BaseNamespace, BroadcastMixin):
                             'colls': data[13], 'carrier': data[14],
                             'compressed_tx': data[15], 'ts': str(ts)
                         })
-                self.emit('networkWidget:network', {
-                    'key': 'networkWidget:network', 'data': {'results': results}
-                })
+                if len(results) > 0 :
+                    self.emit('networkWidget:network', {
+                        'key': 'networkWidget:network', 'data': {'results': results}
+                    })
             return cur_stats
 
         def send_network_stats():

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -394,7 +394,6 @@ class CPUWidgetNamespace(BaseNamespace, BroadcastMixin):
                     'umode_nice': val.nice, 'smode': val.system,
                     'idle': val.idle, 'ts': str(ts)
                 })
-                logger.debug('Time is %s' % ts)
             self.emit('cpuWidget:cpudata', {
                 'key': 'cpuWidget:cpudata', 'data': cpu_stats
             })

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -355,7 +355,7 @@ class DisksWidgetNamespace(BaseNamespace, BroadcastMixin):
                             'ios_progress': data[8],
                             'ms_ios': data[9],
                             'weighted_ios': data[10],
-                            'ts': str(datetime.utcnow().replace(tzinfo=utc))
+                            'ts': str(datetime.utcnow().replace(tzinfo=utc).isoformat())
                         }]
                     })
             return cur_stats
@@ -386,7 +386,7 @@ class CPUWidgetNamespace(BaseNamespace, BroadcastMixin):
             cpu_stats = {}
             cpu_stats['results'] = []
             vals = psutil.cpu_times_percent(percpu=True)
-            ts = datetime.utcnow().replace(tzinfo=utc)
+            ts = datetime.utcnow().replace(tzinfo=utc).isoformat()
             for i, val in enumerate(vals):
                 name = 'cpu%d' % i
                 cpu_stats['results'].append({
@@ -394,6 +394,7 @@ class CPUWidgetNamespace(BaseNamespace, BroadcastMixin):
                     'umode_nice': val.nice, 'smode': val.system,
                     'idle': val.idle, 'ts': str(ts)
                 })
+                logger.debug('Time is %s' % ts)
             self.emit('cpuWidget:cpudata', {
                 'key': 'cpuWidget:cpudata', 'data': cpu_stats
             })
@@ -426,7 +427,7 @@ class NetworkWidgetNamespace(BaseNamespace, BroadcastMixin):
                     if (fields[0][:-1] not in interfaces):
                         continue
                     cur_stats[fields[0][:-1]] = fields[1:]
-            ts = datetime.utcnow().replace(tzinfo=utc)
+            ts = datetime.utcnow().replace(tzinfo=utc).isoformat()
             if (isinstance(prev_stats, dict)):
                 results = []
                 for interface in cur_stats.keys():
@@ -495,7 +496,7 @@ class MemoryWidgetNamespace(BaseNamespace, BroadcastMixin):
                     elif (re.match('Dirty:', l) is not None):
                         dirty = int(l.split()[1])
                         break  # no need to look at lines after dirty.
-            ts = datetime.utcnow().replace(tzinfo=utc)
+            ts = datetime.utcnow().replace(tzinfo=utc).isoformat()
             self.emit('memoryWidget:memory', {
                 'key': 'memoryWidget:memory', 'data': {'results': [{
                     'total': total, 'free': free, 'buffers': buffers,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/network_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/network_utilization.js
@@ -36,7 +36,7 @@ NetworkUtilizationWidget = RockStorWidgetView.extend({
     this.dataBuffers = {};
     this.dataLength = 300;
     this.currentTs = null;
-    this.networkInterfaces = new NetworkConnectionCollection();
+    this.networkInterfaces = new NetworkDeviceCollection();
     this.networkInterfaces.on("reset", this.getInitialData, this);
     this.selectedInterface = null;
     this.colors = ["#1224E3", "#F25805", "#04D6D6", "#F5CC73", "#750413"];


### PR DESCRIPTION
New clean PR starting from old #1311 PR for #1302 and #1289 (branch not in sync with rockstor/master so updating all data_collector again)

To @schakrava 
Main problem was in UTC dates : while Chrome/Chromium nicely accepts date like "2016-05-23 09:46:21.821559+00:00" (pls note empty space between date and time!), Firefox and Safari don't like it (both return "invalid date") and need conventional utc format "2016-05-23**T**09:46:21.821559+00:00"

Solved just by adding isoformat to utc ts in data_collector :wink: 

Still having some data.results[0].ts errors but that doesn't seem to affect dashboard widget (it's like firefox been "too fast on first data collection", but that immediately solves on next getData - maybe @priyaganti can investigate it too)

PR ready for merge  

Note: Minimized Memory widget on firefox doesn't render well (used memory graph part seems to be too small to be rendered)