### PR TITLE
Fixing Issue#1567 datacollector orm to api migration

### DIFF
--- a/src/rockstor/storageadmin/urls/pincard.py
+++ b/src/rockstor/storageadmin/urls/pincard.py
@@ -1,0 +1,25 @@
+"""
+Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from django.conf.urls import patterns, url
+from storageadmin.views import PincardView
+
+urlpatterns = patterns(
+    '',
+    url(r'^/(?P<command>create|reset)/(?P<user>\w+)$', PincardView.as_view(), )
+    )

--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -55,3 +55,4 @@ from config_backup import (ConfigBackupListView, ConfigBackupDetailView,
 from email_client import EmailClientView
 from update_subscription import (UpdateSubscriptionListView,
                                  UpdateSubscriptionDetailView)
+from pincard import PincardView

--- a/src/rockstor/storageadmin/views/pincard.py
+++ b/src/rockstor/storageadmin/views/pincard.py
@@ -1,0 +1,48 @@
+"""
+Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from rest_framework.response import Response
+from django.db import transaction
+
+from system.pinmanager import (save_pincard, reset_password)
+
+import rest_framework_custom as rfc
+from storageadmin.util import handle_exception
+
+import logging
+logger = logging.getLogger(__name__)
+
+class PincardView(rfc.GenericView):
+
+    @transaction.atomic
+    def post(self, request, command, user):
+
+        with self._handle_exception(request):
+
+            if (command == 'create'):
+                response_data = save_pincard(user)
+                logger.debug('Created new pincard for user with uid %s' % user)
+
+            if (command == 'reset'):
+                uid = request.data.get('uid')
+                pinlist = request.data.get('pinlist')
+                reset_response, reset_status = reset_password(user, uid, pinlist)
+                response_data = {'response': reset_response,
+                                 'status': reset_status}
+                logger.debug('Received password reset request for user %s' % user)
+                
+            return Response(response_data)
+        e_msg = ('Unsupported command(%s). Valid commands are create, reset' % command)
+        handle_exception(Exception(e_msg), request)

--- a/src/rockstor/system/pinmanager.py
+++ b/src/rockstor/system/pinmanager.py
@@ -15,8 +15,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-import django
-django.setup()
+
 import random, string
 from hashlib import md5
 from pwd import getpwnam

--- a/src/rockstor/urls.py
+++ b/src/rockstor/urls.py
@@ -118,7 +118,9 @@ urlpatterns = patterns('',
                            ConfigBackupUpload.as_view()),
                        url(r'^api/email$', EmailClientView.as_view()),
                        url(r'^api/email/(?P<command>.*)$', EmailClientView.as_view()),
-
+                       # Pincard
+                       url(r'^api/pincardmanager',
+                        include('storageadmin.urls.pincard')),
                        #update subscription
                        (r'^api/update-subscriptions',
                         include('storageadmin.urls.update_subscription')),


### PR DESCRIPTION
Hi @schakrava ,
had my way to #1567 following your suggestions about CRUD ops

Checking comments on commits you'll find checking pincard existence is always with direct db reading (as you suggested it possible on #1556 )

Note: Pincard view is a small one because the system/pinmanager already had all checks

Tests performed:
- Pincard creation both with a Rockstor user and root -> OK (actually on CRUD it seems faster then before)
- Password reset on login page both with normal user and root -> OK
- Password reset on login simulating wrong pins and/or OTP -> OK


Ready for your review / to be merged

Mirko