### PR TITLE
nut timed shutdown option. Fixes #982 and #1458

### DIFF
--- a/conf/upssched.conf
+++ b/conf/upssched.conf
@@ -133,6 +133,7 @@ AT LOWBATT * EXECUTE low-batt
 AT NOCOMM * EXECUTE no-comms
 AT SHUTDOWN * EXECUTE shutdown
 
-# remark out these 2 lines to shutdown after # seconds on battery
+# example config for timed shutdown after # seconds on battery
 #AT ONBATT * START-TIMER early-shutdown 120
 #AT ONLINE * CANCEL-TIMER early-shutdown
+

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
@@ -104,6 +104,18 @@
             <input class="form-control" type="text" id="password" name="password" value="{{config.password}}" placeholder="NUT user password">
           </div>
         </div>
+
+        <!--  nut shutdown timer -->
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="shutdowntimer">Shutdown Timing<span class="required"> *</span></label>
+          <div class="col-sm-4">
+            <select class="form-control" id="shutdowntimer" name="shutdowntimer">
+            {{display_nutShutdownTimer_options}}
+            </select>
+          </div>
+        </div>
+
+        <!-- Cancel and Submit buttons -->
         <div class="form-group">
         <div class="col-sm-offset-4 col-sm-8">
           <button id="cancel" class="btn btn-default">Cancel</button>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
@@ -77,7 +77,7 @@
         <div class="form-group" id="ups-port">
           <label class="col-sm-4 control-label" for="port">UPS Port</label>
           <div class="col-sm-4">
-            <input class="form-control" type="text" id="port" name="port" value="{{config.port}}" placeholder="auto">
+            <input class="form-control" type="text" id="port" name="port" value="{{config.port}}" placeholder="auto or serial device name">
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -271,7 +271,7 @@ To alert on temperature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         this.$('#nut-form #shutdowntimer').tooltip({
             html: true,
             placement: 'right',
-            title: 'How long the UPS is "On Battery (OB)" before NUT triggers a Full System Shutdown.'
+            title: 'How long the UPS is "On Battery (OB)" before NUT initiates a "Forced Shutdown" (FSD) event.'
         });
         this.$('#replication-form #network_interface').tooltip({
             html: true,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -271,7 +271,7 @@ To alert on temperature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         this.$('#nut-form #shutdowntimer').tooltip({
             html: true,
             placement: 'right',
-            title: 'How long the UPS is "On Battery (OB)" before NUT initiates a "Forced Shutdown" (FSD) event.'
+            title: 'How long the UPS is "On Battery (OB)" before NUT initiates a "Forced Shutdown" (FSD) event. In netclient mode the netserver setting, if set for a shorter period, takes priority and the netserver will attempt to ensuring all netclients are shutdown first.'
         });
         this.$('#replication-form #network_interface').tooltip({
             html: true,

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -241,7 +241,12 @@ def establish_config_defaults(config):
         config['upsname'] = 'ups'
     if ('nutserver' in config) and (config['nutserver'] == ''):
         config['nutserver'] = 'localhost'
-
+    # Establish a port default of auto as this works with most USB connected
+    # UPS devices which is a more common connection type going forward.
+    # Note that this setting persists but netclient mode, which doesn't use
+    # the port option, is unaffected by this setting so persistence is harmless.
+    if ('port' in config) and (config['port'] == ''):
+        config['port'] = 'auto'
 
 def configure_nut(config):
     """

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -122,13 +122,22 @@ def config_upssched():
     """
     # the upssched config file
     upsshed_conf_template = ('%s/upssched.conf' % settings.CONFROOT)
-    # would be better if we could set a file creation mask first then copy
+    # As our custom parser for nut.conf, ups.conf, upsd.conf, upsd.users
+    # and upsmon.conf can only work on whole word keys we cannot use it
+    # for editing upssched.conf which can have multiple simultaneous entries
+    # of multi word keys, ie:
+    # "AT ONBATT * START-TIMER on-batt 10"
+    # "AT ONBATT * START-TIMER early-shutdown 120"
+    # TODO: add upssched.conf parser / config editor to replace straight copy
+    # TODO: from template.
+    # Would be better if we could set a file creation mask first then copy
     # TODO: set file creation mask to 640
     shutil.copyfile(upsshed_conf_template, UPSSCHED_CONF)
     run_command([CHOWN, 'root.nut', UPSSCHED_CONF])
     run_command([CHMOD, '640', UPSSCHED_CONF])
     # the upssched command file
     upsshed_cmd_template = ('%s/upssched-cmd' % settings.CONFROOT)
+
     shutil.copyfile(upsshed_cmd_template, UPSSCHED_CMD)
     run_command([CHOWN, 'root.root', UPSSCHED_CMD])
     # going with existing rights but this should be reviewed

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -178,7 +178,7 @@ def update_upssched_early_shutdown(seconds):
                     # line by moving along to the next line in our template.
                     continue
                 # replace our template start timer line with our own version
-                outo.write(timer_start_pattern + ' %s' % seconds)
+                outo.write(timer_start_pattern + ' %s' % seconds + '\n')
                 # set our flag to cope with future duplicate entries
                 start_timer_found = True
             if (re.match(timer_stop_pattern, line) is not None):
@@ -198,10 +198,10 @@ def update_upssched_early_shutdown(seconds):
         if seconds != '0':
             if not start_timer_found:
                 # add our missing start timer line with the appropriate seconds
-                outo.write(timer_start_pattern + ' %s' % seconds)
+                outo.write(timer_start_pattern + ' %s' % seconds + '\n')
             if not stop_timer_found:
                 # add out missing stop timer line
-                outo.write(timer_stop_pattern)
+                outo.write(timer_stop_pattern + '\n')
     # Now we deploy our template derived upssched.conf temp file by file move.
     # Would be better if we could set a file creation mask first then do the
     # move / overwrite.

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -157,6 +157,14 @@ def update_upssched_early_shutdown(seconds):
     timer_stop_line = 'AT ONLINE * CANCEL-TIMER early-shutdown'
     start_timer_found = False
     stop_timer_found = False
+    # Ensure we have a sane 'seconds' value:
+    try:
+        int(seconds)
+    except:
+        logger.info('Enforcing default NUT timed shutdown value of 0 '
+                    '(When Battery Low) as the passed seconds value could not '
+                    'be interpreted as an integer.')
+        seconds = '0'
     # Establish our upssched.conf template file.
     upssched_conf_template = ('%s/upssched.conf' % settings.CONFROOT)
     # Check for the existence of this template file.

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -274,8 +274,6 @@ def pre_process_nut_config(config):
     nut_configs[NUT_MONITOR_CONFIG]['MONITOR'] = ('%s@%s 1 %s %s %s' % (
         config['upsname'], config['nutserver'], config['nutuser'],
         config['password'], config['upsmon']))
-    logger.info(
-        'NUT MONITOR LINE = %s' % nut_configs[NUT_MONITOR_CONFIG]['MONITOR'])
 
     # move section headings from config to nut_configs OrderedDicts
     # this way all following entries will pertain to them in their respective

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-# todo revise comments for brevity
+# TODO: revise comments for brevity
 
 # for CentOS nut systemd files are:-
 # from nut package
@@ -123,7 +123,7 @@ def config_upssched():
     # the upssched config file
     upsshed_conf_template = ('%s/upssched.conf' % settings.CONFROOT)
     # would be better if we could set a file creation mask first then copy
-    # todo set file creation mask to 640
+    # TODO: set file creation mask to 640
     shutil.copyfile(upsshed_conf_template, UPSSCHED_CONF)
     run_command([CHOWN, 'root.nut', UPSSCHED_CONF])
     run_command([CHMOD, '640', UPSSCHED_CONF])
@@ -146,7 +146,7 @@ def establish_config_defaults(config):
     """
     # An empty config dictionary will be false so raise exception as what else.
     if not config:
-        # todo I am unsure if this is the best way to raise an exception here.
+        # TODO: I am unsure if this is the best way to raise an exception here.
         e_msg = ('No NUT-UPS configuration found, make sure you have'
                  'configured this service properly.')
         raise Exception(e_msg)
@@ -216,7 +216,7 @@ def pre_process_nut_config(config):
     by a config file path & name string, each top level entry (config file) is
     paired with an OrderedDict of options. This way we have:-
     "file -> options_in_order" pairs.
-    OrderedDict allows for section head sub-sectin ordering eg:-
+    OrderedDict allows for section head sub-section ordering eg:-
     [myups]
     driver = apcsmart
     port = /dev/ttyS1
@@ -253,7 +253,8 @@ def pre_process_nut_config(config):
     # set nut shutdown command wrapped in double inverted commas
     config['SHUTDOWNCMD'] = ('"%s"' % settings.NUT_SYSTEM_SHUTDOWNCMD)
 
-    # set nut network LISTEN to LISTEN_ON_IP when in netserver mode, else ll.
+    # set nut network LISTEN to LISTEN_ON_IP when in netserver mode, else set
+    # to local loop back / localhost.
     if config['MODE'] == 'netserver':
         config['LISTEN'] = settings.NUT_LISTEN_ON_IP
     else:
@@ -307,6 +308,7 @@ def update_config_in(config_file, config, remove_all, header):
     :param config_file: path and filename of config file to update
     :param config: OrderedDict of options with possible section-- tags on index
     :param remove_all: list of entries to always remark out regardless
+    :param header: string to announce automated config file entries boundary
     :return:
     """
     file_descriptor, tempNamePath = mkstemp(prefix='rocknut')

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -151,7 +151,7 @@ def update_upssched_early_shutdown(seconds):
     :return: True if no errors were encountered
     """
     timer_start_pattern = 'AT ONBATT * START-TIMER early-shutdown'
-    timer_stop_pattern = 'CANCEL-TIMER early-shutdown'
+    timer_stop_pattern = 'AT ONLINE * CANCEL-TIMER early-shutdown'
     start_timer_found = False
     stop_timer_found = False
     # Establish our upssched.conf template file.

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -128,6 +128,7 @@ def config_upssched():
     # of multi word keys, ie:
     # "AT ONBATT * START-TIMER on-batt 10"
     # "AT ONBATT * START-TIMER early-shutdown 120"
+    # "AT ONLINE * CANCEL-TIMER early-shutdown"
     # TODO: add upssched.conf parser / config editor to replace straight copy
     # TODO: from template.
     # Would be better if we could set a file creation mask first then copy

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -247,6 +247,11 @@ def establish_config_defaults(config):
     # the port option, is unaffected by this setting so persistence is harmless.
     if ('port' in config) and (config['port'] == ''):
         config['port'] = 'auto'
+    # Establish a default Shutdown Timing setting of 0 as this was the effective
+    # default behaviour prior to the timed shutdown config option
+    if ('shutdowntimer' in config) and (config['shutdowntimer'] == ''):
+        config['shutdowntimer'] = '0'
+
 
 def configure_nut(config):
     """

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -115,7 +115,7 @@ nut_option_delimiter = {"LISTEN": " ", "MAXAGE": " ",
                         "NOTIFYFLAG NOPARENT": " "}
 
 
-def config_upssched():
+def config_upssched(seconds):
     """
     Overwite nut default upssched.conf and upssched-cmd files with Rockstor
     versions. Set owner.group and permissions to originals.
@@ -128,7 +128,7 @@ def config_upssched():
     # "AT ONBATT * START-TIMER early-shutdown 120"
     # "AT ONLINE * CANCEL-TIMER early-shutdown"
     # so calling upssched.conf specific parser / editor
-    update_upssched_early_shutdown('240')
+    update_upssched_early_shutdown(seconds)
     # the upssched command file
     upsshed_cmd_template = ('%s/upssched-cmd' % settings.CONFROOT)
     shutil.copyfile(upsshed_cmd_template, UPSSCHED_CMD)
@@ -306,7 +306,7 @@ def configure_nut(config):
         # read access. Fixed by chown root.nut on all files we edit as a matter
         # of course.
         run_command([CHOWN, 'root.nut', config_file])
-    config_upssched()
+    config_upssched(config['shutdowntimer'])
 
 
 def pre_process_nut_config(config):


### PR DESCRIPTION
Adds an additional selector on the NUT configuration page to chose one of several "Shutdown Timing" options ranging from 30 seconds to 32 minutes. There is also a default option of "When Battery Low" which equates to the prior behaviour, i.e shutdown only when On Battery (OB) and Low Battery (LB). This default is also enforced in the back-end config file parser.

As the prior instantiation of NUT already enabled NUT's build in scheduler along with an early-shutdown directive (disabled) this pr addresses the front end capability to select from a range of common values and the back end config file parser to edit existing relevant lines within the prior existing template file for all schedules: /opt/rockstor/conf/upssched.conf. Previously this file was wholesale copied to the working location of /etc/nut/upssched.conf but this pr introduces an on-the-fly edit that accounts for user additions of early shutdown lines such as were already provided but in remarked out form.  Given some instructions were available on the community forum on how to enable the early shutdown by un-remarking the last to lines:

```
#AT ONBATT * START-TIMER early-shutdown 120
#AT ONLINE * CANCEL-TIMER early-shutdown
```

the parser has been made aware of this possibility and also checks for and removes duplicate entries concerning the same timer events. This should ensure that user edits of this sort (i.e un-remarking these 2 lines) will be unaffected until a new configuration is submitted, which in turn allows the user to review the new setting within the config page as this will take prescience.

Fixes #982 

While working on this issue and it's associated default it was though prudent to establish a default entry for the port setting. Previously this had no default and a misleading greyed out place holder / example entry of auto which was reported by several users on the forum to be confusing. The new behaviour is to enforce a default of "auto" when no entry is made as this works for most NUT USB drivers and is likely to be the more commonly employed device type going forward. This enhancement was detailed in issue #1458 and the addition of the new default along with an improved text field placeholder text:

Fixes #1458.

This pr has been tested using 4 different NUT drivers across 3 different UPS models and all behaviours were as expected given the various drivers restrictions, ie not all NUT drivers are able to power down the UPS device successfully. This short coming  is now more evident as previously the UPS would be run until the battery was low and hence would be nearing the built in power off mechanism associated with that state anyway. Where as now if set to power off after 1 minute on a UPS that has significantly more battery reserve there can be an appreciable time period prior to the UPS powering down. On drivers where this function was supported / working the UPS device was powered off as expected according to the reported ups.delay.shutdown register which is often around 20 seconds.

The function of Net Server and Net Client were also tested to ensure they obeyed the remit of the early shutdown setting: this was done by having one Rockstor machine in Net Server mode (with the UPS device attached) instruct a second Rockstor machine to shutdown first. The second machine was on the same network and configured in Net Client mode.  Note that the Net Client machine's early shutdown timer would also take precedence but only if it's setting was shorter than that of the Net Server's shutdown timer setting. This is expected behaviour.

Ready for review.

A couple of unrelated (smard) user facing typos were also included.

A reformat from the previous 2 spaces to the project default of 4 spaces was not enacted where relevant in order to aid in code review. This can be done at a later date if required.
