### PR TITLE
fix django 1.8 error on pool create. Fixes #1551

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -265,6 +265,7 @@ class PoolListView(PoolMixin, rfc.GenericView):
             dnames = [d.name for d in disks]
             p = Pool(name=pname, raid=raid_level, compression=compression,
                      mnt_options=mnt_options)
+            p.save()
             p.disk_set.add(*disks)
             p.save()
             # added for loop to save disks


### PR DESCRIPTION
Due to a recent Django 1.8 update we are now subject to tighter automated checks. This pr simply adds an addition p.save() to appease another of these check fails.

Akin to an earlier change in disk.py

https://github.com/rockstor/rockstor-core/pull/1546/commits/fd59e32b22ec0d3e44c35b7c52eb0703c29482b4

but this time in pool.py

Issue error reproduced prior to this pr and not after it's addition.
Pool was added and deleted several times and once deleted it was also successfully imported.

