### PR TITLE
Web-UI initiated balance status enhancement. Fixes #1405

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -798,6 +798,7 @@ def scrub_status(pool):
 
 @task()
 def start_balance(mnt_pt, force=False, convert=None):
+    logger.debug('START_BALANCE() called with mnt_pt=%s, force=%s, convert=%s' % (mnt_pt, force, convert))
     cmd = ['btrfs', 'balance', 'start', mnt_pt]
     # TODO: Confirm -f is doing what is intended, man states for reducing
     # TODO: metadata from say raid1 to single.
@@ -835,9 +836,15 @@ def balance_status(pool):
     logger.debug('run_command returned rc=%s' % rc)
     if (len(out) > 0):
         if (re.match('Balance', out[0]) is not None):
-            stats['status'] = 'running'
             if (re.search('cancel requested', out[0]) is not None):
-                stats['status'] = 'aborting'
+                stats['status'] = 'cancelling'
+            elif (re.search('pause requested', out[0]) is not None):
+                stats['status'] = 'pausing'
+            elif (re.search('paused', out[0]) is not None):
+                stats['status'] = 'paused'
+            else:
+                stats['status'] = 'running'
+            # make sure we have a second line before parsing it.
             if ((len(out) > 1 and
                     re.search('chunks balanced', out[1]) is not None)):
                 percent_left = out[1].split()[-2][:-1]

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -810,8 +810,12 @@ def start_balance(mnt_pt, force=False, convert=None):
     if (convert is not None):
         cmd.insert(3, '-dconvert=%s' % convert)
         cmd.insert(3, '-mconvert=%s' % convert)
-    # TODO: elseif to apply "--full-balance" when no filters are requested.
-    # TODO: this avoids a problematic 10 second count down delay.
+    else:
+        # As we are running with no convert filters a warning and 10 second
+        # countdown with ^C prompt will result unless we use "--full-balance".
+        # This warning is now present in the Web-UI "Start a new balance"
+        # button tooltip.
+        cmd.insert(3, '--full-balance')
     logger.debug('start_balance command=%s' % cmd)
     # cmd=['btrfs', 'balance', 'start', u'/mnt2/raid5-pool']
     #

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -799,22 +799,45 @@ def scrub_status(pool):
 @task()
 def start_balance(mnt_pt, force=False, convert=None):
     cmd = ['btrfs', 'balance', 'start', mnt_pt]
+    # TODO: Confirm -f is doing what is intended, man states for reducing
+    # TODO: metadata from say raid1 to single.
+    # With no filters we also get a warning that block some balances due to
+    # expected long execution time, in this case "--full-balance" is required.
+    # N.B. currently force in Web-UI does not mean force here.
     if (force):
         cmd.insert(3, '-f')
     if (convert is not None):
         cmd.insert(3, '-dconvert=%s' % convert)
         cmd.insert(3, '-mconvert=%s' % convert)
+    # TODO: elseif to apply "--full-balance" when no filters are requested.
+    # TODO: this avoids a problematic 10 second count down delay.
+    logger.debug('start_balance command=%s' % cmd)
+    # cmd=['btrfs', 'balance', 'start', u'/mnt2/raid5-pool']
+    #
     run_command(cmd)
 
 
 def balance_status(pool):
+    """
+    Wrapper around btrfs balance status pool_mount_point to extract info about
+    the current status of a balance.
+    :param pool: pool object to query
+    :return: dictionary containing parsed info about the balance status,
+    ie indexed by 'status' and 'percent_done'.
+    """
+    logger.debug('balance_status called with pool object of name=%s' % pool.name)
     stats = {'status': 'unknown', }
     mnt_pt = mount_root(pool)
     out, err, rc = run_command([BTRFS, 'balance', 'status', mnt_pt],
                                throw=False)
+    logger.debug('run_command returned out=%s' % out)
+    logger.debug('run_command returned err=%s' % err)
+    logger.debug('run_command returned rc=%s' % rc)
     if (len(out) > 0):
         if (re.match('Balance', out[0]) is not None):
             stats['status'] = 'running'
+            if (re.search('cancel requested', out[0]) is not None):
+                stats['status'] = 'aborting'
             if ((len(out) > 1 and
                     re.search('chunks balanced', out[1]) is not None)):
                 percent_left = out[1].split()[-2][:-1]
@@ -826,6 +849,7 @@ def balance_status(pool):
         elif (re.match('No balance', out[0]) is not None):
             stats['status'] = 'finished'
             stats['percent_done'] = 100
+    logger.debug('balance_status() returning stats=%s' % stats)
     return stats
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -798,7 +798,6 @@ def scrub_status(pool):
 
 @task()
 def start_balance(mnt_pt, force=False, convert=None):
-    logger.debug('START_BALANCE() called with mnt_pt=%s, force=%s, convert=%s' % (mnt_pt, force, convert))
     cmd = ['btrfs', 'balance', 'start', mnt_pt]
     # TODO: Confirm -f is doing what is intended, man states for reducing
     # TODO: metadata from say raid1 to single.
@@ -816,9 +815,6 @@ def start_balance(mnt_pt, force=False, convert=None):
         # This warning is now present in the Web-UI "Start a new balance"
         # button tooltip.
         cmd.insert(3, '--full-balance')
-    logger.debug('start_balance command=%s' % cmd)
-    # cmd=['btrfs', 'balance', 'start', u'/mnt2/raid5-pool']
-    #
     run_command(cmd)
 
 
@@ -830,14 +826,10 @@ def balance_status(pool):
     :return: dictionary containing parsed info about the balance status,
     ie indexed by 'status' and 'percent_done'.
     """
-    logger.debug('balance_status called with pool object of name=%s' % pool.name)
     stats = {'status': 'unknown', }
     mnt_pt = mount_root(pool)
     out, err, rc = run_command([BTRFS, 'balance', 'status', mnt_pt],
                                throw=False)
-    logger.debug('run_command returned out=%s' % out)
-    logger.debug('run_command returned err=%s' % err)
-    logger.debug('run_command returned rc=%s' % rc)
     if (len(out) > 0):
         if (re.match('Balance', out[0]) is not None):
             if (re.search('cancel requested', out[0]) is not None):
@@ -860,7 +852,6 @@ def balance_status(pool):
         elif (re.match('No balance', out[0]) is not None):
             stats['status'] = 'finished'
             stats['percent_done'] = 100
-    logger.debug('balance_status() returning stats=%s' % stats)
     return stats
 
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -20,7 +20,7 @@
 </script>
 <div class="messages"></div>
 
-  <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Restripe data across all disks of the pool. Do this only if you need to."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
+  <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Rebalance data and metadata across all disks in this pool. WARNING: very intense and potentially long operation. Do this only if needed."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
 <br>
 {{#if collectionNotEmpty}}
   <table id="poolrebalances-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of pool balances">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -19,7 +19,6 @@
  */
 </script>
 <div class="messages"></div>
-
   <a class="btn btn-primary btn-spacing" href="#" id="js-poolrebalance-start" title="Rebalance data and metadata across all disks in this pool. WARNING: very intense and potentially long operation. Do this only if needed."><i class="glyphicon glyphicon-edit "></i>Start a new balance</a>
 <br>
 {{#if collectionNotEmpty}}
@@ -30,7 +29,7 @@
         <th>Status</th>
         <th>Start Time</th>
         <th>Percent finished</th>
-	<th>Errors</th>
+        <th>Errors or Notes</th>
       </tr>
     </thead>
     <tbody>

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -354,10 +354,10 @@ class PoolDetailView(DiskMixin, PoolMixin, rfc.GenericView):
 
                 if (PoolBalance.objects.filter(
                         pool=pool,
-                        status__regex=r'(started|running)').exists()):
-                    e_msg = ('A Balance process is already running for this '
-                             'pool(%s). Resize is not supported during a '
-                             'balance process.' % pool.name)
+                        status__regex=r'(started|running|cancelling|pausing|paused)').exists()):
+                    e_msg = ('A Balance process is already running or paused '
+                             'for this pool(%s). Resize is not supported '
+                             'during a balance process.' % pool.name)
                     handle_exception(Exception(e_msg), request)
 
                 resize_pool(pool, dnames)


### PR DESCRIPTION
Fixes #1405 - When a Web-UI initiated balance is in progress and the Pool page is refreshed there is no indication of the percentage of progress until the balance task initiated has reached 100%. Given balance tasks can be very long lived processes it is a better user experience to have an indication of the current status of percent complete.

Prior behaviour is to only indicate status as started or complete.

These alterations allow for in progress 'percentage finished' updates via 'Pools' page refresh. They also extend the balance status reporting to include running, pausing, paused, cancelling, and cancelled, however these status updates are only available via a page update. But this at least paves the way for future improvements on balance status reporting. Also note that with the addition of these changes it will be easier to accommodate and report accordingly the status intervention affected by a balance pause/resume button and a balance cancel button, see #1413. Also partially addresses elements of #862.

Origin Note: This pr is as a result of a requested split of previously submitted #1418 with the intention to return to a more single issue focused approach. Previously it was developed along with it's associated unit tests that are now part of this pr's sister (pr #1444) which was also split out from #1418.

Ready for review.
