### PR TITLE
null value in column "details" when parsing smart error log. Fixes #1498

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -177,23 +177,23 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
     # log contains errors but otherwise executes successfully so we catch this.
     overide_rc = 64
     e_msg = 'Drive %s has logged S.M.A.R.T errors. Please view ' \
-                 'the Error logs tab for this device.' % local_base_dev
+            'the Error logs tab for this device.' % local_base_dev
     screen_return_codes(e_msg, overide_rc, o, e, rc, smart_command)
     ecode_map = {
-        'ABRT' : 'Command ABoRTed',
-        'AMNF' : 'Address Mark Not Found',
-        'CCTO' :  'Command Completion Timed Out',
-        'EOM' : 'End Of Media',
-        'ICRC' : 'Interface Cyclic Redundancy Code (CRC) error',
-        'IDNF' : 'IDentity Not Found',
-        'ILI' : '(packet command-set specific)',
-        'MC' : 'Media Changed',
-        'MCR' : 'Media Change Request',
-        'NM' : 'No Media',
-        'obs' : 'obsolete',
-        'TK0NF' : 'TracK 0 Not Found',
-        'UNC' : 'UNCorrectable Error in Data',
-        'WP' : 'Media is Write Protected',
+        'ABRT': 'Command ABoRTed',
+        'AMNF': 'Address Mark Not Found',
+        'CCTO': 'Command Completion Timed Out',
+        'EOM': 'End Of Media',
+        'ICRC': 'Interface Cyclic Redundancy Code (CRC) error',
+        'IDNF': 'IDentity Not Found',
+        'ILI': '(packet command-set specific)',
+        'MC': 'Media Changed',
+        'MCR': 'Media Change Request',
+        'NM': 'No Media',
+        'obs': 'obsolete',
+        'TK0NF': 'TracK 0 Not Found',
+        'UNC': 'UNCorrectable Error in Data',
+        'WP': 'Media is Write Protected',
     }
     summary = {}
     log_l = []
@@ -211,8 +211,11 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
                     fields = o[j].split()
                     err_num = fields[1]
                     if ('lifetime:' in fields):
-                        lifetime_hours = int(fields[fields.index('lifetime:')+1])
-                if (re.match('When the command that caused the error occurred, the device was', o[j].strip()) is not None):
+                        lifetime_hours = int(
+                            fields[fields.index('lifetime:') + 1])
+                if (re.match('When the command that caused the error occurred, '
+                             'the device was',
+                             o[j].strip()) is not None):
                     state = o[j].strip().split('the device was ')[1]
                 if (re.search('Error: ', o[j]) is not None):
                     e_substr = o[j].split('Error: ')[1]
@@ -220,8 +223,10 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
                     etype = e_fields[0]
                     if (etype in ecode_map):
                         etype = ecode_map[etype]
-                    details = ' '.join(e_fields[1:]) if (len(e_fields) > 1) else 'No Sector Details Available'
-                    summary[err_num] = list([lifetime_hours, state, etype, details])
+                    details = ' '.join(e_fields[1:]) if (
+                        len(e_fields) > 1) else 'No Sector Details Available'
+                    summary[err_num] = list(
+                        [lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     print ('summary_d %s' % summary)
     logger.debug('SMART ERROR LOGS RETURNING summary=%s' % summary)

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -31,7 +31,7 @@ CAT = '/usr/bin/cat'
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
-TESTMODE = False
+TESTMODE = True
 
 
 def info(device, custom_options='', test_mode=TESTMODE):
@@ -224,6 +224,8 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
                     summary[err_num] = list([lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     print ('summary_d %s' % summary)
+    logger.debug('SMART ERROR LOGS RETURNING summary=%s' % summary)
+    logger.debug('SMART ERROR LOGS RETURNING log_l=%s' % log_l)
     return (summary, log_l)
 
 

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -220,7 +220,7 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
                     etype = e_fields[0]
                     if (etype in ecode_map):
                         etype = ecode_map[etype]
-                    details = ' '.join(e_fields[1:]) if (len(e_fields) > 1) else None
+                    details = ' '.join(e_fields[1:]) if (len(e_fields) > 1) else 'No Sector Details Available'
                     summary[err_num] = list([lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     print ('summary_d %s' % summary)

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -31,7 +31,7 @@ CAT = '/usr/bin/cat'
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
-TESTMODE = True
+TESTMODE = False
 
 
 def info(device, custom_options='', test_mode=TESTMODE):
@@ -229,8 +229,6 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
                         [lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     print ('summary_d %s' % summary)
-    logger.debug('SMART ERROR LOGS RETURNING summary=%s' % summary)
-    logger.debug('SMART ERROR LOGS RETURNING log_l=%s' % log_l)
     return (summary, log_l)
 
 


### PR DESCRIPTION
Using the smartctl outputs supplied by forum member alexey it was found that when no details are specified in the "smartctl -l error" output the resulting 'details' list element was given a "None" value, this caused an exception in the Web-UI code. The solution presented in this pull request involves replacing the None attribution to the 'details' list element with a string = 'No Sector Details Available'.

This change circumvents the "null value in column "details" violates not-null constraint ..." error and also informs the user via the details column that no such information is available.

Fixes #1498 

Thanks to alexey in the following forum thread for contributing the required smartctl outputs:
https://forum.rockstor.com/t/smart-not-working/2137

The resulting code was tested both on the supplied smartctl dumps and on a qemu SATA drive emulation and on a real drive that had existing "smartctl -l error" log entries and a real drive that had not error log entries. All parsing was as expected with no observed regression.

Ready for review.
