### PR TITLE
enhance disk role/management subsystem. Fixes #1494 

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -84,8 +84,8 @@ def add_pool(pool, disks):
 def get_pool_info(disk):
     """
     Extracts any pool information by running btrfs fi show <disk> and collates
-    the results by 'Label', 'uuid', and current boot disk name. The disk name
-    is then translated to the by-id type found in /dev/disk/by-id so that it's
+    the results by 'Label', 'uuid', and a list of disk names. The disks names
+    found are translated to the by-id type (/dev/disk/by-id)so that their
     counterparts in the db's Disk.name field can be found.
     N.B. devices without serial may have no by-id counterpart.
     Used by CommandView()._refresh_pool_state() and

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -51,6 +51,7 @@ def add_pool(pool, disks):
     :return o, err, rc from last command executed.
     """
     disks_fp = ['/dev/disk/by-id/' + d for d in disks]
+    logger.debug('disks_fp LIST=%s' % disks_fp)
     cmd = [MKFS_BTRFS, '-f', '-d', pool.raid, '-m', pool.raid, '-L',
            pool.name, ]
     cmd.extend(disks_fp)
@@ -93,6 +94,7 @@ def get_pool_info(disk):
     :return: a dictionary with keys of 'disks', 'label', and 'uuid';
     disks keys a list of devices, while label and uuid keys are for strings.
     """
+    logger.debug('GET_POOL_INFO called with disk=%s' % disk)
     cmd = [BTRFS, 'fi', 'show', '/dev/disk/by-id/%s' % disk]
     o, e, rc = run_command(cmd)
     pool_info = {'disks': [], }
@@ -114,6 +116,7 @@ def get_pool_info(disk):
             # pool field reference.
             dev_byid, is_byid = get_dev_byid_name(l.split()[-1], True)
             pool_info['disks'].append(dev_byid)
+    logger.debug('GET_POOL_INFO RETURN=%s' % pool_info)
     return pool_info
 
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -51,7 +51,6 @@ def add_pool(pool, disks):
     :return o, err, rc from last command executed.
     """
     disks_fp = ['/dev/disk/by-id/' + d for d in disks]
-    logger.debug('disks_fp LIST=%s' % disks_fp)
     cmd = [MKFS_BTRFS, '-f', '-d', pool.raid, '-m', pool.raid, '-L',
            pool.name, ]
     cmd.extend(disks_fp)
@@ -94,7 +93,6 @@ def get_pool_info(disk):
     :return: a dictionary with keys of 'disks', 'label', and 'uuid';
     disks keys a list of devices, while label and uuid keys are for strings.
     """
-    logger.debug('GET_POOL_INFO called with disk=%s' % disk)
     cmd = [BTRFS, 'fi', 'show', '/dev/disk/by-id/%s' % disk]
     o, e, rc = run_command(cmd)
     pool_info = {'disks': [], }
@@ -116,7 +114,6 @@ def get_pool_info(disk):
             # pool field reference.
             dev_byid, is_byid = get_dev_byid_name(l.split()[-1], True)
             pool_info['disks'].append(dev_byid)
-    logger.debug('GET_POOL_INFO RETURN=%s' % pool_info)
     return pool_info
 
 
@@ -183,7 +180,6 @@ def resize_pool(pool, dev_list_byid, add=True):
         the device member/pool sanity check fails.
     """
     dev_list_byid = ['/dev/disk/by-id/' + d for d in dev_list_byid]
-    logger.debug('resize_pool called with pool name=%s, dev_list_byid=%s, add = %s' %(pool, dev_list_byid, add))
     root_mnt_pt = mount_root(pool)
     cur_dev = cur_devices(root_mnt_pt)
     resize_flag = 'add'

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -183,6 +183,7 @@ def resize_pool(pool, dev_list_byid, add=True):
         the device member/pool sanity check fails.
     """
     dev_list_byid = ['/dev/disk/by-id/' + d for d in dev_list_byid]
+    logger.debug('resize_pool called with pool name=%s, dev_list_byid=%s, add = %s' %(pool, dev_list_byid, add))
     root_mnt_pt = mount_root(pool)
     cur_dev = cur_devices(root_mnt_pt)
     resize_flag = 'add'

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -61,7 +61,6 @@ var Disk = Backbone.Model.extend({
         // A drive with no role shouldn't present a problem for use.
         var role = this.get('role');
         if (role == null) {
-            console.log("bb DISK model: ACCEPTING ROLE OF null")
             return true;
         }
         // try json conversion and return false if it fails
@@ -77,31 +76,23 @@ var Disk = Backbone.Model.extend({
         //
         // Accept use of 'openLUKS' device
         if (roleAsJson.hasOwnProperty('openLUKS')) {
-            console.log("bb DISK model: ACCEPTING ROLE OF openLUKS json = " + role);
             return true;
         }
         // Accept use of 'partitions' device but only if it is accompanied
         // by a 'redirect' role, ie so there is info to 'redirect' to the
         // by-id name held as the value to the 'redirect' role key.
         if (roleAsJson.hasOwnProperty('partitions') && roleAsJson.hasOwnProperty('redirect')) {
-            console.log("bb DISK model: EXAMINING ROLE OF partitioned COMBINED WITH redirect ROLE")
             // then we need to confirm if the fstype of the redirected
             // partition is "" else we can't use it
-            console.log("the redirect value = " + roleAsJson.redirect);
-            console.log("the fstype at the redirect partition = " + roleAsJson.partitions[roleAsJson.redirect]);
             if (roleAsJson.partitions.hasOwnProperty(roleAsJson.redirect)) {
-                console.log("redirect value found in partition list")
                 if (roleAsJson.partitions[roleAsJson.redirect] == "") {
-                    console.log("bb DISK model: ACCEPTING partition as empty fs type")
                     return true;
                 }
             }
-            console.log("rejecting as non empty fstype in redirect partition")
         }
         // In all other cases return false, ie:
         // reject roles of for example root, mdraid, LUKS,
         // partitioned (when not accompanied by a valid redirect role) etc
-        console.log("bb DISK model: REJECTING ROLE with json = " + role);
         return false;
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -38,6 +38,7 @@ var AppRouter = Backbone.Router.extend({
         'disks/blink/:diskName': 'blinkDrive',
         'disks/smartcustom/:diskName': 'smartcustomDrive',
         'disks/spindown/:diskName': 'spindownDrive',
+        'disks/role/:diskName': 'roleDrive',
         'disks/:diskName': 'showDisk',
         'pools': 'showPools',
         'pools/:poolName': 'showPool',
@@ -186,6 +187,14 @@ var AppRouter = Backbone.Router.extend({
         this.renderSidebar('storage', 'disks');
         this.cleanup();
         this.currentLayout = new SpindownDiskView({diskName: diskName});
+        $('#maincontent').empty();
+        $('#maincontent').append(this.currentLayout.render().el);
+    },
+
+    roleDrive: function(diskName) {
+        this.renderSidebar('storage', 'disks');
+        this.cleanup();
+        this.currentLayout = new SetroleDiskView({diskName: diskName});
         $('#maincontent').empty();
         $('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
@@ -3,7 +3,7 @@
     <tr>
       <th>No.</th>
       <th>Name</th>
-      <th>Size</th>
+      <th>Capacity</th>
       <th>Select All <input type="checkbox" id="checkAll"/></th>
     </tr>
   </thead>
@@ -11,7 +11,12 @@
   {{#each disks}}
   <tr>
     <td>{{mathHelper @index}}</td>
-    <td>{{this.name}}</td>
+    <td>{{this.name}}
+      {{#if this.parted}}
+      <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition (Redirect Role), click to review. Note: Capacity is for whole disk when adding so may be inaccurate." rel="tooltip">
+        <i class="glyphicon glyphicon-tags"></i></a>
+      {{/if}}
+    </td>
     <td>{{humanReadableSize this.size}}</td>
     <td><input type="checkbox" name="diskname" id="{{this.name}}" value="{{this.name}}" class="diskname"></td>
   {{/each}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
@@ -4,7 +4,6 @@
       <th>No.</th>
       <th>Name</th>
       <th>Size</th>
-      <th>In use</th>
       <th>Select All <input type="checkbox" id="checkAll"/></th>
     </tr>
   </thead>
@@ -14,7 +13,6 @@
     <td>{{mathHelper @index}}</td>
     <td>{{this.name}}</td>
     <td>{{humanReadableSize this.size}}</td>
-    <td>{{this.parted}}</td>
     <td><input type="checkbox" name="diskname" id="{{this.name}}" value="{{this.name}}" class="diskname"></td>
   {{/each}}
   </tbody>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -53,6 +53,10 @@
             <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive" rel="tooltip">
             <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
         {{/if}}
+        {{#if (hasUserRole this.role)}}
+            <a href="#" class="User_Role_drive" data-disk-name="{{this.name}}" title="User Assigned Role" rel="tooltip">
+            <i class="glyphicon glyphicon-tag"></i></a>
+        {{/if}}
       </td>
       <td>
         {{#checkSerialStatus this.serial this.name}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -23,11 +23,11 @@
         {{#if this.offline}}
             <a href="#" class="delete" data-disk-name="{{this.name}}" title="Disk is unusable because it is detached.
             Click to delete it from the system if it is not to be reattached." rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>
-        {{else if (displayInfo this.role)}}
-            <a href="#" class="raid_member" data-disk-name="{{this.name}}" title="Disk is a mdraid member." rel="tooltip">
+        {{else if (isMdraidMember this.role)}}
+            <a href="#" class="raid_member" data-disk-name="{{this.name}}" title="Mdraid member (UI pending)." rel="tooltip">
               <i class="glyphicon glyphicon-info-sign"></i></a>
         {{else if (isRootDevice this.role)}}
-              <i class="glyphicon glyphicon-registration-mark" title="Rockstor System Drive" rel="tooltip"></i>
+              <i class="glyphicon glyphicon-registration-mark" title="Rockstor System Drive." rel="tooltip"></i>
         {{else if this.parted}}
             {{#if (hasUserRole this.role)}}
                 <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="User Assigned Role found on partitioned disk, click to edit." rel="tooltip">
@@ -48,7 +48,7 @@
             {{/if}}
         {{else}} <!-- We are non of the above top level ifs / else ifs at this point -->
             {{#if (hasUserRole this.role)}}
-                <a href="#" class="user_role_drive" data-disk-name="{{this.name}}" title="Whole Disk User Assigned Role found, click to edit" rel="tooltip">
+                <a href="#" class="user_role_drive" data-disk-name="{{this.name}}" title="Whole Disk User Assigned Role found, click to edit." rel="tooltip">
                 <i class="glyphicon glyphicon-tag"></i></a>
             {{/if}}
             {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
@@ -58,19 +58,19 @@
             {{/if}}
         {{/if}}
         {{#if (isLuksContainer this.role)}}
-            <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (UI pending)" rel="tooltip">
+            <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (UI pending)." rel="tooltip">
             <i class="glyphicon glyphicon-lock"></i></a>
         {{/if}}
         {{#if (isOpenLuks this.role)}}
-            <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Container (UI pending)" rel="tooltip">
+            <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Container (UI pending)." rel="tooltip">
             <i class="glyphicon glyphicon-eye-open"></i></a>
         {{/if}}
         {{#if (isBcache this.role)}}
-            <a href="#" class="bcache_backing_drive" data-disk-name="{{this.name}}" title="Bcache Backing Drive (UI pending)" rel="tooltip">
+            <a href="#" class="bcache_backing_drive" data-disk-name="{{this.name}}" title="Bcache Backing Drive (UI pending)." rel="tooltip">
             <i class="glyphicon glyphicon-link"></i></a>
         {{/if}}
         {{#if (isBcacheCdev this.role)}}
-            <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive (UI pending)" rel="tooltip">
+            <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive (UI pending)." rel="tooltip">
             <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
         {{/if}}
       </td>
@@ -80,7 +80,7 @@
           Please ensure that disks are provided with unique serial numbers before proceeding further.</div>
         {{else if this.serial}}
         {{this.serial}}
-        &nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/{{this.name}}" title="A tool to physically identify the hard drive with this serial number" rel="tooltip">
+        &nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/{{this.name}}" title="A tool to physically identify the hard drive with this serial number." rel="tooltip">
           <i class="fa fa-lightbulb-o fa-lg"></i></a>&nbsp;
         {{/checkSerialStatus}}
       </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -39,10 +39,13 @@
                     <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
                 {{/if}}
             {{else}}
-                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions and no User Assigned Role.
-                Click to configure or wipe." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
-                <!-- Later we can have this click do User Assigned Role config -->
-                <!-- which can also wipe if need be, either whole or partition -->
+                {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
+                    <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions: one of which has an existing BTRFS filesystem on it. A User Assigned redirect role is required prior to import.
+                    Click to configure or wipe." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
+                {{else}}
+                    <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions and no User Assigned Role.
+                    Click to configure or wipe." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
+                {{/if}}
             {{/if}}
         {{else}} <!-- We are non of the above top level ifs / else ifs at this point -->
             {{#if (hasUserRole this.role)}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -31,27 +31,27 @@
               <i class="glyphicon glyphicon-registration-mark"></i></a>
         {{else if this.parted}}
             {{#if (hasUserRole this.role)}}
-                <a href="#" class="user_role_part" data-disk-name="{{this.name}}" title="User Assigned Role found, click to edit (pending feature)" rel="tooltip">
+                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="User Assigned Role found on partitioned disk, click to edit." rel="tooltip">
                 <i class="glyphicon glyphicon-tags"></i></a>
                 {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
-                    <a href="#" class="btrfs_wipe" data-disk-name="{{this.name}}" title="Partition is unusable because it has an existing BTRFS filesystem on it.
-                    Click to wipe it clean." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this partition automatically (Note: only a single device is supported with btrfs in partition)." rel="tooltip">
+                    <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition is unusable because it has an existing BTRFS filesystem on it.
+                    Click to configure or wipe." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this partition automatically (Note: whole disk btrfs is recommended)." rel="tooltip">
                     <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
                 {{/if}}
             {{else}}
-                <a href="#" class="wipe" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions and no User Assigned Role (pending feature)
-                Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
+                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions and no User Assigned Role.
+                Click to configure or wipe." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
                 <!-- Later we can have this click do User Assigned Role config -->
                 <!-- which can also wipe if need be, either whole or partition -->
             {{/if}}
         {{else}} <!-- We are non of the above top level ifs / else ifs at this point -->
             {{#if (hasUserRole this.role)}}
-                <a href="#" class="user_role_drive" data-disk-name="{{this.name}}" title="Whole Disk User Assigned Role found, click to edit (pending feature)" rel="tooltip">
+                <a href="#" class="user_role_drive" data-disk-name="{{this.name}}" title="Whole Disk User Assigned Role found, click to edit" rel="tooltip">
                 <i class="glyphicon glyphicon-tag"></i></a>
             {{/if}}
             {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
-                <a href="#" class="btrfs_wipe" data-disk-name="{{this.name}}" title="Disk is unusable because it has an existing whole disk BTRFS filesystem on it.
-                Click to wipe it clean." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this disk automatically. Multi-device support included; assuming all members are whole disk" rel="tooltip">
+                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Disk is unusable because it has an existing whole disk BTRFS filesystem on it.
+                Click to configure or wipe." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this disk automatically. Multi-device support included." rel="tooltip">
                 <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
             {{/if}}
         {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -30,12 +30,30 @@
             <a href="#" class="root_drive" data-disk-name="{{this.name}}" title="Rockstor System Drive" rel="tooltip">
               <i class="glyphicon glyphicon-registration-mark"></i></a>
         {{else if this.parted}}
-            <a href="#" class="wipe" data-disk-name="{{this.name}}" title="Disk is unusable because it has a non btrfs filesystem on it.
-            Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
-        {{else if (displayBtrfs this.btrfs_uuid this.pool_name)}}
-            <a href="#" class="btrfs_wipe" data-disk-name="{{this.name}}" title="Disk is unusable because it has a BTRFS filesystem on it.
-            Click to wipe it clean." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this disk automatically." rel="tooltip">
-            <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
+            {{#if (hasUserRole this.role)}}
+                <a href="#" class="user_role_part" data-disk-name="{{this.name}}" title="User Assigned Role found, click to edit (pending feature)" rel="tooltip">
+                <i class="glyphicon glyphicon-tags"></i></a>
+                {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
+                    <a href="#" class="btrfs_wipe" data-disk-name="{{this.name}}" title="Partition is unusable because it has an existing BTRFS filesystem on it.
+                    Click to wipe it clean." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this partition automatically (Note: only a single device is supported with btrfs in partition)." rel="tooltip">
+                    <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
+                {{/if}}
+            {{else}}
+                <a href="#" class="wipe" data-disk-name="{{this.name}}" title="Disk is unusable as it contains partitions and no User Assigned Role (pending feature)
+                Click to wipe it clean." rel="tooltip"><i class="glyphicon glyphicon-cog"></i></a>
+                <!-- Later we can have this click do User Assigned Role config -->
+                <!-- which can also wipe if need be, either whole or partition -->
+            {{/if}}
+        {{else}} <!-- We are non of the above top level ifs / else ifs at this point -->
+            {{#if (hasUserRole this.role)}}
+                <a href="#" class="user_role_drive" data-disk-name="{{this.name}}" title="Whole Disk User Assigned Role found, click to edit (pending feature)" rel="tooltip">
+                <i class="glyphicon glyphicon-tag"></i></a>
+            {{/if}}
+            {{#if (isNullPoolBtrfs this.btrfs_uuid this.pool_name)}}
+                <a href="#" class="btrfs_wipe" data-disk-name="{{this.name}}" title="Disk is unusable because it has an existing whole disk BTRFS filesystem on it.
+                Click to wipe it clean." rel="tooltip"><i class="fa fa-eraser"></i></a>&nbsp;<a href="#" class="btrfs_import" data-disk-name="{{this.name}}" title="Click to import data (pools, shares and snapshots) on this disk automatically. Multi-device support included; assuming all members are whole disk" rel="tooltip">
+                <i class="glyphicon glyphicon-circle-arrow-down"></i></a>
+            {{/if}}
         {{/if}}
         {{#if (isLuksContainer this.role)}}
             <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container" rel="tooltip">
@@ -52,10 +70,6 @@
         {{#if (isBcacheCdev this.role)}}
             <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive" rel="tooltip">
             <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
-        {{/if}}
-        {{#if (hasUserRole this.role)}}
-            <a href="#" class="User_Role_drive" data-disk-name="{{this.name}}" title="User Assigned Role" rel="tooltip">
-            <i class="glyphicon glyphicon-tag"></i></a>
         {{/if}}
       </td>
       <td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -45,6 +45,14 @@
             <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Container" rel="tooltip">
             <i class="glyphicon glyphicon-eye-open"></i></a>
         {{/if}}
+        {{#if (isBcache this.role)}}
+            <a href="#" class="bcache_backing_drive" data-disk-name="{{this.name}}" title="Bcache Backing Drive" rel="tooltip">
+            <i class="glyphicon glyphicon-link"></i></a>
+        {{/if}}
+        {{#if (isBcacheCdev this.role)}}
+            <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive" rel="tooltip">
+            <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
+        {{/if}}
       </td>
       <td>
         {{#checkSerialStatus this.serial this.name}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -27,8 +27,7 @@
             <a href="#" class="raid_member" data-disk-name="{{this.name}}" title="Disk is a mdraid member." rel="tooltip">
               <i class="glyphicon glyphicon-info-sign"></i></a>
         {{else if (isRootDevice this.role)}}
-            <a href="#" class="root_drive" data-disk-name="{{this.name}}" title="Rockstor System Drive" rel="tooltip">
-              <i class="glyphicon glyphicon-registration-mark"></i></a>
+              <i class="glyphicon glyphicon-registration-mark" title="Rockstor System Drive" rel="tooltip"></i>
         {{else if this.parted}}
             {{#if (hasUserRole this.role)}}
                 <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="User Assigned Role found on partitioned disk, click to edit." rel="tooltip">
@@ -59,19 +58,19 @@
             {{/if}}
         {{/if}}
         {{#if (isLuksContainer this.role)}}
-            <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container" rel="tooltip">
+            <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (UI pending)" rel="tooltip">
             <i class="glyphicon glyphicon-lock"></i></a>
         {{/if}}
         {{#if (isOpenLuks this.role)}}
-            <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Container" rel="tooltip">
+            <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Container (UI pending)" rel="tooltip">
             <i class="glyphicon glyphicon-eye-open"></i></a>
         {{/if}}
         {{#if (isBcache this.role)}}
-            <a href="#" class="bcache_backing_drive" data-disk-name="{{this.name}}" title="Bcache Backing Drive" rel="tooltip">
+            <a href="#" class="bcache_backing_drive" data-disk-name="{{this.name}}" title="Bcache Backing Drive (UI pending)" rel="tooltip">
             <i class="glyphicon glyphicon-link"></i></a>
         {{/if}}
         {{#if (isBcacheCdev this.role)}}
-            <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive" rel="tooltip">
+            <a href="#" class="bcache_caching_drive" data-disk-name="{{this.name}}" title="Bcache Caching Drive (UI pending)" rel="tooltip">
             <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
         {{/if}}
       </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -112,7 +112,7 @@
             <input type="checkbox" name="delete_tick" id="delete_tick">
             <i class="fa fa-eraser"></i>
             Tick to wipe the contents of the above 'active' device (including
-            it's filesystem).
+            it's filesystem). Note 'Whole Disk' removes all partitions as well.
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -10,8 +10,14 @@
 </p>
 <p class="bg-info">
   <strong>Note: </strong> No drive role is required for general purpose
-  data drives. Roles are intended primarily for specific single drive use
-  and not recommended for multi device pool members.
+  data drives. Roles are intended primarily for specific <strong>single</strong>
+  drive use and not recommended for multi device pool members.
+  <br>
+  "Whole Disk" is the default and recommended setting for general purpose use.
+  <br>
+  A device must first be wiped before it can take part as a pool member. Unless
+  a btrfs import is desired, in which case select the (btrfs) labeled device
+  and Submit. An import icon will then be offered on the Disk Page.
 </p>
 <h4>Roles and their use:</h4>
 <ul>
@@ -49,6 +55,7 @@
     The <i>Archive</i> role can be combined with the <i>Redirect</i> role.
     <br>
     <i>N.B. Not currently implemented</i>
+    <p></p>
   </li>
   <li>
     The <strong>External Import</strong> role is, like the <i>Archive</i> role
@@ -59,12 +66,13 @@
     The <i>External Import</i> role can be combined with the <i>Redirect</i> role.
     <br>
     <i>N.B. Not currently implemented</i>
+    <p></p>
     <p class="text-warning">
-      Please note that with this role the external drive is considered to be
-      the master source of truth. If a file is changed on the external drive
-      and the drive is then re-attached to Rockstor then the next sync
-      operation will update Rockstor's version of that file. Not the other way
-      around.
+      Please note: With the <i>External Import</i> role the external drive is
+      considered to be the master source of truth. If a file is changed on the
+      external drive and the drive is then re-attached to Rockstor then the
+      next sync operation will update Rockstor's version of that file.
+      Not the other way around.
     </p>
   </li>
 </ul>
@@ -101,13 +109,14 @@
           <label class="col-sm-4 control-label" for="delete_tick"></label>
           <div class="col-sm-4">
             <input type="checkbox" name="delete_tick" id="delete_tick">
-            Tick to permanently delete the contents of the above device.
+            Tick to wipe the contents of the above 'active' device (including
+            it's filesystem).
           </div>
         </div>
 
         <div class="form-group" id="delete_tick_warning">
           <div class="col-sm-offset-4 col-sm-8">
-            <h4><strong>WARNING: THIS WILL DELETE ALL DATA ON THE ABOVE DEVICE.</strong></h4>
+            <h4><strong><p style="color:red">WARNING: THIS WILL DELETE ALL DATA ON THE ABOVE DEVICE.</p></strong></h4>
             If unsure please click Cancel.
           </div>
         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,0 +1,102 @@
+<h3>Add a drive specific Role</h3>
+<p>
+  Drive specific Roles are a way for Rockstor to know how you want to use this
+  specific drive and can drastically alter the options associated with a device.
+  Below is a list of disk roles and their intended use. Note that not
+  all roles can be combined.
+  <p class="text-warning">
+    Changing a disk role can result in loss of data, please take care when
+    making any changes on this page.
+  </p>
+</p>
+<ul>
+  <li>
+    The <strong>Redirect</strong> role. This role is always require for any
+    drive that is partitioned. Without it Rockstor cannot be sure which of the
+    partitions on a drive you wish to use. It is required even if there is only
+    one partition found. Without the addition of this role the only way a
+    partitioned drive can be used is for it's entire contents to be wiped,
+    including any and all partitions and all date there in.
+    The only time Rockstor will add this role itself is when a user imports a
+    multi device pool that has a btrfs in partition member. All other cases
+    require the user to manually set the desired partition, including the
+    initial btrfs import device; only additional devices within the imported
+    pool will automatically have a redirect role set if required.
+    <p>
+      N.B.Rockstor only supports the use of one partition per device. This
+      means that each device can have a maximum of one redirect role.
+    </p>
+    <p class="text-warning">
+      Please note that a drive's <i>Redirect</i> role will affect the action
+      taken when it is wiped from withing the Rockstor interface. If a valid
+      redirect to an existing partition exists then the contents of that
+      partiton will be deleted. But if there is no redirect role then the entire
+      drive and all it's partitions and associated data will be wiped.
+    </p>
+    <p class="bg-info">
+      <strong>Note: </strong> No drive role is required for general purpose
+      data drives. Roles are intended primarily for specific single drive use
+      and not recommended for multi device pool members.
+    </p>
+  </li>
+  <li>
+    The <strong>Archive</strong> role is intended to be used by a single
+    external drive (eg USB) and can be combined with the
+    <strong>Redirect</strong> role. <i>N.B. Not currently implemented</i>
+  </li>
+  <li>
+    The <strong>External Import</strong> role is, like the <i>Archive</i> role
+    above, intended to be used by a single external drive (eg USB) and is
+    primarily aimed at sync type use where you wish for an external drives data
+    to be imported onto a specifically designated internal Rockstor pool.
+    This role can be combined with the <i>Redirect</i> role.
+    <p class="text-warning">
+      Please note that with this role the external drive is considered to be
+      the master source of truth. If a file is changed on the external drive
+      and the drive is then re-attached to Rockstor then the next sync
+      opperation will update Rockstor's version of that file. Not the other way
+      around.
+    </p>
+    <i>N.B. Not currently implemented</i>
+  </li>
+</ul>
+
+<div class="row">
+  <div class="col-md-8">
+    <label class="control-label"></label>
+    <div class="form-box">
+      <form class="form-horizontal" id="add-role-disk-form" name="aform">
+        <div class="messages"></div>
+
+        <!-- Form Header Info -->
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
+            <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+          </div>
+        </div>
+
+        <!-- redirect partition selection -->
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="disk_partitions">Select
+            the Partition to use<span class="required"> *</span></label>
+          <div class="col-sm-4">
+            <select class="form-control" id="disk_partitions"
+                    name="disk_partitions">
+              {{display_disk_partitions}}
+            </select>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-4 col-sm-8">
+            <a id="cancel" class="btn btn-default">Cancel</a>
+            <input type="Submit" id="role-disk" class="btn btn-primary"
+                   value="Submit"></input>
+          </div>
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -81,6 +81,7 @@
           <div class="col-sm-offset-4 col-sm-8">
             <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
             <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+            <h5>A selection of "Whole disk" means no Redirect role.</h5>
           </div>
         </div>
 
@@ -93,6 +94,21 @@
                     name="redirect_part">
               {{display_disk_partitions}}
             </select>
+          </div>
+        </div>
+
+        <div class="checkbox">
+          <label class="col-sm-4 control-label" for="delete_tick"></label>
+          <div class="col-sm-4">
+            <input type="checkbox" name="delete_tick" id="delete_tick">
+            Tick to permanently delete the contents of the above device.
+          </div>
+        </div>
+
+        <div class="form-group" id="delete_tick_warning">
+          <div class="col-sm-offset-4 col-sm-8">
+            <h4><strong>WARNING: THIS WILL DELETE ALL DATA ON THE ABOVE DEVICE.</strong></h4>
+            If unsure please click Cancel.
           </div>
         </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,9 +1,9 @@
-<h3>Add a drive specific Role</h3>
+<h3>Configure drive Role or Wipe an existing Filesystem.</h3>
   Drive specific Roles are a way for Rockstor to know how you want to use this
   specific drive and can drastically alter the options associated with a device.
   Below is a list of disk roles and their intended use. Note that not
   all roles can be combined.
-<br>
+<p></p>
 <p class="text-warning">
   Changing a disk role can result in loss of data, please take care when
   making any changes on this page.
@@ -29,7 +29,7 @@
     partitioned drive can be used is for it's entire contents to first be wiped,
     including any and all partitions and all date there in: resulting in the
     drive no longer being partitioned. The drive can then be used in the
-    Rockstor default <i>whole disk</i> configuration: no partitions and no roles.
+    Rockstor default <i>Whole Disk</i> configuration: no partitions and no roles.
     The only time Rockstor will add the <i>redirect</i> role itself is when a
     user imports a
     multi device pool that has a btrfs in partition member. All other cases
@@ -42,10 +42,11 @@
     </p>
     <p class="text-warning">
       Please note that a drive's <i>Redirect</i> role will affect the action
-      taken when it is wiped from withing the Rockstor interface. If a valid
+      taken when it is wiped from within the Rockstor interface. If a valid
       redirect to an existing partition exists then the contents of that
-      partiton will be deleted. But if there is no redirect role then the entire
-      drive and all it's partitions and associated data will be wiped.
+      partition will be deleted. But if there is no redirect role then the
+      entire drive and all it's partitions and associated data will be wiped.
+      The command used internally to accomplish the wipe is "wipefs -a devname".
     </p>
   </li>
   <li>
@@ -109,6 +110,7 @@
           <label class="col-sm-4 control-label" for="delete_tick"></label>
           <div class="col-sm-4">
             <input type="checkbox" name="delete_tick" id="delete_tick">
+            <i class="fa fa-eraser"></i>
             Tick to wipe the contents of the above 'active' device (including
             it's filesystem).
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,30 +1,38 @@
 <h3>Add a drive specific Role</h3>
-<p>
   Drive specific Roles are a way for Rockstor to know how you want to use this
   specific drive and can drastically alter the options associated with a device.
   Below is a list of disk roles and their intended use. Note that not
   all roles can be combined.
-  <p class="text-warning">
-    Changing a disk role can result in loss of data, please take care when
-    making any changes on this page.
-  </p>
+<br>
+<p class="text-warning">
+  Changing a disk role can result in loss of data, please take care when
+  making any changes on this page.
 </p>
+<p class="bg-info">
+  <strong>Note: </strong> No drive role is required for general purpose
+  data drives. Roles are intended primarily for specific single drive use
+  and not recommended for multi device pool members.
+</p>
+<h4>Roles and their use:</h4>
 <ul>
   <li>
     The <strong>Redirect</strong> role. This role is always require for any
     drive that is partitioned. Without it Rockstor cannot be sure which of the
     partitions on a drive you wish to use. It is required even if there is only
     one partition found. Without the addition of this role the only way a
-    partitioned drive can be used is for it's entire contents to be wiped,
-    including any and all partitions and all date there in.
-    The only time Rockstor will add this role itself is when a user imports a
+    partitioned drive can be used is for it's entire contents to first be wiped,
+    including any and all partitions and all date there in: resulting in the
+    drive no longer being partitioned. The drive can then be used in the
+    Rockstor default <i>whole disk</i> configuration: no partitions and no roles.
+    The only time Rockstor will add the <i>redirect</i> role itself is when a
+    user imports a
     multi device pool that has a btrfs in partition member. All other cases
     require the user to manually set the desired partition, including the
     initial btrfs import device; only additional devices within the imported
     pool will automatically have a redirect role set if required.
     <p>
-      N.B.Rockstor only supports the use of one partition per device. This
-      means that each device can have a maximum of one redirect role.
+      N.B.Rockstor only supports the use of one partition (redirect role) per
+      device. Although other partitions may exist they will be ignored.
     </p>
     <p class="text-warning">
       Please note that a drive's <i>Redirect</i> role will affect the action
@@ -33,31 +41,31 @@
       partiton will be deleted. But if there is no redirect role then the entire
       drive and all it's partitions and associated data will be wiped.
     </p>
-    <p class="bg-info">
-      <strong>Note: </strong> No drive role is required for general purpose
-      data drives. Roles are intended primarily for specific single drive use
-      and not recommended for multi device pool members.
-    </p>
   </li>
   <li>
     The <strong>Archive</strong> role is intended to be used by a single
-    external drive (eg USB) and can be combined with the
-    <strong>Redirect</strong> role. <i>N.B. Not currently implemented</i>
+    external drive (eg USB).
+    <br>
+    The <i>Archive</i> role can be combined with the <i>Redirect</i> role.
+    <br>
+    <i>N.B. Not currently implemented</i>
   </li>
   <li>
     The <strong>External Import</strong> role is, like the <i>Archive</i> role
     above, intended to be used by a single external drive (eg USB) and is
     primarily aimed at sync type use where you wish for an external drives data
-    to be imported onto a specifically designated internal Rockstor pool.
-    This role can be combined with the <i>Redirect</i> role.
+    to be imported onto a specifically designated internal Rockstor share.
+    <br>
+    The <i>External Import</i> role can be combined with the <i>Redirect</i> role.
+    <br>
+    <i>N.B. Not currently implemented</i>
     <p class="text-warning">
       Please note that with this role the external drive is considered to be
       the master source of truth. If a file is changed on the external drive
       and the drive is then re-attached to Rockstor then the next sync
-      opperation will update Rockstor's version of that file. Not the other way
+      operation will update Rockstor's version of that file. Not the other way
       around.
     </p>
-    <i>N.B. Not currently implemented</i>
   </li>
 </ul>
 
@@ -78,11 +86,11 @@
 
         <!-- redirect partition selection -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="disk_partitions">Select
-            the Partition to use<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="redirect_part">Select
+            Partition to use (filesystem)<span class="required"> *</span></label>
           <div class="col-sm-4">
-            <select class="form-control" id="disk_partitions"
-                    name="disk_partitions">
+            <select class="form-control" id="redirect_part"
+                    name="redirect_part">
               {{display_disk_partitions}}
             </select>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -79,7 +79,12 @@
                                 {{#each disks}}
                                     <tr>
                                         <td>{{mathHelper @index}}</td>
-                                        <td>{{this.name}}</td>
+                                        <td>{{this.name}}
+                                            {{#if this.parted}}
+                                                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition (Redirect Role), click to edit. Capacity is for whole disk." rel="tooltip">
+                                                    <i class="glyphicon glyphicon-tags"></i></a>
+                                            {{/if}}
+                                        </td>
                                         <td>{{humanReadableSize this.size}}</td>
                                         <td>
                                             <input type="checkbox" class="disk" name="{{this.name}}" id="{{this.id}}" value="{{this.name}}" />

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -24,14 +24,14 @@
 
 <div class="pull-right">
  <a href="#add_share?poolName={{poolName}}" id="add_share" class="btn btn-primary"><i class="glyphicon glyphicon-edit "></i> Add Share</a>
- {{#if isPoolNameRockstor}}
+ {{#if isPoolRoleRoot}}
  <!-- Don't display the delete button if rockstor_rockstor pool -->
  {{else}}
  <button id="delete-pool" class="btn btn-danger" type="button"><i class="glyphicon glyphicon-trash" data-name="{{pool.name}}" data-action="delete"></i> Delete</button>
  {{/if}}
 </div>
 <span class="h2">{{poolName}}</span>
-{{#if isPoolNameRockstor}}
+{{#if isPoolRoleRoot}}
    <br>
    <div class="alert alert-danger">
      <h4>Warning! This Pool is created during install and contains the OS. You can create Shares in it like in any other pool on the system. However, operations like resize, compression and deletion are not allowed.</h4>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -129,7 +129,7 @@
       <div class="modal-footer">
         <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
         <button id="js-confirm-pool-delete" class="btn btn-primary">Confirm</button>
-      </div
-    </div
+      </div>
+    </div>
   </div>
 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -50,7 +50,22 @@
                 {{this.mnt_options}}</a></strong>
                 {{/unless}}
             </td>
-            <td>{{getDisks this.disks}}</td>
+            <td>
+                {{#if (isRoot this.role)}}
+                    {{#each this.disks}}"{{this.name}}"&nbsp;{{/each}}
+                {{else}}
+                    {{#each this.disks}}
+                    "{{this.name}}
+                    {{#if this.parted}}
+                        <a href="#disks/role/{{this.name}}" class="user_role_part"
+                            data-disk-name="{{this.name}}"
+                            title="Partition (Redirect Role), click to review."
+                            rel="tooltip"><i class="glyphicon glyphicon-tags"></i></a>
+                    {{/if}}
+                    "&nbsp;
+                    {{/each}}
+                {{/if}}
+            </td>
             <td>{{#if (isRoot this.role)}}
                     N/A
                 {{else}}
@@ -74,8 +89,8 @@
            <div class="modal-footer">
             <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
             <button id="js-confirm-pool-delete" data-name="{{this.name}}" class="btn btn-primary">Confirm</button>
-           </div
-          </div
+           </div>
+          </div>
          </div>
         </div>
     {{/each}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
@@ -1,20 +1,39 @@
- <h3>Disks</h3>
-            
-<table id="pool-disk-table" class="table table-condensed table-bordered table-hover">
-              <thead>
-                <tr>
-                  <th scope="col" abbr="Name">Name</th>
-                  <th scope="col" abbr="Capacity">Capacity</th>
-                </tr>
-              </thead>
-              <tbody>
-              {{#each pool.disks}}
-                <tr>
-                    <td>{{this.name}}</td>
-                    <td>{{humanReadableSize this.size}}</td>
-                </tr>
-              {{/each}}
-              </tbody>
-            </table>
-            
-            <a id="js-resize-pool" class="btn btn-primary" href="#"><i class="glyphicon glyphicon-edit "></i> Resize Pool</a></br>
+<h3>Disks</h3>
+
+<table id="pool-disk-table"
+       class="table table-condensed table-bordered table-hover">
+    <thead>
+    <tr>
+        <th scope="col" abbr="Name">Name</th>
+        <th scope="col" abbr="Capacity">Capacity</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#if (isRoot pool.role)}}
+    {{#each pool.disks}}
+    <tr>
+        <td>{{this.name}}</td>
+        <td>{{humanReadableSize this.size}}</td>
+    </tr>
+    {{/each}}
+    {{else}}
+    {{#each pool.disks}}
+    <tr>
+        <td>{{this.name}}
+            {{#if this.parted}}
+            <a href="#disks/role/{{this.name}}" class="user_role_part"
+               data-disk-name="{{this.name}}"
+               title="Partition (Redirect Role), click to review."
+               rel="tooltip">
+                <i class="glyphicon glyphicon-tags"></i></a>
+            {{/if}}
+        </td>
+        <td>{{humanReadableSize this.size}}</td>
+    </tr>
+    {{/each}}
+    {{/if}}
+    </tbody>
+</table>
+
+<a id="js-resize-pool" class="btn btn-primary" href="#">
+    <i class="glyphicon glyphicon-edit "></i> Resize Pool</a></br>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -153,13 +153,23 @@ AddPoolView = Backbone.View.extend({
             // by a 'redirect' role, ie so there is info to 'redirect' to the
             // by-id name held as the value to the 'redirect' role key.
             if (roleAsJson.hasOwnProperty('partitions') && roleAsJson.hasOwnProperty('redirect')) {
-                console.log("add_pool ACCEPTING ROLE OF partitioned COMBINED WITH redirect ROLE")
+                console.log("add_pool EXAMINING ROLE OF partitioned COMBINED WITH redirect ROLE")
                 // then we need to confirm if the fstype of the redirected
                 // partition is "" else we can't use it
-                return true;
+                console.log("the redirect value = " + roleAsJson.redirect);
+                console.log("the fstype at the redirect partition = " + roleAsJson.partitions[roleAsJson.redirect]);
+                if (roleAsJson.partitions.hasOwnProperty(roleAsJson.redirect)) {
+                    console.log("redirect value found in partition list")
+                    if (roleAsJson.partitions[roleAsJson.redirect] == "") {
+                        console.log("add_pool ACCEPTING partition as empty fs type")
+                        return true;
+                    }
+                }
+                console.log("rejecting as non empty fstype in redirect partition")
             }
             // In all other cases return false, ie:
-            // reject roles of for example root, mdraid, LUKS, partitioned etc
+            // reject roles of for example root, mdraid, LUKS,
+            // partitioned (when not accompanied by a valid redirect role) etc
             console.log("add_pool REJECTING ROLE with json = " + role);
             return false;
         }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -130,7 +130,6 @@ AddPoolView = Backbone.View.extend({
             // check if our role is null = db default
             // A drive with no role shouldn't present a problem for use.
             if (role == null) {
-                console.log("add_pool ACCEPTING ROLE OF null")
                 return true;
             }
             // try json conversion and return false if it fails
@@ -146,31 +145,23 @@ AddPoolView = Backbone.View.extend({
             //
             // Accept use of 'openLUKS' device
             if (roleAsJson.hasOwnProperty('openLUKS')) {
-                console.log("add_pool ACCEPTING ROLE OF openLUKS json = " + role);
                 return true;
             }
             // Accept use of 'partitions' device but only if it is accompanied
             // by a 'redirect' role, ie so there is info to 'redirect' to the
             // by-id name held as the value to the 'redirect' role key.
             if (roleAsJson.hasOwnProperty('partitions') && roleAsJson.hasOwnProperty('redirect')) {
-                console.log("add_pool EXAMINING ROLE OF partitioned COMBINED WITH redirect ROLE")
                 // then we need to confirm if the fstype of the redirected
                 // partition is "" else we can't use it
-                console.log("the redirect value = " + roleAsJson.redirect);
-                console.log("the fstype at the redirect partition = " + roleAsJson.partitions[roleAsJson.redirect]);
                 if (roleAsJson.partitions.hasOwnProperty(roleAsJson.redirect)) {
-                    console.log("redirect value found in partition list")
                     if (roleAsJson.partitions[roleAsJson.redirect] == "") {
-                        console.log("add_pool ACCEPTING partition as empty fs type")
                         return true;
                     }
                 }
-                console.log("rejecting as non empty fstype in redirect partition")
             }
             // In all other cases return false, ie:
             // reject roles of for example root, mdraid, LUKS,
             // partitioned (when not accompanied by a valid redirect role) etc
-            console.log("add_pool REJECTING ROLE with json = " + role);
             return false;
         }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -154,6 +154,8 @@ AddPoolView = Backbone.View.extend({
             // by-id name held as the value to the 'redirect' role key.
             if (roleAsJson.hasOwnProperty('partitions') && roleAsJson.hasOwnProperty('redirect')) {
                 console.log("add_pool ACCEPTING ROLE OF partitioned COMBINED WITH redirect ROLE")
+                // then we need to confirm if the fstype of the redirected
+                // partition is "" else we can't use it
                 return true;
             }
             // In all other cases return false, ie:

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -95,7 +95,7 @@ AddPoolView = Backbone.View.extend({
         $(this.el).empty();
         var _this = this;
         this.filteredCollection = _.reject(this.collection.models, function (disk) {
-            return _.isNull(disk.get('pool')) && !disk.get('parted') &&
+            return _.isNull(disk.get('pool')) &&
                 !disk.get('offline') && _.isNull(disk.get('btrfs_uuid')) &&
                 isSerialUsable(disk.get('serial')) &&
                 isRoleUsable(disk.get('role'));
@@ -124,7 +124,7 @@ AddPoolView = Backbone.View.extend({
         // Using the disk.role system we can filter drives on their usability.
         // Roles for inclusion: openLUKS containers
         // Roles to dismiss: LUKS containers, mdraid members, the 'root' role,
-        // and partitioned.
+        // and partitions (if not accompanied by a redirect role).
         // Defaults to reject (return false)
         function isRoleUsable(role) {
             // check if our role is null = db default
@@ -147,6 +147,13 @@ AddPoolView = Backbone.View.extend({
             // Accept use of 'openLUKS' device
             if (roleAsJson.hasOwnProperty('openLUKS')) {
                 console.log("add_pool ACCEPTING ROLE OF openLUKS json = " + role);
+                return true;
+            }
+            // Accept use of 'partitions' device but only if it is accompanied
+            // by a 'redirect' role, ie so there is info to 'redirect' to the
+            // by-id name held as the value to the 'redirect' role key.
+            if (roleAsJson.hasOwnProperty('partitions') && roleAsJson.hasOwnProperty('redirect')) {
+                console.log("add_pool ACCEPTING ROLE OF partitioned COMBINED WITH redirect ROLE")
                 return true;
             }
             // In all other cases return false, ie:

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -407,6 +407,32 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
+        // Identify User assigned role disks by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isBcache'
+        // Initially only the redirect role is a User assigned role.
+        Handlebars.registerHelper('hasUserRole', function (role) {
+            // check if our role is null = db default
+            if (role == null) {
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                var roleAsJson = JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('redirect')) {
+                // We have a User assigned role which we tag to avoid
+                // it's accidental re-use / delete.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
             if (btrfsUid && _.isNull(poolName)) {
                 return true;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -218,6 +218,22 @@ DisksView = RockstorLayoutView.extend({
         // where the above helper is replaced by many smaller ones like this.
         // N.B. untested. Presumably we do {{humanReadableAPM this.apm_level}}
         // in upstream disks_table.jst
+
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
         Handlebars.registerHelper('humanReadableAPM', function (apm) {
             var apmhtml = '';
             if (apm == 0 || apm == null) {
@@ -231,6 +247,7 @@ DisksView = RockstorLayoutView.extend({
             }
             return new Handlebars.SafeString(apmhtml);
         });
+
         // Simple helper to return true / false on powerState = null or unknown
         // Untested. Presumably we do:
         // {{#if (powerstateNullorUnknown this.power_state)}}
@@ -241,6 +258,7 @@ DisksView = RockstorLayoutView.extend({
             }
             return false;
         });
+
         // Simple helper to return true / false on powerState = active/idle
         // Untested. Presumably we do:
         // {{#if (powerStateActiveIdle this.power_state)}}
@@ -251,22 +269,14 @@ DisksView = RockstorLayoutView.extend({
             }
             return false;
         });
+
         Handlebars.registerHelper('displayInfo', function (role) {
             // check for the legacy / pre json formatted role field contents.
             if (role == 'isw_raid_member' || role == 'linux_raid_member') {
                 return true;
             }
-            // now check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('mdraid')) {
                 // in the case of an mdraid property we are assured it is an
@@ -284,17 +294,8 @@ DisksView = RockstorLayoutView.extend({
         // true = device hosts the / partition
         // false = root not found on this device
         Handlebars.registerHelper('isRootDevice', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('root')) {
                 // Only the system device will have a 'root' role entry, we
@@ -309,18 +310,9 @@ DisksView = RockstorLayoutView.extend({
         // Identify LUKS container by return of true / false.
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isRootDevice'
-               Handlebars.registerHelper('isLuksContainer', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+        Handlebars.registerHelper('isLuksContainer', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('LUKS')) {
                 // Once a container is created it has an fstype of crypto_LUKS
@@ -335,17 +327,8 @@ DisksView = RockstorLayoutView.extend({
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isRootDevice'
         Handlebars.registerHelper('isOpenLuks', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('openLUKS')) {
                 // Once a LUKS container is open it has a type of crypt
@@ -360,17 +343,8 @@ DisksView = RockstorLayoutView.extend({
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isRootDevice'
         Handlebars.registerHelper('isBcache', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('bcache')) {
                 // We have a bcache backing device which must now be accessed
@@ -386,17 +360,8 @@ DisksView = RockstorLayoutView.extend({
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isBcache'
         Handlebars.registerHelper('isBcacheCdev', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('bcachecdev')) {
                 // We have a bcache caching device which we tag to avoid
@@ -412,17 +377,8 @@ DisksView = RockstorLayoutView.extend({
         // helper 'isBcache'
         // Initially only the redirect role is a User assigned role.
         Handlebars.registerHelper('hasUserRole', function (role) {
-            // check if our role is null = db default
-            if (role == null) {
-                return false;
-            }
-            // try json conversion and return false if it fails
-            // @todo not sure if this is redundant?
-            try {
-                var roleAsJson = JSON.parse(role);
-            } catch (e) {
-                return false;
-            }
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
             // We have a json string ie non legacy role info so we can examine:
             if (roleAsJson.hasOwnProperty('redirect')) {
                 // We have a User assigned role which we tag to avoid

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -270,7 +270,7 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
-        Handlebars.registerHelper('displayInfo', function (role) {
+        Handlebars.registerHelper('isMdraidMember', function (role) {
             // check for the legacy / pre json formatted role field contents.
             if (role == 'isw_raid_member' || role == 'linux_raid_member') {
                 return true;
@@ -290,7 +290,7 @@ DisksView = RockstorLayoutView.extend({
 
         // Identify root device by return of true / false.
         // Works by examining the Disk.role field. Based on sister handlebars
-        // helper 'displayInfo'.
+        // helper 'isMdraidMember'.
         // true = device hosts the / partition
         // false = root not found on this device
         Handlebars.registerHelper('isRootDevice', function (role) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -356,6 +356,57 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
+        // Identify bcache backing devices by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isRootDevice'
+        Handlebars.registerHelper('isBcache', function (role) {
+            // check if our role is null = db default
+            if (role == null) {
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                var roleAsJson = JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('bcache')) {
+                // We have a bcache backing device which must now be accessed
+                // indirectly via a virtual device, hence we tag it to avoid
+                // accidental re-use / delete.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
+        // Identify bcache caching devices by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isBcache'
+        Handlebars.registerHelper('isBcacheCdev', function (role) {
+            // check if our role is null = db default
+            if (role == null) {
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                var roleAsJson = JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('bcachecdev')) {
+                // We have a bcache caching device which we tag to avoid
+                // it's accidental re-use / delete.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
             if (btrfsUid && _.isNull(poolName)) {
                 return true;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -433,7 +433,7 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
-        Handlebars.registerHelper('displayBtrfs', function (btrfsUid, poolName) {
+        Handlebars.registerHelper('isNullPoolBtrfs', function (btrfsUid, poolName) {
             if (btrfsUid && _.isNull(poolName)) {
                 return true;
             }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -321,5 +321,12 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         Handlebars.registerHelper('humanReadableSize', function(size){
             return humanize.filesize(size * 1024);
         });
+
+        Handlebars.registerHelper('isRoot', function(role){
+            if (role == 'root') {
+                return true;
+            }
+            return false;
+        });
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -70,14 +70,14 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
     },
 
     renderSubViews: function() {
-        var poolNameIsRockstor = false;
+        var poolRoleIsRoot = false;
         if (this.pool.get('role') == 'root') {
-            poolNameIsRockstor = true;
+            poolRoleIsRoot = true;
         }
         $(this.el).html(this.template({
             share: this.poolShares.models[0].attributes.results,
             poolName: this.pool.get('name'),
-            isPoolNameRockstor: poolNameIsRockstor,
+            isPoolRoleRoot: poolRoleIsRoot,
         }));
 
         this.subviews['pool-info'] = new PoolInfoModule({ model: this.pool.toJSON() });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -211,18 +211,6 @@ PoolsView = RockstorLayoutView.extend({
             return opts.inverse(this);
         });
 
-        Handlebars.registerHelper('getDisks', function(disks) {
-            var dNames =  _.reduce(disks,
-                    function(s, disk, i, list) {
-                if (i < (list.length-1)){
-                    return s + disk.name + ',';
-                } else {
-                    return s + disk.name;
-                }
-            }, '');
-            return dNames;
-        });
-
         Handlebars.registerHelper('isRoot', function(role) {
             if (role == 'root') {
                 return true;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -191,6 +191,8 @@ SetroleDiskView = RockstorLayoutView.extend({
         if (part_selected != current_redirect) {
             if (this.$('#delete_tick').prop('checked')) {
                 // un-tick to reassure user & remove the warning via tick_toggle
+                // Remark out the following line to test backend redirect
+                // & wipe validation by enabling their combination in the UI.
                 this.$('#delete_tick').removeAttr('checked');
                 this.delete_tick_toggle();
             }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -101,25 +101,28 @@ SetroleDiskView = RockstorLayoutView.extend({
             return err_msg;
         };
 
-        // $.validator.addMethod('validateRedirect', function (value) {
-        //     var redirect_role = $('#redirect_part').val();
-        //     if (partitions[current_redirect] == 'btrfs') {
-        //         err_msg = 'Existing btrfs partition found; if you wish to ' +
-        //             'use the redirect role either select this btrfs partition ' +
-        //             'or delete the partition / whole disk and re-assign as ' +
-        //             'redirecting to a non btrfs partiton when one exists is' +
-        //             'not supported.';
-        //         return false;
-        //     }
-        //     return true;
-        // }, role_err_msg);
+        $.validator.addMethod('validateRedirect', function (value) {
+            var redirect_role = $('#redirect_part').val();
+            // check to see if we are attempting to change an existing btrfs
+            // redirect, if so refuse the action and explain why.
+            if ((partitions[current_redirect] == 'btrfs') && (redirect_role != current_redirect)) {
+                err_msg = 'Existing btrfs partition found; if you wish to ' +
+                    'use the redirect role either select this btrfs partition ' +
+                    'or remove the btrfs partition or whipe the whole disk and re-assign.' +
+                    'Redirecting is only supported to a non btrfs partiton when ' +
+                    'no btrfs partition exists on the same device.';
+                return false;
+            }
+            return true;
+        }, role_err_msg);
 
 
         this.$('#add-role-disk-form').validate({
             onfocusout: false,
             onkeyup: false,
             rules: {
-                redirect_part: 'required',
+                // redirect_part: 'required',
+                redirect_part: 'validateRedirect'
             },
 
             submitHandler: function () {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -1,0 +1,189 @@
+/*
+ *
+ * @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+
+SetroleDiskView = RockstorLayoutView.extend({
+    events: {
+        'click #cancel': 'cancel'
+    },
+
+    initialize: function () {
+        var _this = this;
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.template = window.JST.disk_setrole_disks;
+        this.disks = new DiskCollection();
+        this.diskName = this.options.diskName;
+        this.dependencies.push(this.disks);
+        this.initHandlebarHelpers();
+    },
+
+    render: function () {
+        this.fetch(this.renderDisksForm, this);
+        return this;
+    },
+
+    renderDisksForm: function () {
+        if (this.$('[rel=tooltip]')) {
+            this.$("[rel=tooltip]").tooltip('hide');
+        }
+        var _this = this;
+        var disk_name = this.diskName;
+        // retrieve local copy of disk serial number
+        var serialNumber = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('serial');
+        // retrieve local copy of current disk role
+        var diskRole = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('role');
+        // parse the diskRole json to a local object
+        try {
+            var role_obj = JSON.parse(diskRole);
+            } catch (e) {
+                // as we can't convert this drives role to json we assume
+                // it's isRoleUsable status by false
+                console.log('diskRole in setrole_disks.js failed json convert')
+                role_obj = null;
+            }
+        // extract our partitions obj from the role_obj if there is one.
+        if (role_obj.hasOwnProperty('partitions')) {
+            var partitions = role_obj.partitions;
+        } else {
+            // else we set our partitions to be an empty object
+            var partitions = {};
+        }
+        // extract any existing redirect role value.
+        if (role_obj.hasOwnProperty('redirect')) {
+            // if there is a redirect role then set our current role to it
+            var current_redirect = role_obj['redirect'];
+        } else {
+            var current_redirect = '';
+        }
+
+        $(this.el).html(this.template({
+            diskName: this.diskName,
+            serialNumber: serialNumber,
+            diskRole: diskRole,
+            role_obj: role_obj,
+            partitions: partitions,
+            current_redirect: current_redirect
+        }));
+
+        this.$('#add-role-disk-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+
+        var err_msg = '';
+        var role_err_msg = function () {
+            return err_msg;
+        };
+
+        // $.validator.addMethod('validateRedirect', function (value) {
+        //     var redirect_role = $('#redirect_part').val();
+        //     if (partitions[current_redirect] == 'btrfs') {
+        //         err_msg = 'Existing btrfs partition found; if you wish to ' +
+        //             'use the redirect role either select this btrfs partition ' +
+        //             'or delete the partition / whole disk and re-assign as ' +
+        //             'redirecting to a non btrfs partiton when one exists is' +
+        //             'not supported.';
+        //         return false;
+        //     }
+        //     return true;
+        // }, role_err_msg);
+
+
+        this.$('#add-role-disk-form').validate({
+            onfocusout: false,
+            onkeyup: false,
+            rules: {
+                redirect_part: 'required',
+            },
+
+            submitHandler: function () {
+                var button = $('#role-disk');
+                if (buttonDisabled(button)) return false;
+                disableButton(button);
+                var submitmethod = 'POST';
+                var posturl = '/api/disks/' + disk_name + '/role-drive';
+                $.ajax({
+                    url: posturl,
+                    type: submitmethod,
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    data: JSON.stringify(_this.$('#add-role-disk-form').getJSON()),
+                    success: function () {
+                        enableButton(button);
+                        _this.$('#add-role-disk-form :input').tooltip('hide');
+                        app_router.navigate('disks', {trigger: true});
+                    },
+                    error: function (xhr, status, error) {
+                        enableButton(button);
+                    }
+                });
+                return false;
+            }
+        });
+    },
+
+    initHandlebarHelpers: function () {
+        // helper to fill dropdown with drive partitions and their fstype
+        // eg by generating dynamicaly lines of the following
+        // <option value="virtio-serial-6-part-2">part2 (ntfs)</option>
+        Handlebars.registerHelper('display_disk_partitions', function () {
+            var html = '';
+            // loop through this devices partitions and mark one as selected
+            // if it equals the current redirect role, hence defaulting to the
+            // partition of the current redirect settings.
+            // for each partition in our partitions set our selector value as
+            // the partition name and add it's value which is the fstype.
+            // Default to the partition matching a current redirect, if any.
+            for (var part in this.partitions) {
+                if (part == this.current_redirect) {
+                    html += '<option value="' + part + '" selected="selected">';
+                } else {
+                    html += '<option value="' + part + '">';
+                }
+                // add our fstype held as the value against this partition
+                var partition_fstype = this.partitions[part];
+                if (partition_fstype == '') {
+                    partition_fstype = 'None';
+                }
+                // strip the last part of our by-id name to get our partition
+                // ie virtio-serial-part2 but we want part2
+                short_part_name = part.split('-').slice(-1)[0];
+                html += short_part_name + ' (' + partition_fstype + ')' + '</option>';
+            }
+            return new Handlebars.SafeString(html);
+        });
+    },
+
+    cancel: function (event) {
+        event.preventDefault();
+        this.$('#add-spindown-disk-form :input').tooltip('hide');
+        app_router.navigate('disks', {trigger: true});
+    }
+
+});

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -120,7 +120,7 @@ SetroleDiskView = RockstorLayoutView.extend({
             if ((partitions[current_redirect] == 'btrfs') && (redirect_role != current_redirect)) {
                 err_msg = 'Existing btrfs partition found; if you wish to ' +
                     'use the redirect role either select this btrfs partition ' +
-                    'or remove the btrfs partition or whipe the whole disk and re-assign.' +
+                    'or wipe it or the whole disk and re-assign.' +
                     'Redirecting is only supported to a non btrfs partiton when ' +
                     'no btrfs partition exists on the same device.';
                 return false;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -139,6 +139,8 @@ SetroleDiskView = RockstorLayoutView.extend({
                 } else {
                     // we have redirect_role == current_redirect
                     // now check if the device is in an active Rockstor pool
+                    // Un-remark next line to test backend validation of same.
+                    // disk_pool = null;
                     if (disk_pool != null) {
                         // device is part of Rockstor pool, reject wipe request
                         err_msg = "Selected device is part of a Rockstor " +
@@ -206,7 +208,7 @@ SetroleDiskView = RockstorLayoutView.extend({
         if (part_selected != current_redirect) {
             if (this.$('#delete_tick').prop('checked')) {
                 // un-tick to reassure user & remove the warning via tick_toggle
-                // Remark out the following line to test backend redirect
+                // Un-Remark the following line to test backend redirect
                 // & wipe validation by enabling their combination in the UI.
                 this.$('#delete_tick').removeAttr('checked');
                 this.delete_tick_toggle();

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -74,7 +74,6 @@ SetroleDiskView = RockstorLayoutView.extend({
             } catch (e) {
                 // as we can't convert this drives role to json we assume
                 // it's isRoleUsable status by false
-                console.log('diskRole in setrole_disks.js failed json convert')
                 role_obj = null;
             }
         // extract our partitions obj from the role_obj if there is one.
@@ -121,7 +120,7 @@ SetroleDiskView = RockstorLayoutView.extend({
                 err_msg = 'Existing btrfs partition found; if you wish to ' +
                     'use the redirect role either select this btrfs partition ' +
                     'or wipe it or the whole disk and re-assign.' +
-                    'Redirecting is only supported to a non btrfs partiton when ' +
+                    'Redirecting is only supported to a non btrfs partition when ' +
                     'no btrfs partition exists on the same device.';
                 return false;
             }
@@ -203,8 +202,6 @@ SetroleDiskView = RockstorLayoutView.extend({
     redirect_part_changed: function() {
         var part_selected = this.$('#redirect_part').val();
         var current_redirect = this.current_redirect;
-        console.log('redirect_part_changed, part_selected = ' + part_selected);
-        console.log('current_redirect=' + current_redirect);
         if (part_selected != current_redirect) {
             if (this.$('#delete_tick').prop('checked')) {
                 // un-tick to reassure user & remove the warning via tick_toggle
@@ -217,7 +214,6 @@ SetroleDiskView = RockstorLayoutView.extend({
             // as yet uninitialized / un-applied redirect.
             this.$('#delete_tick').attr('disabled', true);
         } else {
-            console.log('part_selected == current_redirect =' + current_redirect);
             // we are showing the current redirect so re-enable the delete_tick
             this.$('#delete_tick').removeAttr('disabled');
             this.delete_tick_toggle();
@@ -233,8 +229,6 @@ SetroleDiskView = RockstorLayoutView.extend({
             // Add our 'use whole disk' option which will allow for an existing
             // redirect to be removed, preparing for whole disk btrfs.
             // Also serves to indicate no redirect role in operation.
-            console.log('disk_btrfs_uuid=' + this.disk_btrfs_uuid);
-            console.log('partitions=' + this.partitions);
             if ( (this.disk_btrfs_uuid != null) && (_.isEmpty(this.partitions)) ) {
                 var uuid_message = 'btrfs'
             } else {
@@ -252,7 +246,6 @@ SetroleDiskView = RockstorLayoutView.extend({
             }
             // close the "Whole Disk" option
             html += '</option>';
-            console.log('current html=' + html);
             // loop through this devices partitions and mark one as selected
             // if it equals the current redirect role, hence defaulting to the
             // partition of the current redirect settings.
@@ -283,7 +276,6 @@ SetroleDiskView = RockstorLayoutView.extend({
                 // end this partition option
                 html += '</option>';
             }
-            console.log('final html=' + html);
             return new Handlebars.SafeString(html);
         });
     },

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -62,15 +62,12 @@ class CommandView(NFSExportMixin, APIView):
             try:
                 mount_root(p)
                 first_dev = p.disk_set.first()
-                logger.debug('first_dev.role=%s' % first_dev.role)
                 first_dev_name = first_dev.name
                 # if we are looking at a device with a redirect role then
                 # redirect accordingly.
                 if first_dev.role is not None:
                     disk_role_dict = json.loads(first_dev.role)
-                    logger.debug('disk_role_dict=%s' % disk_role_dict)
                     if 'redirect' in disk_role_dict:
-                        logger.debug('FOUND redirect role')
                         # consider replacing None with first_dev.name
                         first_dev_name = disk_role_dict.get('redirect', None)
                 pool_info = get_pool_info(first_dev_name)

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -64,14 +64,15 @@ class CommandView(NFSExportMixin, APIView):
                 first_dev = p.disk_set.first()
                 logger.debug('first_dev.role=%s' % first_dev.role)
                 first_dev_name = first_dev.name
+                # if we are looking at a device with a redirect role then
+                # redirect accordingly.
                 if first_dev.role is not None:
                     disk_role_dict = json.loads(first_dev.role)
                     logger.debug('disk_role_dict=%s' % disk_role_dict)
-                    if 'openLUKS' in disk_role_dict:
-                        logger.debug('FOUND openLUKS role')
-                        # consider replacing None with first_dev.name and
-                        # loosing our if 'openLUKS'
-                        first_dev_name = disk_role_dict.get('openLUKS', None)
+                    if 'redirect' in disk_role_dict:
+                        logger.debug('FOUND redirect role')
+                        # consider replacing None with first_dev.name
+                        first_dev_name = disk_role_dict.get('redirect', None)
                 pool_info = get_pool_info(first_dev_name)
                 p.name = pool_info['label']
                 p.raid = pool_raid('%s%s' % (settings.MNT_PT, p.name))['data']

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -565,8 +565,12 @@ class DiskDetailView(rfc.GenericView):
             is_delete_ticked = request.data.get('delete_tick', False)
             logger.debug('delete_tick value in disk.py=%s' % is_delete_ticked)
             logger.debug('role_disk has previous disk.role=%s' % disk.role)
-            # Get our previous roles into a dictionary
-            roles = json.loads(disk.role)
+            # Get our previous roles into a dictionary.
+            if disk.role != None:
+                roles = json.loads(disk.role)
+            else:
+                # roles default to None so substitute empty dict for simplicity.
+                roles = {}
             # If we have received a redirect role then add/update our dict
             # with it's value (the by-id partition)
             # First establish our prior_redirect if it exists.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -219,9 +219,9 @@ class DiskMixin(object):
                 # N.B. value of d.fstype here is essentially a place holder as
                 # the presence or otherwise of the 'root' key is all we need.
                 disk_roles_identified['root'] = str(d.fstype)
-            if d.partitions != []:
-                # PARTITIONS: scan_disks() has built an updated partitions list
-                # so create a partitions role containing this list.
+            if d.partitions != {}:
+                # PARTITIONS: scan_disks() has built an updated partitions dict
+                # so create a partitions role containing this dictionary.
                 disk_roles_identified['partitions'] = d.partitions
             # Now we join the previous non scan_disks identified roles dict
             # with those we have identified from our fresh scan_disks() data

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -222,7 +222,15 @@ class DiskMixin(object):
             if d.partitions != {}:
                 # PARTITIONS: scan_disks() has built an updated partitions dict
                 # so create a partitions role containing this dictionary.
-                disk_roles_identified['partitions'] = d.partitions
+                # Convert scan_disks() transient (but just scanned so current)
+                # sda type names to a more useful by-id type name as found
+                # in /dev/disk/by-id for each partition name.
+                byid_partitions = {
+                    get_dev_byid_name(part, True)[0]:
+                        d.partitions.get(part, "") for part in d.partitions}
+                # In the above we fail over to "" on failed index for now.
+                logger.debug('byid_partitons=%s' % byid_partitions)
+                disk_roles_identified['partitions'] = byid_partitions
             # Now we join the previous non scan_disks identified roles dict
             # with those we have identified from our fresh scan_disks() data
             # and return the result to our db entry in json format.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -386,8 +386,8 @@ class DiskDetailView(rfc.GenericView):
             if len(fields) > 0:
                 if re.match('part.+', fields[-1]) is not None:
                     # strip the redirection to partition device.
-                    logger.debug('return=%s' % fields[:-1]).join('-')
-                    return fields[:-1].join('-')
+                    logger.debug('return=%s' % '-'.join(fields[:-1]))
+                    return '-'.join(fields[:-1])
             # we have found no indication of role name based changes.
             logger.debug('return=%s' % disk_name)
             return disk_name

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -266,9 +266,9 @@ class DiskMixin(object):
                 # Also note that with no serial number some device types will
                 # not have a by-id type name expected by the smart subsystem.
                 # This has only been observed in no serial virtio devices.
-                if (re.match('fake-serial-', do.serial) is not None) or \
-                        (re.match('virtio-|md-|mmc-|nvme-|dm-name-luks-',
-                                  do.name) is not None):
+                if (re.match('fake-serial-', do.serial) is not None) or (
+                    re.match('virtio-|md-|mmc-|nvme-|dm-name-luks-|bcache',
+                             do.name) is not None):
                     # Virtio disks (named virtio-*), md devices (named md-*),
                     # and an sdcard reader that provides devs named mmc-* have
                     # no smart capability so avoid cluttering logs with

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -380,11 +380,12 @@ class DiskDetailView(rfc.GenericView):
     @transaction.atomic
     def _wipe(self, dname, request):
         disk = self._validate_disk(dname, request)
-        disk_role_dict = json.loads(disk.role)
-        if 'openLUKS' in disk_role_dict:
-            wipe_disk(disk_role_dict.get('openLUKS', None))
-        else:
-            wipe_disk(disk.name)
+        disk_name = disk.name
+        if disk.role is not None:
+            disk_role_dict = json.loads(disk.role)
+            if 'openLUKS' in disk_role_dict:
+                disk_name = disk_role_dict.get('openLUKS', None)
+        wipe_disk(disk_name)
         disk.parted = False
         disk.btrfs_uuid = None
         disk.save()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -593,7 +593,7 @@ class DiskDetailView(rfc.GenericView):
             if redirect_role_change:
                 if is_delete_ticked:
                     # changing redirect and wiping concurrently are blocked
-                    e_msg = ("Wiping a device while changing it's redirct role"
+                    e_msg = ("Wiping a device while changing it's redirect role"
                              " is not supported. Please do one at a time")
                     raise Exception(e_msg)
                 # We have a redirect role change and no delete ticked so
@@ -604,11 +604,18 @@ class DiskDetailView(rfc.GenericView):
             else:
                 # no redirect role change so we can wipe if requested by tick
                 if is_delete_ticked:
+                    if disk.pool != None:
+                        # Disk is a member of a Rockstor pool so refuse to wipe.
+                        e_msg = ('Wiping a Rockstor pool member is '
+                                 'not supported. Please use pool resize to '
+                                 'remove this disk from the pool first.')
+                        raise Exception(e_msg)
                     # Not sure if this is the correct way to call our wipe.
                     return self._wipe(dname, request)
             return Response(DiskInfoSerializer(disk).data)
         except Exception, e:
-            e_msg = ('Failed to set disk role on device(%s). Error: %s'
+            e_msg = ('Failed to configure drive role or wipe existing '
+                     'filesystem on device (%s). Error: %s'
                      % (dname, e.__str__()))
             handle_exception(Exception(e_msg), request)
 

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -380,7 +380,11 @@ class DiskDetailView(rfc.GenericView):
     @transaction.atomic
     def _wipe(self, dname, request):
         disk = self._validate_disk(dname, request)
-        wipe_disk(disk.name)
+        disk_role_dict = json.loads(disk.role)
+        if 'openLUKS' in disk_role_dict:
+            wipe_disk(disk_role_dict.get('openLUKS', None))
+        else:
+            wipe_disk(disk.name)
         disk.parted = False
         disk.btrfs_uuid = None
         disk.save()

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -56,8 +56,8 @@ class PoolMixin(object):
     def _role_filter_disk_names(disks, request):
         """
         Takes a series of disk objects and filters them based on their roles.
-        For disk with an openLUKS role the openLUKS role value is substituted
-        for that disks name. This effects a name re-direction for crypt disks.
+        For disk with a redirect role the role's value is substituted for that
+        disks name. This effects a name re-direction for redirect disks.
         :param disks:  list of disks object
         :param request:
         :return: list of disk names post role filter processing
@@ -66,19 +66,19 @@ class PoolMixin(object):
             # Build dictionary of disks with roles
             role_disks = {d for d in disks if d.role is not None}
             logger.debug('role_filter role only disks=%s' % role_disks)
-            # Build dictionary of crypt drives with their openLUKS role values.
-            # by using only role_disks we avoid json.load(None)
-            crypt_disks = {d.name: json.loads(d.role).get("openLUKS", None) for
-                           d in role_disks if
-                           'openLUKS' in json.loads(d.role)}
-            logger.debug('role_filter_disk_names crypt_disk=%s' % crypt_disks)
-            # Replace d.name with openLUKS mapper name for crypt type disks.
-            # Substitute openLUKS role value for crypt (openLUKS) mapped disks.
-            # Our role system stores the dm mapped /dev/disk/by-id name for
-            # /dev/mapper mount points so use that value instead name:
+            # Build a dictionary of redirected disk names with their associated
+            # redirect role values.
+            # By using only role_disks we avoid json.load(None)
+            redirect_disks = {d.name: json.loads(d.role).get("redirect", None)
+                              for d in role_disks if
+                              'redirect' in json.loads(d.role)}
+            logger.debug('role_filter_disk_names redirect_disk=%s' % redirect_disks)
+            # Replace d.name with redirect role value for redirect role disks.
+            # Our role system stores the /dev/disk/by-id name (without path) for
+            # redirected disks so use that value instead as our disk name:
             dnames = [
-                d.name if d.name not in crypt_disks else crypt_disks[d.name] for
-                d in disks]
+                d.name if d.name not in redirect_disks else redirect_disks[
+                    d.name] for d in disks]
             logger.debug('role_filter_disk_names RETURNING=%s' % dnames)
             return dnames
         except:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1348,6 +1348,7 @@ def get_dev_byid_name(device_name, remove_path=False):
     indicates if a by-id type name was found. ie (return_name, is_byid)
     """
     logger.debug('GET_DEV_BYID_NAME CALLED WITH DEV-NAME=%s' % device_name)
+    logger.debug('GET_DEV_BYID_NAME remove path = %s' % remove_path)
     # Until we find a by-id type name set this flag as False.
     is_byid = False
     # Until we find a by-id type name we will be returning device_name
@@ -1387,7 +1388,9 @@ def get_dev_byid_name(device_name, remove_path=False):
         # Return the longest by-id name found in the DEVLINKS line
         # or the first if multiple by-id names were of equal length.
         return_name = byid_name
-    # Honour our path strip request in all cases if we can.
+    # Honour our path strip request in all cases if we can, or if
+    # no remove_path request by parameter flag or no path delimiter chars found
+    # in return_name then leave as is.
     if remove_path:
         # Strip the path from the beginning of our return_name.
         # For use in Disk.name db field for example.
@@ -1395,9 +1398,9 @@ def get_dev_byid_name(device_name, remove_path=False):
         return_name_fields = return_name.split('/')
         if len(return_name_fields) > 1:
             # Original device_name has path delimiters in: assume it has a path.
-            return return_name_fields[-1], is_byid
-    # No remove_path request by parameter flag or no path delimiter chars found
-    # in return_name so leave as is and returning.
+            # return return_name_fields[-1], is_byid
+            return_name = return_name_fields[-1]
+    logger.debug('GET_DEV_BYID_NAME RETURN=%s %s' % (return_name, is_byid))
     return return_name, is_byid
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -193,6 +193,22 @@ def scan_disks(min_size):
         # N.B. this also facilitates a simpler mechanism of classification.
         if (dmap['FSTYPE'] == 'swap'):
             continue
+        # convert size into KB
+        size_str = dmap['SIZE']
+        if (size_str[-1] == 'G'):
+            dmap['SIZE'] = int(float(size_str[:-1]) * 1024 * 1024)
+        elif (size_str[-1] == 'T'):
+            dmap['SIZE'] = int(float(size_str[:-1]) * 1024 * 1024 * 1024)
+        else:
+            # Move to next line if we don't understand the size as GB or TB
+            # Note that this may cause an entry to be ignored if formatting
+            # changes.
+            # Previous to the explicit ignore swap clause this often caught
+            # swap but if swap was in GB and above min_size then it could
+            # show up when not in a partition (the previous caveat clause).
+            continue
+        if (dmap['SIZE'] < min_size):
+            continue
         # ----- Now we are done with easy exclusions we begin classification.
         # ------------ Start more complex classification -------------
         if (dmap['NAME'] == base_root_disk):  # as returned by root_disk()
@@ -365,22 +381,6 @@ def scan_disks(min_size):
                     # then ignore / skip this btrfs device if it's a partition
                     if is_partition:
                         continue
-            # convert size into KB
-            size_str = dmap['SIZE']
-            if (size_str[-1] == 'G'):
-                dmap['SIZE'] = int(float(size_str[:-1]) * 1024 * 1024)
-            elif (size_str[-1] == 'T'):
-                dmap['SIZE'] = int(float(size_str[:-1]) * 1024 * 1024 * 1024)
-            else:
-                # Move to next line if we don't understand the size as GB or TB
-                # Note that this may cause an entry to be ignored if formatting
-                # changes.
-                # Previous to the explicit ignore swap clause this often caught
-                # swap but if swap was in GB and above min_size then it could
-                # show up when not in a partition (the previous caveat clause).
-                continue
-            if (dmap['SIZE'] < min_size):
-                continue
             # No more continues so the device we have is to be passed to our db
             # entry system views/disk.py ie _update_disk_state()
             # Do final tidy of data in dmap and ready for entry in dnames dict.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1067,6 +1067,28 @@ def get_base_device_byid(dev_byid, test_mode=False):
     # return the consequent result
     return base_dev_byid
 
+def get_bcache_device_type(device):
+    """
+    Helper function for scan_disks() to identify specific bcache device types:
+    We can either parse the output of bcache-super-show for the following lines:
+    sb.version....1 [backing device]
+    sb.version....3 [cache device]
+    or we can look for signature file entries within /sys/block/sdX/bcache :
+    Backing devices have an "label" entry
+    Cache devices have a "cache_replacement_policy"
+    The passed device will have already been identified as having:
+    lsblk FSTYPE=bcache
+    :param device: as presented by lsblk output ie sdX type with no path
+    :return: "bdev" for "backing device" or "cdev" for "cache device" or
+    None ie neither indicator is found.
+    """
+    sys_path = ('/sys/block/%s/bcache/' % device)
+    if os.path.isfile(sys_path + 'label'):
+        return "bdev"
+    if os.path.isfile(sys_path + 'cache_replacement_policy'):
+        return "cdev"
+    return None
+
 
 def get_base_device(device, test_mode=False):
     """

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -377,11 +377,19 @@ def scan_disks(min_size):
             # counterpart device for use as a serial number.
             # Note however that we are only interested in the 'backing device'
             # type of bcache as it has the counterpart virtual block device.
-            if (dmap['FSTYPE'] == 'bcache') and \
-                            get_bcache_device_type(dmap['NAME']) == 'bdev':
-                bdev_uuid = dmap['UUID']
-                # We set out bdev_flag to inform the next device interpretation.
-                bdev_flag = True
+            if (dmap['FSTYPE'] == 'bcache'):
+                bcache_dev_type = get_bcache_device_type(dmap['NAME'])
+                logger.debug('bcache_dev_type=%s' % bcache_dev_type)
+                if bcache_dev_type == 'bdev':
+                    bdev_uuid = dmap['UUID']
+                    # We set out bdev_flag to inform the next device
+                    # interpretation.
+                    bdev_flag = True
+                elif bcache_dev_type == 'cdev':
+                    # We have a bcache caching device, not a backing device.
+                    # Change fstype as an indicator to _update_disk_state()
+                    # role system. N.B. fstype bcache-cdev is fictitious.
+                    dmap['FSTYPE'] = 'bcache-cdev'
             else:
                 # we are a non bcache bdev but we might be the virtual device
                 # if we are listed directly after a bcache bdev.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -400,7 +400,6 @@ def scan_disks(min_size):
             # type of bcache as it has the counterpart virtual block device.
             if (dmap['FSTYPE'] == 'bcache'):
                 bcache_dev_type = get_bcache_device_type(dmap['NAME'])
-                logger.debug('bcache_dev_type=%s' % bcache_dev_type)
                 if bcache_dev_type == 'bdev':
                     bdev_uuid = dmap['UUID']
                     # We set out bdev_flag to inform the next device
@@ -454,9 +453,7 @@ def scan_disks(min_size):
     # Transfer our collected disk / dev entries of interest to the disks list.
     for d in dnames.keys():
         disks.append(Disk(*dnames[d]))
-        # logger.debug('ADDING disks LIST ELEMENT=%s' % Disk(*dnames[d]))
-        logger.debug('disks item = %s ', Disk(*dnames[d]))
-    # logger.debug('scan_disks() returning %s' % disks)
+        # logger.debug('disks item = %s ', Disk(*dnames[d]))
     return disks
 
 
@@ -1441,7 +1438,6 @@ def get_dev_byid_name(device_name, remove_path=False):
     or without path as per remove_path). The second boolean element of the
     tuple indicates if a by-id type name was found. ie (return_name, is_byid)
     """
-    logger.debug('GET_DEV_BYID_NAME CALLED WITH DEV-NAME=%s' % device_name)
     # Until we find a by-id type name set this flag as False.
     is_byid = False
     # Until we find a by-id type name we will be returning device_name
@@ -1500,7 +1496,6 @@ def get_dev_byid_name(device_name, remove_path=False):
             # Original device_name has path delimiters in: assume it has a path
             # return return_name_fields[-1], is_byid
             return_name = return_name_fields[-1]
-    logger.debug('GET_DEV_BYID_NAME RETURN=%s %s' % (return_name, is_byid))
     return return_name, is_byid
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -951,9 +951,12 @@ def get_disk_serial(device_name, device_type=None, test=None):
         device_name = '/dev/mapper/%s' % device_name
         # Assuming device mapped (DM) so without it's own serial.
         uuid_search_string = 'DM_UUID'
-        # TODO: Could just get uuid via "cryptsetup luksUUID <device>" as
-        # TODO: then the serial is stable between mapper name changes so tracks
-        # TODO: the underlying container.
+        # Note that we can't use "cryptsetup luksUUID <device>" as this is for
+        # use with the container, not the consequent mapped virtual device of
+        # the open container. Default udev rules include the virtual device
+        # name so this precludes name changes of the vdev as it would also
+        # change that devices serial which in turn makes it appear as a
+        # different device to Rockstor.
     # Set search string / flag for md personality if need be.
     if re.match('md', device_name) is not None:
         uuid_search_string = 'MD_UUID'
@@ -982,7 +985,7 @@ def get_disk_serial(device_name, device_type=None, test=None):
             # md or dm device so search for the appropriate uuid string
             if line_fields[1] == uuid_search_string:
                 # TODO: in the case of DM_UUID consider extracting only the
-                # TODO: UUID to cope with container mount point changes
+                # TODO: UUID to cope with open container name changes
                 serial_num = line_fields[2]
                 # we have found our hw serial equivalent so break to return
                 break

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1355,6 +1355,12 @@ def get_dev_byid_name(device_name, remove_path=False):
     return_name = device_name
     byid_name = ''  # Should never be returned prior to reassignment.
     longest_byid_name_length = 0
+    # caveats for mapped devices that require paths for udevadm to work
+    # ie openLUKS containers are named eg luks-<uuid> but are not found by
+    # udevadmin via --name unless a /dev/mapper path is provided.
+    if re.match('luks-', str(device_name)) is not None:
+        device_name = '/dev/mapper/%s' % device_name
+    # other special device name considerations can go here.
     out, err, rc = run_command(
         [UDEVADM, 'info', '--query=property', '--name', str(device_name)],
         throw=False)
@@ -1374,7 +1380,7 @@ def get_dev_byid_name(device_name, remove_path=False):
                         # as we can most easily use this format for working
                         # form lsblk device name to by-id name via dm-name-
                         # patch on the front.
-                        if re.match('/dev/disk/by-id/dm-name-', fields[index]):
+                        if re.match('/dev/disk/by-id/dm-name-', fields[index]) is not None:
                             # we have our dm-name match so assign it
                             byid_name = fields[index]
                             break

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -394,7 +394,7 @@ def scan_disks(min_size):
         disks.append(Disk(*dnames[d]))
         # logger.debug('ADDING disks LIST ELEMENT=%s' % Disk(*dnames[d]))
         logger.debug('disks item = %s ', Disk(*dnames[d]))
-    logger.debug('scan_disks() returning %s' % disks)
+    # logger.debug('scan_disks() returning %s' % disks)
     return disks
 
 
@@ -1348,7 +1348,6 @@ def get_dev_byid_name(device_name, remove_path=False):
     indicates if a by-id type name was found. ie (return_name, is_byid)
     """
     logger.debug('GET_DEV_BYID_NAME CALLED WITH DEV-NAME=%s' % device_name)
-    logger.debug('GET_DEV_BYID_NAME remove path = %s' % remove_path)
     # Until we find a by-id type name set this flag as False.
     is_byid = False
     # Until we find a by-id type name we will be returning device_name

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -272,6 +272,25 @@ def scan_disks(min_size):
                         # device (the base device) as a raid member, at least in
                         # part.
                         dnames[dname][8] = dmap['FSTYPE']
+                    # Akin to back porting a partitions FSTYPE to it's base
+                    # device, as with 'linux_raid_member' above, we can do the
+                    # same for btrfs if found in a partition.
+                    # This is intended to facilitate the user redirection role
+                    # so that the base disk can be labeled with it's partitions
+                    # fstype, label (for pool updates) uuid, and size.
+                    # N.B. The base device info will end up pertaining to the
+                    # highest partition numbers details. Design limitation.
+                    if dmap['FSTYPE'] == 'btrfs' and dnames[dname][8] is None:
+                        # We are a btrfs partition where the base device has
+                        # no fstype entry: backport: fstype, label, uuid & size.
+                        # fstype backport
+                        dnames[dname][8] = dmap['FSTYPE']
+                        # label backport is at index 9
+                        dnames[dname][9] = dmap['LABEL']
+                        # and uuid backport
+                        dnames[dname][10] = dmap['UUID']
+                        # and size backport
+                        dnames[dname][3] = dmap['SIZE']
                     # Build a list of the partitions we find.
                     # Back port our current name as a partition entry in our
                     # base devices 'partitions' list 14th item (index 13).


### PR DESCRIPTION
As the role system enhancements within this pr are non trivial a developers technical manual entry is planned in order to aid in further development / enhancement in this area. As such this pr messaging is constrained (in the interests of brevity) to bullet point abstractions of the changes as full explanations, and intended future use, can be reserved for the developers documentation to come.
A brief exposition of the merits of the approach taken is included.

Bullet points of changes made in this pr:

- extend the existing disk role system to accommodate general purpose use (previously used to flag mdraid members only)
- replace overloaded use of the partition property in the disks model for more specific disk categorization via the role system enhancements.
- add recognition of whole disk LUKS containers and their un-encrypted virtual devices to scan_disks()
- add recognition of bcache backing and caching device formats and their consequent virtual devices to scan_disks() (requires additional udev rules to be included in 'unofficial bcache package')
- add greater partition awareness to scan_disks() with a priority on reporting btrfs in partition.
- add filesystem within partition reporting to scan_disks() again with a priority on btrfs in partition.
- add contextual reporting of above on disk Web-UI page.
- add roles config Web-UI interface to report partition and filesystem status of a device and allow wiping of either specific partitions (once a redirect role is configured) and the whole disk. An introduction of future roles is included in the user facing text.
- add the 'User assigned' redirect role - essentially a flag that causes all disk actions to be redirected to a disk's partition.
- The disk wipe dialog was replaced by the above Roles config UI due to a required interdependence.
- all disk tables were updated to indicate redirect roles.
- disk and pool models and mechanisms were updated to be aware of both auto assigned (LUKS / bcache / root drive label) roles and User assigned roles (currently only redirect role).

The scope of this pr is larger than usual but was required for the following reasons:

- To develop and test the role system a number of auto and manual roles were required, hence the requirement to add recognition for root, LUKS, and bcache devices to prove role subsystem capability in more than one arena.
- To facilitate the testing of a user assigned role a web-ui interface was required in order to prove viability and the intended role mechanism with the interplay of auto and manual roles and added context that a redirect role, for example, brings: ie to the wipefs facility.
- The usability component of facilitating partition use via a redirect role attribution and how that tied into the existing UI also required a 'proof of concept' Web-UI.

The essence of this pr is to extend the disk management and recognition to accommodate more device types and partitions there in and to establish a mechanism by which those devices might be excluded or included contextually. The approach taken restricts Rockstor's use of partitions to one per disk. This is a majority use case in a NAS appliance. This approach also allows for the continued simplicity of a disk 'levels of analysis' approach which helps to keep the UI simple and approachable and avoids users having to be aware of partitions, except in specific use cases. One such case is the interoperability requirement faced when dealing with prior use (partitioned) external media for import or shared or intermittent use scenarios. However there is still a UI bias towards 'whole disk' for pool device members as this is a more elegant / ideal arrangement.

Testing methods employed are to follow in additional comment.

Fixes #1494 

Ready for review.