### PR TITLE
work around failure of udev to observe btrfs device add. Fixes #1606

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -31,7 +31,7 @@ from storageadmin.models import (Disk, Pool, Share, PoolBalance)
 from fs.btrfs import (add_pool, pool_usage, resize_pool, umount_root,
                       btrfs_uuid, mount_root, start_balance, usage_bound,
                       remove_share)
-from system.osi import remount
+from system.osi import remount, trigger_udev_update
 from storageadmin.util import handle_exception
 from django.conf import settings
 import rest_framework_custom as rfc
@@ -369,7 +369,8 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 for d_o in disks:
                     d_o.pool = pool
                     d_o.save()
-
+                # Now we ensure udev info is updated via system wide trigger
+                trigger_udev_update()
             elif (command == 'remove'):
                 if (new_raid != pool.raid):
                     e_msg = ('Raid configuration cannot be changed while '

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1691,3 +1691,15 @@ def hostid():
             return puuid
     except:
         return '%s-%s' % (run_command([HOSTID])[0][0], str(uuid.uuid4()))
+
+
+def trigger_udev_update():
+    """
+    In some instances udev info can be out of date after some btrfs opperations.
+    To cause a system wide update of all udev info, and the output of lsblk,
+    we can execute:
+    udevadm trigger
+    This function is a simple wrapper to call the above command via run_command
+    :return: o, e, rc as returned by run_command
+    """
+    return run_command([UDEVADM, 'trigger'])


### PR DESCRIPTION
In some rare instances it is possible for udev and lsblk to fail to reflect the current state of a pools disk members. This was initially observed while testing btrfs in partition device members in issue #1494, however the same has now been reproduced using whole disk members.

Please see issue #1606 for examples of where this discrepancy was observed and the subsequent testing of 'udevadmin trigger' to cause udev and lsblk to again reflect the current state of btrfs pools. All proof was via command line to isolate any Rockstor mechanisms.

This pr creates a simple wrapper around 'udevadmin trigger' and calls this directly after a pool resize action is requested to add one or more devices. The call method mimics that of resize_pool() for consistency. Exception handling was tested by substituting a nonsense command, in this scenario a user visible error was returned.

Fixes #1606 

This pr was made against current master and a fresh build was used for testing.
