### PR TITLE
Broken samba config - correctly build smb.conf

### DIFF
--- a/src/rockstor/smart_manager/views/active_directory.py
+++ b/src/rockstor/smart_manager/views/active_directory.py
@@ -219,6 +219,7 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
                     cmd += ['--update', '--enablelocauthorize',]
                     run_command(cmd)
                 config['workgroup'] = self._domain_workgroup(domain, method=method)
+                self._save_config(service, config)
                 update_global_config(smb_config, config)
                 self._join_domain(config, method=method)
                 if (method == 'sssd' and config.get('enumerate') is True):

--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -19,13 +19,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import shutil
 from rest_framework.response import Response
 from storageadmin.util import handle_exception
-from system.services import systemctl
+from system.services import systemctl, service_status
 from system.samba import (update_global_config, restart_samba,
                           get_global_config)
 from django.db import transaction
 from django.conf import settings
 from base_service import BaseServiceDetailView
-from smart_manager.models import Service
+from active_directory import ActiveDirectoryServiceView
+from smart_manager.models import Service, ServiceStatus
 from storageadmin.models import SambaShare
 from system.osi import md5sum
 from smart_manager.serializers import ServiceStatusSerializer
@@ -52,14 +53,8 @@ class SambaServiceView(BaseServiceDetailView):
         execute a command on the service
         """
         service = Service.objects.get(name=self.service_name)
+        
         if (command == 'config'):
-            aso = Service.objects.get(name='active-directory')
-            if (aso.config is not None):
-                e_msg = ('Active Directory service is configured, so '
-                         'Workgroup is automatically retrieved and cannot '
-                         'be set manually')
-                handle_exception(Exception(e_msg), request)
-
             try:
                 config = request.data.get('config', {})
                 global_config = {}
@@ -68,13 +63,20 @@ class SambaServiceView(BaseServiceDetailView):
                     gc_param = l.strip().split('=')
                     if (len(gc_param) == 2):
                         global_config[gc_param[0].strip().lower()] = gc_param[1].strip()
-                if ('workgroup' not in global_config):
-                    global_config['workgroup'] = config['workgroup']
-                self._save_config(service, global_config)
+                #Default set current workgroup to one got via samba config page
+                global_config['workgroup'] = config['workgroup']
+                #Check Active Directory config and status
+                #if AD configured and ON set workgroup to AD retrieved workgroup
+                #else AD not running and leave workgroup to one choosen by user
                 adso = Service.objects.get(name='active-directory')
                 adconfig = {}
                 if (adso.config is not None):
                     adconfig = self._get_config(adso)
+                    adso_out, adso_err, adso_status = service_status('active-directory', adconfig)
+                    if adso_status == 0:
+                        global_config['workgroup'] = adconfig['workgroup']
+
+                self._save_config(service, global_config)
                 update_global_config(global_config, adconfig)
                 restart_samba(hard=True)
             except Exception, e:

--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -70,11 +70,14 @@ class SambaServiceView(BaseServiceDetailView):
                 #else AD not running and leave workgroup to one choosen by user
                 adso = Service.objects.get(name='active-directory')
                 adconfig = {}
+                adso_status = 1
                 if (adso.config is not None):
                     adconfig = self._get_config(adso)
                     adso_out, adso_err, adso_status = service_status('active-directory', adconfig)
                     if adso_status == 0:
                         global_config['workgroup'] = adconfig['workgroup']
+                    else:
+                        adconfig = None
 
                 self._save_config(service, global_config)
                 update_global_config(global_config, adconfig)

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -53,7 +53,8 @@ var AppRouter = Backbone.Router.extend({
 	    "shares/:shareName/?cView=:cView": "showShare",
 	    "snapshots": "showSnapshots",
 	    "services": "showServices",
-	    "services/:serviceName/edit": "configureService",
+        "services/:serviceName/edit": "configureService",
+	    "services/:serviceName/edit/?adStatus=:adStatus": "configureService",
 	    "users": "showUsers",
 	    "users/:username/edit": "editUser",
 	    "add-user": "addUser",
@@ -290,10 +291,11 @@ var AppRouter = Backbone.Router.extend({
 
     },
 
-    configureService: function(serviceName) {
+    configureService: function(serviceName, adStatus) {
 	    this.renderSidebar("system", "services");
 	    this.cleanup();
-	    this.currentLayout = new ConfigureServiceView({serviceName: serviceName});
+        var service_options = _.isUndefined(adStatus) ? {serviceName: serviceName} : {serviceName: serviceName, adStatus: adStatus}
+        this.currentLayout = new ConfigureServiceView(service_options);
 	    $('#maincontent').empty();
 	    $('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
@@ -28,9 +28,14 @@
                 <form class="form-horizontal" id="smb-form" name="aform">
                     <div class="messages"></div>
                     <div class="form-group">
-                        <label class="col-sm-4 control-label" for="workgroup">Workgroup<span class="required"> *</span></label>
+                        <label class="col-sm-4 control-label" for="workgroup">Workgroup<span class="required"> * 
+                            {{#isEnabledAD}}
+                            <i class="fa fa-info-circle" title="Workgroup field disabled: Active Directory is running and workgroup name has been retrieved from domain"></i>
+                            {{/isEnabledAD}}                          
+                            </span>
+                        </label>
                         <div class="col-sm-4">
-                            <input class="form-control" type="text" id="workgroup" name="workgroup" value="{{config.workgroup}}" placeholder="MYGROUP" title="the Windows NT domain name or workgroup name, for example, MYGROUP.">
+                            <input class="form-control" type="text" id="workgroup" name="workgroup" value="{{config.workgroup}}" placeholder="MYGROUP" {{#isEnabledAD}} disabled {{/isEnabledAD}} title="the Windows NT domain name or workgroup name, for example, MYGROUP.">
                         </div>
                     </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -20,40 +20,46 @@
 </script>
 
 <div class="row">
-  <div class="col-md-8">
-    <div class="panel panel-default">
-<div class="panel-heading">Configure {{serviceName}}</div>
+    <div class="col-md-8">
+        <div class="panel panel-default">
+            <div class="panel-heading">Configure {{serviceName}}</div>
 
-    <div class="panel-body">
-      <form class="form-horizontal" id="smb-form" name="aform">
-        <div class="messages"></div>
-        <div class="form-group">
-          <label class="col-sm-4 control-label" for="workgroup">Workgroup<span class="required"> *</span></label>
-          <div class="col-sm-4">
-            <input class="form-control" type="text" id="workgroup" name="workgroup" value="{{config.workgroup}}" placeholder="MYGROUP" title="the Windows NT domain name or workgroup name, for example, MYGROUP.">
-          </div>
-        </div>
+            <div class="panel-body">
+                <form class="form-horizontal" id="smb-form" name="aform">
+                    <div class="messages"></div>
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="workgroup">Workgroup<span class="required"> *</span></label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="text" id="workgroup" name="workgroup" value="{{config.workgroup}}" placeholder="MYGROUP" title="the Windows NT domain name or workgroup name, for example, MYGROUP.">
+                        </div>
+                    </div>
 
-        <div class="form-group">
-          <label class="col-sm-4 control-label" for="global_config">Custom global configuration </label>
-          <div class="col-sm-8">
-            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control" title="You can provide custom parameters here. These lines will be added to the [global] section of smb.conf">
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="global_config">Custom global configuration </label>
+                        <div class="col-sm-8">
+                            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control" title="You can provide custom parameters here. These lines will be added to the [global] section of smb.conf">
               {{#each config}}
-              {{@key}} = {{this}}
+			    {{#if (smb_check_custom_params @key)}} 
+                    {{@key}} = {{this}}
+			    {{/if}}
               {{/each}}
             </textarea>
-          </div>
-        </div>
+                        </div>
+                    </div>
 
-        <div class="form-group">
-          <div class="col-sm-8 col-sm-offset-4">
-            <button id="cancel" class="btn btn-default">Cancel</button>
-            <button type="Submit" id="submit" class="btn btn-primary">Submit</button>
-          </div>
-        </div>
-      </form>
+                    <div class="form-group">
+                        <div class="col-sm-8 col-sm-offset-4">
+                            <button id="cancel" class="btn btn-default">Cancel</button>
+                            <button type="Submit" id="submit" class="btn btn-primary">Submit</button>
+                        </div>
+                    </div>
+                </form>
 
-    </div> <!-- panel-body -->
-  </div><!--panel-default-->
-  </div> <!-- col-md-8 -->
-</div> <!-- row -->
+            </div>
+            <!-- panel-body -->
+        </div>
+        <!--panel-default-->
+    </div>
+    <!-- col-md-8 -->
+</div>
+<!-- row -->

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -37,6 +37,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
         var _this = this;
         this.constructor.__super__.initialize.apply(this, arguments);
         this.serviceName = this.options.serviceName;
+        this.adStatus = this.options.adStatus;
         // set template
         this.template = window.JST['services_configure_' + this.serviceName];
         this.rules = {
@@ -116,11 +117,13 @@ ConfigureServiceView = RockstorLayoutView.extend({
     },
 
     render: function() {
+
         this.fetch(this.renderServiceConfig, this);
         return this;
     },
 
     renderServiceConfig: function() {
+
         var _this = this;
         var default_port = 443;
         if (this.service.get('name') == 'replication') {
@@ -140,7 +143,8 @@ ConfigureServiceView = RockstorLayoutView.extend({
             config: configObj,
             shares: this.shares,
             network: this.network,
-            defaultPort: default_port
+            defaultPort: default_port,
+            adStatus: this.adStatus
         }));
 
         this.$('#nis-form :input').tooltip({
@@ -341,6 +345,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
     },
 
     cancel: function(event) {
+
         event.preventDefault();
         app_router.navigate("services", {
             trigger: true
@@ -348,6 +353,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
     },
 
     toggleFormFields: function() {
+
         if (this.$('#security').val() == 'ads') {
             this.$('#realm').removeAttr('disabled');
         } else {
@@ -362,6 +368,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
     },
 
     toggleNutFields: function() {
+
         if (this.$('#mode').val() == 'standalone') {
             this.$('#monitor-mode').hide();
             this.$('#upsmon').attr('value', 'master');
@@ -395,6 +402,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
     },
 
     toggleCertUrl: function() {
+
         var cbox = this.$('#enabletls');
         if (cbox.prop('checked')) {
             this.$('#cert-ph').css('visibility', 'visible');
@@ -407,6 +415,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
 
         //ShellInABox
         Handlebars.registerHelper('display_shelltype_options', function() {
+
             var html = '',
                 _this = this;
             var avail_shells = ['LOGIN', 'SSH'];
@@ -422,6 +431,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         });
 
         Handlebars.registerHelper('display_shellstyle_options', function() {
+
             var html = '',
                 _this = this;
             var avail_styles = {
@@ -445,8 +455,18 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
             return key != 'workgroup';
         });
 
+        Handlebars.registerHelper('isEnabledAD', function(opts){
+
+            var _this = this;
+            if(_this.adStatus == 0) {
+                return opts.fn(this);
+            }
+            return opts.inverse(this);
+        });
+
         //NUT-UPS
         Handlebars.registerHelper('display_nutMode_options', function() {
+
             var html = '',
                 _this = this;
             var nutModeTypes = ['standalone', 'netserver', 'netclient'];
@@ -462,6 +482,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         });
 
         Handlebars.registerHelper('display_monitorMode_options', function() {
+
             var html = '',
                 _this = this;
             var nutMonitorTypes = ['master', 'slave'];
@@ -477,6 +498,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         });
 
         Handlebars.registerHelper('display_nutDriver_options', function() {
+
             var html = '',
                 _this = this;
             var nutDriverTypes = ['apcsmart', 'apcsmart-old', 'apcupsd-ups', 'bcmxcp', 'bcmxcp_usb', 'belkin', 'belkinunv', 'bestfcom', 'bestfortress', 'bestuferrups', 'bestups', 'blazer_ser', 'blazer_usb', 'dummy-ups', 'etapro', 'everups', 'gamatronic', 'genericups', 'isbmex', 'ivtscd', 'liebert', 'liebert-esp2', 'masterguard', 'metasys', 'mge-shut', 'mge-utalk', 'microdowell', 'nutclient', 'nutdrv_qx', 'oldmge-shut', 'oneac', 'optiups', 'powercom', 'powerpanel', 'rhino', 'richcomm_usb', 'riello_ser', 'riello_usb', 'safenet', 'skel', 'snmp-ups', 'solis', 'tripplite', 'tripplite_usb', 'tripplitesu', 'upscode2', 'usbhid-ups', 'victronups'];
@@ -493,6 +515,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
 
         //Replication
         Handlebars.registerHelper('display_networkInterface_options', function() {
+
             var html = '',
                 _this = this;
             this.network.each(function(ni, index) {
@@ -512,6 +535,7 @@ To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
 
         //Rockon template
         Handlebars.registerHelper('display_rockon_shares', function() {
+
             var html = '',
                 _this = this;
             if (this.shares.length === 0) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -26,485 +26,511 @@
 
 ConfigureServiceView = RockstorLayoutView.extend({
     events: {
-	"click #cancel": "cancel",
-	"click #security": "toggleFormFields",
-	"click #enabletls": "toggleCertUrl",
-	"click #mode": "toggleNutFields"
+        "click #cancel": "cancel",
+        "click #security": "toggleFormFields",
+        "click #enabletls": "toggleCertUrl",
+        "click #mode": "toggleNutFields"
     },
 
-    initialize: function () {
-	// call initialize of base
-	var _this = this;
-	this.constructor.__super__.initialize.apply(this, arguments);
-	this.serviceName = this.options.serviceName;
-	// set template
-	this.template = window.JST['services_configure_' + this.serviceName];
-	this.rules = {
-	    ntpd: {server: 'required'},
-	    smb: {workgroup: 'required'},
-	    nis: {domain: 'required', server: 'required'},
-	    snmpd: {
-		syslocation: 'required',
-		syscontact: 'required',
-		rocommunity: 'required'
-	    },
-	    ldap: {
-		server: 'required',
-		basedn: 'required',
-		cert: {
-		    required: {
-			depends: function (element) {
-			    return _this.$('#enabletls').prop('checked');
-			}
-		    }
-		}
-	    },
-	    docker: {
-		rootshare: 'required'
-	    },
-	    nut: {
-		mode: 'required',
-		upsmon: 'required',
-		upsname: 'required',
-		driver: 'required',
-		nutuser: 'required',
-		password: 'required',
-		nutserver: {
-		    required: {
-			depends: function (element) {
-			    return (_this.$('#mode').val() == 'netclient');
-			}
-		    }
-		}
-	    },
-		shellinaboxd: {
-		shelltype: 'required',
-		css: 'required'
-		},
-	    "active-directory": {
-		domain: 'required',
-		username: 'required',
-		password: 'required'
-	    },
-	    replication: {
-		listener_port: 'required',
-		network_interface: 'required'
-	    },
-	    rockstor: {
-		listener_port: 'required'
-	    }
-	}
+    initialize: function() {
+        // call initialize of base
+        var _this = this;
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.serviceName = this.options.serviceName;
+        // set template
+        this.template = window.JST['services_configure_' + this.serviceName];
+        this.rules = {
+            ntpd: {
+                server: 'required'
+            },
+            smb: {
+                workgroup: 'required'
+            },
+            nis: {
+                domain: 'required',
+                server: 'required'
+            },
+            snmpd: {
+                syslocation: 'required',
+                syscontact: 'required',
+                rocommunity: 'required'
+            },
+            ldap: {
+                server: 'required',
+                basedn: 'required',
+                cert: {
+                    required: {
+                        depends: function(element) {
+                            return _this.$('#enabletls').prop('checked');
+                        }
+                    }
+                }
+            },
+            docker: {
+                rootshare: 'required'
+            },
+            nut: {
+                mode: 'required',
+                upsmon: 'required',
+                upsname: 'required',
+                driver: 'required',
+                nutuser: 'required',
+                password: 'required',
+                nutserver: {
+                    required: {
+                        depends: function(element) {
+                            return (_this.$('#mode').val() == 'netclient');
+                        }
+                    }
+                }
+            },
+            shellinaboxd: {
+                shelltype: 'required',
+                css: 'required'
+            },
+            "active-directory": {
+                domain: 'required',
+                username: 'required',
+                password: 'required'
+            },
+            replication: {
+                listener_port: 'required',
+                network_interface: 'required'
+            },
+            rockstor: {
+                listener_port: 'required'
+            }
+        }
 
-	this.formName = this.serviceName + '-form';
-	this.service = new Service({name: this.serviceName});
-	this.dependencies.push(this.service);
-	this.shares = new ShareCollection();
-	this.shares.setPageSize(100);
-	this.dependencies.push(this.shares);
-	this.network = new NetworkConnectionCollection();
-	this.dependencies.push(this.network);
-	this.initHandlebarHelpers();
+        this.formName = this.serviceName + '-form';
+        this.service = new Service({
+            name: this.serviceName
+        });
+        this.dependencies.push(this.service);
+        this.shares = new ShareCollection();
+        this.shares.setPageSize(100);
+        this.dependencies.push(this.shares);
+        this.network = new NetworkConnectionCollection();
+        this.dependencies.push(this.network);
+        this.initHandlebarHelpers();
     },
 
-    render: function () {
-	this.fetch(this.renderServiceConfig, this);
-	return this;
+    render: function() {
+        this.fetch(this.renderServiceConfig, this);
+        return this;
     },
 
-    renderServiceConfig: function () {
-	var _this = this;
-	var default_port = 443;
-	if (this.service.get('name') == 'replication') {
-	    default_port = 10002;
-	}
-	var config = this.service.get('config');
-	var configObj = {};
-	if (config != null) {
-	    configObj = JSON.parse(config);
-	}
-	if (configObj.listener_port) { default_port = configObj.listener_port; }
-	$(this.el).html(this.template({
-	    service: this.service,
-	    serviceName: this.service.get('display_name'),
-	    config: configObj,
-	    shares: this.shares,
-	    network: this.network,
-	    defaultPort: default_port
-	}));
+    renderServiceConfig: function() {
+        var _this = this;
+        var default_port = 443;
+        if (this.service.get('name') == 'replication') {
+            default_port = 10002;
+        }
+        var config = this.service.get('config');
+        var configObj = {};
+        if (config != null) {
+            configObj = JSON.parse(config);
+        }
+        if (configObj.listener_port) {
+            default_port = configObj.listener_port;
+        }
+        $(this.el).html(this.template({
+            service: this.service,
+            serviceName: this.service.get('display_name'),
+            config: configObj,
+            shares: this.shares,
+            network: this.network,
+            defaultPort: default_port
+        }));
 
-	this.$('#nis-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
-	this.$('#snmpd-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
-	this.$('#ldap-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
-	this.$('#ntpd-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
-	this.$('#smb-form :input').tooltip({
-	    html: true,
-	    placement: 'right'
-	});
-	this.$('#docker-form #root_share').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'We strongly recommend that you create a separate Share(at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.'
-	});
-	this.$('#active-directory-form #domain').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Windows Active Directory or Domain Controller to connect to.'
-	});
-	this.$('#active-directory-form #username').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Administrator username to use for authentication while joining the domain. Eg: Administrator'
-	});
-	this.$('#active-directory-form #password').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Password for the above username.'
-	});
-	this.$('#active-directory-form #idmap_range').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Default should work for most cases. rid idmap backend is the only one supported. The default range is 10000 - 999999.'
-	});
-	this.$('#smartd-form #smartd_config').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Following are a few example directives. For complete information, read smard.conf manpage.<br> \
+        this.$('#nis-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+        this.$('#snmpd-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+        this.$('#ldap-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+        this.$('#ntpd-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+        this.$('#smb-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+        this.$('#docker-form #root_share').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'We strongly recommend that you create a separate Share(at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.'
+        });
+        this.$('#active-directory-form #domain').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Windows Active Directory or Domain Controller to connect to.'
+        });
+        this.$('#active-directory-form #username').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Administrator username to use for authentication while joining the domain. Eg: Administrator'
+        });
+        this.$('#active-directory-form #password').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Password for the above username.'
+        });
+        this.$('#active-directory-form #idmap_range').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Default should work for most cases. rid idmap backend is the only one supported. The default range is 10000 - 999999.'
+        });
+        this.$('#smartd-form #smartd_config').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Following are a few example directives. For complete information, read smard.conf manpage.<br> \
 To monitor all possible errors on all disks: <br> <strong>DEVICESCAN -a</strong> <br> \
 To monitor /dev/sdb and /dev/sdc but ignore other devices: <br> <strong>/dev/sdb -a</strong> <br> <strong>/dev/sdc -a</strong> <br> \
 To email potential problems: <br> <strong>DEVICESCAN -m user@example.com</strong> <br> \
 To alert on temparature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br>'
-	});
-	this.$('#nut-form #mode').tooltip({
-	    html: true,
-	    placement: 'right',
-	    container: 'body',
-	    title: "<strong>Nut Mode</strong> — Select the overall mode of Network UPS Tools operation. The drop-down list offers the following options:<br> \
+        });
+        this.$('#nut-form #mode').tooltip({
+            html: true,
+            placement: 'right',
+            container: 'body',
+            title: "<strong>Nut Mode</strong> — Select the overall mode of Network UPS Tools operation. The drop-down list offers the following options:<br> \
 <ul>\
 <li><strong>Standalone</strong> — The most common and recommended mode if you have a locally connected UPS and don't wish for Rockstor to act as a NUT server to any other LAN connected machines.</li> \
 <li><strong>Net server</strong> — Is like Standalone only it also offers NUT services to other machines on the network who are running in Net client mode.</li> \
 <li><strong>Net client</strong> — Connect to an existing Nut server.</li> \
 </ul>"
-	});
-	this.$('#nut-form #upsname').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'The internal name for the UPS eg "ups". A single word with no special characters ( " = # space or backslash ) Defaults to "ups".'
-	});
-	this.$('#nut-form #nutserver').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'The hostname or IP address of the NUT server when in Net Client mode. Otherwise this is usually localhost'
-	});
-	this.$('#nut-form #nutuser').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'The NUT username (not a Rockstor user). Must be a single word without special characters and is case sensitive. Defaults to "monuser".'
-	});
-	this.$('#nut-form #password').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'The password for the above nut user.'
-	});
-	this.$('#nut-form #upsmon').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: "<strong>Monitor Mode</strong>:<br> \
+        });
+        this.$('#nut-form #upsname').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'The internal name for the UPS eg "ups". A single word with no special characters ( " = # space or backslash ) Defaults to "ups".'
+        });
+        this.$('#nut-form #nutserver').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'The hostname or IP address of the NUT server when in Net Client mode. Otherwise this is usually localhost'
+        });
+        this.$('#nut-form #nutuser').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'The NUT username (not a Rockstor user). Must be a single word without special characters and is case sensitive. Defaults to "monuser".'
+        });
+        this.$('#nut-form #password').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'The password for the above nut user.'
+        });
+        this.$('#nut-form #upsmon').tooltip({
+            html: true,
+            placement: 'right',
+            title: "<strong>Monitor Mode</strong>:<br> \
 <ul>\
 <li><strong>Master</strong> - Default, this system will shutdown last, allowing slave nut systems time to shutdown first. UPS data port is most likely directly connected to this system.</li> \
 <li><strong>Slave</strong> - This system shuts down as soon as power is critical, it does not wait for any other nut systems. Mostly used when in netclient mode and no direct UPS data connection.</li> \
 </ul>"
-	});
-	this.$('#nut-form #driver').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Driver for you UPS. Please see the NUT <a href="http://www.networkupstools.org/stable-hcl.html" target="_blank">Hardware Compatibility List for guidance.</a>'
-	});
-	this.$('#nut-form #desc').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Human Friendly name for this UPS device. Defaults to "Rockstor UPS".'
-	});
-	this.$('#nut-form #port').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Device name for how this UPS is connected. E.g for the first serial port use "/dev/ttyS0" or if using a USB to serial port adapter then "/dev/ttyUSB0". Use "auto" if connected direct via USB.'
-	});
-	this.$('#replication-form #network_interface').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Select one of the available Network interfaces to be used by the listener.'
-	});
-	this.$('#replication-form #listener_port').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'A valid port number(between 1-65535) for the listener. Default/Suggested port -- 10002'
-	});
-	this.$('#rockstor-form #network_interface').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Select the Network connection for Rockstor. If you leave the selection blank, service will listen on all interfaces.<b>WARNING!!!</b> UI may become inaccessible after changing the interface. It should be available on the new interface IP/Hostname after a momentary pause.'
-	});
-	this.$('#rockstor-form #listener_port').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'While default port(443) is recommended for most users, advanced users can change it to access UI on a different port. <b>Changing the port will make UI inaccessible.</b> After a momentary pause, it should be available on the new port.'
-	});
-	this.$('#shellinaboxd-form #shelltype').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: '<strong>LOGIN</strong> is default Shell In a Box connection method, like a login via console (root direct login not allowed, su required)<br/> \
-		<strong>SSH</strong> connection with root user allowed. Less secure for system'
-	});
-	this.$('#shellinaboxd-form #css').tooltip({
-	    html: true,
-	    placement: 'right',
-	    title: 'Choose between Black on White or White on Black layout'
-	});
-	this.$('#shellinaboxd-form #detach').tooltip({
-	    html: true,
-	    placement: 'left',
-	    title: 'Remember to allow Rockstor server on popup blockers to avoid annoying messages'
-	});
+        });
+        this.$('#nut-form #driver').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Driver for you UPS. Please see the NUT <a href="http://www.networkupstools.org/stable-hcl.html" target="_blank">Hardware Compatibility List for guidance.</a>'
+        });
+        this.$('#nut-form #desc').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Human Friendly name for this UPS device. Defaults to "Rockstor UPS".'
+        });
+        this.$('#nut-form #port').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Device name for how this UPS is connected. E.g for the first serial port use "/dev/ttyS0" or if using a USB to serial port adapter then "/dev/ttyUSB0". Use "auto" if connected direct via USB.'
+        });
+        this.$('#replication-form #network_interface').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Select one of the available Network interfaces to be used by the listener.'
+        });
+        this.$('#replication-form #listener_port').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'A valid port number(between 1-65535) for the listener. Default/Suggested port -- 10002'
+        });
+        this.$('#rockstor-form #network_interface').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Select the Network connection for Rockstor. If you leave the selection blank, service will listen on all interfaces.<b>WARNING!!!</b> UI may become inaccessible after changing the interface. It should be available on the new interface IP/Hostname after a momentary pause.'
+        });
+        this.$('#rockstor-form #listener_port').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'While default port(443) is recommended for most users, advanced users can change it to access UI on a different port. <b>Changing the port will make UI inaccessible.</b> After a momentary pause, it should be available on the new port.'
+        });
+        this.$('#shellinaboxd-form #shelltype').tooltip({
+            html: true,
+            placement: 'right',
+            title: '<strong>LOGIN</strong> is default Shell In a Box connection method, like a login via console (root direct login not allowed, su required)<br/> \
+        <strong>SSH</strong> connection with root user allowed. Less secure for system'
+        });
+        this.$('#shellinaboxd-form #css').tooltip({
+            html: true,
+            placement: 'right',
+            title: 'Choose between Black on White or White on Black layout'
+        });
+        this.$('#shellinaboxd-form #detach').tooltip({
+            html: true,
+            placement: 'left',
+            title: 'Remember to allow Rockstor server on popup blockers to avoid annoying messages'
+        });
 
-	this.validator = this.$('#' + this.formName).validate({
-	    onfocusout: false,
-	    onkeyup: false,
-	    rules: this.rules[this.serviceName],
+        this.validator = this.$('#' + this.formName).validate({
+            onfocusout: false,
+            onkeyup: false,
+            rules: this.rules[this.serviceName],
 
-	    submitHandler: function () {
-		var button = _this.$('#submit');
-		if (buttonDisabled(button)) return false;
-		disableButton(button);
+            submitHandler: function() {
+                var button = _this.$('#submit');
+                if (buttonDisabled(button)) return false;
+                disableButton(button);
                 var data;
-		if (_this.formName == 'snmpd-form') {
-		    var optionsText = _this.$('#options').val();
-		    var entries = [];
-		    if (!_.isNull(optionsText) && optionsText.trim() != '') entries = optionsText.trim().split('\n');
-		    var params = (_this.$('#' + _this.formName).getJSON());
-		    params.aux = entries;
-		    data = JSON.stringify({config: params});
-		} else {
-		    data = JSON.stringify({config: _this.$('#' + _this.formName).getJSON()});
-		}
+                if (_this.formName == 'snmpd-form') {
+                    var optionsText = _this.$('#options').val();
+                    var entries = [];
+                    if (!_.isNull(optionsText) && optionsText.trim() != '') entries = optionsText.trim().split('\n');
+                    var params = (_this.$('#' + _this.formName).getJSON());
+                    params.aux = entries;
+                    data = JSON.stringify({
+                        config: params
+                    });
+                } else {
+                    data = JSON.stringify({
+                        config: _this.$('#' + _this.formName).getJSON()
+                    });
+                }
 
-		var jqxhr = $.ajax({
-		    url: "/api/sm/services/" + _this.serviceName + "/config",
-		    type: "POST",
-		    contentType: 'application/json',
-		    dataType: "json",
-		    data: data
-		});
+                var jqxhr = $.ajax({
+                    url: "/api/sm/services/" + _this.serviceName + "/config",
+                    type: "POST",
+                    contentType: 'application/json',
+                    dataType: "json",
+                    data: data
+                });
 
-		jqxhr.done(function () {
-		    enableButton(button);
-		    app_router.navigate("services", {trigger: true});
-		});
+                jqxhr.done(function() {
+                    enableButton(button);
+                    app_router.navigate("services", {
+                        trigger: true
+                    });
+                });
 
-		jqxhr.fail(function (xhr, status, error) {
-		    enableButton(button);
-		});
+                jqxhr.fail(function(xhr, status, error) {
+                    enableButton(button);
+                });
 
-	    }
-	});
+            }
+        });
 
-	this.toggleNutFields();
-	return this;
+        this.toggleNutFields();
+        return this;
     },
 
-    cancel: function (event) {
-	event.preventDefault();
-	app_router.navigate("services", {trigger: true});
+    cancel: function(event) {
+        event.preventDefault();
+        app_router.navigate("services", {
+            trigger: true
+        });
     },
 
-    toggleFormFields: function () {
-	if (this.$('#security').val() == 'ads') {
-	    this.$('#realm').removeAttr('disabled');
-	} else {
-	    this.$('#realm').attr('disabled', 'true');
-	}
-	if (this.$('#security').val() == 'ads'
-	    || this.$('#security').val() == 'domain') {
-	    this.$('#templateshell').removeAttr('disabled');
-	} else {
-	    this.$('#templateshell').attr('disabled', 'true');
-	}
+    toggleFormFields: function() {
+        if (this.$('#security').val() == 'ads') {
+            this.$('#realm').removeAttr('disabled');
+        } else {
+            this.$('#realm').attr('disabled', 'true');
+        }
+        if (this.$('#security').val() == 'ads' ||
+            this.$('#security').val() == 'domain') {
+            this.$('#templateshell').removeAttr('disabled');
+        } else {
+            this.$('#templateshell').attr('disabled', 'true');
+        }
     },
 
-    toggleNutFields: function () {
-	if (this.$('#mode').val() == 'standalone') {
-	    this.$('#monitor-mode').hide();
-	    this.$('#upsmon').attr('value', 'master');
-	    this.$('#ups-name').hide();
-	    this.$('#upsname').attr('value', 'ups');
-	    this.$('#ups-description').hide();
-	    this.$('#desc').attr('value', 'Rockstor UPS');
-	    this.$('#nut-driver').show();
-	    this.$('#ups-port').show();
-	    this.$('#nut-server').hide();
-	    this.$('#nutserver').attr('value', 'localhost');
-	} else if (this.$('#mode').val() == 'netserver') {
-	    this.$('#monitor-mode').show();
-	    this.$('#ups-name').show();
-	    this.$('#ups-description').show();
-	    this.$('#nut-server').hide();
-	    this.$('#nutserver').attr('value', 'localhost');
-	    this.$('#nut-driver').show();
-	    this.$('#ups-port').show();
-	} else { // probably has value of netclient or unknown
-	    this.$('#monitor-mode').hide();
-	    this.$('#upsmon').attr('value', 'slave');
-	    this.$('#ups-name').show();
-	    this.$('#ups-description').show();
-	    this.$('#nut-driver').hide();
-	    this.$('#driver').attr('value', 'nutclient');
-	    this.$('#ups-port').hide();
-	    this.$('#port').attr('value', 'auto');
-	    this.$('#nut-server').show();
-	}
+    toggleNutFields: function() {
+        if (this.$('#mode').val() == 'standalone') {
+            this.$('#monitor-mode').hide();
+            this.$('#upsmon').attr('value', 'master');
+            this.$('#ups-name').hide();
+            this.$('#upsname').attr('value', 'ups');
+            this.$('#ups-description').hide();
+            this.$('#desc').attr('value', 'Rockstor UPS');
+            this.$('#nut-driver').show();
+            this.$('#ups-port').show();
+            this.$('#nut-server').hide();
+            this.$('#nutserver').attr('value', 'localhost');
+        } else if (this.$('#mode').val() == 'netserver') {
+            this.$('#monitor-mode').show();
+            this.$('#ups-name').show();
+            this.$('#ups-description').show();
+            this.$('#nut-server').hide();
+            this.$('#nutserver').attr('value', 'localhost');
+            this.$('#nut-driver').show();
+            this.$('#ups-port').show();
+        } else { // probably has value of netclient or unknown
+            this.$('#monitor-mode').hide();
+            this.$('#upsmon').attr('value', 'slave');
+            this.$('#ups-name').show();
+            this.$('#ups-description').show();
+            this.$('#nut-driver').hide();
+            this.$('#driver').attr('value', 'nutclient');
+            this.$('#ups-port').hide();
+            this.$('#port').attr('value', 'auto');
+            this.$('#nut-server').show();
+        }
     },
 
-    toggleCertUrl: function () {
-	var cbox = this.$('#enabletls');
-	if (cbox.prop('checked')) {
-	    this.$('#cert-ph').css('visibility', 'visible');
-	} else {
-	    this.$('#cert-ph').css('visibility', 'hidden');
-	}
+    toggleCertUrl: function() {
+        var cbox = this.$('#enabletls');
+        if (cbox.prop('checked')) {
+            this.$('#cert-ph').css('visibility', 'visible');
+        } else {
+            this.$('#cert-ph').css('visibility', 'hidden');
+        }
     },
 
-    initHandlebarHelpers: function(){
-	
-	//ShellInABox
-	Handlebars.registerHelper('display_shelltype_options', function(){
-		var html = '',
-		_this = this;
-		var avail_shells = ['LOGIN', 'SSH'];
-		_.each(avail_shells, function(shell, index) {
-			if (shell == _this.config.shelltype) {
-				html += '<option value="' + shell + '" selected="selected">';
-				html += shell + '</option>';
-			} else {
-				html += '<option value="' + shell + '">' + shell + '</option>';
-			}			
-		});
-	    return new Handlebars.SafeString(html);		
-	});
-	
-	Handlebars.registerHelper('display_shellstyle_options', function(){
-		var html = '',
-		_this = this;
-		var avail_styles = {'white-on-black': 'White on Black', 'black-on-white': 'Black on White'};
-		_.each(avail_styles, function(key, val) {
-			if (val == _this.config.css) {
-				html += '<option value="' + val + '" selected="selected">';
-				html += key + '</option>';
-			} else {
-				html += '<option value="' + val + '">' + key + '</option>';
-			}			
-		});
-	    return new Handlebars.SafeString(html);		
-	});
-	
-	//NUT-UPS
-	Handlebars.registerHelper('display_nutMode_options', function(){
-	    var html = '',
-		_this = this;
-	    var nutModeTypes = ['standalone','netserver','netclient'];
-	    _.each(nutModeTypes, function(mode, index) {
-		if (mode == _this.config.mode) {
-		    html += '<option value="' + mode + '" selected="selected">';
-		    html += mode + '</option>';
-		} else {
-		    html += '<option value="' + mode + '">' + mode + '</option>';
-		}
-	    });
-	    return new Handlebars.SafeString(html);
-	});
+    initHandlebarHelpers: function() {
 
-	Handlebars.registerHelper('display_monitorMode_options', function(){
-	    var html = '',
-		_this = this;
-	    var nutMonitorTypes = ['master','slave'];
-	    _.each(nutMonitorTypes, function(upsmon, index) {
-		if (upsmon == _this.config.upsmon) {
-		    html += '<option value="' + upsmon + '" selected="selected">';
-		    html += upsmon + '</option>';
-		} else {
-		    html += '<option value="' + upsmon + '">' + upsmon + '</option>';
-		}
-	    });
-	    return new Handlebars.SafeString(html);
-	});
+        //ShellInABox
+        Handlebars.registerHelper('display_shelltype_options', function() {
+            var html = '',
+                _this = this;
+            var avail_shells = ['LOGIN', 'SSH'];
+            _.each(avail_shells, function(shell, index) {
+                if (shell == _this.config.shelltype) {
+                    html += '<option value="' + shell + '" selected="selected">';
+                    html += shell + '</option>';
+                } else {
+                    html += '<option value="' + shell + '">' + shell + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
 
-	Handlebars.registerHelper('display_nutDriver_options', function(){
-	    var html = '',
-		_this = this;
-	    var nutDriverTypes = ['apcsmart','apcsmart-old','apcupsd-ups','bcmxcp','bcmxcp_usb','belkin','belkinunv','bestfcom','bestfortress','bestuferrups','bestups','blazer_ser','blazer_usb','dummy-ups','etapro','everups','gamatronic','genericups','isbmex','ivtscd','liebert','liebert-esp2','masterguard','metasys','mge-shut','mge-utalk','microdowell','nutclient','nutdrv_qx','oldmge-shut','oneac','optiups','powercom','powerpanel','rhino','richcomm_usb','riello_ser','riello_usb','safenet','skel','snmp-ups','solis','tripplite','tripplite_usb','tripplitesu','upscode2','usbhid-ups','victronups'];
-	    _.each(nutDriverTypes, function(driver, index) {
-		if (driver == _this.config.driver) {
-		    html += '<option value="' + driver + '" selected="selected">';
-		    html += driver + '</option>';
-		} else {
-		    html += '<option value="' + driver + '">' + driver + '</option>';
-		}
-	    });
-	    return new Handlebars.SafeString(html);
-	});
+        Handlebars.registerHelper('display_shellstyle_options', function() {
+            var html = '',
+                _this = this;
+            var avail_styles = {
+                'white-on-black': 'White on Black',
+                'black-on-white': 'Black on White'
+            };
+            _.each(avail_styles, function(key, val) {
+                if (val == _this.config.css) {
+                    html += '<option value="' + val + '" selected="selected">';
+                    html += key + '</option>';
+                } else {
+                    html += '<option value="' + val + '">' + key + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
 
-	//Replication
-	Handlebars.registerHelper('display_networkInterface_options', function(){
-	    var html = '',
-		_this = this;
-	    this.network.each(function(ni, index) {
-		    var niName = ni.get('name');
-            var niLongName = niName + ' [IP: ' + ni.get('ipv4_addresses') + ']';
-		if (!ni.get('master')) {
-		    if (niName == _this.config.network_interface) {
-			html += '<option value="' + niName + '" selected="selected"> ' + niLongName + '</option>';
-		    } else {
-			html += '<option value="' + niName + '">' + niLongName+ '</option>';
-		    }
-		}
-	    });
-	    return new Handlebars.SafeString(html);
-	});
+        //Samba Config page
+        Handlebars.registerHelper('smb_check_custom_params', function(key) {
+
+            return key != 'workgroup';
+        });
+
+        //NUT-UPS
+        Handlebars.registerHelper('display_nutMode_options', function() {
+            var html = '',
+                _this = this;
+            var nutModeTypes = ['standalone', 'netserver', 'netclient'];
+            _.each(nutModeTypes, function(mode, index) {
+                if (mode == _this.config.mode) {
+                    html += '<option value="' + mode + '" selected="selected">';
+                    html += mode + '</option>';
+                } else {
+                    html += '<option value="' + mode + '">' + mode + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
+
+        Handlebars.registerHelper('display_monitorMode_options', function() {
+            var html = '',
+                _this = this;
+            var nutMonitorTypes = ['master', 'slave'];
+            _.each(nutMonitorTypes, function(upsmon, index) {
+                if (upsmon == _this.config.upsmon) {
+                    html += '<option value="' + upsmon + '" selected="selected">';
+                    html += upsmon + '</option>';
+                } else {
+                    html += '<option value="' + upsmon + '">' + upsmon + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
+
+        Handlebars.registerHelper('display_nutDriver_options', function() {
+            var html = '',
+                _this = this;
+            var nutDriverTypes = ['apcsmart', 'apcsmart-old', 'apcupsd-ups', 'bcmxcp', 'bcmxcp_usb', 'belkin', 'belkinunv', 'bestfcom', 'bestfortress', 'bestuferrups', 'bestups', 'blazer_ser', 'blazer_usb', 'dummy-ups', 'etapro', 'everups', 'gamatronic', 'genericups', 'isbmex', 'ivtscd', 'liebert', 'liebert-esp2', 'masterguard', 'metasys', 'mge-shut', 'mge-utalk', 'microdowell', 'nutclient', 'nutdrv_qx', 'oldmge-shut', 'oneac', 'optiups', 'powercom', 'powerpanel', 'rhino', 'richcomm_usb', 'riello_ser', 'riello_usb', 'safenet', 'skel', 'snmp-ups', 'solis', 'tripplite', 'tripplite_usb', 'tripplitesu', 'upscode2', 'usbhid-ups', 'victronups'];
+            _.each(nutDriverTypes, function(driver, index) {
+                if (driver == _this.config.driver) {
+                    html += '<option value="' + driver + '" selected="selected">';
+                    html += driver + '</option>';
+                } else {
+                    html += '<option value="' + driver + '">' + driver + '</option>';
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
+
+        //Replication
+        Handlebars.registerHelper('display_networkInterface_options', function() {
+            var html = '',
+                _this = this;
+            this.network.each(function(ni, index) {
+                var niName = ni.get('name');
+                var niLongName = niName + ' [IP: ' + ni.get('ipv4_addresses') + ']';
+                if (!ni.get('master')) {
+                    if (niName == _this.config.network_interface) {
+                        html += '<option value="' + niName + '" selected="selected"> ' + niLongName + '</option>';
+                    } else {
+                        html += '<option value="' + niName + '">' + niLongName + '</option>';
+                    }
+                }
+            });
+            return new Handlebars.SafeString(html);
+        });
 
 
-	//Rockon template
-	Handlebars.registerHelper('display_rockon_shares', function(){
-	    var html = '',
-		_this = this;
-	    if (this.shares.length ===  0) {
-		html += '<p>You currently have no Shares. You will need a share to run the Rock-ons service.</p>';
-		html += '<a href="#add_share">Add a Share</a>';
-	    } else {
-		html += '<select class="form-control" name="root_share" id="root_share" data-placeholder="Select root share">';
-		html += '<option></option>';
-		this.shares.each( function(share, index) {
-		    var shareName = share.get('name');
-		    if (shareName == _this.config.root_share) {
-			html += '<option value="' + shareName + '" selected="selected">  ' + shareName + ' </option>';
-		    } else {
-			html += '<option value="' + shareName + '">' + shareName + ' </option>';
-		    }
-		});
-		html += '</select>';
-	    }
-	    return new Handlebars.SafeString(html);
-	});
+        //Rockon template
+        Handlebars.registerHelper('display_rockon_shares', function() {
+            var html = '',
+                _this = this;
+            if (this.shares.length === 0) {
+                html += '<p>You currently have no Shares. You will need a share to run the Rock-ons service.</p>';
+                html += '<a href="#add_share">Add a Share</a>';
+            } else {
+                html += '<select class="form-control" name="root_share" id="root_share" data-placeholder="Select root share">';
+                html += '<option></option>';
+                this.shares.each(function(share, index) {
+                    var shareName = share.get('name');
+                    if (shareName == _this.config.root_share) {
+                        html += '<option value="' + shareName + '" selected="selected">  ' + shareName + ' </option>';
+                    } else {
+                        html += '<option value="' + shareName + '">' + shareName + ' </option>';
+                    }
+                });
+                html += '</select>';
+            }
+            return new Handlebars.SafeString(html);
+        });
     }
-
-
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
@@ -28,7 +28,7 @@
 ServicesView = Backbone.View.extend({
 
     events: {
-	'click .configure': "configureService",
+	'click .configure': 'configureService',
 	'switchChange.bootstrapSwitch': 'switchStatus'
     },
 
@@ -73,6 +73,7 @@ ServicesView = Backbone.View.extend({
 		}
 	    }
 	});
+    _this.adStatus = _this.collection.where({ 'name': 'active-directory' })[0].get('status') ? '0' : '1';
 	this.renderServices();
 
     },
@@ -125,6 +126,7 @@ ServicesView = Backbone.View.extend({
 	    dataType: "json",
 	    success: function(data, status, xhr) {
 		_this.setStatusLoading(serviceName, false);
+        if (serviceName == 'active-directory') { _this.adStatus = 0; }
 	    },
 	    error: function(xhr, status, error) {
 		_this.setStatusError(serviceName, xhr);
@@ -140,6 +142,7 @@ ServicesView = Backbone.View.extend({
 	    dataType: "json",
 	    success: function(data, status, xhr) {
 		_this.setStatusLoading(serviceName, false);
+        if (serviceName == 'active-directory') { _this.adStatus = 1; }
 	    },
 	    error: function(xhr, status, error) {
 		_this.setStatusError(serviceName, xhr);
@@ -151,7 +154,8 @@ ServicesView = Backbone.View.extend({
 	event.preventDefault();
 	var _this = this;
 	var serviceName = $(event.currentTarget).data('service-name');
-	app_router.navigate('services/' + serviceName + '/edit', {trigger: true});
+    var adStatus = (serviceName === 'smb') ? '/?adStatus=' + _this.adStatus : '';
+	app_router.navigate('services/' + serviceName + '/edit' + adStatus, {trigger: true});
     },
 
     setStatusLoading: function(serviceName, show) {

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -126,6 +126,7 @@ def update_global_config(smb_config=None, ad_config=None):
             tfo.write('%s\n' % RS_CUSTOM_HEADER)
             for k in smb_config:
                 if (ad_config is not None and k == 'workgroup'):
+                    tfo.write('    %s = %s\n' % (k, ad_config[k]))
                     continue
                 tfo.write('    %s = %s\n' % (k, smb_config[k]))
             tfo.write('%s\n\n' % RS_CUSTOM_FOOTER)
@@ -138,9 +139,8 @@ def update_global_config(smb_config=None, ad_config=None):
         if (domain is not None):
             idmap_high = int(smb_config['idmap_range'].split()[2])
             default_range = '%s - %s' % (idmap_high + 1, idmap_high + 1000000)
-            workgroup = smb_config.pop('workgroup', 'MYGROUP')
+            workgroup = ad_config['workgroup']
             tfo.write('%s\n' % RS_AD_HEADER)
-            tfo.write('    workgroup = %s\n' % workgroup)
             tfo.write('    security = ads\n')
             tfo.write('    realm = %s\n' % domain)
             tfo.write('    template shell = /bin/sh\n')

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -32,6 +32,7 @@ SMB_CONFIG = '/etc/samba/smb.conf'
 SYSTEMCTL = '/usr/bin/systemctl'
 CHMOD = '/bin/chmod'
 RS_HEADER = '####BEGIN: Rockstor SAMBA CONFIG####'
+RS_AD_HEADER = '####BEGIN: Rockstor ACTIVE DIRECTORY CONFIG####'
 
 
 def test_parm(config='/etc/samba/smb.conf'):
@@ -115,6 +116,7 @@ def update_global_config(smb_config=None, ad_config=None):
         if (domain is not None):
             idmap_high = int(smb_config['idmap_range'].split()[2])
             default_range = '%s - %s' % (idmap_high + 1, idmap_high + 1000000)
+            tfo.write('%s\n' % RS_AD_HEADER)
             tfo.write('    security = ads\n')
             tfo.write('    realm = %s\n' % domain)
             tfo.write('    template shell = /bin/sh\n')
@@ -137,6 +139,7 @@ def update_global_config(smb_config=None, ad_config=None):
             else:
                 tfo.write('    idmap config %s : backend = rid\n' % workgroup)
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, smb_config['idmap_range']))
+            tfo.write('####END: Rockstor ACTIVE DIRECTORY CONFIG####\n')
         smb_config.pop('idmap_range', None)
         tfo.write('    log level = %s\n' % smb_config.pop('log level', 3))
         tfo.write('    load printers = %s\n' % smb_config.pop('load printers', 'no'))

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -110,20 +110,25 @@ def update_global_config(smb_config=None, ad_config=None):
         #Start building samba [global] section with base config
         tfo.write('[global]\n')
         
-        #Write some defaults samba values
-        logfile = smb_config.pop('log file', '/var/log/samba/log.%m')
-        tfo.write('    log file = %s\n' % logfile)
-        tfo.write('    log level = %s\n' % smb_config.pop('log level', 3))
-        tfo.write('    load printers = %s\n' % smb_config.pop('load printers', 'no'))
-        tfo.write('    cups options = %s\n' % smb_config.pop('cups options', 'raw'))
-        tfo.write('    printcap name = %s\n' % smb_config.pop('printcap name', '/dev/null'))
-        tfo.write('    map to guest = %s\n\n' % smb_config.pop('map to guest', 'Bad User'))
+        #Write some defaults samba params
+        #only if not passed via samba custom config
+        smb_default_options = {
+            'log file' : '/var/log/samba/log.%m',
+            'log level' : 3,
+            'load printers' : 'no',
+            'cups options' : 'raw',
+            'printcap name' : '/dev/null',
+            'map to guest' : 'Bad User'
+        }
+        for key, value in smb_default_options.iteritems():
+            if key not in smb_config:
+                tfo.write('    %s = %s\n' % (key, value))
 
         #Fill samba [global] section with our custom samba params
         #before updating smb_config dict with AD data to avoid
         #adding non samba params like AD username and password
         if (smb_config is not None):
-            tfo.write('%s\n' % RS_CUSTOM_HEADER)
+            tfo.write('\n%s\n' % RS_CUSTOM_HEADER)
             for k in smb_config:
                 if (ad_config is not None and k == 'workgroup'):
                     tfo.write('    %s = %s\n' % (k, ad_config[k]))

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -130,7 +130,7 @@ def update_global_config(smb_config=None, ad_config=None):
                 tfo.write('    %s = %s\n' % (k, smb_config[k]))
             tfo.write('%s\n\n' % RS_CUSTOM_FOOTER)
 
-        #finally add AD config to smb_config and build AD section
+        #Next add AD config to smb_config and build AD section
         if (ad_config is not None):
             smb_config.update(ad_config)
 
@@ -165,8 +165,8 @@ def update_global_config(smb_config=None, ad_config=None):
                 tfo.write('    idmap config %s : range = %s\n' % (workgroup, smb_config['idmap_range']))
             tfo.write('%s\n\n' % RS_AD_FOOTER)
 
-
-
+        #After default [global], custom [global] and AD writes
+        #finally add smb shares
         rockstor_section = False
         for line in sfo.readlines():
             if (re.match(RS_SHARES_HEADER, line) is not None):
@@ -182,12 +182,22 @@ def get_global_config():
         global_section = False
         global_custom_section = False
         for l in sfo.readlines():
+            #Check one, entering smb.conf [global] section
             if (re.match('\[global]', l) is not None):
                 global_section = True
+                continue
+            #Check two, entering Rockstor custome params section under [global] 
+            if (re.match(RS_CUSTOM_HEADER, l) is not None):
+                global_custom_section = True
+                continue
+            if (global_custom_section and
+                re.match(RS_CUSTOM_FOOTER, l) is not None):
+                global_custom_section = False
                 continue
             #we ignore lines outside [global], empty lines, or
             #commends(starting with # or ;)
             if (not global_section or
+                not global_custom_section or
                 len(l.strip()) == 0 or
                 re.match('#', l) is not None or
                 re.match(';', l) is not None):


### PR DESCRIPTION
Opening PR to have a single space for code comments
Reference to #1404 #1407 
To @schakrava : not ready to merge, will tell when ready :)

Roadmap:
- [x] Let our Rockstor smb builder know how to loop inside current smb file like on smb shares, better define AD section, default global section and a global custom section (only one to iterate on with custom configs) (1e5e6fd)
- [x] Ensure skipping AD username and password fields in smb config file :exclamation: (1e5e6fd)
- [x] Nicely handle having custom global configs with AD ON too (currently not possible because of a check over workgroup name - not possible with AD ON, so not able to save custom config on smb [global] (1e5e6fd)
- [x] Samba config page - Avoid having workgroup both in workgroup field and custom params field (42dc6f2)
- [x] If AD ON disable workgroup field on samba config page (not really required, workgroup value by server side checks, just for a better UX) (7daefb5 to 9919b42)
- [x] Code cleaning and indent 4 spaces (42dc6f2)

Testing branch:
- [x] Random turn off/on samba and AD
- [x] AD ON add custom samba params
- [x] AD ON change workgroup, expected to have AD workgroup
- [x] AD OFF change/set workgroup on samba conf page and have it
- [x] AD OFF add custom samba params
- [x] Add / remove new samba shares
- [x] Samba config page workgroup field switches enable/disabled on AD current status