### PR TITLE
issue#1406_single_to_raid1_not_reflected

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -99,7 +99,10 @@ def pool_raid(mnt_pt):
     for l in o:
         fields = l.split()
         if (len(fields) > 1):
-            raid_d[fields[0][:-1].lower()] = fields[1][:-1].lower()
+            block = fields[0][:-1].lower()
+            raid = fields[1][:-1].lower()
+            if not block in raid_d and raid is not 'DUP':
+                raid_d[block] = raid
     if (raid_d['metadata'] == 'single'):
         raid_d['data'] = raid_d['metadata']
     return raid_d


### PR DESCRIPTION
Fix for Issue [Issue 1406](https://github.com/rockstor/rockstor-core/issues/1406)

After a change of the raid level the poll in the Rockstor UI reflects the wrong, old raid level.
pool_raid(mnt_pt) in fs/btrfs.py iterates of the output over the output of btrfs fi df and only returns
the raid level of the last data block. This block is unused and will be removed if another balance is started

```
btrfs fi df /mnt2/rock-pool/
Data, RAID1: total=112.00GiB, used=110.03GiB
Data, single: total=1.00GiB, used=0.00B
System, RAID1: total=32.00MiB, used=48.00KiB
Metadata, RAID1: total=1.00GiB, used=390.86MiB
GlobalReserve, single: total=144.00MiB, used=0.00B
```
Updated pool_raid(mnt_pt)  to only use the raid of the first block
and to ignore 'DUP' if metedata is duplicated on a single device.
```
btrfs fi df /
Data, single: total=2.02GiB, used=1.58GiB
System, DUP: total=8.00MiB, used=16.00KiB
System, single: total=4.00MiB, used=0.00B
Metadata, DUP: total=343.50MiB, used=80.80MiB
Metadata, single: total=8.00MiB, used=0.00B
GlobalReserve, single: total=32.00MiB, used=0.00B
```