### PR TITLE
Issue #1379  Adding funtionality for setting "writable" for a snapshot scheduler in the GUI. 

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -501,7 +501,7 @@ def remove_snap(pool, share_name, snap_name):
 
 def add_snap_helper(orig, snap, writable):
     cmd = [BTRFS, 'subvolume', 'snapshot', orig, snap]
-    if (!writable):
+    if (not writable):
         cmd.insert(3, '-r')
     try:
         return run_command(cmd)

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -499,9 +499,9 @@ def remove_snap(pool, share_name, snap_name):
                 return run_command([BTRFS, 'subvolume', 'delete', snap], log=True)
 
 
-def add_snap_helper(orig, snap, readonly=False):
+def add_snap_helper(orig, snap, writable):
     cmd = [BTRFS, 'subvolume', 'snapshot', orig, snap]
-    if (readonly):
+    if (!writable):
         cmd.insert(3, '-r')
     try:
         return run_command(cmd)
@@ -524,10 +524,10 @@ def add_clone(pool, share, clone, snapshot=None):
     else:
         orig_path = ('%s/%s' % (orig_path, share))
     clone_path = ('%s/%s' % (pool_mnt, clone))
-    return add_snap_helper(orig_path, clone_path)
+    return add_snap_helper(orig_path, clone_path, True)
 
 
-def add_snap(pool, share_name, snap_name, readonly=False):
+def add_snap(pool, share_name, snap_name, writable):
     """
     create a snapshot
     """
@@ -536,7 +536,7 @@ def add_snap(pool, share_name, snap_name, readonly=False):
     snap_dir = ('%s/.snapshots/%s' % (root_pool_mnt, share_name))
     create_tmp_dir(snap_dir)
     snap_full_path = ('%s/%s' % (snap_dir, snap_name))
-    return add_snap_helper(share_full_path, snap_full_path, readonly)
+    return add_snap_helper(share_full_path, snap_full_path, writable)
 
 
 def rollback_snap(snap_name, sname, subvol_name, pool):

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -102,7 +102,8 @@ def main():
             #runaway snapshot creation beyond max_count+1.
             if(delete(aw, share, stype, prefix, max_count)):
                 data = {'snap_type': stype,
-                        'uvisible': meta['visible'], }
+                        'uvisible': meta['visible'],
+                        'writable': meta['writable'], }
                 headers = {'content-type': 'application/json'}
                 aw.api_call(url, data=data, calltype='post', headers=headers, save_error=False)
                 logger.debug('created snapshot at %s' % url)

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -51,6 +51,8 @@ def validate_snap_meta(meta):
         raise Exception('max_count must atleast be 1, not %d' % max_count)
     if ('visible' not in meta or type(meta['visible']) != bool):
         meta['visible'] = False
+    if ('writable' not in meta or type(meta['writable']) != bool):
+        meta['writable'] = False
     return meta
 
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -493,6 +493,13 @@ var TaskDef = Backbone.Model.extend({
             return false;
         }
     },
+    writable: function () {
+        if (this.get('json_meta') != null) {
+            return JSON.parse(this.get('json_meta')).writable;
+        } else {
+            return false;
+        }
+    },
 
 
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/add_task.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/add_task.jst
@@ -153,9 +153,19 @@ $(document).ready(function() {
 	  <div class="form-group">
 	    <div class="col-sm-offset-4 col-sm-6">
 	      <div class="checkbox">
-		<label>
-		  <input class="checkbox" type="checkbox" id="visible" name="meta.visible" {{#if taskObj.visible}} checked="true" {{/if}} title="Make snapshots visible to the end user"> Make snapshots visible?
-		</label>
+			<label>
+			  <input class="checkbox" type="checkbox" id="writable" name="meta.writable" {{#if taskObj.writable}} checked="true" {{/if}} title="Make snapshots writable"> Make snapshots writable?
+			</label>
+	      </div>
+	    </div>
+	  </div>
+
+	  <div class="form-group">
+	    <div class="col-sm-offset-4 col-sm-6">
+	      <div class="checkbox">
+			<label>
+			  <input class="checkbox" type="checkbox" id="visible" name="meta.visible" {{#if taskObj.visible}} checked="true" {{/if}} title="Make snapshots visible to the end user"> Make snapshots visible?
+			</label>
 	      </div>
 	    </div>
 	  </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/snapshot_fields.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/snapshot_fields.jst
@@ -29,6 +29,12 @@
 </div>
 <div class="checkbox" style="clear: both">
   <label>
+    <input  type="checkbox" checked="true" id="writable" name="meta.writable" title="Make snapshots writable.">
+    Make snapshots writable?
+  </label>
+</div>
+<div class="checkbox" style="clear: both">
+  <label>
     <input  type="checkbox" checked="true" id="visible" name="meta.visible" title="Make snapshots visible to the end user.">
     Make snapshots visible?
   </label>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshot_add_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshot_add_template.jst
@@ -43,9 +43,9 @@
         </div>
 
         <div class="form-group">
-          <label class="col-xs-4 control-label" for=writable">Writable<span class="required"> *</span></label>
+          <label class="col-xs-4 control-label" for="snapshot-writable"> </label>
           <div class="col-sm-4">
-            {{display_writeable_options}}
+            <input type="checkbox" name="writable" id="snapshot-writable" title="Snapshots can be made writable by selecting this checkbox"> Writable?
            </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
@@ -68,6 +68,7 @@ AddScheduledTaskView = RockstorLayoutView.extend({
 				pool: this.taskDef.pool(),
 				maxCount: this.taskDef.max_count(),
 				visible: this.taskDef.visible(),
+				writable: this.taskDef.writable(),
 				enabled: this.taskDef.get('enabled'),
 		};
 		var isSnapshot = false;

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -121,8 +121,7 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         qgroup_id = '0/na'
         if (snap_type == 'replication'):
             writable = False
-        add_snap(share.pool, share.subvol_name, snap_name, readonly=not
-                 writable)
+        add_snap(share.pool, share.subvol_name, snap_name, writable)
         snap_id = share_id(share.pool, snap_name)
         qgroup_id = ('0/%s' % snap_id)
         qgroup_assign(qgroup_id, share.pqgroup, ('%s/%s' % (settings.MNT_PT, share.pool.name)))


### PR DESCRIPTION
Ok, sorry for previous pull request being a bit of a mess. Decided to do it a bit more proper through a separate branch.

So, this will (as per issue #1379) enable scheduling of read only snapshots. This is very useful when having a samba shadow copy and possibility of ransomware encrypting all snapshots made visible through shadow copy framework.