### PR TITLE
Show sector sizes for 512e disks. Fixes #1590

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -54,7 +54,7 @@ def info(device, custom_options='', test_mode=TESTMODE):
                'Serial Number:|Serial number:',
                'LU WWN Device Id:|Logical Unit id:',
                'Firmware Version:|Revision', 'User Capacity:',
-               'Sector Size:|Logical block size:', 'Rotation Rate:',
+               'Sector Sizes?:|Logical block size:', 'Rotation Rate:',
                'Device is:', 'ATA Version is:',
                'SATA Version is:', 'Local Time is:',
                'SMART support is:.* Available',


### PR DESCRIPTION
Update the match string to parse smartctl output for differing logical/physical sector sizes, e.g. `Sector Sizes: 512 bytes logical/4096 bytes physical`.

For reference, the corresponding code responsible for the smartctl output is in the "Print sector sizes" section of  `print_drive_info()` in [ataprint.cpp](https://www.smartmontools.org/browser/tags/RELEASE_6_2/smartmontools/ataprint.cpp?rev=3841#L592).