### PR TITLE
improve nvme system disk compatibility. Fixes #1397

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -742,13 +742,24 @@ def root_disk():
                     # partition ie on md126 directly.
                     end = re.search('\d+', disk).end()
                     return disk[5:end]
-                else:
-                    # catch all that assumes we have eg /dev/sda3 and want "sda"
-                    # so start from 6th char and remove the last char
-                    # /dev/sda3 = sda
-                    # TODO: consider changing to same method as in md devs above
-                    # TODO: to cope with more than one numeric in name.
-                    return disk[5:-1]
+                if (re.match('/dev/nvme', disk) is not None):
+                    # We have an nvme device. These have the following naming
+                    # conventions.
+                    # Base device examples: nvme0n1 or nvme1n1
+                    # First partition on the first device would be nvme0n1p1
+                    # The first number after 'nvme' is the device number.
+                    # Partitions are indicated by the p# combination ie 'p1'.
+                    # We need to also account for a root install on the base
+                    # device itself as with the /dev/md parsing just in case,
+                    # so look for the end of the base device name via 'n1'.
+                    end = re.search('n1', disk).end()
+                    return disk[5:end]
+                # catch all that assumes we have eg /dev/sda3 and want "sda"
+                # so start from 6th char and remove the last char
+                # /dev/sda3 = sda
+                # TODO: consider changing to same method as in md devs above
+                # TODO: to cope with more than one numeric in name.
+                return disk[5:-1]
     msg = ('root filesystem is not BTRFS. During Rockstor installation, '
            'you must select BTRFS instead of LVM and other options for '
            'root filesystem. Please re-install Rockstor properly.')


### PR DESCRIPTION
As nvme device names differ in format from previously accounted for devices the root_disk() method failed to properly return the base device name of a partition ie:
base device name = nvme0n1
Rockstor system partition on the above base device:
3rd partition = nvme0n1p3
This lead to an unintentional return of the base device from scan_disks() as a device of interest. This in turn lead to db issues where the system disk was represented twice, once as it's base device and again as the usual system disk partition entry.

The changes presented here have been tested on regular, bios raid, and mdadm system disk installs and no regressions were observed.

Fixes #1397 

Thanks to @snafu in the following forum thread for helping to pinpoint this bug and for testing the changes presented here (to master) on an nvme system disk install by hand applying them to latest stable (3.8-14).
https://forum.rockstor.com/t/unable-to-update-disk-state-for-nvme-device/1567

Please note that this patch does not address outstanding serial retrieval issues for nvme devices however @snafu in the above referenced thread has developed a working set of udev rules towards the end of that thread.