### PR TITLE
update unit test settings re new replication / env structure. Fixes #1609

### DIFF
--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -298,11 +298,12 @@ END_UID = 6000
 VALID_SHELLS = ('${buildout:depdir}/bin/rcli', '/bin/bash', '/sbin/nologin',)
 
 SCHEDULER = ('127.0.0.1', ${django-settings-conf:schedulerport})
-REPLICA_DATA_PORT = ${django-settings-conf:reppubport}
-REPLICA_META_PORT = ${django-settings-conf:reprecvport}
-REPLICA_SINK_PORT = ${django-settings-conf:repsinkport}
-MAX_REPLICA_SEND_ATTEMPTS = 10
-DEFAULT_SEND_CREDIT = 1000
+REPLICATION = {
+    'ipc_socket': '/var/run/replication.sock',
+    'max_send_attempts': 10,
+    'max_snap_retain': 5,
+    'listener_port': 10002,
+}
 
 SHARE_REGEX = r'[A-Za-z0-9][A-Za-z0-9_.-]*'
 POOL_REGEX = SHARE_REGEX


### PR DESCRIPTION
When attempting to run the fs unit test subset a problem with test-settings.conf.in came to light which prevented these unit tests from executing:

    ./bin/test --settings=test-settings -v 3 -p test_btrfs*

resulted in:

    ....
    AttributeError: 'Settings' object has no attribute 'REPLICATION'

After applying this patch to current master branch and rebuilding the test_btrfs unit tests executed as expected.

Fixes #1609 

