### PR TITLE
Update django-pipeline. #1190

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -18,10 +18,6 @@ extends = base-buildout.cfg
 
 parts =
       stop-rockstor
-      rpm-deps
-      rpm-deps-nut
-      rpm-deps-ad
-      delete-prod-rpm
       django
       scripts
       postgres-setup

--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -169,46 +169,35 @@ INSTALLED_APPS = (
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
-#yum install npm, then npm install yuglify, then ln -s ..../yuglify /usr/bin/yuglify
-#using yuglify compresses js and css to some extent. What do we do with .jst files?
-#PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.yuglify.YuglifyCompressor'
-#PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.yuglify.YuglifyCompressor'
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = None
-
-#for handlebars
-#PIPELINE_TEMPLATE_EXT = '.handlebars'
-PIPELINE_TEMPLATE_FUNC = 'Handlebars.compile'
-#PIPELINE_TEMPLATE_NAMESPACE = 'Handlebars.templates'
-
-# Don't wrap in anonymous function so that license is at the top.
-PIPELINE_DISABLE_WRAPPER = True
-
-
-PIPELINE_JS = {
-    'storageadmin': {
-        'source_filenames': (
-            'storageadmin/js/license.js',
-            'storageadmin/js/templates/**/*.jst',
-            'storageadmin/js/templates/**/**/*.jst',
-            'storageadmin/js/socket_listen.js',
-            'storageadmin/js/rockstor.js',
-            'storageadmin/js/rockstor_widgets.js',
-            'storageadmin/js/rockstor_logger.js',
-            'storageadmin/js/paginated_collection.js',
-            'storageadmin/js/router.js',
-            'storageadmin/js/graph.js',
-            'storageadmin/js/d3.slider2.js',
-            'storageadmin/js/models/models.js',
-            'storageadmin/js/views/common/*.js',
-            'storageadmin/js/views/*.js',
-            'storageadmin/js/views/pool/**/*.js',
-            'storageadmin/js/views/dashboard/*.js',
-            ),
-        'output_filename': 'storageadmin/js/storageadmin.js'
-        },
-    }
-
+PIPELINE = {
+    'DISABLE_WRAPPER': True,
+    'JS_COMPRESSOR': None,
+    'CSS_COMPRESSOR': None,
+    'TEMPLATE_FUNC': 'Handlebars.compile',
+    'JAVASCRIPT': {
+        'storageadmin': {
+            'source_filenames': (
+                'storageadmin/js/license.js',
+                'storageadmin/js/templates/**/*.jst',
+                'storageadmin/js/templates/**/**/*.jst',
+                'storageadmin/js/socket_listen.js',
+                'storageadmin/js/rockstor.js',
+                'storageadmin/js/rockstor_widgets.js',
+                'storageadmin/js/rockstor_logger.js',
+                'storageadmin/js/paginated_collection.js',
+                'storageadmin/js/router.js',
+                'storageadmin/js/graph.js',
+                'storageadmin/js/d3.slider2.js',
+                'storageadmin/js/models/models.js',
+                'storageadmin/js/views/common/*.js',
+                'storageadmin/js/views/*.js',
+                'storageadmin/js/views/pool/**/*.js',
+                'storageadmin/js/views/dashboard/*.js',
+                ),
+            'output_filename': 'storageadmin/js/storageadmin.js'
+            },
+        }
+}
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -423,3 +412,5 @@ ZTASKD_URL = 'ipc:///var/run/rockon-ztaskd'
 TASK_SCHEDULER = {
 	       'max_log': 100 #max number of task log entries to keep
 }
+
+OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'distribute >= 0.6.35',
         'django == 1.6.11',
         'django-oauth-toolkit == 0.9.0',
-        'django-pipeline == 1.2.23',
+        'django-pipeline == 1.6.9',
         'django-ztask == 0.1.5',
         'djangorestframework == 3.1.1',
         'gevent == 1.1.2',

--- a/src/rockstor/smart_manager/urls/services.py
+++ b/src/rockstor/smart_manager/urls/services.py
@@ -17,18 +17,29 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.conf.urls import patterns, url
-from smart_manager.views import (NISServiceView, BaseServiceView,
-                                 SambaServiceView, NFSServiceView,
-                                 NTPServiceView, ActiveDirectoryServiceView,
-                                 LdapServiceView, SFTPServiceView,
-                                 ReplicationServiceView,
-                                 TaskSchedulerServiceView,
-                                 DataCollectorServiceView, ServiceMonitorView,
-                                 AFPServiceView, SNMPServiceView,
-                                 DockerServiceView, SMARTDServiceView,
-                                 NUTServiceView, ZTaskdServiceView,
-                                 BootstrapServiceView, ShellInABoxServiceView,
-                                 RockstorServiceView)
+from smart_manager.views import (
+    AFPServiceView,
+    ActiveDirectoryServiceView,
+    BaseServiceView,
+    BootstrapServiceView,
+    DataCollectorServiceView,
+    DockerServiceView,
+    LdapServiceView,
+    NFSServiceView,
+    NISServiceView,
+    NTPServiceView,
+    NUTServiceView,
+    ReplicationServiceView,
+    RockstorServiceView,
+    SFTPServiceView,
+    SMARTDServiceView,
+    SNMPServiceView,
+    SambaServiceView,
+    ShellInABoxServiceView,
+    ServiceMonitorView,
+    TaskSchedulerServiceView,
+    ZTaskdServiceView,
+)
 
 command_regex = ('config|start|stop')
 
@@ -80,7 +91,7 @@ urlpatterns = patterns(
     url(r'^rockstor-bootstrap$', BootstrapServiceView.as_view()),
     url(r'^rockstor-bootstrap/(?P<command>%s)$' % command_regex, BootstrapServiceView.as_view()),
     url(r'^shellinaboxd$', ShellInABoxServiceView.as_view()),
-    url(r'^shellinaboxd/(?P<command>%s)$' % command_regex, ShellInABoxServiceView.as_view()),    
+    url(r'^shellinaboxd/(?P<command>%s)$' % command_regex, ShellInABoxServiceView.as_view()),
     url(r'^rockstor$', RockstorServiceView.as_view()),
     url(r'^rockstor/(?P<command>%s)$' % command_regex, RockstorServiceView.as_view()),
 )


### PR DESCRIPTION
As part of updating django, we'll need to update django-pipeline as
well. Splitting it into a separate step and taking it out of the way
makes the next patch less messy.