### PR TITLE
add raid56 warning. Fixes #1372

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -59,7 +59,7 @@
 	<div class="form-group">
           <label class="col-sm-4 control-label" for="mnt_options">Mount options</label>
           <div class="col-sm-6">
-            <input class="form-control" type="text" name="mnt_options" id="mnt_options" data-html="true" title="This is for <strong>Advanced users</strong> to provide specific BTRFS mount options.<br>Type them as a commma separated string of options without any spaces.<br> Allowed options are <strong>alloc_start, autodefrag, clear_cache, commit, compress-force, discard, fatal_errors, inode_cache, max_inline, metadata_ratio, noacl, noatime, nodatacow, nodatasum, nospace_cache, space_cache, ssd, ssd_spread, thread_pool</strong>">
+            <input class="form-control" type="text" name="mnt_options" id="mnt_options" data-html="true" title="This is for <strong>Advanced users</strong> to provide specific BTRFS mount options.<br>Type them as a commma separated string of options without any spaces.<br> Allowed options are <strong>alloc_start, autodefrag, clear_cache, commit, compress-force, discard, fatal_errors, inode_cache, max_inline, metadata_ratio, noacl, noatime, nodatacow, nodatasum, nospace_cache, space_cache, ssd, nossd, ssd_spread, thread_pool</strong>">
           </div>
         </div>
           <div id="SelectedDisksTable"> </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/raid_change.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/raid_change.jst
@@ -8,7 +8,7 @@
 <form id="raid-change-form">
   <div class="row">
   <div class="form-group col-md-4">
-     <label for="raid-level">Select a new raid level</label>
+     <label for="raid-level">Select a new raid level<br>raid5 & raid6 are not production-ready</label>
     <select id="raid-level" name="raid-level" class="form-control">
       <option value="">Select a new raid level</option>
       {{display_raid_levels}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -159,7 +159,7 @@ AddPoolView = Backbone.View.extend({
         this.$('#raid_level').tooltip({
             html: true,
             placement: 'right',
-            title: "Desired RAID level of the pool<br><strong>Single</strong>: No software raid. (Recommended while using hardware raid).<br><strong>Raid0</strong>, <strong>Raid1</strong>, <strong>Raid10</strong>, <strong>Raid5</strong> and <strong>Raid6</strong> are similar to conventional implementations with key differences.<br>See documentation for more information"
+            title: "Desired RAID level of the pool<br><strong>Single</strong>: No software raid. (Recommended while using hardware raid).<br><strong>Raid0</strong>, <strong>Raid1</strong>, <strong>Raid10</strong>, <strong>Raid5</strong>, and <strong>Raid6</strong> are similar to conventional raid levels. See documentation for more information.<br><strong>WARNING: Raid5 and Raid6 are not production-ready</strong>"
         });
 
         this.$('#compression').tooltip({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
@@ -91,7 +91,7 @@ PoolAddDisks = RockstorWizardPage.extend({
             var html = '',
                 _this = this;
             if (this.model.get('raidChange')) {
-                html += '<h4>Select a new raid level</h4>';
+                html += '<h4>Select a new raid level<br>raid5 & raid6 are not production-ready</h4>';
                 var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
                 html += '<div class="">';
                 html += '<select id="raid-level" name="raid-level" title="Select a new raid level for the pool">';


### PR DESCRIPTION
Adds User facing advisory notes to each raid level tooltip or selection label.
Ie Create pool - raid level tooltip has:

"WARNING: Raid5 and Raid6 are not production-ready" added in bold to the end.

and the 2 raid change selection points have:

"raid5 & raid6 are not production-ready"

on a line of it's own following the existing "Select a new raid level" label.

Tested against current master branch and the UI is as expected.
Note that longer messages than these cause unwanted line wrap.

Fixes #1372 

Also slipped in a missing nossd option in a tooltip while I was there, @priyaganti Sorry didn't convert to newer handlebars helper as you have done elsewhere as wanted to get this pr done quickly.
