### PR TITLE
glitch in smart error log ui, plus cosmetic table changes Fixes #1001

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -138,7 +138,6 @@
       <table id="smartattributes-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="List of S.M.A.R.T attributes">
 	<thead>
 	  <tr>
-	    <th>Id</th>
 	    <th>Name</th>
 	    <th>Failed</th>
 	    <th>Norm-ed Value</th>
@@ -148,13 +147,13 @@
 	    <th>Type</th>
 	    <th>Updated</th>
 	    <th>Flag</th>
+      <th>Id</th>
 	  </tr>
 	</thead>
 	<tbody>
 	  {{#each attributes as |attribute|}}
 	  <tr>
-	    <td>{{attribute.aid}}</td>
-	    <td>{{attribute.name}}</td>
+      <td>{{attribute.name}}</td>
 	    <td>{{attribute.failed}}</td>
 	    <td>{{attribute.normed_value}}</td>
 	    <td>{{attribute.worst}}</td>
@@ -163,6 +162,7 @@
 	    <td>{{attribute.atype}}</td>
 	    <td>{{attribute.updated}}</td>
 	    <td>{{attribute.flag}}</td>
+      <td>{{attribute.aid}}</td>
 	  </tr>
 	  {{else}}
 	  <h3>No S.M.A.R.T Attributes found (ATA/SATA only)</h3>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -177,7 +177,6 @@
       <table id="smartcapabilites-table" class="table table-condensed table-bordered table-hover table-striped tablesorter" summary="Table of S.M.A.R.T capabilities">
 	<thead>
 	  <tr>
-	    <th>Id</th>
 	    <th>Name</th>
 	    <th>Flag</th>
 	    <th>Capabilities</th>
@@ -186,7 +185,6 @@
 	<tbody>
 	  {{#each capabilities as |capability|}}
 	  <tr>
-	    <td>{{capability.id}}</td>
 	    <td>{{capability.name}}</td>
 	    <td>{{capability.flag}}</td>
 	    <td>{{capability.capabilities}}</td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -153,7 +153,7 @@
 	<tbody>
 	  {{#each attributes as |attribute|}}
 	  <tr>
-      <td>{{attribute.name}}</td>
+      <td><strong>{{attribute.name}}</strong></td>
 	    <td>{{attribute.failed}}</td>
 	    <td>{{attribute.normed_value}}</td>
 	    <td>{{attribute.worst}}</td>
@@ -185,7 +185,7 @@
 	<tbody>
 	  {{#each capabilities as |capability|}}
 	  <tr>
-	    <td>{{capability.name}}</td>
+	    <td><strong>{{capability.name}}</strong></td>
 	    <td>{{capability.flag}}</td>
 	    <td>{{capability.capabilities}}</td>
 	  </tr>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -158,7 +158,7 @@
 	    <td>{{attribute.normed_value}}</td>
 	    <td>{{attribute.worst}}</td>
 	    <td>{{attribute.threshold}}</td>
-	    <td>{{attribute.raw_value}}</td>
+	    <td><strong>{{attribute.raw_value}}</strong></td>
 	    <td>{{attribute.atype}}</td>
 	    <td>{{attribute.updated}}</td>
 	    <td>{{attribute.flag}}</td>

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -76,7 +76,7 @@ class DiskSMARTDetailView(rfc.GenericView):
                                 atype=t[6], updated=t[7], failed=t[8],
                                 raw_value=t[9])
             sa.save()
-        for c in cap:
+        for c in sorted(cap.keys(), reverse=True):
             t = cap[c]
             SMARTCapability(info=si, name=c, flag=t[0], capabilities=t[1]).save()
         for enum in sorted(e_summary.keys(), key=int, reverse=True):

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -69,7 +69,7 @@ class DiskSMARTDetailView(rfc.GenericView):
         ts = datetime.utcnow().replace(tzinfo=utc)
         si = SMARTInfo(disk=disk, toc=ts)
         si.save()
-        for k in attributes:
+        for k in sorted(attributes.keys(), reverse=True):
             t = attributes[k]
             sa = SMARTAttribute(info=si, aid=t[0], name=t[1], flag=t[2],
                                 normed_value=t[3], worst=t[4], threshold=t[5],

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -79,7 +79,7 @@ class DiskSMARTDetailView(rfc.GenericView):
         for c in cap:
             t = cap[c]
             SMARTCapability(info=si, name=c, flag=t[0], capabilities=t[1]).save()
-        for enum in sorted(e_summary.keys(), reverse=True):
+        for enum in sorted(e_summary.keys(), key=int, reverse=True):
             l = e_summary[enum]
             SMARTErrorLogSummary(info=si, error_num=enum, lifetime_hours=l[0],
                                  state=l[1], etype=l[2], details=l[3]).save()


### PR DESCRIPTION
By switching to an integer sort from lexical we address the reported issue of mis-ordering in the SMART errror log summary section where 99 would be ordered ahead of 100.

Fixes #1001 

While attending to the cosmetic side of the SMART table views a few other minor cosmetic changes were also made to the other table view:

Attributes table: the Id column was moved from the beginning to the end of the table and the now leading name column was bolded in line with the formatting of the Identity leading column. Bolding was also added to the often referenced Raw Value column as well, leading to a 'bold bracketing' of the other contextual values. The entire table as also sorted by the name column.

Capabilities table: the initial 'id' column was redundant as it referenced an internal db field that was not present in the smartctr output and so was removed.  The name column entries were also bolded as per the Attributes table changes and likewise the entire table was sorted via this column.

Ready for review.

Please note that disk_details_layout.jst was not re-formatted and includes a mix of tabs and spaces in it's formatting, this was left as is to aid in reviewing code changes. This re-formatting can be carried out after review or in another formatting only pr if required. I am happy to do either.

All changes have been tested on a number of real drives containing either 0, 1, or many error log entries, as well as on KVM virtual sata and virtio drives. To address the specific issue this pr initially references I edited the output of an existing error log smartctl dump and used the build in smartctl test system. Issue #1001 details output of before and after error log summary table views.

No regressions were observed.
