### PR TITLE
3.8 14.03 broke samba config. May fix #1385

### DIFF
--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -22,8 +22,11 @@ import shutil
 from tempfile import mkstemp
 import re
 import os
+import logging
 from storageadmin.models import SambaCustomConfig
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 TESTPARM = '/usr/bin/testparm'
@@ -176,6 +179,8 @@ def get_global_config():
                 global_section = False
                 continue
             fields = l.strip().split('=')
+            logger.debug('FIELDS = %s', fields)
+            logger.debug('LEN OF FIELDS = %s', len(fields))
             config[fields[0].strip()] = fields[1].strip()
     return config
 

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -164,8 +164,8 @@ def update_global_config(smb_config=None, ad_config=None):
                 rockstor_section = True
             if (rockstor_section is True):
                 tfo.write(line)
-        test_parm(npath)
-        shutil.move(npath, SMB_CONFIG)
+    test_parm(npath)
+    shutil.move(npath, SMB_CONFIG)
 
 def get_global_config():
     config = {}

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -39,6 +39,8 @@ RS_HEADER = '####BEGIN: Rockstor SAMBA CONFIG####'
 def test_parm(config='/etc/samba/smb.conf'):
     cmd = [TESTPARM, '-s', config]
     o, e, rc = run_command(cmd, throw=False)
+    logger.debug('test_parm received rc of %s', rc)
+    logger.debug('test_parm was passed %s', config)
     if (rc != 0):
         try:
             os.remove(npath)
@@ -99,6 +101,8 @@ def refresh_smb_config(exports):
 
 
 def update_global_config(smb_config=None, ad_config=None):
+    logger.debug('update_global_config called with smb_config = %s', smb_config)
+    logger.debug('update_global_config called with ad_config = %s', ad_config)
     fh, npath = mkstemp()
     if (smb_config is None):
         smb_config = {}
@@ -184,6 +188,7 @@ def get_global_config():
             if len(fields) < 2:
                 continue
             config[fields[0].strip()] = fields[1].strip()
+    logger.debug('get_global_config returning %s', config)
     return config
 
 

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -130,9 +130,10 @@ def update_global_config(smb_config=None, ad_config=None):
             tfo.write('    winbind enum groups = yes\n')
             tfo.write('    idmap config * : backend = tdb\n')
             tfo.write('    idmap config * : range = %s\n' % default_range)
-            #enable rfc2307 schema and collect UIDS from AD DC we assume if
-            #rfc2307 then winbind nss info too - collects AD DC home and shell
-            #for each user
+            # enable rfc2307 schema and collect UIDS from AD DC we assume if
+            # rfc2307 then winbind nss info too - collects AD DC home and shell
+            # for each user
+            # TODO rfc2307 is now an unresolved reference
             if (rfc2307):
                 tfo.write('    idmap config %s : backend = ad\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' %

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -181,6 +181,8 @@ def get_global_config():
             fields = l.strip().split('=')
             logger.debug('FIELDS = %s', fields)
             logger.debug('LEN OF FIELDS = %s', len(fields))
+            if len(fields) < 2:
+                continue
             config[fields[0].strip()] = fields[1].strip()
     return config
 

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -22,11 +22,9 @@ import shutil
 from tempfile import mkstemp
 import re
 import os
-import logging
 from storageadmin.models import SambaCustomConfig
 from django.conf import settings
 
-logger = logging.getLogger(__name__)
 
 
 TESTPARM = '/usr/bin/testparm'
@@ -39,8 +37,6 @@ RS_HEADER = '####BEGIN: Rockstor SAMBA CONFIG####'
 def test_parm(config='/etc/samba/smb.conf'):
     cmd = [TESTPARM, '-s', config]
     o, e, rc = run_command(cmd, throw=False)
-    logger.debug('test_parm received rc of %s', rc)
-    logger.debug('test_parm was passed %s', config)
     if (rc != 0):
         try:
             os.remove(npath)
@@ -101,8 +97,6 @@ def refresh_smb_config(exports):
 
 
 def update_global_config(smb_config=None, ad_config=None):
-    logger.debug('update_global_config called with smb_config = %s', smb_config)
-    logger.debug('update_global_config called with ad_config = %s', ad_config)
     fh, npath = mkstemp()
     if (smb_config is None):
         smb_config = {}
@@ -184,12 +178,9 @@ def get_global_config():
                 global_section = False
                 continue
             fields = l.strip().split('=')
-            logger.debug('FIELDS = %s', fields)
-            logger.debug('LEN OF FIELDS = %s', len(fields))
             if len(fields) < 2:
                 continue
             config[fields[0].strip()] = fields[1].strip()
-    logger.debug('get_global_config returning %s', config)
     return config
 
 


### PR DESCRIPTION
@schakrava I've run out of time on this one for today but to ease hand over I've created this pr.

However I think with this pr the new samba config global import / update mechanism is now working as intended. And is best tested by yourself in this case anyway.

N.B. Very little (next to none) testing but parser now appears to import existing [global] config correctly and also appears to re-write this config correctly.

So over to you for review / testing.

Please see issue #1385 for the development history that lead to this issue.