### PR TITLE
improve dashboard disk activity widget for by-id names. Fixes #1366

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -306,7 +306,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
         if (d.name == 'root') {
           return '';
         } else {
-          return d.name + ' (' + (d.dx*100).toFixed(2) + '%)';
+          return d.name;
         }
       })
       .attr('fill-opacity', 1.0);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -52,7 +52,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
       this.disks.pageSize = RockStorGlobals.maxPageSize;
 
     this.topDisks = [];
-    this.topDisksWidth = this.maximized ? 400 : 200;
+    this.topDisksWidth = this.maximized ? 520 : 240;
     this.topDisksHeight = 50;
 
     this.selectedDisk = null;
@@ -170,6 +170,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
     var _this = this;
     this.disks.each(function(disk) {
       var name = disk.get('name');
+      var temp_name = disk.get('temp_name');
       _this.disksData[name] = [];
       for (var i=0; i<_this.dataLength; i++) {
         _this.disksData[name].push(_this.genEmptyDiskData());

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -85,10 +85,10 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
       yaxis: {
         min: 0
       },
-			series: {
-        lines: { show: true, fill: false },
-        shadowSize: 0	// Drawing is faster without shadows
-			}
+      series: {
+        lines: {show: true, fill: false},
+        shadowSize: 0 // Drawing is faster without shadows
+      }
     };
     this.dataGraphOptions = {
       grid : {
@@ -112,10 +112,10 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
         min: 0,
         tickFormatter: this.valueTickFormatter
       },
-			series: {
-        lines: { show: true, fill: false },
-        shadowSize: 0	// Drawing is faster without shadows
-			}
+      series: {
+        lines: {show: true, fill: false},
+        shadowSize: 0 // Drawing is faster without shadows
+      }
     };
   },
 
@@ -386,7 +386,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
   resize: function(event) {
     var _this = this;
     this.constructor.__super__.resize.apply(this, arguments);
-    this.topDisksWidth = this.maximized ? 400 : 200;
+    this.topDisksWidth = this.maximized ? 520 : 240;
     //this.$('#top-disks-ph').empty();
     this.$('#top-disks-ph').css('width', this.topDisksWidth);
     this.topDisksVis.attr('width', this.topDisksWidth);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -59,7 +59,8 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
 
     this.updateFreq = 1000;
     this.sortAttrs = ['reads_completed']; // attrs to sort by
-    this.numTop = 5; // maximum number of top disks to display
+    // maximum number of top disks to display
+    this.numTop = this.maximized ? 5 : 3;
     this.partition = d3.layout.partition()
     .value(function(d) {
       return _.reduce(_this.sortAttrs, function(s, a) { return s + d[a]; }, 0);
@@ -387,6 +388,8 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
     var _this = this;
     this.constructor.__super__.resize.apply(this, arguments);
     this.topDisksWidth = this.maximized ? 520 : 240;
+    // maximum number of top disks to display
+    this.numTop = this.maximized ? 5 : 3;
     //this.$('#top-disks-ph').empty();
     this.$('#top-disks-ph').css('width', this.topDisksWidth);
     this.topDisksVis.attr('width', this.topDisksWidth);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -306,7 +306,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
         if (d.name == 'root') {
           return '';
         } else {
-          return d.name;
+          return d.name.split('_').pop();
         }
       })
       .attr('fill-opacity', 1.0);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/disk_utilization.js
@@ -59,7 +59,7 @@ DiskUtilizationWidget = RockStorWidgetView.extend({
 
     this.updateFreq = 1000;
     this.sortAttrs = ['reads_completed']; // attrs to sort by
-    this.numTop = 5; // no of top shares
+    this.numTop = 5; // maximum number of top disks to display
     this.partition = d3.layout.partition()
     .value(function(d) {
       return _.reduce(_this.sortAttrs, function(s, a) { return s + d[a]; }, 0);


### PR DESCRIPTION
With the introduction of by-id names in pr #1357 the dashboard 'Disk Activity Widget' suffered from mostly overwritten writing detailing the drive names and their snapshot percentage of use in the horizontal 'Top Disks' bar. This is mostly addressed by increasing the disk bar width to make use of previously unused horizontal space and removing the text percentage indicator as this is redundant given the graphical display and costs 9 horizontal characters per disk name. The by-id name is then subdivided so that only the guaranteed unique serial component is used as drive identifier. Given the increased use of available widget width along with dropping the 9 characters per name on the text percentage we have a roughly similar though slightly higher text density.

Further improvements can be had in this widget but this pr represents a move in the right direction and largely, but not wholly, reverts the regression introduced by the use of the much longer by-id names.
