### PR TITLE
balance not updated during execution plus fs unittests (initial commit) #1405 #1022

### DIFF
--- a/base-buildout.cfg
+++ b/base-buildout.cfg
@@ -120,6 +120,8 @@ eggs = ${buildout:eggs}
 test =
      storageadmin
      smart_manager
+     fs
+     system
 extra-paths = ${buildout:directory}/src
 
 [scripts]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -181,4 +181,4 @@ update-command = ${delete-prod-rpm:command}
 
 [js-libraries]
 url = http://rockstor.com/downloads/jslibs-dev/lib.tgz
-md5sum = 95dd3e225dc8bbed5c24ac3eeb94146b
+md5sum = cd2a5bcbbcab583520d99625de2ebdb1

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,6 +31,7 @@ parts =
       shellinabox-conf
       stop-shellinabox
       django-settings-conf
+      test-settings-conf
       mime-types
       init-gunicorn
       extra-stuff
@@ -48,6 +49,7 @@ parts =
       bootstrap-systemd-conf
       def-kernel
       start-rockstor
+
 
 [rpm-deps-ad]
 recipe = plone.recipe.command
@@ -113,6 +115,11 @@ taplib = ${django-settings-conf:rootdir}/smart_manager/taplib
 output = ${django-settings-conf:rootdir}/settings.py
 debug = True
 kernel = '4.6.0-1.el7.elrepo.x86_64'
+
+[test-settings-conf]
+recipe = collective.recipe.template
+input = ${buildout:directory}/conf/test-settings.conf.in
+output = ${buildout:directory}/src/rockstor/test-settings.py
 
 [postgres-setup]
 recipe = plone.recipe.command

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -1,0 +1,383 @@
+"""
+Copyright (c) 2012 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 3 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+# Django settings for Rockstor project.
+import os
+
+DEBUG = ${django-settings-conf:debug}
+TEMPLATE_DEBUG = DEBUG
+
+ALLOWED_HOSTS = [ '*', ]
+
+#this settings file is to run unit tests in directories like fs and system, which require no databases.
+DATABASES = {
+}
+
+DATABASE_ROUTERS = ['smart_manager.db_router.SmartManagerDBRouter',]
+
+# Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# although not all choices may be available on all operating systems.
+# In a Windows environment this must be set to your system time zone.
+TIME_ZONE = 'America/Chicago'
+
+# Language code for this installation. All choices can be found here:
+# http://www.i18nguy.com/unicode/language-identifiers.html
+LANGUAGE_CODE = 'en-us'
+
+SITE_ID = 1
+
+# If you set this to False, Django will make some optimizations so as not
+# to load the internationalization machinery.
+USE_I18N = True
+
+# If you set this to False, Django will not format dates, numbers and
+# calendars according to the current locale.
+USE_L10N = True
+
+# If you set this to False, Django will not use timezone-aware datetimes.
+USE_TZ = True
+
+# Absolute filesystem path to the directory that will hold user-uploaded files.
+# Example: "/home/media/media.lawrence.com/media/"
+MEDIA_ROOT = ''
+
+# URL that handles the media served from MEDIA_ROOT. Make sure to use a
+# trailing slash.
+# Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
+MEDIA_URL = ''
+
+# Absolute path to the directory static files should be collected to.
+# Don't put anything in this directory yourself; store your static files
+# in apps' "static/" subdirectories and in STATICFILES_DIRS.
+# Example: "/home/media/media.lawrence.com/static/"
+STATIC_ROOT = 'static'
+
+# URL prefix for static files.
+# Example: "http://media.lawrence.com/static/"
+STATIC_URL = '/static/'
+
+# URL that handles the media served from MEDIA_ROOT. Make sure to use a
+# trailing slash.
+# Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
+MEDIA_URL = '/media/'
+
+# Absolute filesystem path to the directory that will hold user-uploaded files.
+# Example: "/home/media/media.lawrence.com/media/"
+MEDIA_ROOT = os.path.join('${buildout:depdir}', 'static')
+
+# Additional locations of static files
+#STATICFILES_DIRS = (
+#    # Put strings here, like "/home/html/static" or "C:/www/django/static".
+#    # Always use forward slashes, even on Windows.
+#    # Don't forget to use absolute paths, not relative paths.
+#    ('storageadmin', '${django-settings-conf:static_dir}')
+#)
+
+# List of finder classes that know how to find static files in
+# various locations.
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    # 'django.contrib.staticfiles.finders.FileSystemFinder',
+    # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
+)
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'odk7(t)1y$ls)euj3$2xs7e^i=a9b&amp;xtf&amp;z=-2bz$687&amp;^q0+3'
+
+# List of callables that know how to import templates from various sources.
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+#     'django.template.loaders.eggs.Loader',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'storageadmin.middleware.ProdExceptionMiddleware',
+    # Uncomment the next line for simple clickjacking protection:
+    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+ROOT_URLCONF = 'urls'
+
+# Python dotted path to the WSGI application used by Django's runserver.
+WSGI_APPLICATION = 'wsgi.application'
+
+TEMPLATE_DIRS = (
+    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+    # Always use forward slashes, even on Windows.
+    # Don't forget to use absolute paths, not relative paths.
+    '${django-settings-conf:template_dir1}',
+    '${django-settings-conf:template_dir2}',
+)
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    # Uncomment the next line to enable the admin:
+    'django.contrib.admin',
+    # Uncomment the next line to enable admin documentation:
+    # 'django.contrib.admindocs',
+    'storageadmin',
+    'pipeline',
+    'rest_framework',
+    'smart_manager',
+    #no south required as we don't want any db table creation.
+    #'south',
+    'oauth2_provider',
+    'django_ztask',
+)
+
+STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+
+PIPELINE_CSS_COMPRESSOR = None
+PIPELINE_JS_COMPRESSOR = None
+
+# Don't wrap in anonymous function so that license is at the top.
+PIPELINE_DISABLE_WRAPPER = True
+
+PIPELINE_JS = {
+    'storageadmin': {
+        'source_filenames': (
+            'storageadmin/js/license.js',
+            'storageadmin/js/templates/**/*.jst',
+            'storageadmin/js/templates/**/**/*.jst',
+            'storageadmin/js/socket_listen.js',
+            'storageadmin/js/rockstor.js',
+            'storageadmin/js/rockstor_widgets.js',
+            'storageadmin/js/rockstor_logger.js',
+            'storageadmin/js/paginated_collection.js',
+            'storageadmin/js/router.js',
+            'storageadmin/js/graph.js',
+            'storageadmin/js/d3.slider2.js',
+            'storageadmin/js/models/models.js',
+            'storageadmin/js/views/*.js',
+            'storageadmin/js/views/pool/**/*.js',
+            'storageadmin/js/views/dashboard/*.js',
+            ),
+        'output_filename': 'storageadmin/js/storageadmin.js'
+        },
+    }
+
+
+# A sample logging configuration. The only tangible logging
+# performed by this configuration is to send an email to
+# the site admins on every HTTP 500 error when DEBUG=False.
+# See http://docs.djangoproject.com/en/dev/topics/logging for
+# more details on how to customize your logging configuration.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'formatters': {
+        'standard': {
+            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+            'datefmt': "%d/%b/%Y %H:%M:%S"
+            },
+        },
+    'handlers': {
+        'mail_admins': {
+            'level': 'DEBUG',
+            #'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '${django-settings-conf:logfile}',
+            'maxBytes': 1000000,
+            'backupCount': 3,
+            'formatter': 'standard',
+            },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+        'storageadmin': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+        },
+        'smart_manager': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+        },
+	'system': {
+		  'handlers': ['file'],
+		  'level': 'DEBUG',
+	},
+	'scripts': {
+		   'handlers': ['file'],
+		   'level': 'DEBUG',
+	},
+	'fs': {
+	      'handlers': ['file'],
+	      'level': 'DEBUG',
+	},
+    }
+}
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+   "django.contrib.auth.context_processors.auth",
+   "django.core.context_processors.debug",
+   "django.core.context_processors.i18n",
+   "django.core.context_processors.media",
+   "django.core.context_processors.static",
+   "django.core.context_processors.tz",
+   "django.contrib.messages.context_processors.messages",
+   "django.core.context_processors.request"
+)
+
+SMB_CONF = '${django-settings-conf:smb_conf}'
+MNT_PT = '/mnt2/'
+NFS_EXPORT_ROOT = '/export/'
+SFTP_MNT_ROOT = '/mnt3/'
+
+TAP_DIR = '${django-settings-conf:taplib}'
+TAP_SERVER = ('127.0.0.1', ${django-settings-conf:tapport})
+MAX_TAP_WORKERS = 10
+SPROBE_SINK = ('127.0.0.1', ${django-settings-conf:sinkport})
+
+SUPPORT = {
+        'email': 'suman@rockstor.com',
+        'log_loc': '${buildout:depdir}/var/log',
+}
+
+"""
+Minimum disk size allowed is 1GB. Anything less is not really usable. Reduce
+this to 100MB if you really need to, but any less would just break things.
+"""
+MIN_DISK_SIZE = 1024 * 1024
+
+"""
+Maximum number of seconds to keep data collected by smart probes. The logic
+behind this needs to evolve quite a bit.
+"""
+PROBE_DATA_INTERVAL = 600
+
+"""
+Minimum share size allowed is 100KB. This is purely arbitrary. 4K is what is
+strictly required by btrfs. Similarly the maximum is 2^64 bytes which is more than
+enough for all practical purposes and also is the max allowed in btrfs.
+"""
+MIN_SHARE_SIZE = 100
+MAX_SHARE_SIZE = 18014398509481984L
+
+START_UID = 5000
+END_UID = 6000
+VALID_SHELLS = ('${buildout:depdir}/bin/rcli', '/bin/bash', '/sbin/nologin',)
+
+SCHEDULER = ('127.0.0.1', ${django-settings-conf:schedulerport})
+REPLICA_DATA_PORT = ${django-settings-conf:reppubport}
+REPLICA_META_PORT = ${django-settings-conf:reprecvport}
+REPLICA_SINK_PORT = ${django-settings-conf:repsinkport}
+MAX_REPLICA_SEND_ATTEMPTS = 10
+DEFAULT_SEND_CREDIT = 1000
+
+SHARE_REGEX = r'[A-Za-z0-9][A-Za-z0-9_.-]*'
+POOL_REGEX = SHARE_REGEX
+USERNAME_REGEX = r'[A-Za-z][-a-zA-Z0-9_]*$'
+ROOT_DIR = '${buildout:depdir}/'
+
+#things get purged when they are > MAX_TS_RECORDS x MAX_TS_MULTIPLIER of if the service just
+#starts and they are > MAX_TS_RECORDS.
+MAX_TS_RECORDS = 40000
+MAX_TS_MULTIPLIER = 3
+
+
+#various system binaries used by lower level code.
+COMMANDS = {
+	 'ntpdate': '/usr/sbin/ntpdate',
+	 'systemctl': '/usr/bin/systemctl',
+}
+
+SYSCONFIG = {
+	  'ntp': '/etc/ntp.conf',
+}
+
+SOUTH_TESTS_MIGRATE = False
+
+REST_FRAMEWORK = {
+	'DEFAULT_PAGINATION_CLASS': 'rest_framework_custom.custom_pagination.CustomPagination',
+	'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+	'PAGE_SIZE': 15,
+	'MAX_LIMIT': 10000,
+}
+
+CONFROOT = '${buildout:depdir}/conf'
+CERTDIR = '${buildout:depdir}/certs'
+COMPRESSION_TYPES = ('lzo', 'zlib', 'no',)
+
+SUPPORTED_KERNEL_VERSION = ${django-settings-conf:kernel}
+
+SNAP_TS_FORMAT = '%Y%m%d%H%M'
+ROOT_POOL = 'rockstor_rockstor'
+
+
+MODEL_DEFS = {
+	   'pqgroup': '-1/-1',
+}
+
+SSHD_HEADER = '###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###'
+
+OAUTH_INTERNAL_APP = 'cliapp'
+
+# Header string to separate auto config options from rest of config file.
+# this could be generalized across all Rockstor config files, problems during
+# upgrades though
+NUT_HEADER = '###BEGIN: Rockstor NUT Config. DO NOT EDIT BELOW THIS LINE###'
+
+# The ip address for the LISTEN directive in upsd.conf when in netserver mode
+# when set to 0.0.0.0 it will accept connections from any machine.
+# default port is 3493
+# Note this might later be tied into multi lan configs ie ups monitoring on
+# admin interface for example.
+NUT_LISTEN_ON_IP = '0.0.0.0'
+
+# The command that the root part of upsmon uses to shutdown the system.
+NUT_SYSTEM_SHUTDOWNCMD = '/sbin/shutdown -h +0'
+
+
+UPDATE_CHANNELS = {
+		'stable': {
+		'name': 'Stable',
+		'description': 'Subscription channel for stable updates',
+		'url': 'updates.rockstor.com:8999/rockstor-stable',
+		},
+		'testing': {
+		'name': 'Testing',
+		'description': 'Subscription channel for testing updates',
+		'url': 'rockstor.com/rockrepo-testing',
+		},
+}

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -259,7 +259,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
    "django.core.context_processors.request"
 )
 
-SMB_CONF = '${django-settings-conf:smb_conf}'
 MNT_PT = '/mnt2/'
 NFS_EXPORT_ROOT = '/export/'
 SFTP_MNT_ROOT = '/mnt3/'

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -475,13 +475,16 @@ def share_id(pool, share_name):
     """
     Returns the subvolume id, becomes the share's uuid.
     @todo: this should be part of add_share -- btrfs create should atomically
+    Works by iterating over the output of btrfs subvolume list, received from
+    subvol_list_helper() looking for a match in share_name. If found the same
+    line is parsed for the ID, example line in output:
+    'ID 257 gen 13616 top level 5 path rock-ons-root'
     :param pool: a pool object.
-    :param share_name:
-    :return: the id
+    :param share_name: target share name to find
+    :return: the id for the given share_name or an Exception stating no id found
     """
     root_pool_mnt = mount_root(pool)
     out, err, rc = subvol_list_helper(root_pool_mnt)
-    logger.debug('subvol_list_helper() returned out=%s, err=%s, rc=%rc in share_id()')
     subvol_id = None
     for line in out:
         if (re.search(share_name + '$', line) is not None):

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -44,14 +44,31 @@ QID = '2015'
 
 def add_pool(pool, disks):
     """
-    pool is a btrfs filesystem.
+    Makes a btrfs pool (filesystem) of name 'pool' using the by-id disk names
+    provided, then enables quotas for this pool.
+    :param pool: name of pool to create.
+    :param disks: list of by-id disk names without paths to make the pool from.
+    :return o, err, rc from last command executed.
     """
+
     disks_fp = ['/dev/disk/by-id/' + d for d in disks]
     cmd = [MKFS_BTRFS, '-f', '-d', pool.raid, '-m', pool.raid, '-L',
            pool.name, ]
     cmd.extend(disks_fp)
-    out, err, rc = run_command(cmd)
-    enable_quota(pool)
+    # run the create pool command, any exceptions are logged and raised by
+    # run_command as a CommandException.
+    out, err, rc = run_command(cmd, log=True)
+    # only execute enable_quota on above btrfs command having an rc=0
+    if rc == 0:
+        # N.B. enable_quota wraps switch_quota() which doesn't enable logging
+        # so log what we have on rc != 0.
+        out2, err2, rc2 = enable_quota(pool)
+        if rc2 != 0:
+            logger.error('Error while enabling quota on newly created '
+                         'pool = %s' % pool.name)
+            return out2, err2, rc2
+    else:
+        logger.error('Error while creating new pool')
     return out, err, rc
 
 
@@ -93,6 +110,7 @@ def get_pool_info(disk):
 
 
 def pool_raid(mnt_pt):
+    # TODO: propose name change to get_pool_raid_levels(mnt_pt)
     o, e, rc = run_command([BTRFS, 'fi', 'df', mnt_pt])
     # data, system, metadata, globalreserve
     raid_d = {}
@@ -210,7 +228,7 @@ def mount_root(pool):
                 if (device.name == last_device.name):
                     #exhausted mounting using all devices in the pool
                     raise e
-                logger.error('Error mouting: %s. Will try using another device.' % mnt_cmd)
+                logger.error('Error mounting: %s. Will try using another device.' % mnt_cmd)
                 logger.exception(e)
     raise Exception('Failed to mount Pool(%s) due to an unknown reason.' % pool.name)
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -696,6 +696,7 @@ def share_usage(pool, share_id):
     Returns the referenced and exclusive share usage information for a given
     share_id by parsing the output of btrfs qgroup show pool_mount_point for a
     line beginning with share_id (qgroupid).
+    N.B. qgroupid defaults to a unique identifier of the form 0/<subvolume id>
     :return rusage, eusage tuple referencing respectively the rfer and excl
     usage of the given share_id/qgroupid. Sizes are converted into KiB units.
     """
@@ -714,8 +715,7 @@ def share_usage(pool, share_id):
             rusage = convert_to_kib(fields[-2])
             # last column [-1] = excl = exclusive data held in subvol
             # ie what would be re-claimed if the subvol was deleted.
-            # TODO: currently hard wired to return rfer in place of excl
-            eusage = convert_to_kib(fields[-2])
+            eusage = convert_to_kib(fields[-1])
             break
     logger.debug('share_usage returning rusage=%s and eusage=%s' % (rusage, eusage))
     return (rusage, eusage)

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -189,12 +189,27 @@ def resize_pool(pool, dev_list_byid, add=True):
     return run_command(resize_cmd)
 
 
-#Try mounting by-label first. If that is not possible, mount using every device
-#in the set, one by one until success.
 def mount_root(pool):
+    """
+    Mounts a given pool at the default mount root (usually /mnt2/) using the
+    pool.name as the final path entry. Ie pool.name = test-pool will be mounted
+    at /mnt2/test-pool. Any mount options held in pool.mnt_options will be added
+    to the mount command via the -o option as will a compress=pool.compression
+    entry.
+    N.B. Initially the mount target is defined by /dev/disk/by-label/pool.name,
+    if this fails then an attempt to mount by each member of
+    /dev/disk/by-id/pool.disk_set.all() but only if there are any members.
+    If this second method also fails then an exception is raised, currently all
+    but the last failed mount by device name is logged. If no disk members were
+    reported by pool.disk_set.count() a separate Exception is raised.
+    :param pool: pool object
+    :return: either the relevant mount point or an Exception which either
+    indicates 'no disks in pool' or 'Unknown Reason'
+    """
     root_pool_mnt = DEFAULT_MNT_DIR + pool.name
     if (is_share_mounted(pool.name)):
         return root_pool_mnt
+    # Creates a directory to act as the mount point.
     create_tmp_dir(root_pool_mnt)
     mnt_device = '/dev/disk/by-label/%s' % pool.name
     mnt_cmd = [MOUNT, mnt_device, root_pool_mnt, ]
@@ -209,9 +224,8 @@ def mount_root(pool):
             mnt_cmd.extend(['-o', mnt_options])
         run_command(mnt_cmd)
         return root_pool_mnt
-
-    #If we cannot mount by-label, let's try mounting by device one by one
-    #until we get our first success.
+    # If we cannot mount by-label, let's try mounting by device; one by one
+    # until we get our first success.
     if (pool.disk_set.count() < 1):
         raise Exception('Cannot mount Pool(%s) as it has no disks in it.' % pool.name)
     last_device = pool.disk_set.last()
@@ -226,7 +240,7 @@ def mount_root(pool):
                 return root_pool_mnt
             except Exception, e:
                 if (device.name == last_device.name):
-                    #exhausted mounting using all devices in the pool
+                    # exhausted mounting using all devices in the pool
                     raise e
                 logger.error('Error mounting: %s. Will try using another device.' % mnt_cmd)
                 logger.exception(e)
@@ -679,7 +693,11 @@ def update_quota(pool, qgroup, size_bytes):
 
 def share_usage(pool, share_id):
     """
-    for now, exclusive byte count
+    Returns the referenced and exclusive share usage information for a given
+    share_id by parsing the output of btrfs qgroup show pool_mount_point for a
+    line beginning with share_id (qgroupid).
+    :return rusage, eusage tuple referencing respectively the rfer and excl
+    usage of the given share_id/qgroupid. Sizes are converted into KiB units.
     """
     logger.debug('share_usage() CALLED WITH pool name of=%s and share_id=%s' % (pool.name, share_id))
     root_pool_mnt = mount_root(pool)

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -256,7 +256,13 @@ def umount_root(root_pool_mnt):
 
 
 def is_subvol(mnt_pt):
+    """
+    Simple wrapper around "btrfs subvolume show mnt_pt"
+    :param mnt_pt: mount point of subvolume to query
+    :return: True if subvolume mnt_pt exists, else False
+    """
     show_cmd = [BTRFS, 'subvolume', 'show', mnt_pt]
+    # Throw=False on run_command to silence CommandExceptions.
     o, e, rc = run_command(show_cmd, throw=False)
     if (rc == 0):
         return True

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -832,8 +832,12 @@ def start_balance(mnt_pt, force=False, convert=None):
     if (convert is not None):
         cmd.insert(3, '-dconvert=%s' % convert)
         cmd.insert(3, '-mconvert=%s' % convert)
-    # TODO: elseif to apply "--full-balance" when no filters are requested.
-    # TODO: this avoids a problematic 10 second count down delay.
+    else:
+        # As we are running with no convert filters a warning and 10 second
+        # countdown with ^C prompt will result unless we use "--full-balance".
+        # This warning is now present in the Web-UI "Start a new balance"
+        # button tooltip.
+        cmd.insert(3, '--full-balance')
     logger.debug('start_balance command=%s' % cmd)
     # cmd=['btrfs', 'balance', 'start', u'/mnt2/raid5-pool']
     #

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -149,7 +149,7 @@ class BTRFSTests(unittest.TestCase):
                                  'level %s' % raid_level)
 
     def test_is_subvol_exists(self):
-        mount_point='/mnt2/test-pool/test-share'
+        mount_point = '/mnt2/test-pool/test-share'
         o = ['/mnt2/test-pool/test-share', '\tName: \t\t\ttest-share',
              '\tUUID: \t\t\t80c240a2-c353-7540-bb5e-b6a71a50a02e',
              '\tParent UUID: \t\t-', '\tReceived UUID: \t\t-',
@@ -157,9 +157,19 @@ class BTRFSTests(unittest.TestCase):
              '\tSubvolume ID: \t\t258', '\tGeneration: \t\t13',
              '\tGen at creation: \t13', '\tParent ID: \t\t5',
              '\tTop level ID: \t\t5', '\tFlags: \t\t\t-', '\tSnapshot(s):', '']
-        e=['']
-        rc=0
+        e = ['']
+        rc = 0
         # btrfs subvol show has return code of 0 (no errors) when subvol exists
         self.mock_run_command.return_value = (o, e, rc)
         self.assertEqual(is_subvol(mount_point), True,
                          msg='Did NOT return True for existing subvol')
+
+    def test_is_subvol_nonexistent(self):
+        mount_point = '/mnt2/test-pool/test-share'
+        o = ['']
+        e = ["ERROR: cannot find real path for '/mnt2/test-pool/test-share': No such file or directory", '']
+        rc = 1
+        # btrfs subvol show has return code of 1 when subvol doesn't exist.
+        self.mock_run_command.return_value = (o, e, rc)
+        self.assertEqual(is_subvol(mount_point), False,
+                         msg='Did NOT return False for nonexistent subvol')

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -33,12 +33,12 @@ class BTRFSTests(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    # sample test
-    def test_add_pool_mkfs_fail(self):
-        pool = Pool(raid='raid0', name='mypool')
-        disks = ('sdb', 'sdc')
-        self.mock_run_command.side_effect = Exception('mkfs error')
-        self.assertEqual(add_pool(pool, disks), 1)
+    # # sample test
+    # def test_add_pool_mkfs_fail(self):
+    #     pool = Pool(raid='raid0', name='mypool')
+    #     disks = ('sdb', 'sdc')
+    #     self.mock_run_command.side_effect = Exception('mkfs error')
+    #     self.assertEqual(add_pool(pool, disks), 1)
 
     def test_get_pool_raid_levels_identification(self):
         """
@@ -161,8 +161,8 @@ class BTRFSTests(unittest.TestCase):
         rc = 0
         # btrfs subvol show has return code of 0 (no errors) when subvol exists
         self.mock_run_command.return_value = (o, e, rc)
-        self.assertEqual(is_subvol(mount_point), True,
-                         msg='Did NOT return True for existing subvol')
+        self.assertTrue(is_subvol(mount_point),
+                        msg='Did NOT return True for existing subvol')
 
     def test_is_subvol_nonexistent(self):
         mount_point = '/mnt2/test-pool/test-share'
@@ -171,5 +171,16 @@ class BTRFSTests(unittest.TestCase):
         rc = 1
         # btrfs subvol show has return code of 1 when subvol doesn't exist.
         self.mock_run_command.return_value = (o, e, rc)
-        self.assertEqual(is_subvol(mount_point), False,
+        self.assertFalse(is_subvol(mount_point),
                          msg='Did NOT return False for nonexistent subvol')
+
+
+    # def test_is_subvol_exception(self):
+    #     mount_point = '/mnt2/test-pool/test-share'
+    #     o = ['']
+    #     e = ["not important as we are throwing exception in run_command"]
+    #     rc = 1
+    #     # btrfs subvol show has return code of 1 when subvol doesn't exist.
+    #     self.mock_run_command.side_effect = Exception('mkfs error')
+    #     self.assertFalse(is_subvol(mount_point),
+    #                  msg='Did NOT return False for exception')

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -258,6 +258,9 @@ class BTRFSTests(unittest.TestCase):
                          msg='Failed to retrieve expected rfer and excl usage')
 
 
+# TODO: add test_balance_status_finished
+
+
     def test_balance_status_in_progress(self):
         """
         Moc return value of run_command executing btrfs balance status
@@ -303,29 +306,41 @@ class BTRFSTests(unittest.TestCase):
         self.mock_mount_root.return_value = '/mnt2/test-mount'
         self.assertEqual(balance_status(pool), expected_results,
                          msg="Failed to correctly identify balance cancel requested status")
-    #
-    #
-    # def test_balance_status_pause_requested(self):
-    #     """
-    #     As per test_balance_status_in_progress(self) but while pause requested
-    #     :return:
-    #     """
-    #     out = ["Balance on '/mnt2/rock-pool' is running, pause requested",
-    #            '3 out of about 114 chunks balanced (4 considered),  97% left',
-    #            '']
-    #     err=['']
-    #     rc=1
-    #     self.mock_is_mounted.return_value = True
-    #
-    #
-    # def test_balance_status_paused(self):
-    #     """
-    #     Test to see if balance_status() correctly identifies a Paused balance state.
-    #     :return:
-    #     """
-    #     out = ["Balance on '/mnt2/rock-pool' is paused",
-    #            '3 out of about 114 chunks balanced (4 considered),  97% left',
-    #            '']
-    #     err = ['']
-    #     rc = 1
-    #     self.mock_is_mounted.return_value = True
+
+
+    def test_balance_status_pause_requested(self):
+        """
+        As per test_balance_status_in_progress(self) but while pause requested
+        :return:
+        """
+        pool = Pool(raid='raid0', name='test-pool')
+        out = ["Balance on '/mnt2/rock-pool' is running, pause requested",
+               '3 out of about 114 chunks balanced (4 considered),  97% left',
+               '']
+        err = ['']
+        # N.B. the return code for in progress balance = 1
+        rc = 1
+        expected_results = {'status': 'pausing', 'percent_done': 3}
+        self.mock_run_command.return_value = (out, err, rc)
+        self.mock_mount_root.return_value = '/mnt2/test-mount'
+        self.assertEqual(balance_status(pool), expected_results,
+                         msg="Failed to correctly identify balance pause requested status")
+
+
+    def test_balance_status_paused(self):
+        """
+        Test to see if balance_status() correctly identifies a Paused balance state.
+        :return:
+        """
+        pool = Pool(raid='raid0', name='test-pool')
+        out = ["Balance on '/mnt2/rock-pool' is paused",
+               '3 out of about 114 chunks balanced (4 considered),  97% left',
+               '']
+        err = ['']
+        # N.B. the return code for in progress balance = 1
+        rc = 1
+        expected_results = {'status': 'paused', 'percent_done': 3}
+        self.mock_run_command.return_value = (out, err, rc)
+        self.mock_mount_root.return_value = '/mnt2/test-mount'
+        self.assertEqual(balance_status(pool), expected_results,
+                         msg="Failed to correctly identify balance paused status")

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -15,7 +15,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
 import unittest
-from fs.btrfs import add_pool
+from fs.btrfs import add_pool, pool_raid
 import mock
 from mock import patch
 
@@ -42,3 +42,43 @@ class BTRFSTests(unittest.TestCase):
         disks = ('sdb', 'sdc')
         self.mock_run_command.side_effect = Exception('mkfs error')
         self.assertEqual(add_pool(pool, disks), 1)
+
+    def test_get_pool_raid_levels(self):
+        """
+        Presents the raid identification function with example data and compares
+        it's return dict to that expected for the given input.
+        :return: 'ok' if all is as expected or a message indicating which raid
+        level was incorrectly identified given the test data.
+        """
+        # setup fake mount point
+        mount_point = '/mnt2/fake-pool'
+        cmd_rc = 0
+        cmd_e = ['']
+        # setup example btrfs fi df mount_point outputs for given inputs.
+        # Outputs are simple lists of whole lines output from btrfs fi df
+        # expected return is a dict of extracted info from above btrfs command.
+        single_fi_df = ['Data, single: total=8.00MiB, used=64.00KiB', 'System, single: total=4.00MiB, used=16.00KiB', 'Metadata, single: total=216.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        single_return = {'data': 'single', 'system': 'single', 'globalreserve': 'single', 'metadata': 'single'}
+        raid0_fi_df = ['Data, RAID0: total=512.00MiB, used=256.00KiB', 'System, RAID0: total=16.00MiB, used=16.00KiB', 'Metadata, RAID0: total=512.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid0_return = {'data': 'raid0', 'system': 'raid0', 'globalreserve': 'single', 'metadata': 'raid0'}
+        raid1_fi_df = ['Data, RAID1: total=512.00MiB, used=192.00KiB', 'System, RAID1: total=32.00MiB, used=16.00KiB', 'Metadata, RAID1: total=256.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid1_return = {'data': 'raid1', 'system': 'raid1', 'globalreserve': 'single', 'metadata': 'raid1'}
+        # Thanks to @grebnek in forum and GitHub for spotting this:
+        # https://btrfs.wiki.kernel.org/index.php/FAQ#Why_do_I_have_.22single.22_chunks_in_my_RAID_filesystem.3F
+        # when converting from single to another raid level it is normal for
+        # a few chunks to remain in single until the next balance operation.
+        raid1_fi_df_some_single_chunks = ['Data, RAID1: total=416.00MiB, used=128.00KiB', 'Data, single: total=416.00MiB, used=0.00B', 'System, RAID1: total=32.00MiB, used=16.00KiB', 'Metadata, RAID1: total=512.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        # for a time we incorrectly parsed the last btrfs fi df mount_point as the following
+        # raid1_some_single_chunks_return = {'data': 'single', 'system': 'raid1', 'globalreserve': 'single', 'metadata': 'raid1'}
+        # but the expected result should be the same as "raid1_return" above. ie data raid1 not single.
+        raid10_fi_df = ['Data, RAID10: total=419.75MiB, used=128.00KiB', 'System, RAID10: total=16.00MiB, used=16.00KiB', 'Metadata, RAID10: total=419.75MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid10_return = {'data': 'raid10', 'system': 'raid10', 'globalreserve': 'single', 'metadata': 'raid10'}
+        raid5_fi_df = ['Data, RAID5: total=215.00MiB, used=128.00KiB', 'System, RAID5: total=8.00MiB, used=16.00KiB', 'Metadata, RAID5: total=215.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid5_return = {'data': 'raid5', 'system': 'raid5', 'globalreserve': 'single', 'metadata': 'raid5'}
+        raid6_fi_df = ['Data, RAID6: total=211.62MiB, used=128.00KiB', 'System, RAID6: total=8.00MiB, used=16.00KiB', 'Metadata, RAID6: total=211.62MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid6_return = {'data': 'raid6', 'system': 'raid6', 'globalreserve': 'single', 'metadata': 'raid6'}
+        # list used to report what raid level is currently under test.
+        raid_levels_tested = ['single', 'raid0', 'raid1', 'raid10', 'raid5',
+                              'raid6']
+        self.mock_run_command.return_value = (single_fi_df, cmd_e, cmd_rc)
+        self.assertEqual(pool_raid(mount_point), single_return)

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -347,7 +347,7 @@ class BTRFSTests(unittest.TestCase):
                          msg="Failed to correctly identify balance paused status")
 
 
-    def test_share_id_found(self):
+    def test_share_id(self):
         """
         Test to see if share_id() successfully returns existing subvolume id's
         :return:
@@ -410,9 +410,12 @@ class BTRFSTests(unittest.TestCase):
         rc = 0
         existing_share = 'snapshot-name'
         existing_share2 = 'sftpdata'
+        nonexistent_share = 'abcdef'
         # if queried for the last entry "snapshot-name" we would expect:
         expected_result = '794'
         expected_result2 = '283'
+        # setup expected Exception when no share is found:
+        expected_exception = 'subvolume id for share: %s not found.' % nonexistent_share
         # setup run_command mock to return the above test data
         self.mock_run_command.return_value = (out, err, rc)
         self.mock_mount_root.return_value = '/mnt2/test-mount'
@@ -420,3 +423,5 @@ class BTRFSTests(unittest.TestCase):
                          msg="Failed to get existing share_id snapshot example")
         self.assertEqual(share_id(pool, existing_share2), expected_result2,
                          msg="Failed to get existing share_id regular example")
+        with self.assertRaises(Exception):
+            share_id(pool, nonexistent_share)

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -251,3 +251,43 @@ class BTRFSTests(unittest.TestCase):
         expected_results = (461404, 3512)
         self.assertEqual(share_usage(pool, share_id), expected_results,
                          msg='Failed to retrieve expected rfer and excl usage')
+
+
+    def test_balance_status_in_progress(self):
+        """
+        Moc return value of run_command executing btrfs balance status
+        pool_mount_point which is invoked inside of target function.
+
+        :return:
+        """
+        # balance_status called with pool object of name=Pool object
+        #
+        # typical return for no current balance operation in progress:
+        # out=["No balance found on '/mnt2/single-to-raid1'", '']
+        # err=['']
+        # rc=0
+        # example return for ongoing balance operation:
+        out = ["Balance on '/mnt2/rock-pool' is running",
+               '7 out of about 114 chunks balanced (8 considered),  94% left',
+               '']
+        e = ['']
+        # N.B. the return code for a in progress balance = 1
+        rc = 1
+        expected_return = {'status': 'running', 'percent_done': 6}
+        # is_mounted returning True avoids mount command calls in mount_root()
+        self.mock_is_mounted.return_value = True
+
+
+    def test_balance_status_cancel_requested(self):
+        """
+        As per test_balance_status_in_progress(self) but while balance is
+        :return:
+        """
+
+        # run_command moc return values.
+        out = ["Balance on '/mnt2/rock-pool' is running, cancel requested",
+               '15 out of about 114 chunks balanced (16 considered),  87% left',
+               '']
+        err=['']
+        rc=1
+        self.mock_is_mounted.return_value = True

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -1,0 +1,44 @@
+"""
+Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+import unittest
+from fs.btrfs import add_pool
+import mock
+from mock import patch
+
+
+class Pool(object):
+
+    def __init__(self, raid, name):
+        self.raid = raid
+        self.name = name
+
+
+class BTRFSTests(unittest.TestCase):
+
+    def setUp(self):
+        self.patch_run_command = patch('fs.btrfs.run_command')
+        self.mock_run_command = self.patch_run_command.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    #sample test
+    def test_add_pool_mkfs_fail(self):
+        pool = Pool(raid='raid0', name='mypool')
+        disks = ('sdb', 'sdc')
+        self.mock_run_command.side_effect = Exception('mkfs error')
+        self.assertEqual(add_pool(pool, disks), 1)

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -14,7 +14,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import unittest
-from fs.btrfs import add_pool, pool_raid
+from fs.btrfs import add_pool, pool_raid, is_subvol
 import mock
 from mock import patch
 
@@ -147,3 +147,19 @@ class BTRFSTests(unittest.TestCase):
             self.assertEqual(pool_raid(mount_point), expected_result,
                              msg='get_pool_raid_level() miss identified raid '
                                  'level %s' % raid_level)
+
+    def test_is_subvol_exists(self):
+        mount_point='/mnt2/test-pool/test-share'
+        o = ['/mnt2/test-pool/test-share', '\tName: \t\t\ttest-share',
+             '\tUUID: \t\t\t80c240a2-c353-7540-bb5e-b6a71a50a02e',
+             '\tParent UUID: \t\t-', '\tReceived UUID: \t\t-',
+             '\tCreation time: \t\t2016-07-27 17:01:09 +0100',
+             '\tSubvolume ID: \t\t258', '\tGeneration: \t\t13',
+             '\tGen at creation: \t13', '\tParent ID: \t\t5',
+             '\tTop level ID: \t\t5', '\tFlags: \t\t\t-', '\tSnapshot(s):', '']
+        e=['']
+        rc=0
+        # btrfs subvol show has return code of 0 (no errors) when subvol exists
+        self.mock_run_command.return_value = (o, e, rc)
+        self.assertEqual(is_subvol(mount_point), True,
+                         msg='Did NOT return True for existing subvol')

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -291,3 +291,29 @@ class BTRFSTests(unittest.TestCase):
         err=['']
         rc=1
         self.mock_is_mounted.return_value = True
+
+
+    def test_balance_status_pause_requested(self):
+        """
+        As per test_balance_status_in_progress(self) but while pause requested
+        :return:
+        """
+        out = ["Balance on '/mnt2/rock-pool' is running, pause requested",
+               '3 out of about 114 chunks balanced (4 considered),  97% left',
+               '']
+        err=['']
+        rc=1
+        self.mock_is_mounted.return_value = True
+
+
+    def test_balance_status_paused(self):
+        """
+        Test to see if balance_status() correctly identifies a Paused balance state.
+        :return:
+        """
+        out = ["Balance on '/mnt2/rock-pool' is paused",
+               '3 out of about 114 chunks balanced (4 considered),  97% left',
+               '']
+        err = ['']
+        rc = 1
+        self.mock_is_mounted.return_value = True

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -258,47 +258,51 @@ class BTRFSTests(unittest.TestCase):
                          msg='Failed to retrieve expected rfer and excl usage')
 
 
-    # def test_balance_status_in_progress(self):
-    #     """
-    #     Moc return value of run_command executing btrfs balance status
-    #     pool_mount_point which is invoked inside of target function.
-    #     :return:
-    #     """
-    #     # balance_status called with pool object of name=Pool object
-    #     #
-    #     # typical return for no current balance operation in progress:
-    #     # out=["No balance found on '/mnt2/single-to-raid1'", '']
-    #     # err=['']
-    #     # rc=0
-    #     # example return for ongoing balance operation:
-    #     pool = Pool(raid='raid0', name='test-pool')
-    #     out = ["Balance on '/mnt2/rock-pool' is running",
-    #            '7 out of about 114 chunks balanced (8 considered),  94% left',
-    #            '']
-    #     err = ['']
-    #     # N.B. the return code for a in progress balance = 1
-    #     rc = 1
-    #     expected_results = {'status': 'running', 'percent_done': 6}
-    #     # is_mounted returning True avoids mount command calls in mount_root()
-    #     self.mock_is_mounted.return_value = True
-    #     self.mock_run_command.return_value = (out, err, rc)
-    #     self.assertEqual(balance_status(pool), expected_results,
-    #                      msg="Failed to correctly identify balance running status")
+    def test_balance_status_in_progress(self):
+        """
+        Moc return value of run_command executing btrfs balance status
+        pool_mount_point which is invoked inside of target function.
+        :return:
+        """
+        # balance_status called with pool object of name=Pool object
+        #
+        # typical return for no current balance operation in progress:
+        # out=["No balance found on '/mnt2/single-to-raid1'", '']
+        # err=['']
+        # rc=0
+        # example return for ongoing balance operation:
+        pool = Pool(raid='raid0', name='test-pool')
+        out = ["Balance on '/mnt2/rock-pool' is running",
+               '7 out of about 114 chunks balanced (8 considered),  94% left',
+               '']
+        err = ['']
+        # N.B. the return code for in progress balance = 1
+        rc = 1
+        expected_results = {'status': 'running', 'percent_done': 6}
+        self.mock_run_command.return_value = (out, err, rc)
+        self.mock_mount_root.return_value = '/mnt2/test-mount'
+        self.assertEqual(balance_status(pool), expected_results,
+                         msg="Failed to correctly identify balance running status")
 
 
-    # def test_balance_status_cancel_requested(self):
-    #     """
-    #     As per test_balance_status_in_progress(self) but while balance is
-    #     :return:
-    #     """
-    #
-    #     # run_command moc return values.
-    #     out = ["Balance on '/mnt2/rock-pool' is running, cancel requested",
-    #            '15 out of about 114 chunks balanced (16 considered),  87% left',
-    #            '']
-    #     err=['']
-    #     rc=1
-    #     self.mock_is_mounted.return_value = True
+    def test_balance_status_cancel_requested(self):
+        """
+        As per test_balance_status_in_progress(self) but while balance is
+        :return:
+        """
+        pool = Pool(raid='raid0', name='test-pool')
+        # run_command moc return values.
+        out = ["Balance on '/mnt2/rock-pool' is running, cancel requested",
+               '15 out of about 114 chunks balanced (16 considered),  87% left',
+               '']
+        err = ['']
+        # N.B. the return code for in progress balance = 1
+        rc = 1
+        expected_results = {'status': 'cancelling', 'percent_done': 13}
+        self.mock_run_command.return_value = (out, err, rc)
+        self.mock_mount_root.return_value = '/mnt2/test-mount'
+        self.assertEqual(balance_status(pool), expected_results,
+                         msg="Failed to correctly identify balance cancel requested status")
     #
     #
     # def test_balance_status_pause_requested(self):

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -13,7 +13,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-
 import unittest
 from fs.btrfs import add_pool, pool_raid
 import mock
@@ -21,14 +20,12 @@ from mock import patch
 
 
 class Pool(object):
-
     def __init__(self, raid, name):
         self.raid = raid
         self.name = name
 
 
 class BTRFSTests(unittest.TestCase):
-
     def setUp(self):
         self.patch_run_command = patch('fs.btrfs.run_command')
         self.mock_run_command = self.patch_run_command.start()
@@ -36,14 +33,14 @@ class BTRFSTests(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    #sample test
+    # sample test
     def test_add_pool_mkfs_fail(self):
         pool = Pool(raid='raid0', name='mypool')
         disks = ('sdb', 'sdc')
         self.mock_run_command.side_effect = Exception('mkfs error')
         self.assertEqual(add_pool(pool, disks), 1)
 
-    def test_get_pool_raid_levels(self):
+    def test_get_pool_raid_levels_identification(self):
         """
         Presents the raid identification function with example data and compares
         it's return dict to that expected for the given input.
@@ -56,29 +53,75 @@ class BTRFSTests(unittest.TestCase):
         cmd_e = ['']
         # setup example btrfs fi df mount_point outputs for given inputs.
         # Outputs are simple lists of whole lines output from btrfs fi df
-        # expected return is a dict of extracted info from above btrfs command.
-        single_fi_df = ['Data, single: total=8.00MiB, used=64.00KiB', 'System, single: total=4.00MiB, used=16.00KiB', 'Metadata, single: total=216.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        single_return = {'data': 'single', 'system': 'single', 'globalreserve': 'single', 'metadata': 'single'}
-        raid0_fi_df = ['Data, RAID0: total=512.00MiB, used=256.00KiB', 'System, RAID0: total=16.00MiB, used=16.00KiB', 'Metadata, RAID0: total=512.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        raid0_return = {'data': 'raid0', 'system': 'raid0', 'globalreserve': 'single', 'metadata': 'raid0'}
-        raid1_fi_df = ['Data, RAID1: total=512.00MiB, used=192.00KiB', 'System, RAID1: total=32.00MiB, used=16.00KiB', 'Metadata, RAID1: total=256.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        raid1_return = {'data': 'raid1', 'system': 'raid1', 'globalreserve': 'single', 'metadata': 'raid1'}
+        single_fi_df = ['Data, single: total=8.00MiB, used=64.00KiB',
+                        'System, single: total=4.00MiB, used=16.00KiB',
+                        'Metadata, single: total=216.00MiB, used=128.00KiB',
+                        'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        # Expected return is a dict of extracted info from above command output.
+        single_return = {'data': 'single', 'system': 'single',
+                         'globalreserve': 'single', 'metadata': 'single'}
+        raid0_fi_df = ['Data, RAID0: total=512.00MiB, used=256.00KiB',
+                       'System, RAID0: total=16.00MiB, used=16.00KiB',
+                       'Metadata, RAID0: total=512.00MiB, used=128.00KiB',
+                       'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid0_return = {'data': 'raid0', 'system': 'raid0',
+                        'globalreserve': 'single', 'metadata': 'raid0'}
+        raid1_fi_df = ['Data, RAID1: total=512.00MiB, used=192.00KiB',
+                       'System, RAID1: total=32.00MiB, used=16.00KiB',
+                       'Metadata, RAID1: total=256.00MiB, used=128.00KiB',
+                       'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid1_return = {'data': 'raid1', 'system': 'raid1',
+                        'globalreserve': 'single', 'metadata': 'raid1'}
         # Thanks to @grebnek in forum and GitHub for spotting this:
         # https://btrfs.wiki.kernel.org/index.php/FAQ#Why_do_I_have_.22single.22_chunks_in_my_RAID_filesystem.3F
-        # when converting from single to another raid level it is normal for
+        # When converting from single to another raid level it is normal for
         # a few chunks to remain in single until the next balance operation.
-        raid1_fi_df_some_single_chunks = ['Data, RAID1: total=416.00MiB, used=128.00KiB', 'Data, single: total=416.00MiB, used=0.00B', 'System, RAID1: total=32.00MiB, used=16.00KiB', 'Metadata, RAID1: total=512.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        # for a time we incorrectly parsed the last btrfs fi df mount_point as the following
-        # raid1_some_single_chunks_return = {'data': 'single', 'system': 'raid1', 'globalreserve': 'single', 'metadata': 'raid1'}
-        # but the expected result should be the same as "raid1_return" above. ie data raid1 not single.
-        raid10_fi_df = ['Data, RAID10: total=419.75MiB, used=128.00KiB', 'System, RAID10: total=16.00MiB, used=16.00KiB', 'Metadata, RAID10: total=419.75MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        raid10_return = {'data': 'raid10', 'system': 'raid10', 'globalreserve': 'single', 'metadata': 'raid10'}
-        raid5_fi_df = ['Data, RAID5: total=215.00MiB, used=128.00KiB', 'System, RAID5: total=8.00MiB, used=16.00KiB', 'Metadata, RAID5: total=215.00MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        raid5_return = {'data': 'raid5', 'system': 'raid5', 'globalreserve': 'single', 'metadata': 'raid5'}
-        raid6_fi_df = ['Data, RAID6: total=211.62MiB, used=128.00KiB', 'System, RAID6: total=8.00MiB, used=16.00KiB', 'Metadata, RAID6: total=211.62MiB, used=128.00KiB', 'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
-        raid6_return = {'data': 'raid6', 'system': 'raid6', 'globalreserve': 'single', 'metadata': 'raid6'}
+        raid1_fi_df_some_single_chunks = [
+            'Data, RAID1: total=416.00MiB, used=128.00KiB',
+            'Data, single: total=416.00MiB, used=0.00B',
+            'System, RAID1: total=32.00MiB, used=16.00KiB',
+            'Metadata, RAID1: total=512.00MiB, used=128.00KiB',
+            'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        # for a time we incorrectly parsed the last btrfs fi df mount_point as
+        # the following:
+        raid1_some_single_chunks_return = {'data': 'single', 'system': 'raid1',
+                                           'globalreserve': 'single',
+                                           'metadata': 'raid1'}
+        # but the expected result should be the same as "raid1_return" above
+        # ie data raid1 not single.
+        raid10_fi_df = ['Data, RAID10: total=419.75MiB, used=128.00KiB',
+                        'System, RAID10: total=16.00MiB, used=16.00KiB',
+                        'Metadata, RAID10: total=419.75MiB, used=128.00KiB',
+                        'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid10_return = {'data': 'raid10', 'system': 'raid10',
+                         'globalreserve': 'single', 'metadata': 'raid10'}
+        raid5_fi_df = ['Data, RAID5: total=215.00MiB, used=128.00KiB',
+                       'System, RAID5: total=8.00MiB, used=16.00KiB',
+                       'Metadata, RAID5: total=215.00MiB, used=128.00KiB',
+                       'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid5_return = {'data': 'raid5', 'system': 'raid5',
+                        'globalreserve': 'single', 'metadata': 'raid5'}
+        raid6_fi_df = ['Data, RAID6: total=211.62MiB, used=128.00KiB',
+                       'System, RAID6: total=8.00MiB, used=16.00KiB',
+                       'Metadata, RAID6: total=211.62MiB, used=128.00KiB',
+                       'GlobalReserve, single: total=16.00MiB, used=0.00B', '']
+        raid6_return = {'data': 'raid6', 'system': 'raid6',
+                        'globalreserve': 'single', 'metadata': 'raid6'}
         # list used to report what raid level is currently under test.
         raid_levels_tested = ['single', 'raid0', 'raid1', 'raid10', 'raid5',
-                              'raid6']
-        self.mock_run_command.return_value = (single_fi_df, cmd_e, cmd_rc)
-        self.assertEqual(pool_raid(mount_point), single_return)
+                              'raid6', 'raid1_some_single_chunks']
+        # list of example fi_df outputs in raid_levels_tested order
+        btrfs_fi_di = [single_fi_df, raid0_fi_df, raid1_fi_df, raid10_fi_df,
+                       raid5_fi_df, raid6_fi_df, raid1_fi_df_some_single_chunks]
+        # list of correctly parsed return dictionaries
+        return_dict = [single_return, raid0_return, raid1_return, raid10_return,
+                       raid5_return, raid6_return, raid1_return]
+        # simple iteration over above example inputs to expected outputs.
+        for raid_level, fi_df, expected_result in map(None, raid_levels_tested,
+                                                      btrfs_fi_di, return_dict):
+            # mock example command output with no error and rc=0
+            self.mock_run_command.return_value = (fi_df, cmd_e, cmd_rc)
+            # assert get_pool_raid_level returns what we expect.
+            self.assertEqual(pool_raid(mount_point), expected_result,
+                             msg='get_pool_raid_level() miss identified raid '
+                                 'level %s' % raid_level)

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -20,7 +20,7 @@
 </script>
 <div class="messages"></div>
 
-  <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Restripe data across all disks of the pool. Do this only if you need to."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
+  <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Rebalance data and metadata across all disks in this pool. WARNING: very intense and potentially long operation. Do this only if needed."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
 <br>
 {{#if collectionNotEmpty}}
   <table id="poolrebalances-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of pool balances">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -19,7 +19,6 @@
  */
 </script>
 <div class="messages"></div>
-
   <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Rebalance data and metadata across all disks in this pool. WARNING: very intense and potentially long operation. Do this only if needed."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
 <br>
 {{#if collectionNotEmpty}}
@@ -30,7 +29,7 @@
         <th>Status</th>
         <th>Start Time</th>
         <th>Percent finished</th>
-	<th>Errors</th>
+        <th>Errors or Notes</th>
       </tr>
     </thead>
     <tbody>

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 from django.db import transaction
 from storageadmin.models import (Disk, Pool, Share)
 from fs.btrfs import enable_quota, btrfs_uuid, pool_usage, mount_root, \
-    get_pool_info, pool_raid, enable_quota
+    get_pool_info, pool_raid
 from storageadmin.serializers import DiskInfoSerializer
 from storageadmin.util import handle_exception
 from share_helpers import (import_shares, import_snapshots)

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -353,10 +353,10 @@ class PoolDetailView(DiskMixin, PoolMixin, rfc.GenericView):
 
                 if (PoolBalance.objects.filter(
                         pool=pool,
-                        status__regex=r'(started|running)').exists()):
-                    e_msg = ('A Balance process is already running for this '
-                             'pool(%s). Resize is not supported during a '
-                             'balance process.' % pool.name)
+                        status__regex=r'(started|running|cancelling|pausing|paused)').exists()):
+                    e_msg = ('A Balance process is already running or paused '
+                             'for this pool(%s). Resize is not supported '
+                             'during a balance process.' % pool.name)
                     handle_exception(Exception(e_msg), request)
 
                 resize_pool(pool, dnames)

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -29,8 +29,7 @@ from storageadmin.serializers import PoolInfoSerializer
 from storageadmin.models import (Disk, Pool, Share, PoolBalance)
 from storageadmin.views import DiskMixin
 from fs.btrfs import (add_pool, pool_usage, resize_pool, umount_root,
-                      btrfs_uuid, mount_root, get_pool_info,
-                      pool_raid, start_balance)
+                      btrfs_uuid, mount_root, start_balance)
 from system.osi import remount
 from storageadmin.util import handle_exception
 from django.conf import settings
@@ -348,7 +347,7 @@ class PoolDetailView(DiskMixin, PoolMixin, rfc.GenericView):
                     handle_exception(Exception(e_msg), request)
 
                 if (new_raid == 'raid5' and num_total_disks < 2):
-                    e_msg == ('A minimum of Two drives are required for the '
+                    e_msg = ('A minimum of Two drives are required for the '
                               'raid level: raid5')
                     handle_exception(Exception(e_msg), request)
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -395,10 +395,12 @@ def kernel_info(supported_version):
 
 
 def create_tmp_dir(dirname):
+    # TODO: suggest name change to create_dir
     return run_command([MKDIR, '-p', dirname])
 
 
 def rm_tmp_dir(dirname):
+    # TODO: suggest name change to remove_dir
     return run_command([RMDIR, dirname])
 
 


### PR DESCRIPTION
Fixes #1405 - When a Web-UI initiated balance is in progress and the Pool page is refreshed there is no indication of the percentage of progress until the balance task initiated has reached 100%. Given balance tasks can be very long lived processes it is a better user experience to have an indication of the current status of percent complete.

Prior behaviour is to only indicate status as started or complete.

These alterations allow for in progress 'percentage finished' updates via 'Pools' page refresh. They also extend the balance status reporting to include running, pausing, paused, cancelling, and cancelled, however these status updates are only available via a page update. But this at least paves the way for future improvements on balance status reporting. Also note that with the addition of these changes it will be easier to accommodate and report accordingly the status intervention affected by a balance pause/resume button and a balance cancel button, see #1413. Also partially addresses elements of #862.

Initial commit on my side for #1022: initially the focus of this pr but due to changing circumstances the above issue also became enrolled, hence the dual personality of the pull request. All commits in this request that do not pertain to the above #1405 issue uniquely relate to furthering unit test coverage and do not affect user run code. But given we are now receiving pull requests on some of what is already covered by unit tests withing this pr (if sparsely as yet) it may be appropriate for these to be merged sooner rather than later so that they might serve to aid in these recent pull requests, most notably now closed #1408 and as yet pre-review pr #1415. The test for the latter will have to be modified to accommodate the scope change introduced by #1415 (if merged).

@schakrava Apologies for making this far more messy than either of us would like (dual target pr) but given the fs/btrfs.py related changes are going to be progressively more difficult to merge with recent  and ongoing pr's on this code, I though it best to merge sooner rather than later. I can there after revert to a more single issue focused pr model and enact on your feedback re unit test advise. Most btrfs.py changes pertain to comment additions where they are not related to the resolution of balance reporting #1405. I am aware that it is almost completely 'happy path' testing stuff and will extend to failure cases upon next engaging with these tests.

~~Ready for review.~~

EDIT: See below commends on progress with splitting this pr into 2 more focused pr's as more recently requested.