### PR TITLE
Docker journald logging

### DIFF
--- a/src/rockstor/scripts/docker_wrapper.py
+++ b/src/rockstor/scripts/docker_wrapper.py
@@ -34,4 +34,4 @@ def main():
         mount_share(so, mnt_pt)
     except Exception, e:
         sys.exit('Failed to mount Docker root(%s). Exception: %s' % (mnt_pt, e.__str__()))
-    run_command([DOCKER, '-d', '--log-driver=journald', '-s', 'btrfs', '-g', mnt_pt])
+    run_command([DOCKER, 'daemon', '--log-driver=journald', '-s', 'btrfs', '-g', mnt_pt])

--- a/src/rockstor/scripts/docker_wrapper.py
+++ b/src/rockstor/scripts/docker_wrapper.py
@@ -34,4 +34,4 @@ def main():
         mount_share(so, mnt_pt)
     except Exception, e:
         sys.exit('Failed to mount Docker root(%s). Exception: %s' % (mnt_pt, e.__str__()))
-    run_command([DOCKER, '-d', '-s', 'btrfs', '-g', mnt_pt])
+    run_command([DOCKER, '-d', '--log-driver=journald', '-s', 'btrfs', '-g', mnt_pt])

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -39,7 +39,7 @@ from rockon_discourse import (discourse_install, discourse_uninstall,
 
 DOCKER = '/usr/bin/docker'
 ROCKON_URL = 'https://localhost/api/rockons'
-DCMD = [DOCKER, 'run', '--log-driver=syslog', ]
+DCMD = [DOCKER, 'run', ]
 DCMD2 = list(DCMD) + ['-d', '--restart=unless-stopped', ]
 
 import logging

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -40,7 +40,7 @@ from rockon_discourse import (discourse_install, discourse_uninstall,
 DOCKER = '/usr/bin/docker'
 ROCKON_URL = 'https://localhost/api/rockons'
 DCMD = [DOCKER, 'run', ]
-DCMD2 = list(DCMD) + ['-d', '--restart=unless-stopped', ]
+DCMD2 = list(DCMD) + ['daemon', '--restart=unless-stopped', ]
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
See #1331. Run the docker service with journald log driver. Also fixes the `-d` argument that will become deprecated.

Unfortunately, this does not change logging for currently installed rock-ons as the `docker run` command is only issued upon installation; re-installation is required.