### PR TITLE
Fix: argument to docker run should still be -d

### DIFF
--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -40,7 +40,7 @@ from rockon_discourse import (discourse_install, discourse_uninstall,
 DOCKER = '/usr/bin/docker'
 ROCKON_URL = 'https://localhost/api/rockons'
 DCMD = [DOCKER, 'run', ]
-DCMD2 = list(DCMD) + ['daemon', '--restart=unless-stopped', ]
+DCMD2 = list(DCMD) + ['-d', '--restart=unless-stopped', ]
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
@schakrava Important, please merge/release ASAP. I overlooked that the command in this case was `docker run`. Passing `daemon` to this will cause it to take this as the image name, failing to install/run. Not sure why this did not appear while I tested this.