### PR TITLE
Samba configuration enhancements

### DIFF
--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -60,8 +60,12 @@ class SambaServiceView(BaseServiceDetailView):
                 global_config = {}
                 gc_lines = config['global_config'].split('\n')
                 for l in gc_lines:
-                    gc_param = l.strip().split('=')
+                    gc_param = l.strip().split(' = ')
                     if (len(gc_param) == 2):
+                        if '=' in gc_param[0]:
+                            e_msg = 'Syntax error, one param has wrong spaces around equal signs'
+                            raise Exception('Syntax error, one param has wrong spaces around equal signs, '
+                                            'please check syntax of \'%s\'' % ''.join(gc_param))
                         global_config[gc_param[0].strip().lower()] = gc_param[1].strip()
                 #Default set current workgroup to one got via samba config page
                 global_config['workgroup'] = config['workgroup']

--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -63,7 +63,6 @@ class SambaServiceView(BaseServiceDetailView):
                     gc_param = l.strip().split(' = ')
                     if (len(gc_param) == 2):
                         if '=' in gc_param[0]:
-                            e_msg = 'Syntax error, one param has wrong spaces around equal signs'
                             raise Exception('Syntax error, one param has wrong spaces around equal signs, '
                                             'please check syntax of \'%s\'' % ''.join(gc_param))
                         global_config[gc_param[0].strip().lower()] = gc_param[1].strip()

--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -1727,6 +1727,26 @@ input[type="radio"].selectedRoot {
   box-shadow: 0 0 12px #555;
 }
 
+.size200.tooltip-inner {
+    width: 200px;
+    max-width: 200px;
+}
+
+.size250.tooltip-inner {
+    width: 250px;
+    max-width: 250px;
+}
+
+.size300.tooltip-inner {
+    width: 300px;
+    max-width: 300px;
+}
+
+.size350.tooltip-inner {
+    width: 350px;
+    max-width: 350px;
+}
+
 /* cpu graph */
 .cpugraph path {
   stroke: steelblue;

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
@@ -42,13 +42,7 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label" for="global_config">Custom global configuration </label>
                         <div class="col-sm-8">
-                            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control">
-              {{#each config}}
-                {{#if (smb_check_custom_params @key)}} 
-                    {{@key}} = {{this}}
-                {{/if}}
-              {{/each}}
-            </textarea>
+                            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control">{{display_smb_params}}</textarea>
                         </div>
                     </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
@@ -42,7 +42,7 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label" for="global_config">Custom global configuration </label>
                         <div class="col-sm-8">
-                            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control" title="You can provide custom parameters here. These lines will be added to the [global] section of smb.conf">
+                            <textarea rows="5" columns="40" id="global_config" name="global_config" class="form-control">
               {{#each config}}
                 {{#if (smb_check_custom_params @key)}} 
                     {{@key}} = {{this}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -176,9 +176,16 @@ ConfigureServiceView = RockstorLayoutView.extend({
             html: true,
             placement: 'right'
         });
-        this.$('#smb-form :input').tooltip({
+        this.$('#smb-form #global_config').tooltip({
             html: true,
-            placement: 'right'
+            placement: 'right',
+            template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div> \
+                    <div class="tooltip-inner size300"></div></div>',
+            title: 'These lines will be added to the [global] section of smb.conf<br/><br/> \
+                    - <strong>Inline comments with # or ; not allowed, Samba testparm <u>will fail</u></strong><br/><br/> \
+                    - <strong>Samba params syntax</strong>:<br/>param = value (1 space both sides of equal sign)<br/><br/> \
+                    - <strong>Samba params with equals inside value field (ex. socket options param)</strong>:<br/>socket options = SO_SNDBUF=131072<br/>(spaces on first equal, <u>no spaces</u> around others)<br/><br/> \
+                    Please check <a href="https://www.samba.org/samba/docs/man/manpages/smb.conf.5.html" target="_new">Samba official docs</a> for further infos'
         });
         this.$('#docker-form #root_share').tooltip({
             html: true,

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -471,9 +471,16 @@ To alert on temperature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         });
 
         //Samba Config page
-        Handlebars.registerHelper('smb_check_custom_params', function(key) {
+        Handlebars.registerHelper('display_smb_params', function() {
 
-            return key != 'workgroup';
+            var params = [],
+                _this = this;
+            _.each(_this.config, function(val, key) {
+                if (key != 'workgroup') {
+                    params.push(key + ' = ' + val);
+                }
+            });
+            return params.join('\n');
         });
 
         Handlebars.registerHelper('isEnabledAD', function(opts) {

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -211,7 +211,7 @@ def get_global_config():
                 re.match('\[', l) is not None):
                 global_section = False
                 continue
-            fields = l.strip().split('=')
+            fields = l.strip().split(' = ')
             if len(fields) < 2:
                 continue
             config[fields[0].strip()] = fields[1].strip()


### PR DESCRIPTION
Hi all guys,
opening this PR, but this is only 1 of 3 mods, so @schakrava please wait merging to avoid more PRs

71a7f09 adds some extra infos to users about smb.conf params syntax & a direct link to smb.conf docu
![warning](https://cloud.githubusercontent.com/assets/17988902/20482113/018de396-afeb-11e6-97a1-23da279c9704.jpg)

On 8e03a68 we've a general improvement I had to code to grant a bigger tooltip!
This is how usually have tooltips:
```javascript
        this.$('#docker-form #root_share').tooltip({
            html: true,
            placement: 'right',
            title: 'bla bla bla.'
        });
```
But Bootstrap tooltips let us define an on the fly new template like this:
```javascript
        this.$('#smb-form #global_config').tooltip({
            html: true,
            placement: 'right',
            template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div> \
                    <div class="tooltip-inner size300"></div></div>',
            title: 'These lines will be added to the [global] section of smb.conf<br/><br/> etc etc'
        });
```
To grant tooltips to work templates have to be always like this
```html
<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner size300"></div></div>'
```

To have a custom size for a better UX (Samba text was too much long), added new 4 classes over tooltip-inner (template body), so now with `size200, size250, size300, size350` you can have 200,250,300,350px width tooltips (more than 350px comes to big, more then modals)

To @priyaganti : there's a width: 400px inside tooltip-inner, but that's totally skipped by Rockstor (having bootstrap default size)

Going on with other Sambas :)

M.
