### PR TITLE
correct disk removal disqualification calculation. Fixes #1553

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -416,7 +416,7 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 size_cut = 0
                 for d in disks:
                     size_cut += d.size
-                if (size_cut >= usage):
+                if size_cut >= (pool.size - usage):
                     e_msg = ('Removing these(%s) disks may shrink the pool by '
                              '%dKB, which is greater than available free space'
                              ' %dKB. This is not supported.' %


### PR DESCRIPTION
Previously we refused a disk removal based on disk > pool usage
but the intended calculation was disk > pool free space.
Hence switch usage for (pool.size - usage) = free space.

So now this action is disqualified if disk > pool free space

This accounts for a worst case scenario.

Fixes #1553 

Previously a 7.5 GB disk was not allowed to be removed from a 463 GB (2 GB used) pool.
After pr this was allowed. Logging was used during development to confirm figures were as expected.
Details and user experience are available in the linked issue #1553 .

