### PR TITLE
Issue#1195 Improve Pool Delete UX

### DIFF
--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -45,5 +45,9 @@ class Share(models.Model):
         rusage = models.BigIntegerField(default=0)
         eusage = models.BigIntegerField(default=0)
 
+        @property
+        def size_gb(self):
+            return self.size / (1024.0 * 1024.0)
+
 	class Meta:
 		app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -126,6 +126,8 @@ class IscsiSerializer(serializers.ModelSerializer):
 
 
 class SharePoolSerializer(serializers.ModelSerializer):
+    size_gb = serializers.FloatField()
+
     class Meta:
         model = Share
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -125,6 +125,11 @@ class IscsiSerializer(serializers.ModelSerializer):
         model = IscsiTarget
 
 
+class SharePoolSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Share
+
+
 class ShareSerializer(serializers.ModelSerializer):
     snapshots = SnapshotSerializer(many=True, source='snapshot_set')
     pool = PoolInfoSerializer()

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -118,6 +118,24 @@ var PoolShareCollection = Backbone.Collection.extend({
   }
 });
 
+
+var PoolShare = Backbone.Model.extend({
+  url: function () {
+    console.log('poolshare');
+      return '/api/pools/' + this.get('poolName');
+    }
+});
+
+var PoolShareCollection = Backbone.Collection.extend({
+  model: PoolShare,
+  initialize: function(model, options) {
+    this.options = options;
+  },
+  url: function () {
+    return '/api/pools/' + this.options.poolName + '/shares';
+  }
+});
+
 var ShareCollection = RockStorPaginatedCollection.extend({
   model: Share,
   baseUrl: '/api/shares',

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -28,83 +28,83 @@
 var Setup = Backbone.Model.extend({});
 
 var Disk = Backbone.Model.extend({
-    url: function () {
-        return '/api/disks/' + this.get('diskName');
-    },
-    available: function () {
-        return _.isNull(this.get('pool')) && !this.get('parted') && !this.get('offline') && _.isNull(this.get('btrfs_uuid'));
-    },
-    isSerialUsable: function () {
-        // Simple disk serial validator to return true unless the given disk
-        // serial number looks fake or untrustworthy.
-        // In the case of a repeat or missing serial scan_disks() will use a
-        // placeholder of fake-serial-<uuid4> so look for this signature text.
-        var diskSerial = this.get('serial')
-        if (diskSerial.substring(0, 12) == 'fake-serial-') {
-            return false;
-        }
-        // Observed in a 4 bay ORICO USB 3.0 enclosure that obfuscated all it's
-        // disk serial numbers and replaced them with '000000000000'.
-        if (diskSerial == '000000000000') {
-            return false;
-        }
-        return true;
+  url: function () {
+    return '/api/disks/' + this.get('diskName');
+  },
+  available: function () {
+    return _.isNull(this.get('pool')) && !this.get('parted') && !this.get('offline') && _.isNull(this.get('btrfs_uuid'));
+  },
+  isSerialUsable: function () {
+    // Simple disk serial validator to return true unless the given disk
+    // serial number looks fake or untrustworthy.
+    // In the case of a repeat or missing serial scan_disks() will use a
+    // placeholder of fake-serial-<uuid4> so look for this signature text.
+    var diskSerial = this.get('serial')
+    if (diskSerial.substring(0, 12) == 'fake-serial-') {
+      return false;
     }
+    // Observed in a 4 bay ORICO USB 3.0 enclosure that obfuscated all it's
+    // disk serial numbers and replaced them with '000000000000'.
+    if (diskSerial == '000000000000') {
+      return false;
+    }
+    return true;
+  }
 });
 
 var DiskCollection = RockStorPaginatedCollection.extend({
-    model: Disk,
-    baseUrl: '/api/disks',
+  model: Disk,
+  baseUrl: '/api/disks',
 });
 
 var Pool = Backbone.Model.extend({
-    url: function () {
-        return '/api/pools/' + this.get('poolName') + '/';
-    },
-    sizeGB: function () {
-        return this.get('size') / (1024 * 1024);
-    },
-    freeGB: function () {
-        return this.get('free') / (1024 * 1024);
-    },
-    usedGB: function () {
-        return (this.get('size') - this.get('free')) / (1024 * 1024);
-    }
+  url: function () {
+    return '/api/pools/' + this.get('poolName') + '/';
+  },
+  sizeGB: function () {
+    return this.get('size') / (1024 * 1024);
+  },
+  freeGB: function () {
+    return this.get('free') / (1024 * 1024);
+  },
+  usedGB: function () {
+    return (this.get('size') - this.get('free')) / (1024 * 1024);
+  }
 });
 
 var SmartInfo = Backbone.Model.extend({
-    url: function () {
-        return '/api/disks/smart/info/' + this.get('diskName');
-    }
+  url: function () {
+    return '/api/disks/smart/info/' + this.get('diskName');
+  }
 });
 
 var PoolCollection = RockStorPaginatedCollection.extend({
-    model: Pool,
-    baseUrl: '/api/pools'
+  model: Pool,
+  baseUrl: '/api/pools'
 });
 
 var SupportCase = Backbone.Model.extend({
-    url: function () {
-        return '/api/support/' + this.get('supportCaseId') + '/';
-    }
+  url: function () {
+    return '/api/support/' + this.get('supportCaseId') + '/';
+  }
 });
 
 var SupportCaseCollection = Backbone.Collection.extend({
-    model: SupportCase,
-    url: '/api/support'
+  model: SupportCase,
+  url: '/api/support'
 });
 
 var Share = Backbone.Model.extend({
-    url: function () {
-        return '/api/shares/' + this.get('shareName');
-    }
+  url: function () {
+    return '/api/shares/' + this.get('shareName');
+  }
 });
 
 
 var PoolShare = Backbone.Model.extend({
   url: function () {
     console.log('poolshare');
-      return '/api/pools/' + this.get('poolName');
+    return '/api/pools/' + this.get('poolName');
   }
 });
 
@@ -119,608 +119,609 @@ var PoolShareCollection = Backbone.Collection.extend({
 });
 
 var ShareCollection = RockStorPaginatedCollection.extend({
-    model: Share,
-    baseUrl: '/api/shares',
-    extraParams: function () {
-        var p = this.constructor.__super__.extraParams.apply(this, arguments);
-        p['sortby'] = 'name';
-        return p;
-    }
+  model: Share,
+  baseUrl: '/api/shares',
+  extraParams: function () {
+    var p = this.constructor.__super__.extraParams.apply(this, arguments);
+    p['sortby'] = 'name';
+    return p;
+  }
 });
 
 var Image = Backbone.Model.extend({
-    url: function () {
-        return '/api/rockons/';
-    }
+  url: function () {
+    return '/api/rockons/';
+  }
 });
 
 var ImageCollection = RockStorPaginatedCollection.extend({
-    model: Image,
-    baseUrl: '/api/rockons/docker/images'
+  model: Image,
+  baseUrl: '/api/rockons/docker/images'
 });
 
 var Container = Backbone.Model.extend({
-    url: function () {
-        return '/api/rockons/';
-    }
+  url: function () {
+    return '/api/rockons/';
+  }
 });
 
 var ContainerCollection = RockStorPaginatedCollection.extend({
-    model: Image,
-    baseUrl: '/api/rockons/docker/containers'
+  model: Image,
+  baseUrl: '/api/rockons/docker/containers'
 });
 
 var Snapshot = Backbone.Model.extend({
-    url: function () {
-        return '/api/shares/' + this.get('shareName') + '/' + this.get('snapName');
-    }
+  url: function () {
+    return '/api/shares/' + this.get('shareName') + '/' + this.get('snapName');
+  }
 });
 
 var SnapshotCollection = RockStorPaginatedCollection.extend({
-    model: Snapshot,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.snapType = options.snapType;
-        }
-    },
-    setUrl: function (shareName) {
-        this.baseUrl = '/api/shares/' + shareName + '/snapshots'
-    },
-    extraParams: function () {
-        var p = this.constructor.__super__.extraParams.apply(this, arguments);
-        p['snap_type'] = this.snapType;
-        return p;
+  model: Snapshot,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.snapType = options.snapType;
     }
+  },
+  setUrl: function (shareName) {
+    this.baseUrl = '/api/shares/' + shareName + '/snapshots'
+  },
+  extraParams: function () {
+    var p = this.constructor.__super__.extraParams.apply(this, arguments);
+    p['snap_type'] = this.snapType;
+    return p;
+  }
 });
 
 var Snapshots = Backbone.Model.extend({
-    urlRoot: '/api/snapshots'
+  urlRoot: '/api/snapshots'
 });
 
 var SnapshotsCollection = RockStorPaginatedCollection.extend({
-    model: Snapshots,
-    baseUrl: '/api/snapshots'
+  model: Snapshots,
+  baseUrl: '/api/snapshots'
 });
 
 
 var Poolscrub = Backbone.Model.extend({
-    url: function () {
-        return '/api/pools/' + this.get('poolName') + '/scrub';
-    }
+  url: function () {
+    return '/api/pools/' + this.get('poolName') + '/scrub';
+  }
 });
 
 var PoolscrubCollection = RockStorPaginatedCollection.extend({
-    model: Poolscrub,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.snapType = options.snapType;
-        }
-    },
-    setUrl: function (poolName) {
-        this.baseUrl = '/api/pools/' + poolName + '/scrub';
-    },
-    extraParams: function () {
-        var p = this.constructor.__super__.extraParams.apply(this, arguments);
-        p['snap_type'] = this.snapType;
-        return p;
+  model: Poolscrub,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.snapType = options.snapType;
     }
+  },
+  setUrl: function (poolName) {
+    this.baseUrl = '/api/pools/' + poolName + '/scrub';
+  },
+  extraParams: function () {
+    var p = this.constructor.__super__.extraParams.apply(this, arguments);
+    p['snap_type'] = this.snapType;
+    return p;
+  }
 });
 
 var PoolRebalance = Backbone.Model.extend({
-    url: function () {
-        return '/api/pools/' + this.get('poolName') + '/balance';
-    }
+  url: function () {
+    return '/api/pools/' + this.get('poolName') + '/balance';
+  }
 });
 
 var PoolRebalanceCollection = RockStorPaginatedCollection.extend({
-    model: PoolRebalance,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.snapType = options.snapType;
-        }
-    },
-    setUrl: function (poolName) {
-        this.baseUrl = '/api/pools/' + poolName + '/balance';
-    },
-    extraParams: function () {
-        var p = this.constructor.__super__.extraParams.apply(this, arguments);
-        p['snap_type'] = this.snapType;
-        return p;
+  model: PoolRebalance,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.snapType = options.snapType;
     }
+  },
+  setUrl: function (poolName) {
+    this.baseUrl = '/api/pools/' + poolName + '/balance';
+  },
+  extraParams: function () {
+    var p = this.constructor.__super__.extraParams.apply(this, arguments);
+    p['snap_type'] = this.snapType;
+    return p;
+  }
 });
 
 var SysInfo = Backbone.Model.extend({
-    url: "/api/tools/sysinfo"
+  url: "/api/tools/sysinfo"
 });
 
 var NFSExport = Backbone.Model.extend();
 
 var NFSExportCollection = RockStorPaginatedCollection.extend({
-    model: NFSExport,
-    setUrl: function (shareName) {
-        this.baseUrl = '/api/shares/' + shareName + '/nfs'
-    }
+  model: NFSExport,
+  setUrl: function (shareName) {
+    this.baseUrl = '/api/shares/' + shareName + '/nfs'
+  }
 });
 
 var NFSExportGroup = Backbone.Model.extend({
-    urlRoot: '/api/nfs-exports'
+  urlRoot: '/api/nfs-exports'
 });
 
 var NFSExportGroupCollection = RockStorPaginatedCollection.extend({
-    model: NFSExportGroup,
-    baseUrl: '/api/nfs-exports'
+  model: NFSExportGroup,
+  baseUrl: '/api/nfs-exports'
 });
 
 var SMBShare = Backbone.Model.extend({
-    url: function () {
-        return '/api/shares/' + this.get('shareName') + '/samba'
-    },
+  url: function () {
+    return '/api/shares/' + this.get('shareName') + '/samba'
+  },
 
 });
 
 var SMBShareCollection = Backbone.Collection.extend({
 
-    model: SMBShare
+  model: SMBShare
 
 });
 
 
 var SambaCollection = RockStorPaginatedCollection.extend({
-    model: SMBShare,
-    baseUrl: '/api/samba',
-    idAttribute: 'sambaShareId'
+  model: SMBShare,
+  baseUrl: '/api/samba',
+  idAttribute: 'sambaShareId'
 });
 
 
 var Service = Backbone.Model.extend({
-    idAttribute: "name",
-    urlRoot: "/api/sm/services"
+  idAttribute: "name",
+  urlRoot: "/api/sm/services"
 });
 
 var ServiceCollection = RockStorPaginatedCollection.extend({
-    model: Service,
-    baseUrl: "/api/sm/services/"
+  model: Service,
+  baseUrl: "/api/sm/services/"
 });
 
 var Appliance = Backbone.Model.extend({urlRoot: '/api/appliances'});
 var ApplianceCollection = RockStorPaginatedCollection.extend({
-    model: Appliance,
-    baseUrl: '/api/appliances'
+  model: Appliance,
+  baseUrl: '/api/appliances'
 });
 
 var User = Backbone.Model.extend({
-    urlRoot: '/api/users',
-    idAttribute: 'username'
+  urlRoot: '/api/users',
+  idAttribute: 'username'
 });
 
 var UserCollection = RockStorPaginatedCollection.extend({
-    model: User,
-    baseUrl: '/api/users'
+  model: User,
+  baseUrl: '/api/users'
 });
 
 var Group = Backbone.Model.extend({
-    urlRoot: '/api/groups',
-    idAttribute: 'groupname'
+  urlRoot: '/api/groups',
+  idAttribute: 'groupname'
 });
 
 var GroupCollection = RockStorPaginatedCollection.extend({
-    model: Group,
-    baseUrl: '/api/groups'
+  model: Group,
+  baseUrl: '/api/groups'
 });
 
 var ISCSITarget = Backbone.Model.extend({
-    url: function () {
-        return '/api/shares/' + this.get('shareName') + '/iscsi/'
-    }
+  url: function () {
+    return '/api/shares/' + this.get('shareName') + '/iscsi/'
+  }
 });
 
 var DashboardConfig = Backbone.Model.extend({
-    url: '/api/dashboardconfig',
-    setConfig: function (wConfigs) {
-        var tmp = [];
-        _.each(wConfigs, function (wConfig) {
-            tmp.push({
-                name: wConfig.name,
-                position: wConfig.position,
-                maximized: wConfig.maximized
-            });
-        });
-        this.set({widgets: JSON.stringify(tmp)});
-    },
+  url: '/api/dashboardconfig',
+  setConfig: function (wConfigs) {
+    var tmp = [];
+    _.each(wConfigs, function (wConfig) {
+      tmp.push({
+        name: wConfig.name,
+        position: wConfig.position,
+        maximized: wConfig.maximized
+      });
+    });
+    this.set({widgets: JSON.stringify(tmp)});
+  },
 
-    getConfig: function () {
-        if (!_.isUndefined(this.get('widgets')) && !_.isNull(this.get('widgets'))) {
-            return JSON.parse(this.get('widgets'));
-        } else {
-            this.setConfig(RockStorWidgets.defaultWidgets());
-            return JSON.parse(this.get("widgets"));
-        }
+  getConfig: function () {
+    if (!_.isUndefined(this.get('widgets')) && !_.isNull(this.get('widgets'))) {
+      return JSON.parse(this.get('widgets'));
+    } else {
+      this.setConfig(RockStorWidgets.defaultWidgets());
+      return JSON.parse(this.get("widgets"));
     }
+  }
 
 });
 
 var Probe = Backbone.Model.extend({
-    urlRoot: function () {
-        return '/api/sm/sprobes/' + this.get('name') + '/';
-    },
-    dataUrl: function () {
-        return '/api/sm/sprobes/' + this.get('name') + '/' + this.id + '/data';
-    },
-    parse: function (response) {
-        if (response.results && response.results.length > 0) {
-            return response.results[0];
-        } else {
-            return {};
-        }
+  urlRoot: function () {
+    return '/api/sm/sprobes/' + this.get('name') + '/';
+  },
+  dataUrl: function () {
+    return '/api/sm/sprobes/' + this.get('name') + '/' + this.id + '/data';
+  },
+  parse: function (response) {
+    if (response.results && response.results.length > 0) {
+      return response.results[0];
+    } else {
+      return {};
     }
+  }
 });
 
 var ProbeCollection = Backbone.Collection.extend({
-    model: Probe,
-    initialize: function (models, options) {
-        if (!_.isUndefined(options) && !_.isNull(options)) {
-            this.name = options.name;
-        }
-    },
-    url: function () {
-        return '/api/sm/sprobes/' + this.name + '/';
-    },
-    parse: function (response) {
-        return response.results;
+  model: Probe,
+  initialize: function (models, options) {
+    if (!_.isUndefined(options) && !_.isNull(options)) {
+      this.name = options.name;
     }
+  },
+  url: function () {
+    return '/api/sm/sprobes/' + this.name + '/';
+  },
+  parse: function (response) {
+    return response.results;
+  }
 });
 
 
 var NetworkDevice = Backbone.Model.extend({
-    urlRoot: '/api/network/devices'
+  urlRoot: '/api/network/devices'
 });
 
 var NetworkDeviceCollection = RockStorPaginatedCollection.extend({
-    model: NetworkDevice,
-    baseUrl: '/api/network/devices'
+  model: NetworkDevice,
+  baseUrl: '/api/network/devices'
 });
 
 var NetworkConnection = Backbone.Model.extend({
-    urlRoot: '/api/network/connections'
+  urlRoot: '/api/network/connections'
 });
 
 var NetworkConnectionCollection = RockStorPaginatedCollection.extend({
-    model: NetworkConnection,
-    baseUrl: '/api/network/connections'
+  model: NetworkConnection,
+  baseUrl: '/api/network/connections'
 });
 
 var ProbeRun = Backbone.Model.extend({
-    dataUrl: function () {
-        return '/api/sm/sprobes/' + this.get('name') + '/' + this.id + '/data?format=json';
-    },
-    downloadUrl: function () {
-        return "/api/sm/sprobes/" + this.get("name") + "/" + this.id
-            + "/data" + "?"
-            + "t1=" + this.get("start") + "&t2=" + this.get("end")
-            + "&download=true";
-    },
+  dataUrl: function () {
+    return '/api/sm/sprobes/' + this.get('name') + '/' + this.id + '/data?format=json';
+  },
+  downloadUrl: function () {
+    return "/api/sm/sprobes/" + this.get("name") + "/" + this.id
+         + "/data" + "?"
+         + "t1=" + this.get("start") + "&t2=" + this.get("end")
+         + "&download=true";
+  },
 });
 
 var ProbeRunCollection = RockStorPaginatedCollection.extend({
-    model: ProbeRun,
-    baseUrl: "/api/sm/sprobes/metadata"
+  model: ProbeRun,
+  baseUrl: "/api/sm/sprobes/metadata"
 })
 
 var ProbeTemplate = Backbone.Model.extend({idAttribute: "uuid"});
 var ProbeTemplateCollection = Backbone.Collection.extend({
-    model: ProbeTemplate,
-    url: "/api/sm/sprobes/?format=json"
+  model: ProbeTemplate,
+  url: "/api/sm/sprobes/?format=json"
 });
 
 var Replica = Backbone.Model.extend({
-    urlRoot: "/api/sm/replicas"
+  urlRoot: "/api/sm/replicas"
 });
 var ReplicaCollection = RockStorPaginatedCollection.extend({
-    model: Replica,
-    baseUrl: "/api/sm/replicas/"
+  model: Replica,
+  baseUrl: "/api/sm/replicas/"
 });
 
 var ReplicaTrail = Backbone.Model.extend({
-    urlRoot: '/api/sm/replicas/trail/replica/' + this.replicaId
+  urlRoot: '/api/sm/replicas/trail/replica/' + this.replicaId
 });
 
 var ReplicaTrailCollection = RockStorPaginatedCollection.extend({
-    model: ReplicaTrail,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.replicaId = options.replicaId;
-        }
-    },
-    baseUrl: function () {
-        if (this.replicaId) {
-            return '/api/sm/replicas/trail/replica/' + this.replicaId;
-        } else {
-            return '/api/sm/replicas/trail';
-        }
+  model: ReplicaTrail,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.replicaId = options.replicaId;
     }
+  },
+  baseUrl: function () {
+    if (this.replicaId) {
+      return '/api/sm/replicas/trail/replica/' + this.replicaId;
+    } else {
+      return '/api/sm/replicas/trail';
+    }
+  }
 });
 
 var ReplicaShare = Backbone.Model.extend({
-    urlRoot: '/api/sm/replicas/rshare'
+  urlRoot: '/api/sm/replicas/rshare'
 });
 
 var ReplicaShareCollection = RockStorPaginatedCollection.extend({
-    model: ReplicaShare,
-    baseUrl: '/api/sm/replicas/rshare'
+  model: ReplicaShare,
+  baseUrl: '/api/sm/replicas/rshare'
 });
 
 var ReceiveTrail = Backbone.Model.extend({
-    urlRoot: '/api/sm/replicas/rtrail/' + this.replicaShareId
+  urlRoot: '/api/sm/replicas/rtrail/' + this.replicaShareId
 });
 
 var ReceiveTrailCollection = RockStorPaginatedCollection.extend({
-    model: ReceiveTrail,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.replicaShareId = options.replicaShareId;
-        }
-    },
-    baseUrl: function () {
-        if (this.replicaShareId) {
-            return '/api/sm/replicas/rtrail/rshare/' + this.replicaShareId;
-        } else {
-            return '/api/sm/replicas/rtrail';
-        }
+  model: ReceiveTrail,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.replicaShareId = options.replicaShareId;
     }
+  },
+  baseUrl: function () {
+    if (this.replicaShareId) {
+      return '/api/sm/replicas/rtrail/rshare/' + this.replicaShareId;
+    } else {
+      return '/api/sm/replicas/rtrail';
+    }
+  }
 });
 
 var TaskDef = Backbone.Model.extend({
-    urlRoot: "/api/sm/tasks/",
-    max_count: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).max_count;
-        }
-        return 0;
-    },
-    share: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).share;
-        }
-        return '';
-    },
-    prefix: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).prefix;
-        }
-        return '';
-    },
-    pool: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).pool;
-        }
-        return '';
-    },
-    visible: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).visible;
-        }
-        return false;
-    },
-    writable: function () {
-        if (this.get('json_meta') != null) {
-            return JSON.parse(this.get('json_meta')).writable;
-        }
-        return false;
+  urlRoot: "/api/sm/tasks/",
+  max_count: function () {
+    if (this.get('json_meta') != null) {
+      return JSON.parse(this.get('json_meta')).max_count;
+    } else {
+      return 0;
     }
+  },
+  share: function () {
+    if (this.get('json_meta') != null) {
+      return JSON.parse(this.get('json_meta')).share;
+    } else {
+      return '';
+    }
+  },
+  prefix: function () {
+    if (this.get('json_meta') != null) {
+      return JSON.parse(this.get('json_meta')).prefix;
+    } else {
+      return '';
+    }
+  },
+  pool: function () {
+    if (this.get('json_meta') != null) {
+      return JSON.parse(this.get('json_meta')).pool;
+    } else {
+      return '';
+    }
+  },
+  visible: function () {
+    if (this.get('json_meta') != null) {
+      return JSON.parse(this.get('json_meta')).visible;
+    } else {
+      return false;
+    }
+  },
+
+
 });
 
 var TaskDefCollection = RockStorPaginatedCollection.extend({
-    model: TaskDef,
-    baseUrl: "/api/sm/tasks/"
+  model: TaskDef,
+  baseUrl: "/api/sm/tasks/"
 });
 
 var Task = Backbone.Model.extend({
-    urlRoot: "/api/sm/tasks/log"
+  urlRoot: "/api/sm/tasks/log"
 });
 
 var TaskCollection = RockStorPaginatedCollection.extend({
-    model: Task,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.taskDefId = options.taskDefId;
-        }
-    },
-    baseUrl: function () {
-        if (this.taskDefId) {
-            return '/api/sm/tasks/log/taskdef/' + this.taskDefId;
-        } else {
-            return '/api/sm/tasks/log';
-        }
+  model: Task,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.taskDefId = options.taskDefId;
     }
+  },
+  baseUrl: function () {
+    if (this.taskDefId) {
+      return '/api/sm/tasks/log/taskdef/' + this.taskDefId;
+    } else {
+      return '/api/sm/tasks/log';
+    }
+  }
 });
 
 var SFTP = Backbone.Model.extend({
-    urlRoot: '/api/sftp'
+  urlRoot: '/api/sftp'
 });
 
 var SFTPCollection = RockStorPaginatedCollection.extend({
-    model: SFTP,
-    baseUrl: '/api/sftp'
+  model: SFTP,
+  baseUrl: '/api/sftp'
 });
 
 
 var AFP = Backbone.Model.extend({
-    urlRoot: '/api/netatalk'
+  urlRoot: '/api/netatalk'
 });
 
 var AFPCollection = RockStorPaginatedCollection.extend({
-    model: AFP,
-    baseUrl: '/api/netatalk'
+  model: AFP,
+  baseUrl: '/api/netatalk'
 });
 
 
 var ReplicaReceive = Backbone.Model.extend({
-    urlRoot: "/api/sm/replicareceives"
+  urlRoot: "/api/sm/replicareceives"
 });
 
 var ReplicaReceiveCollection = RockStorPaginatedCollection.extend({
-    model: ReplicaReceive,
-    baseUrl: "/api/sm/replicareceives"
+  model: ReplicaReceive,
+  baseUrl: "/api/sm/replicareceives"
 });
 
 var ReplicaReceiveTrail = Backbone.Model.extend({
-    urlRoot: "/api/sm/replicareceivetrail"
+  urlRoot: "/api/sm/replicareceivetrail"
 });
 
 var ReplicaReceiveTrailCollection = RockStorPaginatedCollection.extend({
-    model: ReplicaReceiveTrail,
-    baseUrl: "/api/sm/replicareceivetrai"
+  model: ReplicaReceiveTrail,
+  baseUrl: "/api/sm/replicareceivetrai"
 });
 
 var AdvancedNFSExport = Backbone.Model.extend();
 
 var AdvancedNFSExportCollection = RockStorPaginatedCollection.extend({
-    model: AdvancedNFSExport,
-    baseUrl: "/api/adv-nfs-exports"
+  model: AdvancedNFSExport,
+  baseUrl: "/api/adv-nfs-exports"
 });
 
 
 var AccessKey = Backbone.Model.extend({
-    url: function () {
-        return '/api/oauth_app';
-    }
+  url: function () {
+    return '/api/oauth_app';
+  }
 });
 
 var AccessKeyCollection = RockStorPaginatedCollection.extend({
-    model: AccessKey,
-    baseUrl: '/api/oauth_app'
+  model: AccessKey,
+  baseUrl: '/api/oauth_app'
 });
 
 var Certificate = Backbone.Model.extend({
-    urlRoot: '/api/certificate',
+  urlRoot: '/api/certificate',
 });
 
 var ConfigBackup = Backbone.Model.extend({
-    urlRoot: '/api/config-backup',
+  urlRoot: '/api/config-backup',
 });
 
 var ConfigBackupCollection = RockStorPaginatedCollection.extend({
-    model: ConfigBackup,
-    baseUrl: '/api/config-backup'
+  model: ConfigBackup,
+  baseUrl: '/api/config-backup'
 });
 
 var EmailAccount = Backbone.Model.extend({
-    urlRoot: '/api/email',
+  urlRoot: '/api/email',
 });
 
 var RockOn = Backbone.Model.extend({
-    urlRoot: '/api/rockons'
+  urlRoot: '/api/rockons'
 });
 
 var RockOnCollection = RockStorPaginatedCollection.extend({
-    model: RockOn,
-    baseUrl: '/api/rockons'
+  model: RockOn,
+  baseUrl: '/api/rockons'
 });
 
 var RockOnVolume = Backbone.Model.extend({
-    urlRoot: '/api/rockons/volumes/' + this.rid
+  urlRoot: '/api/rockons/volumes/' + this.rid
 });
 
 var RockOnVolumeCollection = RockStorPaginatedCollection.extend({
-    model: RockOnVolume,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.rid = options.rid;
-        }
-    },
-    baseUrl: function () {
-        if (this.rid) {
-            return '/api/rockons/volumes/' + this.rid;
-        } else {
-            return '/api/rockons/volumes';
-        }
+  model: RockOnVolume,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.rid = options.rid;
     }
+  },
+  baseUrl: function () {
+    if (this.rid) {
+      return '/api/rockons/volumes/' + this.rid;
+    } else {
+      return '/api/rockons/volumes';
+    }
+  }
 });
 
 var RockOnPort = Backbone.Model.extend({
-    urlRoot: '/api/rockon/ports/' + this.rid
+  urlRoot: '/api/rockon/ports/' + this.rid
 });
 
 var RockOnPortCollection = RockStorPaginatedCollection.extend({
-    model: RockOnPort,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.rid = options.rid;
-        }
-    },
-    baseUrl: function () {
-        if (this.rid) {
-            return '/api/rockons/ports/' + this.rid;
-        } else {
-            return '/api/rockons/ports';
-        }
+  model: RockOnPort,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.rid = options.rid;
     }
+  },
+  baseUrl: function () {
+    if (this.rid) {
+      return '/api/rockons/ports/' + this.rid;
+    } else {
+      return '/api/rockons/ports';
+    }
+  }
 });
 
 var RockOnCustomConfig = Backbone.Model.extend({
-    urlRoot: '/api/rockon/customconfig/' + this.rid
+  urlRoot: '/api/rockon/customconfig/' + this.rid
 });
 
 var RockOnCustomConfigCollection = RockStorPaginatedCollection.extend({
-    model: RockOnCustomConfig,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.rid = options.rid;
-        }
-    },
-    baseUrl: function () {
-        if (this.rid) {
-            return '/api/rockons/customconfig/' + this.rid;
-        } else {
-            return '/api/rockons/customconfig';
-        }
+  model: RockOnCustomConfig,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.rid = options.rid;
     }
+  },
+  baseUrl: function () {
+    if (this.rid) {
+      return '/api/rockons/customconfig/' + this.rid;
+    } else {
+      return '/api/rockons/customconfig';
+    }
+  }
 });
 
 var RockOnEnvironment = Backbone.Model.extend({
-    urlRoot: '/api/rockon/environment/' + this.rid
+  urlRoot: '/api/rockon/environment/' + this.rid
 });
 
 var RockOnEnvironmentCollection = RockStorPaginatedCollection.extend({
-    model: RockOnEnvironment,
-    initialize: function (models, options) {
-        this.constructor.__super__.initialize.apply(this, arguments);
-        if (options) {
-            this.rid = options.rid;
-        }
-    },
-    baseUrl: function () {
-        if (this.rid) {
-            return '/api/rockons/environment/' + this.rid;
-        } else {
-            return '/api/rockons/environment';
-        }
+  model: RockOnEnvironment,
+  initialize: function (models, options) {
+    this.constructor.__super__.initialize.apply(this, arguments);
+    if (options) {
+      this.rid = options.rid;
     }
+  },
+  baseUrl: function () {
+    if (this.rid) {
+      return '/api/rockons/environment/' + this.rid;
+    } else {
+      return '/api/rockons/environment';
+    }
+  }
 });
 
 var EmailAccount = Backbone.Model.extend({
-    urlRoot: '/api/email'
+  urlRoot: '/api/email'
 });
 
 var EmailAccountCollection = RockStorPaginatedCollection.extend({
-    model: EmailAccount,
-    baseUrl: '/api/email'
+  model: EmailAccount,
+  baseUrl: '/api/email'
 });
 
 var UpdateSubscription = Backbone.Model.extend({
-    urlRoot: '/api/update-subscriptions'
+  urlRoot: '/api/update-subscriptions'
 });
 
 var UpdateSubscriptionCollection = RockStorPaginatedCollection.extend({
-    model: UpdateSubscription,
-    baseUrl: '/api/update-subscriptions'
+  model: UpdateSubscription,
+  baseUrl: '/api/update-subscriptions'
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -100,6 +100,24 @@ var Share = Backbone.Model.extend({
     }
 });
 
+
+var PoolShare = Backbone.Model.extend({
+  url: function () {
+    console.log('poolshare');
+      return '/api/pools/' + this.get('poolName');
+    }
+});
+
+var PoolShareCollection = Backbone.Collection.extend({
+  model: PoolShare,
+  initialize: function(model, options) {
+    this.options = options;
+  },
+  url: function () {
+    return '/api/pools/' + this.options.poolName + '/shares';
+  }
+});
+
 var ShareCollection = RockStorPaginatedCollection.extend({
     model: Share,
     baseUrl: '/api/shares',

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -123,7 +123,7 @@ var PoolShare = Backbone.Model.extend({
   url: function () {
     console.log('poolshare');
       return '/api/pools/' + this.get('poolName');
-    }
+  }
 });
 
 var PoolShareCollection = Backbone.Collection.extend({

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -105,7 +105,7 @@ var PoolShare = Backbone.Model.extend({
   url: function () {
     console.log('poolshare');
       return '/api/pools/' + this.get('poolName');
-    }
+  }
 });
 
 var PoolShareCollection = Backbone.Collection.extend({

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -1,3 +1,4 @@
+
 /*
  *
  * @licstart  The following is the entire license notice for the
@@ -77,73 +78,73 @@ RockstorLayoutView = Backbone.View.extend({
 
 RockstorModuleView = Backbone.View.extend({
 
-    tagName: 'div',
-    className: 'module',
-    requestCount: 0,
+  tagName: 'div',
+  className: 'module',
+  requestCount: 0,
 
-    initialize: function() {
-  this.subviews = {};
-  this.dependencies = [];
-    },
+  initialize: function() {
+    this.subviews = {};
+    this.dependencies = [];
+  },
 
-    fetch: function(callback, context) {
-  var allDependencies = [];
-  _.each(this.dependencies, function(dep) {
+  fetch: function(callback, context) {
+    var allDependencies = [];
+    _.each(this.dependencies, function(dep) {
       allDependencies.push(dep.fetch({silent: true}));
-  });
-  $.when.apply($, allDependencies).done(function () {
+    });
+    $.when.apply($, allDependencies).done(function () {
       if (callback) callback.apply(context);
-  });
-    },
+    });
+  },
 
-    render: function() {
-  $(this.el).html(this.template({
+  render: function() {
+    $(this.el).html(this.template({
       module_name: this.module_name,
       model: this.model,
       collection: this.collection
-  }));
+    }));
 
-  return this;
-    }
+    return this;
+  }
 });
 
 RockStorWidgetView = Backbone.View.extend({
-    tagName: 'div',
-    className: 'widget',
+  tagName: 'div',
+  className: 'widget',
 
-    events: {
-  'click .configure-widget': 'configure',
-  'click .resize-widget': 'resize',
-  'click .close-widget': 'close',
-  'click .download-widget': 'download'
-    },
+  events: {
+    'click .configure-widget': 'configure',
+    'click .resize-widget': 'resize',
+    'click .close-widget': 'close',
+    'click .download-widget': 'download'
+  },
 
-    initialize: function() {
-  this.maximized = this.options.maximized;
-  this.name = this.options.name;
-  this.displayName = this.options.displayName;
-  this.parentView = this.options.parentView;
-  this.dependencies = [];
-    },
+  initialize: function() {
+    this.maximized = this.options.maximized;
+    this.name = this.options.name;
+    this.displayName = this.options.displayName;
+    this.parentView = this.options.parentView;
+    this.dependencies = [];
+  },
 
-    render: function() {
-  $(this.el).attr('id', this.name + '_widget');
-    },
+  render: function() {
+    $(this.el).attr('id', this.name + '_widget');
+  },
 
-    configure: function(event) {
-  if (!_.isUndefined(event) && !_.isNull(event)) {
+  configure: function(event) {
+    if (!_.isUndefined(event) && !_.isNull(event)) {
       event.preventDefault();
-  }
-    },
+    }
+  },
 
-    resize: function(event) {
-  if (!_.isUndefined(event) && !_.isNull(event)) {
+  resize: function(event) {
+    if (!_.isUndefined(event) && !_.isNull(event)) {
       event.preventDefault();
-  }
-  var c = $(this.el).closest('div.widgets-container');
-  var w = $(this.el).closest('div.widget-ph'); // current widget
-  var widgetDef = RockStorWidgets.findByName(this.name);
-  if (!this.maximized) {
+    }
+    var c = $(this.el).closest('div.widgets-container');
+    var w = $(this.el).closest('div.widget-ph'); // current widget
+    var widgetDef = RockStorWidgets.findByName(this.name);
+    if (!this.maximized) {
       // Maximizing
       // Remember current position
       this.originalPosition = w.index();
@@ -155,57 +156,57 @@ RockStorWidgetView = Backbone.View.extend({
       w.attr('data-ss-colspan',widgetDef.maxCols);
       w.attr('data-ss-rowspan',widgetDef.maxRows);
       this.maximized = true;
-  } else {
+    } else {
       // Restoring
       w.detach();
       w.attr('data-ss-colspan',widgetDef.cols);
       w.attr('data-ss-rowspan',widgetDef.rows);
       // find current list item at original index
       if (_.isNull(this.originalPosition) ||
-    _.isUndefined(this.originalPosition)) {
-    this.originalPosition = 0;
+          _.isUndefined(this.originalPosition)) {
+            this.originalPosition = 0;
       }
       curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
       // insert widget at original position
       if (curr_w.length > 0) {
-    // if not last widget
-    curr_w.before(w);
+        // if not last widget
+        curr_w.before(w);
       } else {
-    c.append(w);
+        c.append(w);
       }
       this.maximized = false;
-  }
-  // trigger rearrange so shapeshift can do its job
-  c.trigger('ss-rearrange');
-  this.parentView.saveWidgetConfiguration();
-    },
-
-    close: function(event) {
-  if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
-  }
-  this.parentView.removeWidget(this.name, this);
-    },
-
-    download: function(event) {
-  if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
-  }
-    },
-
-    cleanup: function() {
-  logger.debug("In RockStorWidgetView close");
-    },
-
-    fetch: function(callback, context) {
-  var allDependencies = [];
-  _.each(this.dependencies, function(dep) {
-      allDependencies.push(dep.fetch({silent: true}));
-  });
-  $.when.apply($, allDependencies).done(function () {
-      if (callback) callback.apply(context);
-  });
     }
+    // trigger rearrange so shapeshift can do its job
+    c.trigger('ss-rearrange');
+    this.parentView.saveWidgetConfiguration();
+  },
+
+  close: function(event) {
+    if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+    }
+    this.parentView.removeWidget(this.name, this);
+  },
+
+  download: function(event) {
+    if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+    }
+  },
+
+  cleanup: function() {
+    logger.debug("In RockStorWidgetView close");
+  },
+
+  fetch: function(callback, context) {
+    var allDependencies = [];
+    _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+    });
+    $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+    });
+  }
 
 });
 
@@ -227,357 +228,357 @@ function getCookie(name) {
 }
 
 function csrfSafeMethod(method) {
-    // these HTTP methods do not require CSRF protection
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+  // these HTTP methods do not require CSRF protection
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 
 $.ajaxSetup({
-    crossDomain: false, // obviates need for sameOrigin test
-    beforeSend: function(xhr, settings) {
-  if (!csrfSafeMethod(settings.type)) {
+  crossDomain: false, // obviates need for sameOrigin test
+  beforeSend: function(xhr, settings) {
+    if (!csrfSafeMethod(settings.type)) {
       var csrftoken = getCookie('csrftoken');
       xhr.setRequestHeader("X-CSRFToken", csrftoken);
-  }
     }
+  }
 });
 
 function showApplianceList() {
-    var applianceSelectPopup = $('#appliance-select-popup').modal({
-  show: false
-    });
-    $('#appliance-select-content').html((new AppliancesView()).render().el);
-    $('#appliance-select-popup').modal('show');
+  var applianceSelectPopup = $('#appliance-select-popup').modal({
+    show: false
+  });
+  $('#appliance-select-content').html((new AppliancesView()).render().el);
+  $('#appliance-select-popup').modal('show');
 
 }
 
 
 function showSuccessMessage(msg) {
-    $('#messages').html(msg);
-    $('#messages').css('visibility', 'visible');
+  $('#messages').html(msg);
+  $('#messages').css('visibility', 'visible');
 
 }
 
 function hideMessage() {
-    $('#messages').html('&nbsp;');
-    $('#messages').css('visibility', 'hidden');
+  $('#messages').html('&nbsp;');
+  $('#messages').css('visibility', 'hidden');
 
 }
 
 /* Loading indicator */
 
 $(document).ajaxStart(function() {
-    $('#loading-indicator').css('visibility', 'visible');
+  $('#loading-indicator').css('visibility', 'visible');
 });
 
 $(document).ajaxStop(function() {
-    $('#loading-indicator').css('visibility', 'hidden');
+  $('#loading-indicator').css('visibility', 'hidden');
 });
 
 
 function showLoadingIndicator(elementName, context) {
-    var _this = context;
-    _this.$('#'+elementName).css('visibility', 'visible');
+  var _this = context;
+  _this.$('#'+elementName).css('visibility', 'visible');
 }
 
 function hideLoadingIndicator(elementName, context) {
-    var _this = context;
-    _this.$('#'+elementName).css('visibility', 'hidden');
+  var _this = context;
+  _this.$('#'+elementName).css('visibility', 'hidden');
 }
 
 function disableButton(button) {
-    button.data("executing", true);
-    button.attr("disabled", true);
+  button.data("executing", true);
+  button.attr("disabled", true);
 }
 
 function enableButton(button) {
-    button.data("executing", false);
-    button.attr("disabled", false);
+  button.data("executing", false);
+  button.attr("disabled", false);
 }
 
 function buttonDisabled(button) {
-    if (button.data("executing")) {
-  return true;
-    } else {
-  return false;
-    }
+  if (button.data("executing")) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 
 function refreshNavbar() {
-    $.ajax({
-  url: "api/commands/current-user",
-  type: "POST",
-  dataType: "json",
-  global: false, // dont show global loading indicator
-  success: function(data, status, xhr) {
+  $.ajax({
+    url: "api/commands/current-user",
+    type: "POST",
+    dataType: "json",
+    global: false, // dont show global loading indicator
+    success: function(data, status, xhr) {
       var currentUser= data;
       $('#user-name').css({textTransform: 'none'});
       $('#user-name').html(currentUser+' ');
-  },
-  error: function(xhr, status, error) {
+    },
+    error: function(xhr, status, error) {
       //  $('#user-name').html("Hello, <b> Admin! </b>");
-  }
-    });
+    }
+  });
 
-    var navbarTemplate = window.JST.common_navbar;
-    $("#navbar-links").html(navbarTemplate({
-  logged_in: logged_in
+  var navbarTemplate = window.JST.common_navbar;
+  $("#navbar-links").html(navbarTemplate({
+    logged_in: logged_in
 
-    }));
+  }));
 
-    $('.dropdown-toggle').dropdown();
+  $('.dropdown-toggle').dropdown();
 }
 
 // Parses error message from ajax request
 // Returns the value of the detail attribute as json
 // or a string if it cannot be parsed as json
 function parseXhrError(xhr) {
-    var msg = xhr.responseText;
-    try {
-  msg = JSON.parse(msg).detail;
-    } catch(err) {
-    }
-    if (typeof(msg)=="string") {
+  var msg = xhr.responseText;
   try {
-      msg = JSON.parse(msg);
+    msg = JSON.parse(msg).detail;
   } catch(err) {
   }
+  if (typeof(msg)=="string") {
+    try {
+      msg = JSON.parse(msg);
+    } catch(err) {
     }
-    return msg;
+  }
+  return msg;
 }
 
 function getXhrErrorJson(xhr) {
-    var json = {};
-    try { json = JSON.parse(xhr.responseText); } catch(err) { }
-    return json;
+  var json = {};
+  try { json = JSON.parse(xhr.responseText); } catch(err) { }
+  return json;
 }
 
 function setApplianceName() {
-    var appliances = new ApplianceCollection();
-    appliances.fetch({
-  success: function(request) {
+  var appliances = new ApplianceCollection();
+  appliances.fetch({
+    success: function(request) {
       if (appliances.length > 0) {
-    RockStorGlobals.currentAppliance =
+        RockStorGlobals.currentAppliance =
         appliances.find(function(appliance) {
-      return appliance.get('current_appliance') == true;
+          return appliance.get('current_appliance') == true;
         });
-    $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
+        $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
       }
-  },
-  error: function(request, response) {
-  }
+    },
+    error: function(request, response) {
+    }
 
-    });
+  });
 }
 
 function fetchDependencies(dependencies, callback, context) {
-    if (dependencies.length == 0) {
-  if (callback) callback.apply(context);
-    }
-    var requestCount = dependencies.length;
-    _.each(dependencies, function(dependency) {
-  dependency.fetch({
+  if (dependencies.length == 0) {
+    if (callback) callback.apply(context);
+  }
+  var requestCount = dependencies.length;
+  _.each(dependencies, function(dependency) {
+    dependency.fetch({
       success: function(request){
-    requestCount -= 1;
-    if (requestCount == 0) {
-        if (callback) callback.apply(context);
-    }
+        requestCount -= 1;
+        if (requestCount == 0) {
+          if (callback) callback.apply(context);
+        }
       },
       error: function(request, response) {
-    requestCount -= 1;
-    if (requestCount == 0) {
-        if (callback) callback.apply(context);
-    }
+        requestCount -= 1;
+        if (requestCount == 0) {
+          if (callback) callback.apply(context);
+        }
       }
-  });
     });
+  });
 }
 
 function checkBrowser() {
-    var userAgent = navigator.userAgent;
-    if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
-  $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
-    }
-    RockStorGlobals.browserChecked = true;
+  var userAgent = navigator.userAgent;
+  if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
+    $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
+  }
+  RockStorGlobals.browserChecked = true;
 }
 
 RockStorProbeMap = [];
 RockStorGlobals = {
-    navbarLoaded: false,
-    applianceNameSet: false,
-    currentAppliance: null,
-    maxPageSize: 5000,
-    browserChecked: false,
-    kernel: null
+  navbarLoaded: false,
+  applianceNameSet: false,
+  currentAppliance: null,
+  maxPageSize: 5000,
+  browserChecked: false,
+  kernel: null
 }
 
 var RS_DATE_FORMAT = 'MMMM Do YYYY, h:mm:ss a';
 
 // Constants
 probeStates = {
-    STOPPED: 'stopped',
-    CREATED: 'created',
-    RUNNING: 'running',
-    ERROR: 'error'
+  STOPPED: 'stopped',
+  CREATED: 'created',
+  RUNNING: 'running',
+  ERROR: 'error'
 };
 
 var RockstorUtil = function() {
-    var util = {
-  // maintain selected object list
-  // list is an array of contains models
+  var util = {
+    // maintain selected object list
+    // list is an array of contains models
 
-  // does the list contain a model with attr 'name' with value 'value'
-  listContains: function(list, name, value) {
+    // does the list contain a model with attr 'name' with value 'value'
+    listContains: function(list, name, value) {
       return _.find(list, function(obj) {
-    return obj.get(name) == value;
+        return obj.get(name) == value;
       });
-  },
+    },
 
-  // add obj from collection with attr 'name' and value 'value' to list
-  addToList: function(list, collection, name, value) {
+    // add obj from collection with attr 'name' and value 'value' to list
+    addToList: function(list, collection, name, value) {
       list.push(collection.find(function(obj) {
-    return obj.get(name) == value;
+        return obj.get(name) == value;
       }));
-  },
+    },
 
-  // remove obj with attr 'name' and value 'value'
-  removeFromList: function(list, name, value) {
+    // remove obj with attr 'name' and value 'value'
+    removeFromList: function(list, name, value) {
       var i = _.indexOf(_.map(list, function(obj) {
-    return obj.get(name);
+        return obj.get(name);
       }), value);
       if (i != -1) {
-    list.splice(i,1);
+        list.splice(i,1);
       }
-  }
-    };
-    return util;
+    }
+  };
+  return util;
 }();
 
 RockstorWizardPage = Backbone.View.extend({
 
-    initialize: function() {
-  this.evAgg = this.options.evAgg;
-  this.parent = this.options.parent;
-    },
+  initialize: function() {
+    this.evAgg = this.options.evAgg;
+    this.parent = this.options.parent;
+  },
 
-    render: function() {
-  $(this.el).html(this.template({
+  render: function() {
+    $(this.el).html(this.template({
       model: this.model
-  }));
-  return this;
-    },
+    }));
+    return this;
+  },
 
-    save: function() {
-  return $.Deferred().resolve();
-    }
+  save: function() {
+    return $.Deferred().resolve();
+  }
 });
 
 WizardView = Backbone.View.extend({
-    tagName: 'div',
+  tagName: 'div',
 
-    events: {
-  'click #next-page': 'nextPage',
-  'click #prev-page': 'prevPage'
-    },
+  events: {
+    'click #next-page': 'nextPage',
+    'click #prev-page': 'prevPage'
+  },
 
-    initialize: function() {
-  this.template = window.JST.wizard_wizard;
-  this.pages = null;
-  this.currentPage = null;
-  this.currentPageNum = -1;
-  this.contentEl = '#ph-wizard-contents';
-  this.evAgg = _.extend({}, Backbone.Events);
-  this.evAgg.bind('nextPage', this.nextPage, this);
-  this.evAgg.bind('prevPage', this.prevPage, this);
-  this.parent = this.options.parent;
-  this.title = this.options.title;
-    },
+  initialize: function() {
+    this.template = window.JST.wizard_wizard;
+    this.pages = null;
+    this.currentPage = null;
+    this.currentPageNum = -1;
+    this.contentEl = '#ph-wizard-contents';
+    this.evAgg = _.extend({}, Backbone.Events);
+    this.evAgg.bind('nextPage', this.nextPage, this);
+    this.evAgg.bind('prevPage', this.prevPage, this);
+    this.parent = this.options.parent;
+    this.title = this.options.title;
+  },
 
-    setPages: function(pages) {
-  this.pages = pages;
-    },
+  setPages: function(pages) {
+    this.pages = pages;
+  },
 
-    render: function() {
-  $(this.el).html(this.template({
+  render: function() {
+    $(this.el).html(this.template({
       title: this.title,
       model: this.model
-  }));
-  this.nextPage();
-  return this;
-    },
+    }));
+    this.nextPage();
+    return this;
+  },
 
-    nextPage: function() {
-  var _this = this;
-  var promise = !_.isNull(this.currentPage) ?
-    this.currentPage.save() :
-    $.Deferred().resolve();
-  promise.done(function(result, status, jqXHR) {
+  nextPage: function() {
+    var _this = this;
+    var promise = !_.isNull(this.currentPage) ?
+                  this.currentPage.save() :
+                  $.Deferred().resolve();
+    promise.done(function(result, status, jqXHR) {
       _this.incrementPage();
-  });
-  promise.fail(function(jqXHR, status, error) {
+    });
+    promise.fail(function(jqXHR, status, error) {
       console.log(error);
-  });
-    },
+    });
+  },
 
-    incrementPageNum: function() {
-  this.currentPageNum = this.currentPageNum + 1;
-    },
+  incrementPageNum: function() {
+    this.currentPageNum = this.currentPageNum + 1;
+  },
 
-    decrementPageNum: function() {
-  this.currentPageNum = this.currentPageNum - 1;
-    },
+  decrementPageNum: function() {
+    this.currentPageNum = this.currentPageNum - 1;
+  },
 
-    incrementPage: function() {
-  if (!this.lastPage()) {
+  incrementPage: function() {
+    if (!this.lastPage()) {
       this.incrementPageNum();
       this.setCurrentPage();
       this.renderCurrentPage();
-  } else {
+    } else {
       this.finish();
-  }
-    },
+    }
+  },
 
-    decrementPage: function() {
-  if (!this.firstPage()) {
+  decrementPage: function() {
+    if (!this.firstPage()) {
       this.decrementPageNum();
       this.setCurrentPage();
       this.renderCurrentPage();
-  }
-    },
+    }
+  },
 
-    setCurrentPage: function() {
-  this.currentPage = new this.pages[this.currentPageNum]({
+  setCurrentPage: function() {
+    this.currentPage = new this.pages[this.currentPageNum]({
       model: this.model,
       evAgg: this.evAgg
-  });
-    },
+    });
+  },
 
-    renderCurrentPage: function() {
-  this.$(this.contentEl).html(this.currentPage.render().el);
-  this.modifyButtonText();
-    },
+  renderCurrentPage: function() {
+    this.$(this.contentEl).html(this.currentPage.render().el);
+    this.modifyButtonText();
+  },
 
-    prevPage: function() {
-  this.decrementPage();
-    },
+  prevPage: function() {
+    this.decrementPage();
+  },
 
-    modifyButtonText: function() {
-  if (this.lastPage()) {
+  modifyButtonText: function() {
+    if (this.lastPage()) {
       this.$('#next-page').html('Finish');
-  } else {
+    } else {
       this.$('#next-page').html('Next');
-  }
-    },
-
-    firstPage: function() {
-  return (this.currentPageNum == 0);
-    },
-
-    lastPage: function() {
-  return (this.currentPageNum == (this.pages.length - 1));
-    },
-
-    finish: function() {
-  console.log('finish');
     }
+  },
+
+  firstPage: function() {
+    return (this.currentPageNum == 0);
+  },
+
+  lastPage: function() {
+    return (this.currentPageNum == (this.pages.length - 1));
+  },
+
+  finish: function() {
+    console.log('finish');
+  }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -26,21 +26,21 @@
 
 PaginationMixin = {
   events: {
-	  "click .go-to-page": "goToPage",
-	  "click .prev-page": "prevPage",
-	  "click .next-page": "nextPage"
+    "click .go-to-page": "goToPage",
+    "click .prev-page": "prevPage",
+    "click .next-page": "nextPage"
   },
   goToPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
+    if (event) event.preventDefault();
+    this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
   },
   prevPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.prevPage();
+    if (event) event.preventDefault();
+    this.collection.prevPage();
   },
   nextPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.nextPage();
+    if (event) event.preventDefault();
+    this.collection.nextPage();
   }
 };
 
@@ -49,26 +49,26 @@ RockstorLayoutView = Backbone.View.extend({
   className: 'layout',
 
   initialize: function() {
-	  this.subviews = {};
-	  this.dependencies = [];
+    this.subviews = {};
+    this.dependencies = [];
   },
 
   fetch: function(callback, context) {
-	  var allDependencies = [];
-	  _.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	  });
-	  $.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	  });
+    var allDependencies = [];
+    _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+    });
+    $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+    });
   },
 
   renderDataTables: function(){
-		$('table.data-table').DataTable({
-		  "iDisplayLength": 15,
-		  "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
-		});
-	},
+    $('table.data-table').DataTable({
+      "iDisplayLength": 15,
+      "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
+    });
+  },
 
 });
 
@@ -82,28 +82,28 @@ RockstorModuleView = Backbone.View.extend({
     requestCount: 0,
 
     initialize: function() {
-	this.subviews = {};
-	this.dependencies = [];
+  this.subviews = {};
+  this.dependencies = [];
     },
 
     fetch: function(callback, context) {
-	var allDependencies = [];
-	_.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	});
-	$.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	});
+  var allDependencies = [];
+  _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+  });
+  $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+  });
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    module_name: this.module_name,
-	    model: this.model,
-	    collection: this.collection
-	}));
+  $(this.el).html(this.template({
+      module_name: this.module_name,
+      model: this.model,
+      collection: this.collection
+  }));
 
-	return this;
+  return this;
     }
 });
 
@@ -112,118 +112,118 @@ RockStorWidgetView = Backbone.View.extend({
     className: 'widget',
 
     events: {
-	'click .configure-widget': 'configure',
-	'click .resize-widget': 'resize',
-	'click .close-widget': 'close',
-	'click .download-widget': 'download'
+  'click .configure-widget': 'configure',
+  'click .resize-widget': 'resize',
+  'click .close-widget': 'close',
+  'click .download-widget': 'download'
     },
 
     initialize: function() {
-	this.maximized = this.options.maximized;
-	this.name = this.options.name;
-	this.displayName = this.options.displayName;
-	this.parentView = this.options.parentView;
-	this.dependencies = [];
+  this.maximized = this.options.maximized;
+  this.name = this.options.name;
+  this.displayName = this.options.displayName;
+  this.parentView = this.options.parentView;
+  this.dependencies = [];
     },
 
     render: function() {
-	$(this.el).attr('id', this.name + '_widget');
+  $(this.el).attr('id', this.name + '_widget');
     },
 
     configure: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
     },
 
     resize: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
-	var c = $(this.el).closest('div.widgets-container');
-	var w = $(this.el).closest('div.widget-ph'); // current widget
-	var widgetDef = RockStorWidgets.findByName(this.name);
-	if (!this.maximized) {
-	    // Maximizing
-	    // Remember current position
-	    this.originalPosition = w.index();
-	    // remove list item from current position
-	    w.detach();
-	    // insert at first position in the list
-	    c.prepend(w);
-	    // resize to max
-	    w.attr('data-ss-colspan',widgetDef.maxCols);
-	    w.attr('data-ss-rowspan',widgetDef.maxRows);
-	    this.maximized = true;
-	} else {
-	    // Restoring
-	    w.detach();
-	    w.attr('data-ss-colspan',widgetDef.cols);
-	    w.attr('data-ss-rowspan',widgetDef.rows);
-	    // find current list item at original index
-	    if (_.isNull(this.originalPosition) ||
-		_.isUndefined(this.originalPosition)) {
-		this.originalPosition = 0;
-	    }
-	    curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
-	    // insert widget at original position
-	    if (curr_w.length > 0) {
-		// if not last widget
-		curr_w.before(w);
-	    } else {
-		c.append(w);
-	    }
-	    this.maximized = false;
-	}
-	// trigger rearrange so shapeshift can do its job
-	c.trigger('ss-rearrange');
-	this.parentView.saveWidgetConfiguration();
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
+  var c = $(this.el).closest('div.widgets-container');
+  var w = $(this.el).closest('div.widget-ph'); // current widget
+  var widgetDef = RockStorWidgets.findByName(this.name);
+  if (!this.maximized) {
+      // Maximizing
+      // Remember current position
+      this.originalPosition = w.index();
+      // remove list item from current position
+      w.detach();
+      // insert at first position in the list
+      c.prepend(w);
+      // resize to max
+      w.attr('data-ss-colspan',widgetDef.maxCols);
+      w.attr('data-ss-rowspan',widgetDef.maxRows);
+      this.maximized = true;
+  } else {
+      // Restoring
+      w.detach();
+      w.attr('data-ss-colspan',widgetDef.cols);
+      w.attr('data-ss-rowspan',widgetDef.rows);
+      // find current list item at original index
+      if (_.isNull(this.originalPosition) ||
+    _.isUndefined(this.originalPosition)) {
+    this.originalPosition = 0;
+      }
+      curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
+      // insert widget at original position
+      if (curr_w.length > 0) {
+    // if not last widget
+    curr_w.before(w);
+      } else {
+    c.append(w);
+      }
+      this.maximized = false;
+  }
+  // trigger rearrange so shapeshift can do its job
+  c.trigger('ss-rearrange');
+  this.parentView.saveWidgetConfiguration();
     },
 
     close: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
-	this.parentView.removeWidget(this.name, this);
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
+  this.parentView.removeWidget(this.name, this);
     },
 
     download: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
     },
 
     cleanup: function() {
-	logger.debug("In RockStorWidgetView close");
+  logger.debug("In RockStorWidgetView close");
     },
 
     fetch: function(callback, context) {
-	var allDependencies = [];
-	_.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	});
-	$.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	});
+  var allDependencies = [];
+  _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+  });
+  $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+  });
     }
 
 });
 
 
 function getCookie(name) {
-	var cookieValue = null;
-	if (document.cookie && document.cookie != '') {
-		var cookies = document.cookie.split(';');
-		for (var i = 0; i < cookies.length; i++) {
-			var cookie = jQuery.trim(cookies[i]);
-			// Does this cookie string begin with the name we want?
-			if (cookie.substring(0, name.length + 1) == (name + '=')) {
-				cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-				break;
-			}
-		}
-	}
-	return cookieValue;
+  var cookieValue = null;
+  if (document.cookie && document.cookie != '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) == (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
 }
 
 function csrfSafeMethod(method) {
@@ -234,16 +234,16 @@ function csrfSafeMethod(method) {
 $.ajaxSetup({
     crossDomain: false, // obviates need for sameOrigin test
     beforeSend: function(xhr, settings) {
-	if (!csrfSafeMethod(settings.type)) {
-	    var csrftoken = getCookie('csrftoken');
-	    xhr.setRequestHeader("X-CSRFToken", csrftoken);
-	}
+  if (!csrfSafeMethod(settings.type)) {
+      var csrftoken = getCookie('csrftoken');
+      xhr.setRequestHeader("X-CSRFToken", csrftoken);
+  }
     }
 });
 
 function showApplianceList() {
     var applianceSelectPopup = $('#appliance-select-popup').modal({
-	show: false
+  show: false
     });
     $('#appliance-select-content').html((new AppliancesView()).render().el);
     $('#appliance-select-popup').modal('show');
@@ -296,32 +296,32 @@ function enableButton(button) {
 
 function buttonDisabled(button) {
     if (button.data("executing")) {
-	return true;
+  return true;
     } else {
-	return false;
+  return false;
     }
 }
 
 
 function refreshNavbar() {
     $.ajax({
-	url: "api/commands/current-user",
-	type: "POST",
-	dataType: "json",
-	global: false, // dont show global loading indicator
-	success: function(data, status, xhr) {
-	    var currentUser= data;
-	    $('#user-name').css({textTransform: 'none'});
-	    $('#user-name').html(currentUser+' ');
-	},
-	error: function(xhr, status, error) {
-	    //	$('#user-name').html("Hello, <b> Admin! </b>");
-	}
+  url: "api/commands/current-user",
+  type: "POST",
+  dataType: "json",
+  global: false, // dont show global loading indicator
+  success: function(data, status, xhr) {
+      var currentUser= data;
+      $('#user-name').css({textTransform: 'none'});
+      $('#user-name').html(currentUser+' ');
+  },
+  error: function(xhr, status, error) {
+      //  $('#user-name').html("Hello, <b> Admin! </b>");
+  }
     });
 
     var navbarTemplate = window.JST.common_navbar;
     $("#navbar-links").html(navbarTemplate({
-	logged_in: logged_in
+  logged_in: logged_in
 
     }));
 
@@ -334,14 +334,14 @@ function refreshNavbar() {
 function parseXhrError(xhr) {
     var msg = xhr.responseText;
     try {
-	msg = JSON.parse(msg).detail;
+  msg = JSON.parse(msg).detail;
     } catch(err) {
     }
     if (typeof(msg)=="string") {
-	try {
-	    msg = JSON.parse(msg);
-	} catch(err) {
-	}
+  try {
+      msg = JSON.parse(msg);
+  } catch(err) {
+  }
     }
     return msg;
 }
@@ -355,48 +355,48 @@ function getXhrErrorJson(xhr) {
 function setApplianceName() {
     var appliances = new ApplianceCollection();
     appliances.fetch({
-	success: function(request) {
-	    if (appliances.length > 0) {
-		RockStorGlobals.currentAppliance =
-		    appliances.find(function(appliance) {
-			return appliance.get('current_appliance') == true;
-		    });
-		$('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
-	    }
-	},
-	error: function(request, response) {
-	}
+  success: function(request) {
+      if (appliances.length > 0) {
+    RockStorGlobals.currentAppliance =
+        appliances.find(function(appliance) {
+      return appliance.get('current_appliance') == true;
+        });
+    $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
+      }
+  },
+  error: function(request, response) {
+  }
 
     });
 }
 
 function fetchDependencies(dependencies, callback, context) {
     if (dependencies.length == 0) {
-	if (callback) callback.apply(context);
+  if (callback) callback.apply(context);
     }
     var requestCount = dependencies.length;
     _.each(dependencies, function(dependency) {
-	dependency.fetch({
-	    success: function(request){
-		requestCount -= 1;
-		if (requestCount == 0) {
-		    if (callback) callback.apply(context);
-		}
-	    },
-	    error: function(request, response) {
-		requestCount -= 1;
-		if (requestCount == 0) {
-		    if (callback) callback.apply(context);
-		}
-	    }
-	});
+  dependency.fetch({
+      success: function(request){
+    requestCount -= 1;
+    if (requestCount == 0) {
+        if (callback) callback.apply(context);
+    }
+      },
+      error: function(request, response) {
+    requestCount -= 1;
+    if (requestCount == 0) {
+        if (callback) callback.apply(context);
+    }
+      }
+  });
     });
 }
 
 function checkBrowser() {
     var userAgent = navigator.userAgent;
     if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
-	$('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
+  $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
     }
     RockStorGlobals.browserChecked = true;
 }
@@ -423,32 +423,32 @@ probeStates = {
 
 var RockstorUtil = function() {
     var util = {
-	// maintain selected object list
-	// list is an array of contains models
+  // maintain selected object list
+  // list is an array of contains models
 
-	// does the list contain a model with attr 'name' with value 'value'
-	listContains: function(list, name, value) {
-	    return _.find(list, function(obj) {
-		return obj.get(name) == value;
-	    });
-	},
+  // does the list contain a model with attr 'name' with value 'value'
+  listContains: function(list, name, value) {
+      return _.find(list, function(obj) {
+    return obj.get(name) == value;
+      });
+  },
 
-	// add obj from collection with attr 'name' and value 'value' to list
-	addToList: function(list, collection, name, value) {
-	    list.push(collection.find(function(obj) {
-		return obj.get(name) == value;
-	    }));
-	},
+  // add obj from collection with attr 'name' and value 'value' to list
+  addToList: function(list, collection, name, value) {
+      list.push(collection.find(function(obj) {
+    return obj.get(name) == value;
+      }));
+  },
 
-	// remove obj with attr 'name' and value 'value'
-	removeFromList: function(list, name, value) {
-	    var i = _.indexOf(_.map(list, function(obj) {
-		return obj.get(name);
-	    }), value);
-	    if (i != -1) {
-		list.splice(i,1);
-	    }
-	}
+  // remove obj with attr 'name' and value 'value'
+  removeFromList: function(list, name, value) {
+      var i = _.indexOf(_.map(list, function(obj) {
+    return obj.get(name);
+      }), value);
+      if (i != -1) {
+    list.splice(i,1);
+      }
+  }
     };
     return util;
 }();
@@ -456,19 +456,19 @@ var RockstorUtil = function() {
 RockstorWizardPage = Backbone.View.extend({
 
     initialize: function() {
-	this.evAgg = this.options.evAgg;
-	this.parent = this.options.parent;
+  this.evAgg = this.options.evAgg;
+  this.parent = this.options.parent;
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    model: this.model
-	}));
-	return this;
+  $(this.el).html(this.template({
+      model: this.model
+  }));
+  return this;
     },
 
     save: function() {
-	return $.Deferred().resolve();
+  return $.Deferred().resolve();
     }
 });
 
@@ -476,108 +476,108 @@ WizardView = Backbone.View.extend({
     tagName: 'div',
 
     events: {
-	'click #next-page': 'nextPage',
-	'click #prev-page': 'prevPage'
+  'click #next-page': 'nextPage',
+  'click #prev-page': 'prevPage'
     },
 
     initialize: function() {
-	this.template = window.JST.wizard_wizard;
-	this.pages = null;
-	this.currentPage = null;
-	this.currentPageNum = -1;
-	this.contentEl = '#ph-wizard-contents';
-	this.evAgg = _.extend({}, Backbone.Events);
-	this.evAgg.bind('nextPage', this.nextPage, this);
-	this.evAgg.bind('prevPage', this.prevPage, this);
-	this.parent = this.options.parent;
-	this.title = this.options.title;
+  this.template = window.JST.wizard_wizard;
+  this.pages = null;
+  this.currentPage = null;
+  this.currentPageNum = -1;
+  this.contentEl = '#ph-wizard-contents';
+  this.evAgg = _.extend({}, Backbone.Events);
+  this.evAgg.bind('nextPage', this.nextPage, this);
+  this.evAgg.bind('prevPage', this.prevPage, this);
+  this.parent = this.options.parent;
+  this.title = this.options.title;
     },
 
     setPages: function(pages) {
-	this.pages = pages;
+  this.pages = pages;
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    title: this.title,
-	    model: this.model
-	}));
-	this.nextPage();
-	return this;
+  $(this.el).html(this.template({
+      title: this.title,
+      model: this.model
+  }));
+  this.nextPage();
+  return this;
     },
 
     nextPage: function() {
-	var _this = this;
-	var promise = !_.isNull(this.currentPage) ?
-		this.currentPage.save() :
-		$.Deferred().resolve();
-	promise.done(function(result, status, jqXHR) {
-	    _this.incrementPage();
-	});
-	promise.fail(function(jqXHR, status, error) {
-	    console.log(error);
-	});
+  var _this = this;
+  var promise = !_.isNull(this.currentPage) ?
+    this.currentPage.save() :
+    $.Deferred().resolve();
+  promise.done(function(result, status, jqXHR) {
+      _this.incrementPage();
+  });
+  promise.fail(function(jqXHR, status, error) {
+      console.log(error);
+  });
     },
 
     incrementPageNum: function() {
-	this.currentPageNum = this.currentPageNum + 1;
+  this.currentPageNum = this.currentPageNum + 1;
     },
 
     decrementPageNum: function() {
-	this.currentPageNum = this.currentPageNum - 1;
+  this.currentPageNum = this.currentPageNum - 1;
     },
 
     incrementPage: function() {
-	if (!this.lastPage()) {
-	    this.incrementPageNum();
-	    this.setCurrentPage();
-	    this.renderCurrentPage();
-	} else {
-	    this.finish();
-	}
+  if (!this.lastPage()) {
+      this.incrementPageNum();
+      this.setCurrentPage();
+      this.renderCurrentPage();
+  } else {
+      this.finish();
+  }
     },
 
     decrementPage: function() {
-	if (!this.firstPage()) {
-	    this.decrementPageNum();
-	    this.setCurrentPage();
-	    this.renderCurrentPage();
-	}
+  if (!this.firstPage()) {
+      this.decrementPageNum();
+      this.setCurrentPage();
+      this.renderCurrentPage();
+  }
     },
 
     setCurrentPage: function() {
-	this.currentPage = new this.pages[this.currentPageNum]({
-	    model: this.model,
-	    evAgg: this.evAgg
-	});
+  this.currentPage = new this.pages[this.currentPageNum]({
+      model: this.model,
+      evAgg: this.evAgg
+  });
     },
 
     renderCurrentPage: function() {
-	this.$(this.contentEl).html(this.currentPage.render().el);
-	this.modifyButtonText();
+  this.$(this.contentEl).html(this.currentPage.render().el);
+  this.modifyButtonText();
     },
 
     prevPage: function() {
-	this.decrementPage();
+  this.decrementPage();
     },
 
     modifyButtonText: function() {
-	if (this.lastPage()) {
-	    this.$('#next-page').html('Finish');
-	} else {
-	    this.$('#next-page').html('Next');
-	}
+  if (this.lastPage()) {
+      this.$('#next-page').html('Finish');
+  } else {
+      this.$('#next-page').html('Next');
+  }
     },
 
     firstPage: function() {
-	return (this.currentPageNum == 0);
+  return (this.currentPageNum == 0);
     },
 
     lastPage: function() {
-	return (this.currentPageNum == (this.pages.length - 1));
+  return (this.currentPageNum == (this.pages.length - 1));
     },
 
     finish: function() {
-	console.log('finish');
+  console.log('finish');
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -25,61 +25,50 @@
  */
 
 PaginationMixin = {
-
-    events: {
-        "click .go-to-page": "goToPage",
-        "click .prev-page": "prevPage",
-        "click .next-page": "nextPage"
-    },
-    goToPage: function(event) {
-        if (event) event.preventDefault();
-        this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
-    },
-    prevPage: function(event) {
-        if (event) event.preventDefault();
-        this.collection.prevPage();
-    },
-    nextPage: function(event) {
-        if (event) event.preventDefault();
-        this.collection.nextPage();
-    }
+  events: {
+	  "click .go-to-page": "goToPage",
+	  "click .prev-page": "prevPage",
+	  "click .next-page": "nextPage"
+  },
+  goToPage: function(event) {
+	  if (event) event.preventDefault();
+	  this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
+  },
+  prevPage: function(event) {
+	  if (event) event.preventDefault();
+	  this.collection.prevPage();
+  },
+  nextPage: function(event) {
+	  if (event) event.preventDefault();
+	  this.collection.nextPage();
+  }
 };
 
 RockstorLayoutView = Backbone.View.extend({
+  tagName: 'div',
+  className: 'layout',
 
-    tagName: 'div',
-    className: 'layout',
+  initialize: function() {
+	  this.subviews = {};
+	  this.dependencies = [];
+  },
 
-    initialize: function() {
-        this.subviews = {};
-        this.dependencies = [];
-    },
+  fetch: function(callback, context) {
+	  var allDependencies = [];
+	  _.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	  });
+	  $.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	  });
+  },
 
-    fetch: function(callback, context) {
-        var allDependencies = [];
-        _.each(this.dependencies, function(dep) {
-            allDependencies.push(dep.fetch({
-                silent: true
-            }));
-        });
-        $.when.apply($, allDependencies).done(function() {
-            if (callback) callback.apply(context);
-        });
-    },
-
-    renderDataTables: function() {
-        $('table.data-table').DataTable({
-            "iDisplayLength": 15,
-            "aLengthMenu": [
-                [15, 30, 45, -1],
-                [15, 30, 45, "All"]
-            ],
-        });
-    },
-
-    cleanup: function() {
-        $('#loading-indicator').css('visibility', 'hidden');
-    }
+  renderDataTables: function(){
+		$('table.data-table').DataTable({
+		  "iDisplayLength": 15,
+		  "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
+		});
+	},
 
 });
 
@@ -93,59 +82,52 @@ RockstorModuleView = Backbone.View.extend({
     requestCount: 0,
 
     initialize: function() {
-        this.subviews = {};
-        this.dependencies = [];
+	this.subviews = {};
+	this.dependencies = [];
     },
 
     fetch: function(callback, context) {
-        var allDependencies = [];
-        _.each(this.dependencies, function(dep) {
-            allDependencies.push(dep.fetch({
-                silent: true
-            }));
-        });
-        $.when.apply($, allDependencies).done(function() {
-            if (callback) callback.apply(context);
-        });
+	var allDependencies = [];
+	_.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	});
+	$.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	});
     },
 
     render: function() {
-        $(this.el).html(this.template({
-            module_name: this.module_name,
-            model: this.model,
-            collection: this.collection
-        }));
+	$(this.el).html(this.template({
+	    module_name: this.module_name,
+	    model: this.model,
+	    collection: this.collection
+	}));
 
-        return this;
-    },
-
-    cleanup: function() {
-        $('#loading-indicator').css('visibility', 'hidden');
+	return this;
     }
 });
 
 RockStorWidgetView = Backbone.View.extend({
-
     tagName: 'div',
     className: 'widget',
 
     events: {
-        'click .configure-widget': 'configure',
-        'click .resize-widget': 'resize',
-        'click .close-widget': 'close',
-        'click .download-widget': 'download'
+	'click .configure-widget': 'configure',
+	'click .resize-widget': 'resize',
+	'click .close-widget': 'close',
+	'click .download-widget': 'download'
     },
 
     initialize: function() {
-        this.maximized = this.options.maximized;
-        this.name = this.options.name;
-        this.displayName = this.options.displayName;
-        this.parentView = this.options.parentView;
-        this.dependencies = [];
+	this.maximized = this.options.maximized;
+	this.name = this.options.name;
+	this.displayName = this.options.displayName;
+	this.parentView = this.options.parentView;
+	this.dependencies = [];
     },
 
     render: function() {
-        $(this.el).attr('id', this.name + '_widget');
+	$(this.el).attr('id', this.name + '_widget');
     },
 
     configure: function(event) {
@@ -155,96 +137,93 @@ RockStorWidgetView = Backbone.View.extend({
     },
 
     resize: function(event) {
-        if (!_.isUndefined(event) && !_.isNull(event)) {
-            event.preventDefault();
-        }
-        var c = $(this.el).closest('div.widgets-container');
-        var w = $(this.el).closest('div.widget-ph'); // current widget
-        var widgetDef = RockStorWidgets.findByName(this.name);
-        if (!this.maximized) {
-            // Maximizing
-            // Remember current position
-            this.originalPosition = w.index();
-            // remove list item from current position
-            w.detach();
-            // insert at first position in the list
-            c.prepend(w);
-            // resize to max
-            w.attr('data-ss-colspan', widgetDef.maxCols);
-            w.attr('data-ss-rowspan', widgetDef.maxRows);
-            this.maximized = true;
-        } else {
-            // Restoring
-            w.detach();
-            w.attr('data-ss-colspan', widgetDef.cols);
-            w.attr('data-ss-rowspan', widgetDef.rows);
-            // find current list item at original index
-            if (_.isNull(this.originalPosition) ||
-                _.isUndefined(this.originalPosition)) {
-                this.originalPosition = 0;
-            }
-            curr_w = c.find("div.widget-ph:eq(" + this.originalPosition + ")");
-            // insert widget at original position
-            if (curr_w.length > 0) {
-                // if not last widget
-                curr_w.before(w);
-            } else {
-                c.append(w);
-            }
-            this.maximized = false;
-        }
-        // trigger rearrange so shapeshift can do its job
-        c.trigger('ss-rearrange');
-        this.parentView.saveWidgetConfiguration();
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+	var c = $(this.el).closest('div.widgets-container');
+	var w = $(this.el).closest('div.widget-ph'); // current widget
+	var widgetDef = RockStorWidgets.findByName(this.name);
+	if (!this.maximized) {
+	    // Maximizing
+	    // Remember current position
+	    this.originalPosition = w.index();
+	    // remove list item from current position
+	    w.detach();
+	    // insert at first position in the list
+	    c.prepend(w);
+	    // resize to max
+	    w.attr('data-ss-colspan',widgetDef.maxCols);
+	    w.attr('data-ss-rowspan',widgetDef.maxRows);
+	    this.maximized = true;
+	} else {
+	    // Restoring
+	    w.detach();
+	    w.attr('data-ss-colspan',widgetDef.cols);
+	    w.attr('data-ss-rowspan',widgetDef.rows);
+	    // find current list item at original index
+	    if (_.isNull(this.originalPosition) ||
+		_.isUndefined(this.originalPosition)) {
+		this.originalPosition = 0;
+	    }
+	    curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
+	    // insert widget at original position
+	    if (curr_w.length > 0) {
+		// if not last widget
+		curr_w.before(w);
+	    } else {
+		c.append(w);
+	    }
+	    this.maximized = false;
+	}
+	// trigger rearrange so shapeshift can do its job
+	c.trigger('ss-rearrange');
+	this.parentView.saveWidgetConfiguration();
     },
 
     close: function(event) {
-        if (!_.isUndefined(event) && !_.isNull(event)) {
-            event.preventDefault();
-        }
-        this.parentView.removeWidget(this.name, this);
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+	this.parentView.removeWidget(this.name, this);
     },
 
     download: function(event) {
-        if (!_.isUndefined(event) && !_.isNull(event)) {
-            event.preventDefault();
-        }
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
     },
 
     cleanup: function() {
-        logger.debug("In RockStorWidgetView close");
+	logger.debug("In RockStorWidgetView close");
     },
 
     fetch: function(callback, context) {
-        var allDependencies = [];
-        _.each(this.dependencies, function(dep) {
-            allDependencies.push(dep.fetch({
-                silent: true
-            }));
-        });
-        $.when.apply($, allDependencies).done(function() {
-            if (callback) callback.apply(context);
-        });
+	var allDependencies = [];
+	_.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	});
+	$.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	});
     }
 
 });
 
 
 function getCookie(name) {
-
-    var cookieValue = null;
-    if (document.cookie && document.cookie != '') {
-        var cookies = document.cookie.split(';');
-        for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
+	var cookieValue = null;
+	if (document.cookie && document.cookie != '') {
+		var cookies = document.cookie.split(';');
+		for (var i = 0; i < cookies.length; i++) {
+			var cookie = jQuery.trim(cookies[i]);
+			// Does this cookie string begin with the name we want?
+			if (cookie.substring(0, name.length + 1) == (name + '=')) {
+				cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+				break;
+			}
+		}
+	}
+	return cookieValue;
 }
 
 function csrfSafeMethod(method) {
@@ -253,20 +232,18 @@ function csrfSafeMethod(method) {
 }
 
 $.ajaxSetup({
-
     crossDomain: false, // obviates need for sameOrigin test
     beforeSend: function(xhr, settings) {
-        if (!csrfSafeMethod(settings.type)) {
-            var csrftoken = getCookie('csrftoken');
-            xhr.setRequestHeader("X-CSRFToken", csrftoken);
-        }
+	if (!csrfSafeMethod(settings.type)) {
+	    var csrftoken = getCookie('csrftoken');
+	    xhr.setRequestHeader("X-CSRFToken", csrftoken);
+	}
     }
 });
 
 function showApplianceList() {
-
     var applianceSelectPopup = $('#appliance-select-popup').modal({
-        show: false
+	show: false
     });
     $('#appliance-select-content').html((new AppliancesView()).render().el);
     $('#appliance-select-popup').modal('show');
@@ -275,14 +252,12 @@ function showApplianceList() {
 
 
 function showSuccessMessage(msg) {
-
     $('#messages').html(msg);
     $('#messages').css('visibility', 'visible');
 
 }
 
 function hideMessage() {
-
     $('#messages').html('&nbsp;');
     $('#messages').css('visibility', 'hidden');
 
@@ -291,72 +266,62 @@ function hideMessage() {
 /* Loading indicator */
 
 $(document).ajaxStart(function() {
-
     $('#loading-indicator').css('visibility', 'visible');
 });
 
 $(document).ajaxStop(function() {
-
     $('#loading-indicator').css('visibility', 'hidden');
 });
 
 
 function showLoadingIndicator(elementName, context) {
-
     var _this = context;
-    _this.$('#' + elementName).css('visibility', 'visible');
+    _this.$('#'+elementName).css('visibility', 'visible');
 }
 
 function hideLoadingIndicator(elementName, context) {
-
     var _this = context;
-    _this.$('#' + elementName).css('visibility', 'hidden');
+    _this.$('#'+elementName).css('visibility', 'hidden');
 }
 
 function disableButton(button) {
-
     button.data("executing", true);
     button.attr("disabled", true);
 }
 
 function enableButton(button) {
-
     button.data("executing", false);
     button.attr("disabled", false);
 }
 
 function buttonDisabled(button) {
-
     if (button.data("executing")) {
-        return true;
+	return true;
     } else {
-        return false;
+	return false;
     }
 }
 
 
 function refreshNavbar() {
-
     $.ajax({
-        url: "api/commands/current-user",
-        type: "POST",
-        dataType: "json",
-        global: false, // dont show global loading indicator
-        success: function(data, status, xhr) {
-            var currentUser = data;
-            $('#user-name').css({
-                textTransform: 'none'
-            });
-            $('#user-name').html(currentUser + ' ');
-        },
-        error: function(xhr, status, error) {
-            //$('#user-name').html("Hello, <b> Admin! </b>");
-        }
+	url: "api/commands/current-user",
+	type: "POST",
+	dataType: "json",
+	global: false, // dont show global loading indicator
+	success: function(data, status, xhr) {
+	    var currentUser= data;
+	    $('#user-name').css({textTransform: 'none'});
+	    $('#user-name').html(currentUser+' ');
+	},
+	error: function(xhr, status, error) {
+	    //	$('#user-name').html("Hello, <b> Admin! </b>");
+	}
     });
 
     var navbarTemplate = window.JST.common_navbar;
     $("#navbar-links").html(navbarTemplate({
-        logged_in: logged_in
+	logged_in: logged_in
 
     }));
 
@@ -367,75 +332,71 @@ function refreshNavbar() {
 // Returns the value of the detail attribute as json
 // or a string if it cannot be parsed as json
 function parseXhrError(xhr) {
-
     var msg = xhr.responseText;
     try {
-        msg = JSON.parse(msg).detail;
-    } catch (err) {}
-    if (typeof(msg) == "string") {
-        try {
-            msg = JSON.parse(msg);
-        } catch (err) {}
+	msg = JSON.parse(msg).detail;
+    } catch(err) {
+    }
+    if (typeof(msg)=="string") {
+	try {
+	    msg = JSON.parse(msg);
+	} catch(err) {
+	}
     }
     return msg;
 }
 
 function getXhrErrorJson(xhr) {
-
     var json = {};
-    try {
-        json = JSON.parse(xhr.responseText);
-    } catch (err) {}
+    try { json = JSON.parse(xhr.responseText); } catch(err) { }
     return json;
 }
 
 function setApplianceName() {
-
     var appliances = new ApplianceCollection();
     appliances.fetch({
-        success: function(request) {
-            if (appliances.length > 0) {
-                RockStorGlobals.currentAppliance =
-                    appliances.find(function(appliance) {
-                        return appliance.get('current_appliance') == true;
-                    });
-                $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
-            }
-        },
-        error: function(request, response) {}
+	success: function(request) {
+	    if (appliances.length > 0) {
+		RockStorGlobals.currentAppliance =
+		    appliances.find(function(appliance) {
+			return appliance.get('current_appliance') == true;
+		    });
+		$('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
+	    }
+	},
+	error: function(request, response) {
+	}
 
     });
 }
 
 function fetchDependencies(dependencies, callback, context) {
-
     if (dependencies.length == 0) {
-        if (callback) callback.apply(context);
+	if (callback) callback.apply(context);
     }
     var requestCount = dependencies.length;
     _.each(dependencies, function(dependency) {
-        dependency.fetch({
-            success: function(request) {
-                requestCount -= 1;
-                if (requestCount == 0) {
-                    if (callback) callback.apply(context);
-                }
-            },
-            error: function(request, response) {
-                requestCount -= 1;
-                if (requestCount == 0) {
-                    if (callback) callback.apply(context);
-                }
-            }
-        });
+	dependency.fetch({
+	    success: function(request){
+		requestCount -= 1;
+		if (requestCount == 0) {
+		    if (callback) callback.apply(context);
+		}
+	    },
+	    error: function(request, response) {
+		requestCount -= 1;
+		if (requestCount == 0) {
+		    if (callback) callback.apply(context);
+		}
+	    }
+	});
     });
 }
 
 function checkBrowser() {
-
     var userAgent = navigator.userAgent;
     if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
-        $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
+	$('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
     }
     RockStorGlobals.browserChecked = true;
 }
@@ -461,34 +422,33 @@ probeStates = {
 };
 
 var RockstorUtil = function() {
-
     var util = {
-        // maintain selected object list
-        // list is an array of contains models
+	// maintain selected object list
+	// list is an array of contains models
 
-        // does the list contain a model with attr 'name' with value 'value'
-        listContains: function(list, name, value) {
-            return _.find(list, function(obj) {
-                return obj.get(name) == value;
-            });
-        },
+	// does the list contain a model with attr 'name' with value 'value'
+	listContains: function(list, name, value) {
+	    return _.find(list, function(obj) {
+		return obj.get(name) == value;
+	    });
+	},
 
-        // add obj from collection with attr 'name' and value 'value' to list
-        addToList: function(list, collection, name, value) {
-            list.push(collection.find(function(obj) {
-                return obj.get(name) == value;
-            }));
-        },
+	// add obj from collection with attr 'name' and value 'value' to list
+	addToList: function(list, collection, name, value) {
+	    list.push(collection.find(function(obj) {
+		return obj.get(name) == value;
+	    }));
+	},
 
-        // remove obj with attr 'name' and value 'value'
-        removeFromList: function(list, name, value) {
-            var i = _.indexOf(_.map(list, function(obj) {
-                return obj.get(name);
-            }), value);
-            if (i != -1) {
-                list.splice(i, 1);
-            }
-        }
+	// remove obj with attr 'name' and value 'value'
+	removeFromList: function(list, name, value) {
+	    var i = _.indexOf(_.map(list, function(obj) {
+		return obj.get(name);
+	    }), value);
+	    if (i != -1) {
+		list.splice(i,1);
+	    }
+	}
     };
     return util;
 }();
@@ -496,137 +456,128 @@ var RockstorUtil = function() {
 RockstorWizardPage = Backbone.View.extend({
 
     initialize: function() {
-        this.evAgg = this.options.evAgg;
-        this.parent = this.options.parent;
+	this.evAgg = this.options.evAgg;
+	this.parent = this.options.parent;
     },
 
     render: function() {
-        $(this.el).html(this.template({
-            model: this.model
-        }));
-        return this;
+	$(this.el).html(this.template({
+	    model: this.model
+	}));
+	return this;
     },
 
     save: function() {
-        return $.Deferred().resolve();
-    },
-
-    cleanup: function() {
-        $('#loading-indicator').css('visibility', 'hidden');
+	return $.Deferred().resolve();
     }
 });
 
 WizardView = Backbone.View.extend({
-
     tagName: 'div',
 
     events: {
-        'click #next-page': 'nextPage',
-        'click #prev-page': 'prevPage'
+	'click #next-page': 'nextPage',
+	'click #prev-page': 'prevPage'
     },
 
     initialize: function() {
-        this.template = window.JST.wizard_wizard;
-        this.pages = null;
-        this.currentPage = null;
-        this.currentPageNum = -1;
-        this.contentEl = '#ph-wizard-contents';
-        this.evAgg = _.extend({}, Backbone.Events);
-        this.evAgg.bind('nextPage', this.nextPage, this);
-        this.evAgg.bind('prevPage', this.prevPage, this);
-        this.parent = this.options.parent;
-        this.title = this.options.title;
+	this.template = window.JST.wizard_wizard;
+	this.pages = null;
+	this.currentPage = null;
+	this.currentPageNum = -1;
+	this.contentEl = '#ph-wizard-contents';
+	this.evAgg = _.extend({}, Backbone.Events);
+	this.evAgg.bind('nextPage', this.nextPage, this);
+	this.evAgg.bind('prevPage', this.prevPage, this);
+	this.parent = this.options.parent;
+	this.title = this.options.title;
     },
 
     setPages: function(pages) {
-        this.pages = pages;
+	this.pages = pages;
     },
 
     render: function() {
-        $(this.el).html(this.template({
-            title: this.title,
-            model: this.model
-        }));
-        this.nextPage();
-        return this;
+	$(this.el).html(this.template({
+	    title: this.title,
+	    model: this.model
+	}));
+	this.nextPage();
+	return this;
     },
 
     nextPage: function() {
-        var _this = this;
-        var promise = !_.isNull(this.currentPage) ?
-            this.currentPage.save() :
-            $.Deferred().resolve();
-        promise.done(function(result, status, jqXHR) {
-            _this.incrementPage();
-        });
-        promise.fail(function(jqXHR, status, error) {
-            console.log(error);
-        });
+	var _this = this;
+	var promise = !_.isNull(this.currentPage) ?
+		this.currentPage.save() :
+		$.Deferred().resolve();
+	promise.done(function(result, status, jqXHR) {
+	    _this.incrementPage();
+	});
+	promise.fail(function(jqXHR, status, error) {
+	    console.log(error);
+	});
     },
 
     incrementPageNum: function() {
-        this.currentPageNum = this.currentPageNum + 1;
+	this.currentPageNum = this.currentPageNum + 1;
     },
 
     decrementPageNum: function() {
-        this.currentPageNum = this.currentPageNum - 1;
+	this.currentPageNum = this.currentPageNum - 1;
     },
 
     incrementPage: function() {
-        if (!this.lastPage()) {
-            this.incrementPageNum();
-            this.setCurrentPage();
-            this.renderCurrentPage();
-        } else {
-            this.finish();
-        }
+	if (!this.lastPage()) {
+	    this.incrementPageNum();
+	    this.setCurrentPage();
+	    this.renderCurrentPage();
+	} else {
+	    this.finish();
+	}
     },
 
     decrementPage: function() {
-        if (!this.firstPage()) {
-            this.decrementPageNum();
-            this.setCurrentPage();
-            this.renderCurrentPage();
-        }
+	if (!this.firstPage()) {
+	    this.decrementPageNum();
+	    this.setCurrentPage();
+	    this.renderCurrentPage();
+	}
     },
 
     setCurrentPage: function() {
-        this.currentPage = new this.pages[this.currentPageNum]({
-            model: this.model,
-            evAgg: this.evAgg
-        });
+	this.currentPage = new this.pages[this.currentPageNum]({
+	    model: this.model,
+	    evAgg: this.evAgg
+	});
     },
 
     renderCurrentPage: function() {
-        this.$(this.contentEl).html(this.currentPage.render().el);
-        this.modifyButtonText();
+	this.$(this.contentEl).html(this.currentPage.render().el);
+	this.modifyButtonText();
     },
 
     prevPage: function() {
-        this.decrementPage();
+	this.decrementPage();
     },
 
     modifyButtonText: function() {
-        if (this.lastPage()) {
-            this.$('#next-page').html('Finish');
-        } else {
-            this.$('#next-page').html('Next');
-        }
+	if (this.lastPage()) {
+	    this.$('#next-page').html('Finish');
+	} else {
+	    this.$('#next-page').html('Next');
+	}
     },
 
     firstPage: function() {
-        return (this.currentPageNum == 0);
+	return (this.currentPageNum == 0);
     },
 
     lastPage: function() {
-        return (this.currentPageNum == (this.pages.length - 1));
+	return (this.currentPageNum == (this.pages.length - 1));
     },
 
     finish: function() {
-        console.log('finish');
-    },
-
-    cleanup: function() {
-        $('#loading-indicator').css('visibility', 'hidden');
+	console.log('finish');
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -1,10 +1,9 @@
-
 /*
  *
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -27,21 +26,21 @@
 
 PaginationMixin = {
   events: {
-    "click .go-to-page": "goToPage",
-    "click .prev-page": "prevPage",
-    "click .next-page": "nextPage"
+	  "click .go-to-page": "goToPage",
+	  "click .prev-page": "prevPage",
+	  "click .next-page": "nextPage"
   },
   goToPage: function(event) {
-    if (event) event.preventDefault();
-    this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
+	  if (event) event.preventDefault();
+	  this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
   },
   prevPage: function(event) {
-    if (event) event.preventDefault();
-    this.collection.prevPage();
+	  if (event) event.preventDefault();
+	  this.collection.prevPage();
   },
   nextPage: function(event) {
-    if (event) event.preventDefault();
-    this.collection.nextPage();
+	  if (event) event.preventDefault();
+	  this.collection.nextPage();
   }
 };
 
@@ -50,26 +49,26 @@ RockstorLayoutView = Backbone.View.extend({
   className: 'layout',
 
   initialize: function() {
-    this.subviews = {};
-    this.dependencies = [];
+	  this.subviews = {};
+	  this.dependencies = [];
   },
 
   fetch: function(callback, context) {
-    var allDependencies = [];
-    _.each(this.dependencies, function(dep) {
-      allDependencies.push(dep.fetch({silent: true}));
-    });
-    $.when.apply($, allDependencies).done(function () {
-      if (callback) callback.apply(context);
-    });
+	  var allDependencies = [];
+	  _.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	  });
+	  $.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	  });
   },
 
   renderDataTables: function(){
-    $('table.data-table').DataTable({
-      "iDisplayLength": 15,
-      "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
-    });
-  },
+		$('table.data-table').DataTable({
+		  "iDisplayLength": 15,
+		  "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
+		});
+	},
 
 });
 
@@ -78,507 +77,507 @@ RockstorLayoutView = Backbone.View.extend({
 
 RockstorModuleView = Backbone.View.extend({
 
-  tagName: 'div',
-  className: 'module',
-  requestCount: 0,
+    tagName: 'div',
+    className: 'module',
+    requestCount: 0,
 
-  initialize: function() {
-    this.subviews = {};
-    this.dependencies = [];
-  },
+    initialize: function() {
+	this.subviews = {};
+	this.dependencies = [];
+    },
 
-  fetch: function(callback, context) {
-    var allDependencies = [];
-    _.each(this.dependencies, function(dep) {
-      allDependencies.push(dep.fetch({silent: true}));
-    });
-    $.when.apply($, allDependencies).done(function () {
-      if (callback) callback.apply(context);
-    });
-  },
+    fetch: function(callback, context) {
+	var allDependencies = [];
+	_.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	});
+	$.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	});
+    },
 
-  render: function() {
-    $(this.el).html(this.template({
-      module_name: this.module_name,
-      model: this.model,
-      collection: this.collection
-    }));
+    render: function() {
+	$(this.el).html(this.template({
+	    module_name: this.module_name,
+	    model: this.model,
+	    collection: this.collection
+	}));
 
-    return this;
-  }
+	return this;
+    }
 });
 
 RockStorWidgetView = Backbone.View.extend({
-  tagName: 'div',
-  className: 'widget',
+    tagName: 'div',
+    className: 'widget',
 
-  events: {
-    'click .configure-widget': 'configure',
-    'click .resize-widget': 'resize',
-    'click .close-widget': 'close',
-    'click .download-widget': 'download'
-  },
+    events: {
+	'click .configure-widget': 'configure',
+	'click .resize-widget': 'resize',
+	'click .close-widget': 'close',
+	'click .download-widget': 'download'
+    },
 
-  initialize: function() {
-    this.maximized = this.options.maximized;
-    this.name = this.options.name;
-    this.displayName = this.options.displayName;
-    this.parentView = this.options.parentView;
-    this.dependencies = [];
-  },
+    initialize: function() {
+	this.maximized = this.options.maximized;
+	this.name = this.options.name;
+	this.displayName = this.options.displayName;
+	this.parentView = this.options.parentView;
+	this.dependencies = [];
+    },
 
-  render: function() {
-    $(this.el).attr('id', this.name + '_widget');
-  },
+    render: function() {
+	$(this.el).attr('id', this.name + '_widget');
+    },
 
-  configure: function(event) {
-    if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
+    configure: function(event) {
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+    },
+
+    resize: function(event) {
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+	var c = $(this.el).closest('div.widgets-container');
+	var w = $(this.el).closest('div.widget-ph'); // current widget
+	var widgetDef = RockStorWidgets.findByName(this.name);
+	if (!this.maximized) {
+	    // Maximizing
+	    // Remember current position
+	    this.originalPosition = w.index();
+	    // remove list item from current position
+	    w.detach();
+	    // insert at first position in the list
+	    c.prepend(w);
+	    // resize to max
+	    w.attr('data-ss-colspan',widgetDef.maxCols);
+	    w.attr('data-ss-rowspan',widgetDef.maxRows);
+	    this.maximized = true;
+	} else {
+	    // Restoring
+	    w.detach();
+	    w.attr('data-ss-colspan',widgetDef.cols);
+	    w.attr('data-ss-rowspan',widgetDef.rows);
+	    // find current list item at original index
+	    if (_.isNull(this.originalPosition) ||
+		_.isUndefined(this.originalPosition)) {
+		this.originalPosition = 0;
+	    }
+	    curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
+	    // insert widget at original position
+	    if (curr_w.length > 0) {
+		// if not last widget
+		curr_w.before(w);
+	    } else {
+		c.append(w);
+	    }
+	    this.maximized = false;
+	}
+	// trigger rearrange so shapeshift can do its job
+	c.trigger('ss-rearrange');
+	this.parentView.saveWidgetConfiguration();
+    },
+
+    close: function(event) {
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+	this.parentView.removeWidget(this.name, this);
+    },
+
+    download: function(event) {
+	if (!_.isUndefined(event) && !_.isNull(event)) {
+	    event.preventDefault();
+	}
+    },
+
+    cleanup: function() {
+	logger.debug("In RockStorWidgetView close");
+    },
+
+    fetch: function(callback, context) {
+	var allDependencies = [];
+	_.each(this.dependencies, function(dep) {
+	    allDependencies.push(dep.fetch({silent: true}));
+	});
+	$.when.apply($, allDependencies).done(function () {
+	    if (callback) callback.apply(context);
+	});
     }
-  },
-
-  resize: function(event) {
-    if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
-    }
-    var c = $(this.el).closest('div.widgets-container');
-    var w = $(this.el).closest('div.widget-ph'); // current widget
-    var widgetDef = RockStorWidgets.findByName(this.name);
-    if (!this.maximized) {
-      // Maximizing
-      // Remember current position
-      this.originalPosition = w.index();
-      // remove list item from current position
-      w.detach();
-      // insert at first position in the list
-      c.prepend(w);
-      // resize to max
-      w.attr('data-ss-colspan',widgetDef.maxCols);
-      w.attr('data-ss-rowspan',widgetDef.maxRows);
-      this.maximized = true;
-    } else {
-      // Restoring
-      w.detach();
-      w.attr('data-ss-colspan',widgetDef.cols);
-      w.attr('data-ss-rowspan',widgetDef.rows);
-      // find current list item at original index
-      if (_.isNull(this.originalPosition) ||
-          _.isUndefined(this.originalPosition)) {
-            this.originalPosition = 0;
-      }
-      curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
-      // insert widget at original position
-      if (curr_w.length > 0) {
-        // if not last widget
-        curr_w.before(w);
-      } else {
-        c.append(w);
-      }
-      this.maximized = false;
-    }
-    // trigger rearrange so shapeshift can do its job
-    c.trigger('ss-rearrange');
-    this.parentView.saveWidgetConfiguration();
-  },
-
-  close: function(event) {
-    if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
-    }
-    this.parentView.removeWidget(this.name, this);
-  },
-
-  download: function(event) {
-    if (!_.isUndefined(event) && !_.isNull(event)) {
-      event.preventDefault();
-    }
-  },
-
-  cleanup: function() {
-    logger.debug("In RockStorWidgetView close");
-  },
-
-  fetch: function(callback, context) {
-    var allDependencies = [];
-    _.each(this.dependencies, function(dep) {
-      allDependencies.push(dep.fetch({silent: true}));
-    });
-    $.when.apply($, allDependencies).done(function () {
-      if (callback) callback.apply(context);
-    });
-  }
 
 });
 
 
 function getCookie(name) {
-  var cookieValue = null;
-  if (document.cookie && document.cookie != '') {
-    var cookies = document.cookie.split(';');
-    for (var i = 0; i < cookies.length; i++) {
-      var cookie = jQuery.trim(cookies[i]);
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, name.length + 1) == (name + '=')) {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
+	var cookieValue = null;
+	if (document.cookie && document.cookie != '') {
+		var cookies = document.cookie.split(';');
+		for (var i = 0; i < cookies.length; i++) {
+			var cookie = jQuery.trim(cookies[i]);
+			// Does this cookie string begin with the name we want?
+			if (cookie.substring(0, name.length + 1) == (name + '=')) {
+				cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+				break;
+			}
+		}
+	}
+	return cookieValue;
 }
 
 function csrfSafeMethod(method) {
-  // these HTTP methods do not require CSRF protection
-  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 
 $.ajaxSetup({
-  crossDomain: false, // obviates need for sameOrigin test
-  beforeSend: function(xhr, settings) {
-    if (!csrfSafeMethod(settings.type)) {
-      var csrftoken = getCookie('csrftoken');
-      xhr.setRequestHeader("X-CSRFToken", csrftoken);
+    crossDomain: false, // obviates need for sameOrigin test
+    beforeSend: function(xhr, settings) {
+	if (!csrfSafeMethod(settings.type)) {
+	    var csrftoken = getCookie('csrftoken');
+	    xhr.setRequestHeader("X-CSRFToken", csrftoken);
+	}
     }
-  }
 });
 
 function showApplianceList() {
-  var applianceSelectPopup = $('#appliance-select-popup').modal({
-    show: false
-  });
-  $('#appliance-select-content').html((new AppliancesView()).render().el);
-  $('#appliance-select-popup').modal('show');
+    var applianceSelectPopup = $('#appliance-select-popup').modal({
+	show: false
+    });
+    $('#appliance-select-content').html((new AppliancesView()).render().el);
+    $('#appliance-select-popup').modal('show');
 
 }
 
 
 function showSuccessMessage(msg) {
-  $('#messages').html(msg);
-  $('#messages').css('visibility', 'visible');
+    $('#messages').html(msg);
+    $('#messages').css('visibility', 'visible');
 
 }
 
 function hideMessage() {
-  $('#messages').html('&nbsp;');
-  $('#messages').css('visibility', 'hidden');
+    $('#messages').html('&nbsp;');
+    $('#messages').css('visibility', 'hidden');
 
 }
 
 /* Loading indicator */
 
 $(document).ajaxStart(function() {
-  $('#loading-indicator').css('visibility', 'visible');
+    $('#loading-indicator').css('visibility', 'visible');
 });
 
 $(document).ajaxStop(function() {
-  $('#loading-indicator').css('visibility', 'hidden');
+    $('#loading-indicator').css('visibility', 'hidden');
 });
 
 
 function showLoadingIndicator(elementName, context) {
-  var _this = context;
-  _this.$('#'+elementName).css('visibility', 'visible');
+    var _this = context;
+    _this.$('#'+elementName).css('visibility', 'visible');
 }
 
 function hideLoadingIndicator(elementName, context) {
-  var _this = context;
-  _this.$('#'+elementName).css('visibility', 'hidden');
+    var _this = context;
+    _this.$('#'+elementName).css('visibility', 'hidden');
 }
 
 function disableButton(button) {
-  button.data("executing", true);
-  button.attr("disabled", true);
+    button.data("executing", true);
+    button.attr("disabled", true);
 }
 
 function enableButton(button) {
-  button.data("executing", false);
-  button.attr("disabled", false);
+    button.data("executing", false);
+    button.attr("disabled", false);
 }
 
 function buttonDisabled(button) {
-  if (button.data("executing")) {
-    return true;
-  } else {
-    return false;
-  }
+    if (button.data("executing")) {
+	return true;
+    } else {
+	return false;
+    }
 }
 
 
 function refreshNavbar() {
-  $.ajax({
-    url: "api/commands/current-user",
-    type: "POST",
-    dataType: "json",
-    global: false, // dont show global loading indicator
-    success: function(data, status, xhr) {
-      var currentUser= data;
-      $('#user-name').css({textTransform: 'none'});
-      $('#user-name').html(currentUser+' ');
-    },
-    error: function(xhr, status, error) {
-      //  $('#user-name').html("Hello, <b> Admin! </b>");
-    }
-  });
+    $.ajax({
+	url: "api/commands/current-user",
+	type: "POST",
+	dataType: "json",
+	global: false, // dont show global loading indicator
+	success: function(data, status, xhr) {
+	    var currentUser= data;
+	    $('#user-name').css({textTransform: 'none'});
+	    $('#user-name').html(currentUser+' ');
+	},
+	error: function(xhr, status, error) {
+	    //	$('#user-name').html("Hello, <b> Admin! </b>");
+	}
+    });
 
-  var navbarTemplate = window.JST.common_navbar;
-  $("#navbar-links").html(navbarTemplate({
-    logged_in: logged_in
+    var navbarTemplate = window.JST.common_navbar;
+    $("#navbar-links").html(navbarTemplate({
+	logged_in: logged_in
 
-  }));
+    }));
 
-  $('.dropdown-toggle').dropdown();
+    $('.dropdown-toggle').dropdown();
 }
 
 // Parses error message from ajax request
 // Returns the value of the detail attribute as json
 // or a string if it cannot be parsed as json
 function parseXhrError(xhr) {
-  var msg = xhr.responseText;
-  try {
-    msg = JSON.parse(msg).detail;
-  } catch(err) {
-  }
-  if (typeof(msg)=="string") {
+    var msg = xhr.responseText;
     try {
-      msg = JSON.parse(msg);
+	msg = JSON.parse(msg).detail;
     } catch(err) {
     }
-  }
-  return msg;
+    if (typeof(msg)=="string") {
+	try {
+	    msg = JSON.parse(msg);
+	} catch(err) {
+	}
+    }
+    return msg;
 }
 
 function getXhrErrorJson(xhr) {
-  var json = {};
-  try { json = JSON.parse(xhr.responseText); } catch(err) { }
-  return json;
+    var json = {};
+    try { json = JSON.parse(xhr.responseText); } catch(err) { }
+    return json;
 }
 
 function setApplianceName() {
-  var appliances = new ApplianceCollection();
-  appliances.fetch({
-    success: function(request) {
-      if (appliances.length > 0) {
-        RockStorGlobals.currentAppliance =
-        appliances.find(function(appliance) {
-          return appliance.get('current_appliance') == true;
-        });
-        $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
-      }
-    },
-    error: function(request, response) {
-    }
+    var appliances = new ApplianceCollection();
+    appliances.fetch({
+	success: function(request) {
+	    if (appliances.length > 0) {
+		RockStorGlobals.currentAppliance =
+		    appliances.find(function(appliance) {
+			return appliance.get('current_appliance') == true;
+		    });
+		$('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
+	    }
+	},
+	error: function(request, response) {
+	}
 
-  });
+    });
 }
 
 function fetchDependencies(dependencies, callback, context) {
-  if (dependencies.length == 0) {
-    if (callback) callback.apply(context);
-  }
-  var requestCount = dependencies.length;
-  _.each(dependencies, function(dependency) {
-    dependency.fetch({
-      success: function(request){
-        requestCount -= 1;
-        if (requestCount == 0) {
-          if (callback) callback.apply(context);
-        }
-      },
-      error: function(request, response) {
-        requestCount -= 1;
-        if (requestCount == 0) {
-          if (callback) callback.apply(context);
-        }
-      }
+    if (dependencies.length == 0) {
+	if (callback) callback.apply(context);
+    }
+    var requestCount = dependencies.length;
+    _.each(dependencies, function(dependency) {
+	dependency.fetch({
+	    success: function(request){
+		requestCount -= 1;
+		if (requestCount == 0) {
+		    if (callback) callback.apply(context);
+		}
+	    },
+	    error: function(request, response) {
+		requestCount -= 1;
+		if (requestCount == 0) {
+		    if (callback) callback.apply(context);
+		}
+	    }
+	});
     });
-  });
 }
 
 function checkBrowser() {
-  var userAgent = navigator.userAgent;
-  if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
-    $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
-  }
-  RockStorGlobals.browserChecked = true;
+    var userAgent = navigator.userAgent;
+    if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
+	$('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
+    }
+    RockStorGlobals.browserChecked = true;
 }
 
 RockStorProbeMap = [];
 RockStorGlobals = {
-  navbarLoaded: false,
-  applianceNameSet: false,
-  currentAppliance: null,
-  maxPageSize: 5000,
-  browserChecked: false,
-  kernel: null
+    navbarLoaded: false,
+    applianceNameSet: false,
+    currentAppliance: null,
+    maxPageSize: 5000,
+    browserChecked: false,
+    kernel: null
 }
 
 var RS_DATE_FORMAT = 'MMMM Do YYYY, h:mm:ss a';
 
 // Constants
 probeStates = {
-  STOPPED: 'stopped',
-  CREATED: 'created',
-  RUNNING: 'running',
-  ERROR: 'error'
+    STOPPED: 'stopped',
+    CREATED: 'created',
+    RUNNING: 'running',
+    ERROR: 'error'
 };
 
 var RockstorUtil = function() {
-  var util = {
-    // maintain selected object list
-    // list is an array of contains models
+    var util = {
+	// maintain selected object list
+	// list is an array of contains models
 
-    // does the list contain a model with attr 'name' with value 'value'
-    listContains: function(list, name, value) {
-      return _.find(list, function(obj) {
-        return obj.get(name) == value;
-      });
-    },
+	// does the list contain a model with attr 'name' with value 'value'
+	listContains: function(list, name, value) {
+	    return _.find(list, function(obj) {
+		return obj.get(name) == value;
+	    });
+	},
 
-    // add obj from collection with attr 'name' and value 'value' to list
-    addToList: function(list, collection, name, value) {
-      list.push(collection.find(function(obj) {
-        return obj.get(name) == value;
-      }));
-    },
+	// add obj from collection with attr 'name' and value 'value' to list
+	addToList: function(list, collection, name, value) {
+	    list.push(collection.find(function(obj) {
+		return obj.get(name) == value;
+	    }));
+	},
 
-    // remove obj with attr 'name' and value 'value'
-    removeFromList: function(list, name, value) {
-      var i = _.indexOf(_.map(list, function(obj) {
-        return obj.get(name);
-      }), value);
-      if (i != -1) {
-        list.splice(i,1);
-      }
-    }
-  };
-  return util;
+	// remove obj with attr 'name' and value 'value'
+	removeFromList: function(list, name, value) {
+	    var i = _.indexOf(_.map(list, function(obj) {
+		return obj.get(name);
+	    }), value);
+	    if (i != -1) {
+		list.splice(i,1);
+	    }
+	}
+    };
+    return util;
 }();
 
 RockstorWizardPage = Backbone.View.extend({
 
-  initialize: function() {
-    this.evAgg = this.options.evAgg;
-    this.parent = this.options.parent;
-  },
+    initialize: function() {
+	this.evAgg = this.options.evAgg;
+	this.parent = this.options.parent;
+    },
 
-  render: function() {
-    $(this.el).html(this.template({
-      model: this.model
-    }));
-    return this;
-  },
+    render: function() {
+	$(this.el).html(this.template({
+	    model: this.model
+	}));
+	return this;
+    },
 
-  save: function() {
-    return $.Deferred().resolve();
-  }
+    save: function() {
+	return $.Deferred().resolve();
+    }
 });
 
 WizardView = Backbone.View.extend({
-  tagName: 'div',
+    tagName: 'div',
 
-  events: {
-    'click #next-page': 'nextPage',
-    'click #prev-page': 'prevPage'
-  },
+    events: {
+	'click #next-page': 'nextPage',
+	'click #prev-page': 'prevPage'
+    },
 
-  initialize: function() {
-    this.template = window.JST.wizard_wizard;
-    this.pages = null;
-    this.currentPage = null;
-    this.currentPageNum = -1;
-    this.contentEl = '#ph-wizard-contents';
-    this.evAgg = _.extend({}, Backbone.Events);
-    this.evAgg.bind('nextPage', this.nextPage, this);
-    this.evAgg.bind('prevPage', this.prevPage, this);
-    this.parent = this.options.parent;
-    this.title = this.options.title;
-  },
+    initialize: function() {
+	this.template = window.JST.wizard_wizard;
+	this.pages = null;
+	this.currentPage = null;
+	this.currentPageNum = -1;
+	this.contentEl = '#ph-wizard-contents';
+	this.evAgg = _.extend({}, Backbone.Events);
+	this.evAgg.bind('nextPage', this.nextPage, this);
+	this.evAgg.bind('prevPage', this.prevPage, this);
+	this.parent = this.options.parent;
+	this.title = this.options.title;
+    },
 
-  setPages: function(pages) {
-    this.pages = pages;
-  },
+    setPages: function(pages) {
+	this.pages = pages;
+    },
 
-  render: function() {
-    $(this.el).html(this.template({
-      title: this.title,
-      model: this.model
-    }));
-    this.nextPage();
-    return this;
-  },
+    render: function() {
+	$(this.el).html(this.template({
+	    title: this.title,
+	    model: this.model
+	}));
+	this.nextPage();
+	return this;
+    },
 
-  nextPage: function() {
-    var _this = this;
-    var promise = !_.isNull(this.currentPage) ?
-                  this.currentPage.save() :
-                  $.Deferred().resolve();
-    promise.done(function(result, status, jqXHR) {
-      _this.incrementPage();
-    });
-    promise.fail(function(jqXHR, status, error) {
-      console.log(error);
-    });
-  },
+    nextPage: function() {
+	var _this = this;
+	var promise = !_.isNull(this.currentPage) ?
+		this.currentPage.save() :
+		$.Deferred().resolve();
+	promise.done(function(result, status, jqXHR) {
+	    _this.incrementPage();
+	});
+	promise.fail(function(jqXHR, status, error) {
+	    console.log(error);
+	});
+    },
 
-  incrementPageNum: function() {
-    this.currentPageNum = this.currentPageNum + 1;
-  },
+    incrementPageNum: function() {
+	this.currentPageNum = this.currentPageNum + 1;
+    },
 
-  decrementPageNum: function() {
-    this.currentPageNum = this.currentPageNum - 1;
-  },
+    decrementPageNum: function() {
+	this.currentPageNum = this.currentPageNum - 1;
+    },
 
-  incrementPage: function() {
-    if (!this.lastPage()) {
-      this.incrementPageNum();
-      this.setCurrentPage();
-      this.renderCurrentPage();
-    } else {
-      this.finish();
+    incrementPage: function() {
+	if (!this.lastPage()) {
+	    this.incrementPageNum();
+	    this.setCurrentPage();
+	    this.renderCurrentPage();
+	} else {
+	    this.finish();
+	}
+    },
+
+    decrementPage: function() {
+	if (!this.firstPage()) {
+	    this.decrementPageNum();
+	    this.setCurrentPage();
+	    this.renderCurrentPage();
+	}
+    },
+
+    setCurrentPage: function() {
+	this.currentPage = new this.pages[this.currentPageNum]({
+	    model: this.model,
+	    evAgg: this.evAgg
+	});
+    },
+
+    renderCurrentPage: function() {
+	this.$(this.contentEl).html(this.currentPage.render().el);
+	this.modifyButtonText();
+    },
+
+    prevPage: function() {
+	this.decrementPage();
+    },
+
+    modifyButtonText: function() {
+	if (this.lastPage()) {
+	    this.$('#next-page').html('Finish');
+	} else {
+	    this.$('#next-page').html('Next');
+	}
+    },
+
+    firstPage: function() {
+	return (this.currentPageNum == 0);
+    },
+
+    lastPage: function() {
+	return (this.currentPageNum == (this.pages.length - 1));
+    },
+
+    finish: function() {
+	console.log('finish');
     }
-  },
-
-  decrementPage: function() {
-    if (!this.firstPage()) {
-      this.decrementPageNum();
-      this.setCurrentPage();
-      this.renderCurrentPage();
-    }
-  },
-
-  setCurrentPage: function() {
-    this.currentPage = new this.pages[this.currentPageNum]({
-      model: this.model,
-      evAgg: this.evAgg
-    });
-  },
-
-  renderCurrentPage: function() {
-    this.$(this.contentEl).html(this.currentPage.render().el);
-    this.modifyButtonText();
-  },
-
-  prevPage: function() {
-    this.decrementPage();
-  },
-
-  modifyButtonText: function() {
-    if (this.lastPage()) {
-      this.$('#next-page').html('Finish');
-    } else {
-      this.$('#next-page').html('Next');
-    }
-  },
-
-  firstPage: function() {
-    return (this.currentPageNum == 0);
-  },
-
-  lastPage: function() {
-    return (this.currentPageNum == (this.pages.length - 1));
-  },
-
-  finish: function() {
-    console.log('finish');
-  }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -26,21 +26,21 @@
 
 PaginationMixin = {
   events: {
-	  "click .go-to-page": "goToPage",
-	  "click .prev-page": "prevPage",
-	  "click .next-page": "nextPage"
+    "click .go-to-page": "goToPage",
+    "click .prev-page": "prevPage",
+    "click .next-page": "nextPage"
   },
   goToPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
+    if (event) event.preventDefault();
+    this.collection.goToPage(parseInt($(event.currentTarget).attr("data-page")));
   },
   prevPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.prevPage();
+    if (event) event.preventDefault();
+    this.collection.prevPage();
   },
   nextPage: function(event) {
-	  if (event) event.preventDefault();
-	  this.collection.nextPage();
+    if (event) event.preventDefault();
+    this.collection.nextPage();
   }
 };
 
@@ -49,26 +49,26 @@ RockstorLayoutView = Backbone.View.extend({
   className: 'layout',
 
   initialize: function() {
-	  this.subviews = {};
-	  this.dependencies = [];
+    this.subviews = {};
+    this.dependencies = [];
   },
 
   fetch: function(callback, context) {
-	  var allDependencies = [];
-	  _.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	  });
-	  $.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	  });
+    var allDependencies = [];
+    _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+    });
+    $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+    });
   },
 
   renderDataTables: function(){
-		$('table.data-table').DataTable({
-		  "iDisplayLength": 15,
-		  "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
-		});
-	},
+    $('table.data-table').DataTable({
+      "iDisplayLength": 15,
+      "aLengthMenu": [[15, 30, 45, -1], [15, 30, 45, "All"]],
+    });
+  },
 
 });
 
@@ -82,28 +82,28 @@ RockstorModuleView = Backbone.View.extend({
     requestCount: 0,
 
     initialize: function() {
-	this.subviews = {};
-	this.dependencies = [];
+  this.subviews = {};
+  this.dependencies = [];
     },
 
     fetch: function(callback, context) {
-	var allDependencies = [];
-	_.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	});
-	$.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	});
+  var allDependencies = [];
+  _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+  });
+  $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+  });
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    module_name: this.module_name,
-	    model: this.model,
-	    collection: this.collection
-	}));
+  $(this.el).html(this.template({
+      module_name: this.module_name,
+      model: this.model,
+      collection: this.collection
+  }));
 
-	return this;
+  return this;
     }
 });
 
@@ -112,118 +112,118 @@ RockStorWidgetView = Backbone.View.extend({
     className: 'widget',
 
     events: {
-	'click .configure-widget': 'configure',
-	'click .resize-widget': 'resize',
-	'click .close-widget': 'close',
-	'click .download-widget': 'download'
+  'click .configure-widget': 'configure',
+  'click .resize-widget': 'resize',
+  'click .close-widget': 'close',
+  'click .download-widget': 'download'
     },
 
     initialize: function() {
-	this.maximized = this.options.maximized;
-	this.name = this.options.name;
-	this.displayName = this.options.displayName;
-	this.parentView = this.options.parentView;
-	this.dependencies = [];
+  this.maximized = this.options.maximized;
+  this.name = this.options.name;
+  this.displayName = this.options.displayName;
+  this.parentView = this.options.parentView;
+  this.dependencies = [];
     },
 
     render: function() {
-	$(this.el).attr('id', this.name + '_widget');
+  $(this.el).attr('id', this.name + '_widget');
     },
 
     configure: function(event) {
-        if (!_.isUndefined(event) && !_.isNull(event)) {
-            event.preventDefault();
-        }
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
     },
 
     resize: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
-	var c = $(this.el).closest('div.widgets-container');
-	var w = $(this.el).closest('div.widget-ph'); // current widget
-	var widgetDef = RockStorWidgets.findByName(this.name);
-	if (!this.maximized) {
-	    // Maximizing
-	    // Remember current position
-	    this.originalPosition = w.index();
-	    // remove list item from current position
-	    w.detach();
-	    // insert at first position in the list
-	    c.prepend(w);
-	    // resize to max
-	    w.attr('data-ss-colspan',widgetDef.maxCols);
-	    w.attr('data-ss-rowspan',widgetDef.maxRows);
-	    this.maximized = true;
-	} else {
-	    // Restoring
-	    w.detach();
-	    w.attr('data-ss-colspan',widgetDef.cols);
-	    w.attr('data-ss-rowspan',widgetDef.rows);
-	    // find current list item at original index
-	    if (_.isNull(this.originalPosition) ||
-		_.isUndefined(this.originalPosition)) {
-		this.originalPosition = 0;
-	    }
-	    curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
-	    // insert widget at original position
-	    if (curr_w.length > 0) {
-		// if not last widget
-		curr_w.before(w);
-	    } else {
-		c.append(w);
-	    }
-	    this.maximized = false;
-	}
-	// trigger rearrange so shapeshift can do its job
-	c.trigger('ss-rearrange');
-	this.parentView.saveWidgetConfiguration();
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
+  var c = $(this.el).closest('div.widgets-container');
+  var w = $(this.el).closest('div.widget-ph'); // current widget
+  var widgetDef = RockStorWidgets.findByName(this.name);
+  if (!this.maximized) {
+      // Maximizing
+      // Remember current position
+      this.originalPosition = w.index();
+      // remove list item from current position
+      w.detach();
+      // insert at first position in the list
+      c.prepend(w);
+      // resize to max
+      w.attr('data-ss-colspan',widgetDef.maxCols);
+      w.attr('data-ss-rowspan',widgetDef.maxRows);
+      this.maximized = true;
+  } else {
+      // Restoring
+      w.detach();
+      w.attr('data-ss-colspan',widgetDef.cols);
+      w.attr('data-ss-rowspan',widgetDef.rows);
+      // find current list item at original index
+      if (_.isNull(this.originalPosition) ||
+    _.isUndefined(this.originalPosition)) {
+    this.originalPosition = 0;
+      }
+      curr_w = c.find("div.widget-ph:eq("+this.originalPosition+")");
+      // insert widget at original position
+      if (curr_w.length > 0) {
+    // if not last widget
+    curr_w.before(w);
+      } else {
+    c.append(w);
+      }
+      this.maximized = false;
+  }
+  // trigger rearrange so shapeshift can do its job
+  c.trigger('ss-rearrange');
+  this.parentView.saveWidgetConfiguration();
     },
 
     close: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
-	this.parentView.removeWidget(this.name, this);
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
+  this.parentView.removeWidget(this.name, this);
     },
 
     download: function(event) {
-	if (!_.isUndefined(event) && !_.isNull(event)) {
-	    event.preventDefault();
-	}
+  if (!_.isUndefined(event) && !_.isNull(event)) {
+      event.preventDefault();
+  }
     },
 
     cleanup: function() {
-	logger.debug("In RockStorWidgetView close");
+  logger.debug("In RockStorWidgetView close");
     },
 
     fetch: function(callback, context) {
-	var allDependencies = [];
-	_.each(this.dependencies, function(dep) {
-	    allDependencies.push(dep.fetch({silent: true}));
-	});
-	$.when.apply($, allDependencies).done(function () {
-	    if (callback) callback.apply(context);
-	});
+  var allDependencies = [];
+  _.each(this.dependencies, function(dep) {
+      allDependencies.push(dep.fetch({silent: true}));
+  });
+  $.when.apply($, allDependencies).done(function () {
+      if (callback) callback.apply(context);
+  });
     }
 
 });
 
 
 function getCookie(name) {
-	var cookieValue = null;
-	if (document.cookie && document.cookie != '') {
-		var cookies = document.cookie.split(';');
-		for (var i = 0; i < cookies.length; i++) {
-			var cookie = jQuery.trim(cookies[i]);
-			// Does this cookie string begin with the name we want?
-			if (cookie.substring(0, name.length + 1) == (name + '=')) {
-				cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-				break;
-			}
-		}
-	}
-	return cookieValue;
+  var cookieValue = null;
+  if (document.cookie && document.cookie != '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) == (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
 }
 
 function csrfSafeMethod(method) {
@@ -234,16 +234,16 @@ function csrfSafeMethod(method) {
 $.ajaxSetup({
     crossDomain: false, // obviates need for sameOrigin test
     beforeSend: function(xhr, settings) {
-	if (!csrfSafeMethod(settings.type)) {
-	    var csrftoken = getCookie('csrftoken');
-	    xhr.setRequestHeader("X-CSRFToken", csrftoken);
-	}
+  if (!csrfSafeMethod(settings.type)) {
+      var csrftoken = getCookie('csrftoken');
+      xhr.setRequestHeader("X-CSRFToken", csrftoken);
+  }
     }
 });
 
 function showApplianceList() {
     var applianceSelectPopup = $('#appliance-select-popup').modal({
-	show: false
+  show: false
     });
     $('#appliance-select-content').html((new AppliancesView()).render().el);
     $('#appliance-select-popup').modal('show');
@@ -296,32 +296,32 @@ function enableButton(button) {
 
 function buttonDisabled(button) {
     if (button.data("executing")) {
-	return true;
+  return true;
     } else {
-	return false;
+  return false;
     }
 }
 
 
 function refreshNavbar() {
     $.ajax({
-	url: "api/commands/current-user",
-	type: "POST",
-	dataType: "json",
-	global: false, // dont show global loading indicator
-	success: function(data, status, xhr) {
-	    var currentUser= data;
-	    $('#user-name').css({textTransform: 'none'});
-	    $('#user-name').html(currentUser+' ');
-	},
-	error: function(xhr, status, error) {
-	    //	$('#user-name').html("Hello, <b> Admin! </b>");
-	}
+  url: "api/commands/current-user",
+  type: "POST",
+  dataType: "json",
+  global: false, // dont show global loading indicator
+  success: function(data, status, xhr) {
+      var currentUser= data;
+      $('#user-name').css({textTransform: 'none'});
+      $('#user-name').html(currentUser+' ');
+  },
+  error: function(xhr, status, error) {
+      //  $('#user-name').html("Hello, <b> Admin! </b>");
+  }
     });
 
     var navbarTemplate = window.JST.common_navbar;
     $("#navbar-links").html(navbarTemplate({
-	logged_in: logged_in
+  logged_in: logged_in
 
     }));
 
@@ -334,14 +334,14 @@ function refreshNavbar() {
 function parseXhrError(xhr) {
     var msg = xhr.responseText;
     try {
-	msg = JSON.parse(msg).detail;
+  msg = JSON.parse(msg).detail;
     } catch(err) {
     }
     if (typeof(msg)=="string") {
-	try {
-	    msg = JSON.parse(msg);
-	} catch(err) {
-	}
+  try {
+      msg = JSON.parse(msg);
+  } catch(err) {
+  }
     }
     return msg;
 }
@@ -355,48 +355,48 @@ function getXhrErrorJson(xhr) {
 function setApplianceName() {
     var appliances = new ApplianceCollection();
     appliances.fetch({
-	success: function(request) {
-	    if (appliances.length > 0) {
-		RockStorGlobals.currentAppliance =
-		    appliances.find(function(appliance) {
-			return appliance.get('current_appliance') == true;
-		    });
-		$('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
-	    }
-	},
-	error: function(request, response) {
-	}
+  success: function(request) {
+      if (appliances.length > 0) {
+    RockStorGlobals.currentAppliance =
+        appliances.find(function(appliance) {
+      return appliance.get('current_appliance') == true;
+        });
+    $('#appliance-name').html('<i class="fa fa-desktop fa-inverse"></i>&nbsp;Hostname: ' + RockStorGlobals.currentAppliance.get('hostname') + '&nbsp;&nbsp;&nbsp;&nbsp;Mgmt IP: ' + RockStorGlobals.currentAppliance.get('ip'));
+      }
+  },
+  error: function(request, response) {
+  }
 
     });
 }
 
 function fetchDependencies(dependencies, callback, context) {
     if (dependencies.length == 0) {
-	if (callback) callback.apply(context);
+  if (callback) callback.apply(context);
     }
     var requestCount = dependencies.length;
     _.each(dependencies, function(dependency) {
-	dependency.fetch({
-	    success: function(request){
-		requestCount -= 1;
-		if (requestCount == 0) {
-		    if (callback) callback.apply(context);
-		}
-	    },
-	    error: function(request, response) {
-		requestCount -= 1;
-		if (requestCount == 0) {
-		    if (callback) callback.apply(context);
-		}
-	    }
-	});
+  dependency.fetch({
+      success: function(request){
+    requestCount -= 1;
+    if (requestCount == 0) {
+        if (callback) callback.apply(context);
+    }
+      },
+      error: function(request, response) {
+    requestCount -= 1;
+    if (requestCount == 0) {
+        if (callback) callback.apply(context);
+    }
+      }
+  });
     });
 }
 
 function checkBrowser() {
     var userAgent = navigator.userAgent;
     if (!/firefox/i.test(userAgent) && !/chrome/i.test(userAgent)) {
-	$('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
+  $('#browsermsg').html('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button>The RockStor WebUI is supported only on Firefox or Chrome. Some features may not work correctly.</div>');
     }
     RockStorGlobals.browserChecked = true;
 }
@@ -423,32 +423,32 @@ probeStates = {
 
 var RockstorUtil = function() {
     var util = {
-	// maintain selected object list
-	// list is an array of contains models
+  // maintain selected object list
+  // list is an array of contains models
 
-	// does the list contain a model with attr 'name' with value 'value'
-	listContains: function(list, name, value) {
-	    return _.find(list, function(obj) {
-		return obj.get(name) == value;
-	    });
-	},
+  // does the list contain a model with attr 'name' with value 'value'
+  listContains: function(list, name, value) {
+      return _.find(list, function(obj) {
+    return obj.get(name) == value;
+      });
+  },
 
-	// add obj from collection with attr 'name' and value 'value' to list
-	addToList: function(list, collection, name, value) {
-	    list.push(collection.find(function(obj) {
-		return obj.get(name) == value;
-	    }));
-	},
+  // add obj from collection with attr 'name' and value 'value' to list
+  addToList: function(list, collection, name, value) {
+      list.push(collection.find(function(obj) {
+    return obj.get(name) == value;
+      }));
+  },
 
-	// remove obj with attr 'name' and value 'value'
-	removeFromList: function(list, name, value) {
-	    var i = _.indexOf(_.map(list, function(obj) {
-		return obj.get(name);
-	    }), value);
-	    if (i != -1) {
-		list.splice(i,1);
-	    }
-	}
+  // remove obj with attr 'name' and value 'value'
+  removeFromList: function(list, name, value) {
+      var i = _.indexOf(_.map(list, function(obj) {
+    return obj.get(name);
+      }), value);
+      if (i != -1) {
+    list.splice(i,1);
+      }
+  }
     };
     return util;
 }();
@@ -456,19 +456,19 @@ var RockstorUtil = function() {
 RockstorWizardPage = Backbone.View.extend({
 
     initialize: function() {
-	this.evAgg = this.options.evAgg;
-	this.parent = this.options.parent;
+  this.evAgg = this.options.evAgg;
+  this.parent = this.options.parent;
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    model: this.model
-	}));
-	return this;
+  $(this.el).html(this.template({
+      model: this.model
+  }));
+  return this;
     },
 
     save: function() {
-	return $.Deferred().resolve();
+  return $.Deferred().resolve();
     }
 });
 
@@ -476,108 +476,108 @@ WizardView = Backbone.View.extend({
     tagName: 'div',
 
     events: {
-	'click #next-page': 'nextPage',
-	'click #prev-page': 'prevPage'
+  'click #next-page': 'nextPage',
+  'click #prev-page': 'prevPage'
     },
 
     initialize: function() {
-	this.template = window.JST.wizard_wizard;
-	this.pages = null;
-	this.currentPage = null;
-	this.currentPageNum = -1;
-	this.contentEl = '#ph-wizard-contents';
-	this.evAgg = _.extend({}, Backbone.Events);
-	this.evAgg.bind('nextPage', this.nextPage, this);
-	this.evAgg.bind('prevPage', this.prevPage, this);
-	this.parent = this.options.parent;
-	this.title = this.options.title;
+  this.template = window.JST.wizard_wizard;
+  this.pages = null;
+  this.currentPage = null;
+  this.currentPageNum = -1;
+  this.contentEl = '#ph-wizard-contents';
+  this.evAgg = _.extend({}, Backbone.Events);
+  this.evAgg.bind('nextPage', this.nextPage, this);
+  this.evAgg.bind('prevPage', this.prevPage, this);
+  this.parent = this.options.parent;
+  this.title = this.options.title;
     },
 
     setPages: function(pages) {
-	this.pages = pages;
+  this.pages = pages;
     },
 
     render: function() {
-	$(this.el).html(this.template({
-	    title: this.title,
-	    model: this.model
-	}));
-	this.nextPage();
-	return this;
+  $(this.el).html(this.template({
+      title: this.title,
+      model: this.model
+  }));
+  this.nextPage();
+  return this;
     },
 
     nextPage: function() {
-	var _this = this;
-	var promise = !_.isNull(this.currentPage) ?
-		this.currentPage.save() :
-		$.Deferred().resolve();
-	promise.done(function(result, status, jqXHR) {
-	    _this.incrementPage();
-	});
-	promise.fail(function(jqXHR, status, error) {
-	    console.log(error);
-	});
+  var _this = this;
+  var promise = !_.isNull(this.currentPage) ?
+    this.currentPage.save() :
+    $.Deferred().resolve();
+  promise.done(function(result, status, jqXHR) {
+      _this.incrementPage();
+  });
+  promise.fail(function(jqXHR, status, error) {
+      console.log(error);
+  });
     },
 
     incrementPageNum: function() {
-	this.currentPageNum = this.currentPageNum + 1;
+  this.currentPageNum = this.currentPageNum + 1;
     },
 
     decrementPageNum: function() {
-	this.currentPageNum = this.currentPageNum - 1;
+  this.currentPageNum = this.currentPageNum - 1;
     },
 
     incrementPage: function() {
-	if (!this.lastPage()) {
-	    this.incrementPageNum();
-	    this.setCurrentPage();
-	    this.renderCurrentPage();
-	} else {
-	    this.finish();
-	}
+  if (!this.lastPage()) {
+      this.incrementPageNum();
+      this.setCurrentPage();
+      this.renderCurrentPage();
+  } else {
+      this.finish();
+  }
     },
 
     decrementPage: function() {
-	if (!this.firstPage()) {
-	    this.decrementPageNum();
-	    this.setCurrentPage();
-	    this.renderCurrentPage();
-	}
+  if (!this.firstPage()) {
+      this.decrementPageNum();
+      this.setCurrentPage();
+      this.renderCurrentPage();
+  }
     },
 
     setCurrentPage: function() {
-	this.currentPage = new this.pages[this.currentPageNum]({
-	    model: this.model,
-	    evAgg: this.evAgg
-	});
+  this.currentPage = new this.pages[this.currentPageNum]({
+      model: this.model,
+      evAgg: this.evAgg
+  });
     },
 
     renderCurrentPage: function() {
-	this.$(this.contentEl).html(this.currentPage.render().el);
-	this.modifyButtonText();
+  this.$(this.contentEl).html(this.currentPage.render().el);
+  this.modifyButtonText();
     },
 
     prevPage: function() {
-	this.decrementPage();
+  this.decrementPage();
     },
 
     modifyButtonText: function() {
-	if (this.lastPage()) {
-	    this.$('#next-page').html('Finish');
-	} else {
-	    this.$('#next-page').html('Next');
-	}
+  if (this.lastPage()) {
+      this.$('#next-page').html('Finish');
+  } else {
+      this.$('#next-page').html('Next');
+  }
     },
 
     firstPage: function() {
-	return (this.currentPageNum == 0);
+  return (this.currentPageNum == 0);
     },
 
     lastPage: function() {
-	return (this.currentPageNum == (this.pages.length - 1));
+  return (this.currentPageNum == (this.pages.length - 1));
     },
 
     finish: function() {
-	console.log('finish');
+  console.log('finish');
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -23,8 +23,12 @@
 <!-- page heading -->
 
 <div class="pull-right">
-  <a href="#add_share?poolName={{poolName}}" id="add_share" class="btn btn-primary"><i class="glyphicon glyphicon-edit "></i> Add Share</a>
-  <button id="delete-pool" class="btn btn-danger" type="button"><i class="glyphicon glyphicon-trash "></i> Delete</button>
+ <a href="#add_share?poolName={{poolName}}" id="add_share" class="btn btn-primary"><i class="glyphicon glyphicon-edit "></i> Add Share</a>
+ {{#if isPoolNameRockstor}}
+ <!-- Don't display the delete button if rockstor_rockstor pool -->
+ {{else}}
+ <button id="delete-pool" class="btn btn-danger" type="button"><i class="glyphicon glyphicon-trash" data-name="{{pool.name}}" data-action="delete"></i> Delete</button>
+ {{/if}}
 </div>
 <span class="h2">{{poolName}}</span>
 {{#if isPoolNameRockstor}}
@@ -110,4 +114,27 @@
     <button class="btn btn-primary" id="submit-resize-modal">Submit</button>
   </div>
   -->
+</div>
+
+<div id="delete-pool-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3 id="myModalLabel">Delete Pool</h3>
+      </div>
+      <div class="modal-body">
+        <div class="messages"></div>
+        <h4>Pool {{pool.name}} will be deleted along with the following shares. Are you sure?</h4>
+        <ul id="pool-shares"></ul>
+        {{#each shares}}
+        <li>{{this.attributes.name}} ({{this.attributes.size}} bytes)</li>
+        {{/each}}
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+        <button id="js-confirm-pool-delete" class="btn btn-primary">Confirm</button>
+      </div
+    </div
+  </div>
 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -119,11 +119,14 @@
       </div>
       <div class="modal-body">
         <div class="messages"></div>
-        <h4>Pool {{pool.name}} will be deleted along with the following shares (and all information associated with shares including Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
-        <ul id="pool-shares"></ul>
+        <h4>Pool {{this.name}} will be deleted (along with the Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
+        <h3>The following shares will be deleted! Are you sure?</h3>
+        <ul>
         {{#each share}}
         <li>{{this.name}} ({{this.size_gb}} GB)</li>
         {{/each}}
+        </ul>
+        <br>
         <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"></i></label>
       </div>
       <div class="modal-footer">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -108,12 +108,6 @@
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
     <div id="pool-resize-raid-modal-contents"></div>
   </div>
-  <!--
-  <div class="modal-footer">
-    <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Close</button>
-    <button class="btn btn-primary" id="submit-resize-modal">Submit</button>
-  </div>
-  -->
 </div>
 
 <div id="delete-pool-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -125,11 +119,12 @@
       </div>
       <div class="modal-body">
         <div class="messages"></div>
-        <h4>Pool {{pool.name}} will be deleted along with the following shares. Are you sure?</h4>
+        <h4>Pool {{pool.name}} will be deleted along with the following shares (and all information associated with shares including Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
         <ul id="pool-shares"></ul>
-        {{#each shares}}
-        <li>{{this.attributes.name}} ({{this.attributes.size}} bytes)</li>
+        {{#each share}}
+        <li>{{this.name}} ({{this.size_gb}} GB)</li>
         {{/each}}
+        <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"></i></label>
       </div>
       <div class="modal-footer">
         <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -148,6 +148,7 @@
         {{#each shares}}
         <li>{{this.attributes.name}} ({{this.attributes.size}} bytes)</li>
         {{/each}}
+        <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"></i></label>
       </div>
       <div class="modal-footer">
         <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -133,3 +133,26 @@
     </div
   </div>
 </div>
+
+<div id="delete-pool-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3 id="myModalLabel">Delete Pool</h3>
+      </div>
+      <div class="modal-body">
+        <div class="messages"></div>
+        <h4>Pool {{pool.name}} will be deleted along with the following shares. Are you sure?</h4>
+        <ul id="pool-shares"></ul>
+        {{#each shares}}
+        <li>{{this.attributes.name}} ({{this.attributes.size}} bytes)</li>
+        {{/each}}
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+        <button id="js-confirm-pool-delete" class="btn btn-primary">Confirm</button>
+      </div
+    </div
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -67,10 +67,11 @@
            </div>
            <div class="modal-body">
             <div class="messages"></div>
-            <h4>Pool {{this.name}} will be deleted along with the Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
+            <h4>Pool {{this.name}} will be deleted (along with the Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
             <!-- Fill in share names here -->
-            <h3>The following shares will be deleted!</h3>
+            <h3>The following shares will be deleted! Are you sure?</h3>
             <ul id="pool-shares"></ul>
+            <br>
             <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"></i></label>
            </div>
            <div class="modal-footer">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -58,6 +58,28 @@
                 {{/if}}
             </td>
         </tr>
+        <div id="delete-pool-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+         <div class="modal-dialog">
+          <div class="modal-content">
+           <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+            <h3 id="myModalLabel">Delete Pool</h3>
+           </div>
+           <div class="modal-body">
+            <div class="messages"></div>
+            <h4>Pool {{this.name}} will be deleted along with the Snapshots, NFSExports, Samba configs, SFTP, Replics). Are you sure?</h4>
+            <!-- Fill in share names here -->
+            <h3>The following shares will be deleted!</h3>
+            <ul id="pool-shares"></ul>
+            <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"></i></label>
+           </div>
+           <div class="modal-footer">
+            <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+            <button id="js-confirm-pool-delete" class="btn btn-primary">Confirm</button>
+           </div
+          </div
+         </div>
+        </div>
     {{/each}}
   </tbody>
 </table>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -26,340 +26,340 @@
 
 PoolDetailsLayoutView = RockstorLayoutView.extend({
 
-	initialize: function() {
-		// call initialize of base
-		this.constructor.__super__.initialize.apply(this, arguments);
-		this.poolName = this.options.poolName;
-		this.cView = this.options.cView;
-		this.template = window.JST.pool_pool_details_layout;
-		this.resize_pool_info_template = window.JST.pool_resize_pool_info;
-		this.compression_info_template = window.JST.pool_compression_info;
-		this.compression_info_edit_template = window.JST.pool_compression_info_edit;
-		this.pool = new Pool({poolName: this.poolName});
-		// create poolscrub models
-		this.poolscrubs = new PoolscrubCollection([],{snapType: 'admin'});
-		this.poolscrubs.pageSize = 5;
-		this.poolscrubs.setUrl(this.poolName);
-		// create pool re-balance models
-		this.poolrebalances = new PoolRebalanceCollection([],{snapType: 'admin'});
-		this.poolrebalances.pageSize = 5;
-		this.poolrebalances.setUrl(this.poolName);
+  initialize: function() {
+    // call initialize of base
+    this.constructor.__super__.initialize.apply(this, arguments);
+    this.poolName = this.options.poolName;
+    this.cView = this.options.cView;
+    this.template = window.JST.pool_pool_details_layout;
+    this.resize_pool_info_template = window.JST.pool_resize_pool_info;
+    this.compression_info_template = window.JST.pool_compression_info;
+    this.compression_info_edit_template = window.JST.pool_compression_info_edit;
+    this.pool = new Pool({poolName: this.poolName});
+    // create poolscrub models
+    this.poolscrubs = new PoolscrubCollection([],{snapType: 'admin'});
+    this.poolscrubs.pageSize = 5;
+    this.poolscrubs.setUrl(this.poolName);
+    // create pool re-balance models
+    this.poolrebalances = new PoolRebalanceCollection([],{snapType: 'admin'});
+    this.poolrebalances.pageSize = 5;
+    this.poolrebalances.setUrl(this.poolName);
 
-		this.dependencies.push(this.pool);
-		this.dependencies.push(this.poolscrubs);
-		this.dependencies.push(this.poolrebalances);
-		this.disks = new DiskCollection();
-		this.disks.pageSize = RockStorGlobals.maxPageSize;
-		this.dependencies.push(this.disks);
-		this.cOpts = {'no': 'Dont enable compression', 'zlib': 'zlib', 'lzo': 'lzo'};
-		this.initHandlebarHelpers();
+    this.dependencies.push(this.pool);
+    this.dependencies.push(this.poolscrubs);
+    this.dependencies.push(this.poolrebalances);
+    this.disks = new DiskCollection();
+    this.disks.pageSize = RockStorGlobals.maxPageSize;
+    this.dependencies.push(this.disks);
+    this.cOpts = {'no': 'Dont enable compression', 'zlib': 'zlib', 'lzo': 'lzo'};
+    this.initHandlebarHelpers();
     this.poolShares = new PoolShareCollection([], {poolName: this.poolName});
-	},
+  },
 
-	events: {
-		'click #delete-pool': 'deletePool',
+  events: {
+    'click #delete-pool': 'deletePool',
     "click #js-confirm-pool-delete": "confirmPoolDelete",
-		"click #js-resize-pool": "resizePool",
-		"click #js-submit-resize": "resizePoolSubmit",
-		"click #js-resize-cancel": "resizePoolCancel",
-		"click #js-edit-compression": "editCompression",
-		"click #js-edit-compression-cancel": "editCompressionCancel",
-		"click #js-submit-compression": "updateCompression",
-	},
+    "click #js-resize-pool": "resizePool",
+    "click #js-submit-resize": "resizePoolSubmit",
+    "click #js-resize-cancel": "resizePoolCancel",
+    "click #js-edit-compression": "editCompression",
+    "click #js-edit-compression-cancel": "editCompressionCancel",
+    "click #js-submit-compression": "updateCompression",
+  },
 
-	render: function() {
+  render: function() {
     this.poolShares.fetch();
-		this.fetch(this.renderSubViews, this);
-		return this;
-	},
+    this.fetch(this.renderSubViews, this);
+    return this;
+  },
 
-	renderSubViews: function() {
-		var poolNameIsRockstor = false;
-		if (this.pool.get('role') == 'root') {
-			poolNameIsRockstor = true;
-		}
+  renderSubViews: function() {
+    var poolNameIsRockstor = false;
+    if (this.pool.get('role') == 'root') {
+      poolNameIsRockstor = true;
+    }
     $(this.el).html(this.template({
       share: this.poolShares.models[0].attributes.results,
-			poolName: this.pool.get('name'),
-			isPoolNameRockstor: poolNameIsRockstor,
-		}));
+      poolName: this.pool.get('name'),
+      isPoolNameRockstor: poolNameIsRockstor,
+    }));
 
-		this.subviews['pool-info'] = new PoolInfoModule({ model: this.pool.toJSON() });
-		this.subviews['pool-usage'] = new PoolUsageModule({ model: this.pool });
-		this.subviews['pool-scrubs'] = new PoolScrubTableModule({poolscrubs: this.poolscrubs, pool: this.pool, parentView: this });
-		this.subviews['pool-rebalances'] = new PoolRebalanceTableModule({poolrebalances: this.poolrebalances, pool: this.pool, parentView: this });
-		this.pool.on('change', this.subviews['pool-info'].render, this.subviews['pool-info']);
-		this.pool.on('change', this.subviews['pool-usage'].render, this.subviews['pool-usage']);
-		this.poolscrubs.on('change', this.subviews['pool-scrubs'].render, this.subviews['pool-scrubs']);
-		this.$('#ph-pool-info').html(this.subviews['pool-info'].render().el);
-		this.$('#ph-pool-usage').html(this.subviews['pool-usage'].render().el);
-		this.$('#ph-pool-scrubs').html(this.subviews['pool-scrubs'].render().el);
-		this.$('#ph-pool-rebalances').html(this.subviews['pool-rebalances'].render().el);
+    this.subviews['pool-info'] = new PoolInfoModule({ model: this.pool.toJSON() });
+    this.subviews['pool-usage'] = new PoolUsageModule({ model: this.pool });
+    this.subviews['pool-scrubs'] = new PoolScrubTableModule({poolscrubs: this.poolscrubs, pool: this.pool, parentView: this });
+    this.subviews['pool-rebalances'] = new PoolRebalanceTableModule({poolrebalances: this.poolrebalances, pool: this.pool, parentView: this });
+    this.pool.on('change', this.subviews['pool-info'].render, this.subviews['pool-info']);
+    this.pool.on('change', this.subviews['pool-usage'].render, this.subviews['pool-usage']);
+    this.poolscrubs.on('change', this.subviews['pool-scrubs'].render, this.subviews['pool-scrubs']);
+    this.$('#ph-pool-info').html(this.subviews['pool-info'].render().el);
+    this.$('#ph-pool-usage').html(this.subviews['pool-usage'].render().el);
+    this.$('#ph-pool-scrubs').html(this.subviews['pool-scrubs'].render().el);
+    this.$('#ph-pool-rebalances').html(this.subviews['pool-rebalances'].render().el);
 
-		if (!_.isUndefined(this.cView) && this.cView == 'edit') {
-			this.$('#ph-compression-info').html(this.compression_info_edit_template({
-				pool: this.pool.toJSON(),
-				cOpts: this.cOpts,
-			}));
-			this.showCompressionTooltips(); } else {
-				this.$('#ph-compression-info').html(this.compression_info_template({
-					pool: this.pool.toJSON(),
-				})); }
+    if (!_.isUndefined(this.cView) && this.cView == 'edit') {
+      this.$('#ph-compression-info').html(this.compression_info_edit_template({
+        pool: this.pool.toJSON(),
+        cOpts: this.cOpts,
+      }));
+      this.showCompressionTooltips(); } else {
+        this.$('#ph-compression-info').html(this.compression_info_template({
+          pool: this.pool.toJSON(),
+        })); }
 
-		this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool:
-			                                                                  this.pool.toJSON()})); this.$("ul.nav.nav-tabs").tabs("div.css-panes > div"); if
-		(!_.isUndefined(this.cView) && this.cView == 'resize') { // scroll to resize section
+    this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool:
+                                                                        this.pool.toJSON()})); this.$("ul.nav.nav-tabs").tabs("div.css-panes > div"); if
+    (!_.isUndefined(this.cView) && this.cView == 'resize') { // scroll to resize section
       $('#content').scrollTop($('#ph-resize-pool-info').offset().top); }
 
-		//$('#pool-resize-raid-modal').modal({show: false});
-		$('#pool-resize-raid-overlay').overlay({load: false});
+    //$('#pool-resize-raid-modal').modal({show: false});
+    $('#pool-resize-raid-overlay').overlay({load: false});
 
-	},
+  },
 
   deletePool: function() {
     var _this = this;
     var button = $(event.currentTarget);
     if (buttonDisabled(button)) return false;
     _this.$('#delete-pool-modal').modal();
-	},
+  },
 
   confirmPoolDelete: function() {
     var _this = this;
-		var button = $(event.currentTarget);
+    var button = $(event.currentTarget);
     var url = "/api/pools/" + this.poolName;
-		if (buttonDisabled(button)) return false;
-		disableButton(button);
+    if (buttonDisabled(button)) return false;
+    disableButton(button);
     if ($("#force-delete").prop("checked")) {
       url += "/force";
     }
-		$.ajax({
-			url: url,
-			type: "DELETE",
-			dataType: "json",
-			success: function() {
-			  enableButton(button);
-			  _this.$('#delete-pool-modal').modal('hide');
-			  $('.modal-backdrop').remove();
-			  app_router.navigate('pools', {trigger: true})
-			},
-			error: function(xhr, status, error) {
-			  enableButton(button);
-			}
-		});
+    $.ajax({
+      url: url,
+      type: "DELETE",
+      dataType: "json",
+      success: function() {
+        enableButton(button);
+        _this.$('#delete-pool-modal').modal('hide');
+        $('.modal-backdrop').remove();
+        app_router.navigate('pools', {trigger: true})
+      },
+      error: function(xhr, status, error) {
+        enableButton(button);
+      }
+    });
   },
 
 
-	resizePool: function(event) {
-		event.preventDefault();
-		var wizardView = new PoolResizeWizardView({
-			model: new Backbone.Model({ pool: this.pool }),
-			title: 'Resize Pool / Change RAID level for ' + this.pool.get('name'),
-			parent: this
-		});
-		$('.overlay-content', '#pool-resize-raid-overlay').html(wizardView.render().el);
-		$('#pool-resize-raid-overlay').overlay().load();
-	},
+  resizePool: function(event) {
+    event.preventDefault();
+    var wizardView = new PoolResizeWizardView({
+      model: new Backbone.Model({ pool: this.pool }),
+      title: 'Resize Pool / Change RAID level for ' + this.pool.get('name'),
+      parent: this
+    });
+    $('.overlay-content', '#pool-resize-raid-overlay').html(wizardView.render().el);
+    $('#pool-resize-raid-overlay').overlay().load();
+  },
 
-	resizePoolSubmit: function(event) {
-		event.preventDefault();
-		var button = this.$('#js-submit-resize');
-		if (buttonDisabled(button)) return false;
-		if(confirm(" Are you sure about Resizing this pool?")){
-			disableButton(button);
-			var _this = this;
-			var raid_level = $('#raid_level').val();
-			var disk_names = [];
-			var err_msg = "Please select atleast one disk";
-			var n = _this.$(".disknew:checked").length;
-			var m = _this.$(".diskadded:unchecked").length;
-			var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
-			if(n >= 0){
-				$('#pool-resize-raid-modal').modal('show');
-			} else if(m > 0) {
-				_this.$(".diskadded:unchecked").each(function(i) {
-					if (i < m) {
-						disk_names.push($(this).val());
-					}
-				});
-				$.ajax({
-					url: '/api/pools/'+_this.pool.get('name')+'/remove',
-					type: 'PUT',
-					dataType: 'json',
-					contentType: 'application/json',
-					data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
-					success: function() {
-						_this.hideResizeTooltips();
-						alert(resize_msg);
-						_this.pool.fetch({
-							success: function(collection, response, options) {
-								_this.cView = 'view';
-								_this.render();
-							}
-						});
+  resizePoolSubmit: function(event) {
+    event.preventDefault();
+    var button = this.$('#js-submit-resize');
+    if (buttonDisabled(button)) return false;
+    if(confirm(" Are you sure about Resizing this pool?")){
+      disableButton(button);
+      var _this = this;
+      var raid_level = $('#raid_level').val();
+      var disk_names = [];
+      var err_msg = "Please select atleast one disk";
+      var n = _this.$(".disknew:checked").length;
+      var m = _this.$(".diskadded:unchecked").length;
+      var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
+      if(n >= 0){
+        $('#pool-resize-raid-modal').modal('show');
+      } else if(m > 0) {
+        _this.$(".diskadded:unchecked").each(function(i) {
+          if (i < m) {
+            disk_names.push($(this).val());
+          }
+        });
+        $.ajax({
+          url: '/api/pools/'+_this.pool.get('name')+'/remove',
+          type: 'PUT',
+          dataType: 'json',
+          contentType: 'application/json',
+          data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
+          success: function() {
+            _this.hideResizeTooltips();
+            alert(resize_msg);
+            _this.pool.fetch({
+              success: function(collection, response, options) {
+                _this.cView = 'view';
+                _this.render();
+              }
+            });
 
-					},
-					error: function(request, status, error) {
-						enableButton(button);
-					}
-				});
-			}
-		}
-	},
+          },
+          error: function(request, status, error) {
+            enableButton(button);
+          }
+        });
+      }
+    }
+  },
 
-	resizePoolCancel: function(event) {
-		event.preventDefault();
-		this.hideResizeTooltips();
-		this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool: this.pool}));
-	},
+  resizePoolCancel: function(event) {
+    event.preventDefault();
+    this.hideResizeTooltips();
+    this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool: this.pool}));
+  },
 
-	resizePoolModalSubmit: function(event) {
-		var _this = this;
-		var raid_level = $('#raid_level').val();
-		var disk_names = [];
-		var err_msg = "Please select atleast one disk";
-		var n = _this.$(".disknew:checked").length;
-		var m = _this.$(".diskadded:unchecked").length;
-		var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
-		_this.$(".disknew:checked").each(function(i) {
-			if (i < n) {
-				disk_names.push($(this).val());
-			}
-		});
-		$.ajax({
-			url: '/api/pools/'+_this.pool.get('name')+'/add',
-			type: 'PUT',
-			dataType: 'json',
-			contentType: 'application/json',
-			data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
-			success: function() {
-				_this.hideResizeTooltips();
-				alert(resize_msg);
-				_this.pool.fetch({
-					success: function(collection, response, options) {
-						_this.cView = 'view';
-						_this.render();
-					}
-				});
-			},
-			error: function(request, status, error) {
-				enableButton(button);
-			}
-		});
+  resizePoolModalSubmit: function(event) {
+    var _this = this;
+    var raid_level = $('#raid_level').val();
+    var disk_names = [];
+    var err_msg = "Please select atleast one disk";
+    var n = _this.$(".disknew:checked").length;
+    var m = _this.$(".diskadded:unchecked").length;
+    var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
+    _this.$(".disknew:checked").each(function(i) {
+      if (i < n) {
+        disk_names.push($(this).val());
+      }
+    });
+    $.ajax({
+      url: '/api/pools/'+_this.pool.get('name')+'/add',
+      type: 'PUT',
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
+      success: function() {
+        _this.hideResizeTooltips();
+        alert(resize_msg);
+        _this.pool.fetch({
+          success: function(collection, response, options) {
+            _this.cView = 'view';
+            _this.render();
+          }
+        });
+      },
+      error: function(request, status, error) {
+        enableButton(button);
+      }
+    });
 
-	},
+  },
 
-	editCompression: function(event) {
-		event.preventDefault();
-		this.$('#ph-compression-info').html(this.compression_info_edit_template({
-			pool: this.pool.toJSON(),
-			cOpts: this.cOpts,
-		}));
-		this.showCompressionTooltips();
-	},
+  editCompression: function(event) {
+    event.preventDefault();
+    this.$('#ph-compression-info').html(this.compression_info_edit_template({
+      pool: this.pool.toJSON(),
+      cOpts: this.cOpts,
+    }));
+    this.showCompressionTooltips();
+  },
 
-	editCompressionCancel: function(event) {
-		event.preventDefault();
-		this.hideCompressionTooltips();
-		this.$('#ph-compression-info').html(this.compression_info_template({
-			pool: this.pool.toJSON(), 
-		}));
-	},
+  editCompressionCancel: function(event) {
+    event.preventDefault();
+    this.hideCompressionTooltips();
+    this.$('#ph-compression-info').html(this.compression_info_template({
+      pool: this.pool.toJSON(), 
+    }));
+  },
 
-	updateCompression: function(event) {
-		var _this = this;
-		event.preventDefault();
-		var button = this.$('#js-submit-compression');
-		if (buttonDisabled(button)) return false;
-		disableButton(button);
-		$.ajax({
-			url: "/api/pools/" + this.pool.get('name') + '/remount',
-			type: "PUT",
-			dataType: "json",
-			data: {
-				"compression": this.$('#compression').val(),
-				"mnt_options": this.$('#mnt_options').val(),
-			},
-			success: function() {
-				_this.hideCompressionTooltips();
-				_this.pool.fetch({
-					success: function(collection, response, options) {
-						_this.cView = 'view';
-						_this.renderSubViews();
-					}
-				});
-			},
-			error: function(xhr, status, error) {
-				enableButton(button);
-			}
-		});
-	},
+  updateCompression: function(event) {
+    var _this = this;
+    event.preventDefault();
+    var button = this.$('#js-submit-compression');
+    if (buttonDisabled(button)) return false;
+    disableButton(button);
+    $.ajax({
+      url: "/api/pools/" + this.pool.get('name') + '/remount',
+      type: "PUT",
+      dataType: "json",
+      data: {
+        "compression": this.$('#compression').val(),
+        "mnt_options": this.$('#mnt_options').val(),
+      },
+      success: function() {
+        _this.hideCompressionTooltips();
+        _this.pool.fetch({
+          success: function(collection, response, options) {
+            _this.cView = 'view';
+            _this.renderSubViews();
+          }
+        });
+      },
+      error: function(xhr, status, error) {
+        enableButton(button);
+      }
+    });
+  },
 
-	showCompressionTooltips: function() {
-		this.$('#ph-compression-info #compression').tooltip({
-			html: true,
-			placement: 'top',
-			container: 'body',
-			title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
-		});
-		this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });
-	},
+  showCompressionTooltips: function() {
+    this.$('#ph-compression-info #compression').tooltip({
+      html: true,
+      placement: 'top',
+      container: 'body',
+      title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
+    });
+    this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });
+  },
 
-	hideCompressionTooltips: function() {
-		this.$('#ph-compression-info #compression').tooltip('hide');
-		this.$('#ph-compression-info #mnt_options').tooltip('hide');
-	},
+  hideCompressionTooltips: function() {
+    this.$('#ph-compression-info #compression').tooltip('hide');
+    this.$('#ph-compression-info #mnt_options').tooltip('hide');
+  },
 
-	showResizeTooltips: function() {
-		this.$('#ph-resize-pool-info #raid_level').tooltip({
-			html: true,
-			placement: 'top',
-			title: "You can transition raid level of this pool to change it's redundancy profile.",
-		});
-	},
+  showResizeTooltips: function() {
+    this.$('#ph-resize-pool-info #raid_level').tooltip({
+      html: true,
+      placement: 'top',
+      title: "You can transition raid level of this pool to change it's redundancy profile.",
+    });
+  },
 
-	hideResizeTooltips: function() {
-		this.$('#ph-resize-pool-info #raid_level').tooltip('hide');
-	},
+  hideResizeTooltips: function() {
+    this.$('#ph-resize-pool-info #raid_level').tooltip('hide');
+  },
 
-	attachModalActions: function() {
+  attachModalActions: function() {
 
-	},
+  },
 
-	cleanup: function() {
-		if (!_.isUndefined(this.statusIntervalId)) {
-			window.clearInterval(this.statusIntervalId);
-		}
-	},
+  cleanup: function() {
+    if (!_.isUndefined(this.statusIntervalId)) {
+      window.clearInterval(this.statusIntervalId);
+    }
+  },
 
-	initHandlebarHelpers: function(){
+  initHandlebarHelpers: function(){
 
-		Handlebars.registerHelper('getPoolCreationDate', function(date){
-			return moment(date).format(RS_DATE_FORMAT);
-		});
-		
-		Handlebars.registerHelper('isPoolCompressionNone', function(compression,opts){
-			if (compression == 'no') {
-				return opts.fn(this);
-			}
-			return opts.inverse(this);
-		});
+    Handlebars.registerHelper('getPoolCreationDate', function(date){
+      return moment(date).format(RS_DATE_FORMAT);
+    });
+    
+    Handlebars.registerHelper('isPoolCompressionNone', function(compression,opts){
+      if (compression == 'no') {
+        return opts.fn(this);
+      }
+      return opts.inverse(this);
+    });
 
-		Handlebars.registerHelper('isMntOptionNone', function(mtOptions,opts){
-			if (_.isUndefined(mtOptions) || _.isNull(mtOptions) || _.isEmpty(mtOptions)) {
-				return opts.fn(this);
-			}  
-			return opts.inverse(this);
-		});
-		
-		Handlebars.registerHelper('selectedCompressionOption', function(existingComp,c,opts){
-			if (existingComp == c) {
-				return opts.fn(this);
-			}  
-			return opts.inverse(this);
-		});
+    Handlebars.registerHelper('isMntOptionNone', function(mtOptions,opts){
+      if (_.isUndefined(mtOptions) || _.isNull(mtOptions) || _.isEmpty(mtOptions)) {
+        return opts.fn(this);
+      }  
+      return opts.inverse(this);
+    });
+    
+    Handlebars.registerHelper('selectedCompressionOption', function(existingComp,c,opts){
+      if (existingComp == c) {
+        return opts.fn(this);
+      }  
+      return opts.inverse(this);
+    });
 
-		Handlebars.registerHelper('humanReadableSize', function(size){
-			return humanize.filesize(size * 1024);
-		});
-	}
+    Handlebars.registerHelper('humanReadableSize', function(size){
+      return humanize.filesize(size * 1024);
+    });
+  }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -26,95 +26,93 @@
 
 PoolDetailsLayoutView = RockstorLayoutView.extend({
 
-  initialize: function() {
-    // call initialize of base
-    this.constructor.__super__.initialize.apply(this, arguments);
-    this.poolName = this.options.poolName;
-    this.cView = this.options.cView;
-    this.template = window.JST.pool_pool_details_layout;
-    this.resize_pool_info_template = window.JST.pool_resize_pool_info;
-    this.compression_info_template = window.JST.pool_compression_info;
-    this.compression_info_edit_template = window.JST.pool_compression_info_edit;
-    this.pool = new Pool({poolName: this.poolName});
-    // create poolscrub models
-    this.poolscrubs = new PoolscrubCollection([],{snapType: 'admin'});
-    this.poolscrubs.pageSize = 5;
-    this.poolscrubs.setUrl(this.poolName);
-    // create pool re-balance models
-    this.poolrebalances = new PoolRebalanceCollection([],{snapType: 'admin'});
-    this.poolrebalances.pageSize = 5;
-    this.poolrebalances.setUrl(this.poolName);
+	initialize: function() {
+		// call initialize of base
+		this.constructor.__super__.initialize.apply(this, arguments);
+		this.poolName = this.options.poolName;
+		this.cView = this.options.cView;
+		this.template = window.JST.pool_pool_details_layout;
+		this.resize_pool_info_template = window.JST.pool_resize_pool_info;
+		this.compression_info_template = window.JST.pool_compression_info;
+		this.compression_info_edit_template = window.JST.pool_compression_info_edit;
+		this.pool = new Pool({poolName: this.poolName});
+		// create poolscrub models
+		this.poolscrubs = new PoolscrubCollection([],{snapType: 'admin'});
+		this.poolscrubs.pageSize = 5;
+		this.poolscrubs.setUrl(this.poolName);
+		// create pool re-balance models
+		this.poolrebalances = new PoolRebalanceCollection([],{snapType: 'admin'});
+		this.poolrebalances.pageSize = 5;
+		this.poolrebalances.setUrl(this.poolName);
 
-    this.dependencies.push(this.pool);
-    this.dependencies.push(this.poolscrubs);
-    this.dependencies.push(this.poolrebalances);
-    this.disks = new DiskCollection();
-    this.disks.pageSize = RockStorGlobals.maxPageSize;
-    this.dependencies.push(this.disks);
-    this.cOpts = {'no': 'Dont enable compression', 'zlib': 'zlib', 'lzo': 'lzo'};
-    this.initHandlebarHelpers();
+		this.dependencies.push(this.pool);
+		this.dependencies.push(this.poolscrubs);
+		this.dependencies.push(this.poolrebalances);
+		this.disks = new DiskCollection();
+		this.disks.pageSize = RockStorGlobals.maxPageSize;
+		this.dependencies.push(this.disks);
+		this.cOpts = {'no': 'Dont enable compression', 'zlib': 'zlib', 'lzo': 'lzo'};
+		this.initHandlebarHelpers();
     this.poolShares = new PoolShareCollection([], {poolName: this.poolName});
-  },
+	},
 
-  events: {
-    'click #delete-pool': 'deletePool',
+	events: {
+		'click #delete-pool': 'deletePool',
     "click #js-confirm-pool-delete": "confirmPoolDelete",
-    "click #js-resize-pool": "resizePool",
-    "click #js-submit-resize": "resizePoolSubmit",
-    "click #js-resize-cancel": "resizePoolCancel",
-    "click #js-edit-compression": "editCompression",
-    "click #js-edit-compression-cancel": "editCompressionCancel",
-    "click #js-submit-compression": "updateCompression",
-  },
+		"click #js-resize-pool": "resizePool",
+		"click #js-submit-resize": "resizePoolSubmit",
+		"click #js-resize-cancel": "resizePoolCancel",
+		"click #js-edit-compression": "editCompression",
+		"click #js-edit-compression-cancel": "editCompressionCancel",
+		"click #js-submit-compression": "updateCompression",
+	},
 
-  render: function() {
+	render: function() {
     this.poolShares.fetch();
-    this.fetch(this.renderSubViews, this);
-    return this;
-  },
+		this.fetch(this.renderSubViews, this);
+		return this;
+	},
 
-  renderSubViews: function() {
-    var poolNameIsRockstor = false;
-    if (this.pool.get('role') == 'root') {
-      poolNameIsRockstor = true;
-    }
+	renderSubViews: function() {
+		var poolNameIsRockstor = false;
+		if (this.pool.get('role') == 'root') {
+			poolNameIsRockstor = true;
+		}
     $(this.el).html(this.template({
-      share: this.poolShares.models[0].attributes.results,
-      poolName: this.pool.get('name'),
-      isPoolNameRockstor: poolNameIsRockstor,
-    }));
+      shares: this.poolShares.models,
+			poolName: this.pool.get('name'),
+			isPoolNameRockstor: poolNameIsRockstor,
+		}));
 
-    this.subviews['pool-info'] = new PoolInfoModule({ model: this.pool.toJSON() });
-    this.subviews['pool-usage'] = new PoolUsageModule({ model: this.pool });
-    this.subviews['pool-scrubs'] = new PoolScrubTableModule({poolscrubs: this.poolscrubs, pool: this.pool, parentView: this });
-    this.subviews['pool-rebalances'] = new PoolRebalanceTableModule({poolrebalances: this.poolrebalances, pool: this.pool, parentView: this });
-    this.pool.on('change', this.subviews['pool-info'].render, this.subviews['pool-info']);
-    this.pool.on('change', this.subviews['pool-usage'].render, this.subviews['pool-usage']);
-    this.poolscrubs.on('change', this.subviews['pool-scrubs'].render, this.subviews['pool-scrubs']);
-    this.$('#ph-pool-info').html(this.subviews['pool-info'].render().el);
-    this.$('#ph-pool-usage').html(this.subviews['pool-usage'].render().el);
-    this.$('#ph-pool-scrubs').html(this.subviews['pool-scrubs'].render().el);
-    this.$('#ph-pool-rebalances').html(this.subviews['pool-rebalances'].render().el);
+		this.subviews['pool-info'] = new PoolInfoModule({ model: this.pool.toJSON() });
+		this.subviews['pool-usage'] = new PoolUsageModule({ model: this.pool });
+		this.subviews['pool-scrubs'] = new PoolScrubTableModule({poolscrubs: this.poolscrubs, pool: this.pool, parentView: this });
+		this.subviews['pool-rebalances'] = new PoolRebalanceTableModule({poolrebalances: this.poolrebalances, pool: this.pool, parentView: this });
+		this.pool.on('change', this.subviews['pool-info'].render, this.subviews['pool-info']);
+		this.pool.on('change', this.subviews['pool-usage'].render, this.subviews['pool-usage']);
+		this.poolscrubs.on('change', this.subviews['pool-scrubs'].render, this.subviews['pool-scrubs']);
+		this.$('#ph-pool-info').html(this.subviews['pool-info'].render().el);
+		this.$('#ph-pool-usage').html(this.subviews['pool-usage'].render().el);
+		this.$('#ph-pool-scrubs').html(this.subviews['pool-scrubs'].render().el);
+		this.$('#ph-pool-rebalances').html(this.subviews['pool-rebalances'].render().el);
 
-    if (!_.isUndefined(this.cView) && this.cView == 'edit') {
-      this.$('#ph-compression-info').html(this.compression_info_edit_template({
-        pool: this.pool.toJSON(),
-        cOpts: this.cOpts,
-      }));
-      this.showCompressionTooltips(); } else {
-        this.$('#ph-compression-info').html(this.compression_info_template({
-          pool: this.pool.toJSON(),
-        })); }
+		if (!_.isUndefined(this.cView) && this.cView == 'edit') {
+			this.$('#ph-compression-info').html(this.compression_info_edit_template({
+				pool: this.pool.toJSON(),
+				cOpts: this.cOpts,
+			}));
+			this.showCompressionTooltips(); } else {
+				this.$('#ph-compression-info').html(this.compression_info_template({
+					pool: this.pool.toJSON(),
+				})); }
 
-    this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool:
-                                                                        this.pool.toJSON()})); this.$("ul.nav.nav-tabs").tabs("div.css-panes > div"); if
-    (!_.isUndefined(this.cView) && this.cView == 'resize') { // scroll to resize section
+		this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool:
+			                                                                  this.pool.toJSON()})); this.$("ul.nav.nav-tabs").tabs("div.css-panes > div"); if
+		(!_.isUndefined(this.cView) && this.cView == 'resize') { // scroll to resize section
       $('#content').scrollTop($('#ph-resize-pool-info').offset().top); }
 
-    //$('#pool-resize-raid-modal').modal({show: false});
-    $('#pool-resize-raid-overlay').overlay({load: false});
-
-  },
+		//$('#pool-resize-raid-modal').modal({show: false});
+		$('#pool-resize-raid-overlay').overlay({load: false});
 
   deletePool: function() {
     var _this = this;
@@ -149,217 +147,218 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
   },
 
 
-  resizePool: function(event) {
-    event.preventDefault();
-    var wizardView = new PoolResizeWizardView({
-      model: new Backbone.Model({ pool: this.pool }),
-      title: 'Resize Pool / Change RAID level for ' + this.pool.get('name'),
-      parent: this
-    });
-    $('.overlay-content', '#pool-resize-raid-overlay').html(wizardView.render().el);
-    $('#pool-resize-raid-overlay').overlay().load();
-  },
 
-  resizePoolSubmit: function(event) {
-    event.preventDefault();
-    var button = this.$('#js-submit-resize');
-    if (buttonDisabled(button)) return false;
-    if(confirm(" Are you sure about Resizing this pool?")){
-      disableButton(button);
-      var _this = this;
-      var raid_level = $('#raid_level').val();
-      var disk_names = [];
-      var err_msg = "Please select atleast one disk";
-      var n = _this.$(".disknew:checked").length;
-      var m = _this.$(".diskadded:unchecked").length;
-      var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
-      if(n >= 0){
-        $('#pool-resize-raid-modal').modal('show');
-      } else if(m > 0) {
-        _this.$(".diskadded:unchecked").each(function(i) {
-          if (i < m) {
-            disk_names.push($(this).val());
-          }
-        });
-        $.ajax({
-          url: '/api/pools/'+_this.pool.get('name')+'/remove',
-          type: 'PUT',
-          dataType: 'json',
-          contentType: 'application/json',
-          data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
-          success: function() {
-            _this.hideResizeTooltips();
-            alert(resize_msg);
-            _this.pool.fetch({
-              success: function(collection, response, options) {
-                _this.cView = 'view';
-                _this.render();
-              }
-            });
+	resizePool: function(event) {
+		event.preventDefault();
+		var wizardView = new PoolResizeWizardView({
+			model: new Backbone.Model({ pool: this.pool }),
+			title: 'Resize Pool / Change RAID level for ' + this.pool.get('name'),
+			parent: this
+		});
+		$('.overlay-content', '#pool-resize-raid-overlay').html(wizardView.render().el);
+		$('#pool-resize-raid-overlay').overlay().load();
+	},
 
-          },
-          error: function(request, status, error) {
-            enableButton(button);
-          }
-        });
-      }
-    }
-  },
+	resizePoolSubmit: function(event) {
+		event.preventDefault();
+		var button = this.$('#js-submit-resize');
+		if (buttonDisabled(button)) return false;
+		if(confirm(" Are you sure about Resizing this pool?")){
+			disableButton(button);
+			var _this = this;
+			var raid_level = $('#raid_level').val();
+			var disk_names = [];
+			var err_msg = "Please select atleast one disk";
+			var n = _this.$(".disknew:checked").length;
+			var m = _this.$(".diskadded:unchecked").length;
+			var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
+			if(n >= 0){
+				$('#pool-resize-raid-modal').modal('show');
+			} else if(m > 0) {
+				_this.$(".diskadded:unchecked").each(function(i) {
+					if (i < m) {
+						disk_names.push($(this).val());
+					}
+				});
+				$.ajax({
+					url: '/api/pools/'+_this.pool.get('name')+'/remove',
+					type: 'PUT',
+					dataType: 'json',
+					contentType: 'application/json',
+					data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
+					success: function() {
+						_this.hideResizeTooltips();
+						alert(resize_msg);
+						_this.pool.fetch({
+							success: function(collection, response, options) {
+								_this.cView = 'view';
+								_this.render();
+							}
+						});
 
-  resizePoolCancel: function(event) {
-    event.preventDefault();
-    this.hideResizeTooltips();
-    this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool: this.pool}));
-  },
+					},
+					error: function(request, status, error) {
+						enableButton(button);
+					}
+				});
+			}
+		}
+	},
 
-  resizePoolModalSubmit: function(event) {
-    var _this = this;
-    var raid_level = $('#raid_level').val();
-    var disk_names = [];
-    var err_msg = "Please select atleast one disk";
-    var n = _this.$(".disknew:checked").length;
-    var m = _this.$(".diskadded:unchecked").length;
-    var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
-    _this.$(".disknew:checked").each(function(i) {
-      if (i < n) {
-        disk_names.push($(this).val());
-      }
-    });
-    $.ajax({
-      url: '/api/pools/'+_this.pool.get('name')+'/add',
-      type: 'PUT',
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
-      success: function() {
-        _this.hideResizeTooltips();
-        alert(resize_msg);
-        _this.pool.fetch({
-          success: function(collection, response, options) {
-            _this.cView = 'view';
-            _this.render();
-          }
-        });
-      },
-      error: function(request, status, error) {
-        enableButton(button);
-      }
-    });
+	resizePoolCancel: function(event) {
+		event.preventDefault();
+		this.hideResizeTooltips();
+		this.$('#ph-resize-pool-info').html(this.resize_pool_info_template({pool: this.pool}));
+	},
 
-  },
+	resizePoolModalSubmit: function(event) {
+		var _this = this;
+		var raid_level = $('#raid_level').val();
+		var disk_names = [];
+		var err_msg = "Please select atleast one disk";
+		var n = _this.$(".disknew:checked").length;
+		var m = _this.$(".diskadded:unchecked").length;
+		var resize_msg = ('Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.');
+		_this.$(".disknew:checked").each(function(i) {
+			if (i < n) {
+				disk_names.push($(this).val());
+			}
+		});
+		$.ajax({
+			url: '/api/pools/'+_this.pool.get('name')+'/add',
+			type: 'PUT',
+			dataType: 'json',
+			contentType: 'application/json',
+			data: JSON.stringify({"disks": disk_names, "raid_level": raid_level}),
+			success: function() {
+				_this.hideResizeTooltips();
+				alert(resize_msg);
+				_this.pool.fetch({
+					success: function(collection, response, options) {
+						_this.cView = 'view';
+						_this.render();
+					}
+				});
+			},
+			error: function(request, status, error) {
+				enableButton(button);
+			}
+		});
 
-  editCompression: function(event) {
-    event.preventDefault();
-    this.$('#ph-compression-info').html(this.compression_info_edit_template({
-      pool: this.pool.toJSON(),
-      cOpts: this.cOpts,
-    }));
-    this.showCompressionTooltips();
-  },
+	},
 
-  editCompressionCancel: function(event) {
-    event.preventDefault();
-    this.hideCompressionTooltips();
-    this.$('#ph-compression-info').html(this.compression_info_template({
-      pool: this.pool.toJSON(), 
-    }));
-  },
+	editCompression: function(event) {
+		event.preventDefault();
+		this.$('#ph-compression-info').html(this.compression_info_edit_template({
+			pool: this.pool.toJSON(),
+			cOpts: this.cOpts,
+		}));
+		this.showCompressionTooltips();
+	},
 
-  updateCompression: function(event) {
-    var _this = this;
-    event.preventDefault();
-    var button = this.$('#js-submit-compression');
-    if (buttonDisabled(button)) return false;
-    disableButton(button);
-    $.ajax({
-      url: "/api/pools/" + this.pool.get('name') + '/remount',
-      type: "PUT",
-      dataType: "json",
-      data: {
-        "compression": this.$('#compression').val(),
-        "mnt_options": this.$('#mnt_options').val(),
-      },
-      success: function() {
-        _this.hideCompressionTooltips();
-        _this.pool.fetch({
-          success: function(collection, response, options) {
-            _this.cView = 'view';
-            _this.renderSubViews();
-          }
-        });
-      },
-      error: function(xhr, status, error) {
-        enableButton(button);
-      }
-    });
-  },
+	editCompressionCancel: function(event) {
+		event.preventDefault();
+		this.hideCompressionTooltips();
+		this.$('#ph-compression-info').html(this.compression_info_template({
+			pool: this.pool.toJSON(), 
+		}));
+	},
 
-  showCompressionTooltips: function() {
-    this.$('#ph-compression-info #compression').tooltip({
-      html: true,
-      placement: 'top',
-      container: 'body',
-      title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
-    });
-    this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });
-  },
+	updateCompression: function(event) {
+		var _this = this;
+		event.preventDefault();
+		var button = this.$('#js-submit-compression');
+		if (buttonDisabled(button)) return false;
+		disableButton(button);
+		$.ajax({
+			url: "/api/pools/" + this.pool.get('name') + '/remount',
+			type: "PUT",
+			dataType: "json",
+			data: {
+				"compression": this.$('#compression').val(),
+				"mnt_options": this.$('#mnt_options').val(),
+			},
+			success: function() {
+				_this.hideCompressionTooltips();
+				_this.pool.fetch({
+					success: function(collection, response, options) {
+						_this.cView = 'view';
+						_this.renderSubViews();
+					}
+				});
+			},
+			error: function(xhr, status, error) {
+				enableButton(button);
+			}
+		});
+	},
 
-  hideCompressionTooltips: function() {
-    this.$('#ph-compression-info #compression').tooltip('hide');
-    this.$('#ph-compression-info #mnt_options').tooltip('hide');
-  },
+	showCompressionTooltips: function() {
+		this.$('#ph-compression-info #compression').tooltip({
+			html: true,
+			placement: 'top',
+			container: 'body',
+			title: "Choose a compression algorithm for this Pool.<br><strong>zlib: </strong>slower but higher compression ratio.<br><strong>lzo: </strong>faster compression/decompression, but ratio smaller than zlib.<br>Enabling compression at the pool level applies to all Shares carved out of this Pool.<br>Don't enable compression here if you like to have finer control at the Share level.<br>You can change the algorithm, disable or enable it later, if necessary."
+		});
+		this.$('#ph-compression-info #mnt_options').tooltip({ placement: 'top' });
+	},
 
-  showResizeTooltips: function() {
-    this.$('#ph-resize-pool-info #raid_level').tooltip({
-      html: true,
-      placement: 'top',
-      title: "You can transition raid level of this pool to change it's redundancy profile.",
-    });
-  },
+	hideCompressionTooltips: function() {
+		this.$('#ph-compression-info #compression').tooltip('hide');
+		this.$('#ph-compression-info #mnt_options').tooltip('hide');
+	},
 
-  hideResizeTooltips: function() {
-    this.$('#ph-resize-pool-info #raid_level').tooltip('hide');
-  },
+	showResizeTooltips: function() {
+		this.$('#ph-resize-pool-info #raid_level').tooltip({
+			html: true,
+			placement: 'top',
+			title: "You can transition raid level of this pool to change it's redundancy profile.",
+		});
+	},
 
-  attachModalActions: function() {
+	hideResizeTooltips: function() {
+		this.$('#ph-resize-pool-info #raid_level').tooltip('hide');
+	},
 
-  },
+	attachModalActions: function() {
 
-  cleanup: function() {
-    if (!_.isUndefined(this.statusIntervalId)) {
-      window.clearInterval(this.statusIntervalId);
-    }
-  },
+	},
 
-  initHandlebarHelpers: function(){
+	cleanup: function() {
+		if (!_.isUndefined(this.statusIntervalId)) {
+			window.clearInterval(this.statusIntervalId);
+		}
+	},
 
-    Handlebars.registerHelper('getPoolCreationDate', function(date){
-      return moment(date).format(RS_DATE_FORMAT);
-    });
+	initHandlebarHelpers: function(){
 
-    Handlebars.registerHelper('isPoolCompressionNone', function(compression,opts){
-      if (compression == 'no') {
-        return opts.fn(this);
-      }
-      return opts.inverse(this);
-    });
+		Handlebars.registerHelper('getPoolCreationDate', function(date){
+			return moment(date).format(RS_DATE_FORMAT);
+		});
+		
+		Handlebars.registerHelper('isPoolCompressionNone', function(compression,opts){
+			if (compression == 'no') {
+				return opts.fn(this);
+			}
+			return opts.inverse(this);
+		});
 
-    Handlebars.registerHelper('isMntOptionNone', function(mtOptions,opts){
-      if (_.isUndefined(mtOptions) || _.isNull(mtOptions) || _.isEmpty(mtOptions)) {
-        return opts.fn(this);
-      }
-      return opts.inverse(this);
-    });
+		Handlebars.registerHelper('isMntOptionNone', function(mtOptions,opts){
+			if (_.isUndefined(mtOptions) || _.isNull(mtOptions) || _.isEmpty(mtOptions)) {
+				return opts.fn(this);
+			}  
+			return opts.inverse(this);
+		});
+		
+		Handlebars.registerHelper('selectedCompressionOption', function(existingComp,c,opts){
+			if (existingComp == c) {
+				return opts.fn(this);
+			}  
+			return opts.inverse(this);
+		});
 
-    Handlebars.registerHelper('selectedCompressionOption', function(existingComp,c,opts){
-      if (existingComp == c) {
-        return opts.fn(this);
-      }
-      return opts.inverse(this);
-    });
-
-    Handlebars.registerHelper('humanReadableSize', function(size){
-      return humanize.filesize(size * 1024);
-    });
-  }
+		Handlebars.registerHelper('humanReadableSize', function(size){
+			return humanize.filesize(size * 1024);
+		});
+	}
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -79,7 +79,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
 			poolNameIsRockstor = true;
 		}
     $(this.el).html(this.template({
-      shares: this.poolShares.models,
+      share: this.poolShares.models[0].attributes.results,
 			poolName: this.pool.get('name'),
 			isPoolNameRockstor: poolNameIsRockstor,
 		}));
@@ -117,33 +117,33 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
 	},
 
   deletePool: function() {
-    console.info('pool shares', this.poolShares);
     var _this = this;
     var button = $(event.currentTarget);
     if (buttonDisabled(button)) return false;
-    // show the dialog
     _this.$('#delete-pool-modal').modal();
 	},
 
   confirmPoolDelete: function() {
-    // TODO: adjust to fit template/scenario (also dry up)
     var _this = this;
 		var button = $(event.currentTarget);
+    var url = "/api/pools/" + this.poolName;
 		if (buttonDisabled(button)) return false;
 		disableButton(button);
+    if ($("#force-delete").prop("checked")) {
+      url += "/force";
+    }
 		$.ajax({
-			url: "/api/pools/" + poolName,
+			url: url,
 			type: "DELETE",
 			dataType: "json",
 			success: function() {
-				_this.collection.fetch({reset: true});
-				enableButton(button);
-				_this.$('#delete-pool-modal').modal('hide');
-				$('.modal-backdrop').remove();
-				app_router.navigate('pools', {trigger: true})
+			  enableButton(button);
+			  _this.$('#delete-pool-modal').modal('hide');
+			  $('.modal-backdrop').remove();
+			  app_router.navigate('pools', {trigger: true})
 			},
 			error: function(xhr, status, error) {
-				enableButton(button);
+			  enableButton(button);
 			}
 		});
   },

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -79,7 +79,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
 			poolNameIsRockstor = true;
 		}
     $(this.el).html(this.template({
-      shares: this.poolShares.models,
+      share: this.poolShares.models[0].attributes.results,
 			poolName: this.pool.get('name'),
 			isPoolNameRockstor: poolNameIsRockstor,
 		}));
@@ -114,38 +114,39 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
 		//$('#pool-resize-raid-modal').modal({show: false});
 		$('#pool-resize-raid-overlay').overlay({load: false});
 
+	},
+
   deletePool: function() {
     var _this = this;
     var button = $(event.currentTarget);
     if (buttonDisabled(button)) return false;
     _this.$('#delete-pool-modal').modal();
-  },
+	},
 
   confirmPoolDelete: function() {
     var _this = this;
-    var button = $(event.currentTarget);
+		var button = $(event.currentTarget);
     var url = "/api/pools/" + this.poolName;
-    if (buttonDisabled(button)) return false;
-    disableButton(button);
+		if (buttonDisabled(button)) return false;
+		disableButton(button);
     if ($("#force-delete").prop("checked")) {
       url += "/force";
     }
-    $.ajax({
-      url: url,
-      type: "DELETE",
-      dataType: "json",
-      success: function() {
-        enableButton(button);
-        _this.$('#delete-pool-modal').modal('hide');
-        $('.modal-backdrop').remove();
-        app_router.navigate('pools', {trigger: true})
-      },
-      error: function(xhr, status, error) {
-        enableButton(button);
-      }
-    });
+		$.ajax({
+			url: url,
+			type: "DELETE",
+			dataType: "json",
+			success: function() {
+			  enableButton(button);
+			  _this.$('#delete-pool-modal').modal('hide');
+			  $('.modal-backdrop').remove();
+			  app_router.navigate('pools', {trigger: true})
+			},
+			error: function(xhr, status, error) {
+			  enableButton(button);
+			}
+		});
   },
-
 
 
 	resizePool: function(event) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -336,7 +336,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
     Handlebars.registerHelper('getPoolCreationDate', function(date){
       return moment(date).format(RS_DATE_FORMAT);
     });
-    
+
     Handlebars.registerHelper('isPoolCompressionNone', function(compression,opts){
       if (compression == 'no') {
         return opts.fn(this);
@@ -347,14 +347,14 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
     Handlebars.registerHelper('isMntOptionNone', function(mtOptions,opts){
       if (_.isUndefined(mtOptions) || _.isNull(mtOptions) || _.isEmpty(mtOptions)) {
         return opts.fn(this);
-      }  
+      }
       return opts.inverse(this);
     });
-    
+
     Handlebars.registerHelper('selectedCompressionOption', function(existingComp,c,opts){
       if (existingComp == c) {
         return opts.fn(this);
-      }  
+      }
       return opts.inverse(this);
     });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -109,40 +109,67 @@ PoolsView = RockstorLayoutView.extend({
 		return this;
 	},
 
+  displayPoolInformation: function (poolName) {
+    // set share name in confirm dialog
+		this.$('#pass-pool-name').html(poolName);
+		//show the dialog
+		this.$('#delete-pool-modal').modal();
+    return false;
+  },
+
 	deletePool: function(event) {
 		var _this = this;
 		var button = $(event.currentTarget);
+    var $poolShares = $("#pool-shares");
+    // Remove share names upon reopening
+    $poolShares.html("");
 		if (buttonDisabled(button)) return false;
-		poolName = button.attr('data-name');
-		// set share name in confirm dialog
-		_this.$('#pass-pool-name').html(poolName);
-		//show the dialog
-		_this.$('#delete-pool-modal').modal();
-		return false;
+		var poolName = button.attr('data-name');
+    var poolShares = new PoolShareCollection([], {poolName: poolName});
+    poolShares.fetch({
+      success: function (data) {
+        var shares = poolShares.models[0].attributes.results;
+        // Only display shares if they exist
+        if (!_.isUndefined(shares)) {
+          _.each(shares, function(share) {
+            $poolShares.append("<li>" + share.name +  " (" + share.size_gb + " GB)</li>");
+          });
+          _this.displayPoolInformation(poolName);
+        }
+      },
+      error: function (err) {
+        // Display anyways
+        _this.displayPoolInformation(poolName);
+      }
+    });
 	},
 
-	//modal confirm button handler
 	confirmPoolDelete: function(event) {
-		var _this = this;
-		var button = $(event.currentTarget);
-		if (buttonDisabled(button)) return false;
-		disableButton(button);
-		$.ajax({
-			url: "/api/pools/" + poolName,
-			type: "DELETE",
-			dataType: "json",
-			success: function() {
-				_this.collection.fetch({reset: true});
-				enableButton(button);
-				_this.$('#delete-pool-modal').modal('hide');
-				$('.modal-backdrop').remove();
-				app_router.navigate('pools', {trigger: true})
-			},
-			error: function(xhr, status, error) {
-				enableButton(button);
-			}
-		});
-	},
+    var _this = this;
+    var button = $(event.currentTarget);
+    var poolName = $("#pass-pool-name").text();
+    var url = "/api/pools/" + poolName;
+    if (buttonDisabled(button)) return false;
+    disableButton(button);
+    // The user has to confirm the pool delete
+    if ($("#force-delete").prop("checked")) {
+      url += "/force";
+    }
+    $.ajax({
+      url: url,
+      type: "DELETE",
+      dataType: "json",
+      success: function() {
+        enableButton(button);
+        _this.$('#delete-pool-modal').modal('hide');
+        $('.modal-backdrop').remove();
+        app_router.navigate('pools', {trigger: true})
+      },
+      error: function(xhr, status, error) {
+        enableButton(button);
+      }
+    });
+  },
 
 	cancel: function(event) {
 		if (event) event.preventDefault();

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -163,7 +163,7 @@ PoolsView = RockstorLayoutView.extend({
         enableButton(button);
         _this.$('#delete-pool-modal').modal('hide');
         $('.modal-backdrop').remove();
-        app_router.navigate('pools', {trigger: true})
+        location.reload();
       },
       error: function(xhr, status, error) {
         enableButton(button);

--- a/src/rockstor/storageadmin/urls/pools.py
+++ b/src/rockstor/storageadmin/urls/pools.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import patterns, url
 from storageadmin.views import (PoolListView, PoolDetailView, PoolScrubView,
-                                PoolBalanceView, get_usage_bound, PoolShareListView)
+                                PoolBalanceView, PoolShareListView)
 from django.conf import settings
 
 pool_regex = settings.POOL_REGEX

--- a/src/rockstor/storageadmin/urls/pools.py
+++ b/src/rockstor/storageadmin/urls/pools.py
@@ -27,6 +27,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', PoolListView.as_view(), name='pool-view'),
     url(r'^/(?P<pname>%s)$' % pool_regex, PoolDetailView.as_view(),),
+    url(r'^/(?P<pname>%s)/shares$' % pool_regex, PoolShareListView.as_view(),),
     url(r'^/(?P<pname>%s)/balance$' % pool_regex, PoolBalanceView.as_view(),),
     url(r'^/(?P<pname>%s)/balance/(?P<command>.*)$' % pool_regex,
         PoolBalanceView.as_view(),),

--- a/src/rockstor/storageadmin/urls/pools.py
+++ b/src/rockstor/storageadmin/urls/pools.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import patterns, url
 from storageadmin.views import (PoolListView, PoolDetailView, PoolScrubView,
-                                PoolBalanceView, get_usage_bound)
+                                PoolBalanceView, get_usage_bound, PoolShareListView)
 from django.conf import settings
 
 pool_regex = settings.POOL_REGEX
@@ -26,7 +26,6 @@ pool_regex = settings.POOL_REGEX
 urlpatterns = patterns(
     '',
     url(r'^$', PoolListView.as_view(), name='pool-view'),
-    url(r'^/usage_bound$', get_usage_bound),
     url(r'^/(?P<pname>%s)$' % pool_regex, PoolDetailView.as_view(),),
     url(r'^/(?P<pname>%s)/balance$' % pool_regex, PoolBalanceView.as_view(),),
     url(r'^/(?P<pname>%s)/balance/(?P<command>.*)$' % pool_regex,
@@ -34,6 +33,5 @@ urlpatterns = patterns(
     url(r'^/(?P<pname>%s)/scrub$' % pool_regex, PoolScrubView.as_view(),),
     url(r'^/(?P<pname>%s)/scrub/(?P<command>.*)$' % pool_regex,
         PoolScrubView.as_view(),),
-    url(r'^/(?P<pname>%s)/(?P<command>.*)$' % pool_regex,
-        PoolDetailView.as_view(),)
+    url(r'^/(?P<pname>%s)/(?P<command>.*)$' % pool_regex, PoolDetailView.as_view(),),
 )

--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from home import (login_page, login_submit, logout_user, home)
 from snapshot import SnapshotView
-from share import (ShareListView, ShareDetailView)
+from share import (ShareListView, ShareDetailView, PoolShareListView)
 from disk import (DiskMixin, DiskListView, DiskDetailView)
 from pool import (PoolListView, PoolDetailView, get_usage_bound)
 from command import CommandView

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -28,7 +28,6 @@ from rest_framework.decorators import api_view
 from django.db import transaction
 from storageadmin.serializers import PoolInfoSerializer
 from storageadmin.models import (Disk, Pool, Share, PoolBalance)
-from storageadmin.views import DiskMixin
 from fs.btrfs import (add_pool, pool_usage, resize_pool, umount_root,
                       btrfs_uuid, mount_root, start_balance, usage_bound)
 from system.osi import remount
@@ -279,7 +278,7 @@ class PoolListView(PoolMixin, rfc.GenericView):
             return Response(PoolInfoSerializer(p).data)
 
 
-class PoolDetailView(DiskMixin, PoolMixin, rfc.GenericView):
+class PoolDetailView(PoolMixin, rfc.GenericView):
     def get(self, *args, **kwargs):
         try:
             pool = Pool.objects.get(name=self.kwargs['pname'])

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -29,7 +29,7 @@ from fs.btrfs import (add_share, remove_share, update_quota, share_usage,
                       set_property, mount_share, qgroup_id, qgroup_create)
 from system.osi import is_share_mounted
 from system.services import systemctl
-from storageadmin.serializers import ShareSerializer
+from storageadmin.serializers import ShareSerializer, SharePoolSerializer
 from storageadmin.util import handle_exception
 from django.conf import settings
 import rest_framework_custom as rfc
@@ -182,6 +182,13 @@ class ShareListView(ShareMixin, rfc.GenericView):
                 set_property(mnt_pt, 'compression', compression)
             return Response(ShareSerializer(s).data)
 
+
+class PoolShareListView(ShareMixin, rfc.GenericView):
+    serializer_class = SharePoolSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        pool = Pool.objects.get(name=self.kwargs.get('pname'))
+        return pool.share_set.all()
 
 class ShareDetailView(ShareMixin, rfc.GenericView):
     serializer_class = ShareSerializer


### PR DESCRIPTION
## Deletion of Pool in Modal

Users are now able to delete a pool from the pool detail page via a force delete checkbox. The size of the share is displayed (rounded to the nearest integer) along with a warning saying that all associated information will be removed.

Also included is a fix where the delete button doesn't show up for the root pool in the pool detail page.

![image](https://cloud.githubusercontent.com/assets/7519543/18699060/9e6b7c3e-7f83-11e6-82f7-80b4eb723248.png)
