### PR TITLE
Fix DataTables error on AFP shares view

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
@@ -39,7 +39,7 @@
         </tbody>
       </table>
       {{else}}
-      <table id="afp-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of afp exports">
+      <table id="afp-exports-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" width="100%" summary="List of afp exports">
         <tbody>
           <tr>
             <td colspan="5">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
@@ -35,9 +35,15 @@
         </tbody>
       </table>
       {{else}}
-            <div class="bg-info">
-              <h3>No sftp shares have been created</h3>
-            </div>
+      <table id="sftp-shares-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of sftp shares">
+        <tbody>
+          <tr>
+            <td colspan="5">
+              <h4>No sftp shares have been created</h4>
+            </td>
+          </tr>
+        </tbody>
+      </table>
       {{/if}}
 
   </div>

--- a/src/rockstor/storageadmin/views/netatalk.py
+++ b/src/rockstor/storageadmin/views/netatalk.py
@@ -83,8 +83,8 @@ class NetatalkDetailView(rfc.GenericView):
     def _refresh_and_reload(request):
         try:
             refresh_afp_config(list(NetatalkShare.objects.all()))
-            return systemctl('netatalk', 'reload')
-        except Exception, e:
+            return systemctl('netatalk', 'reload-or-restart')
+        except Exception as e:
             e_msg = ('Failed to reload Netatalk server. Exception: %s' % e.__str__())
             handle_exception(Exception(e_msg), request)
 
@@ -131,9 +131,9 @@ class NetatalkListView(rfc.GenericView):
                 if (not is_share_mounted(share.name)):
                     mount_share(share, mnt_pt)
             refresh_afp_config(list(NetatalkShare.objects.all()))
-            systemctl('netatalk', 'reload')
+            systemctl('netatalk', 'reload-or-restart')
             return Response()
         except RockStorAPIException:
             raise
-        except Exception, e:
+        except Exception as e:
             handle_exception(e, request)


### PR DESCRIPTION
This was caused by the table displayed in the absence of existing shares being classed `data-table` and stopped the view from loading fully. Partial fix of #1438, which also involves #813.