### PR TITLE
Share Usage reporting right sizes

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -731,6 +731,59 @@ def update_quota(pool, qgroup, size_bytes):
     return run_command(cmd, log=True)
 
 
+def volume_usage(pool, volume_id, pvolume_id=None):
+
+    """
+    New function to collect volumes rusage and eusage instead of share_usage
+    plus parent rusage and eusage (2015/* qgroup)
+    """
+    # Obtain path to share in pool, this preserved because
+    # granting pool exists
+    root_pool_mnt = mount_root(pool)
+    cmd = [BTRFS, 'subvolume', 'list', root_pool_mnt]
+    out, err, rc = run_command(cmd, log=True)
+    short_id = volume_id.split('/')[1]
+    volume_dir = ''
+
+    for line in out:
+        fields = line.split()
+        if (len(fields) > 0 and short_id in fields[1]):
+            volume_dir = root_pool_mnt + '/' + fields[8]
+            break
+
+    """
+    Rockstor volume/subvolume hierarchy is not standard
+    and Snapshots actually not always under Share but on Pool,
+    so btrf sub list -o deprecated because won't always return
+    expected data; volumes (shares & snapshots) sizes got via qgroups.
+    Rockstor structure has default share qgroup 0/* becoming child of
+    2015/* new qgroup and share snapshots 0/*+1 qgroups assigned to new
+    Rockstor 2015/*.
+    Original 0/* qgroup returns current share content size,
+    2015/* qgroup returns 'real' share size considering snapshots sizes too
+    Note: 2015/* rfer and excl sizes are always equal so to compute
+    current real size we can indistinctly use one of them.
+    """
+
+    cmd = [BTRFS, 'qgroup', 'show', volume_dir]
+    out, err, rc = run_command(cmd, log=True)
+    rusage = eusage = 0
+    pqgroup_rusage = pqgroup_eusage = 0
+
+    for line in out:
+        fields = line.split()
+        if (len(fields) > 0 and '/' in fields[0]):
+            qgroup = fields[0]
+            if (qgroup == volume_id):
+                rusage = convert_to_kib(fields[1])
+                eusage = convert_to_kib(fields[2])
+            if (pvolume_id is not None and qgroup == pvolume_id):
+                pqgroup_rusage = convert_to_kib(fields[1])
+                pqgroup_eusage = convert_to_kib(fields[2])
+
+    return (rusage, eusage, pqgroup_rusage, pqgroup_eusage)
+
+
 def share_usage(pool, share_id):
     """
     Return the sum of the qgroup sizes of this share and any child subvolumes

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -769,6 +769,7 @@ def volume_usage(pool, volume_id, pvolume_id=None):
     out, err, rc = run_command(cmd, log=True)
     rusage = eusage = 0
     pqgroup_rusage = pqgroup_eusage = 0
+    share_sizes = []
 
     for line in out:
         fields = line.split()
@@ -777,11 +778,13 @@ def volume_usage(pool, volume_id, pvolume_id=None):
             if (qgroup == volume_id):
                 rusage = convert_to_kib(fields[1])
                 eusage = convert_to_kib(fields[2])
+                share_sizes.extend((rusage, eusage))
             if (pvolume_id is not None and qgroup == pvolume_id):
                 pqgroup_rusage = convert_to_kib(fields[1])
                 pqgroup_eusage = convert_to_kib(fields[2])
+                share_sizes.extend((pqgroup_rusage, pqgroup_eusage))
 
-    return (rusage, eusage, pqgroup_rusage, pqgroup_eusage)
+    return share_sizes
 
 
 def share_usage(pool, share_id):

--- a/src/rockstor/storageadmin/migrations/0003_auto_20170114_1332.py
+++ b/src/rockstor/storageadmin/migrations/0003_auto_20170114_1332.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0002_auto_20161125_0051'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='share',
+            name='pqgroup_eusage',
+            field=models.BigIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='share',
+            name='pqgroup_rusage',
+            field=models.BigIntegerField(default=0),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -42,8 +42,15 @@ class Share(models.Model):
     subvol_name = models.CharField(max_length=4096)
     replica = models.BooleanField(default=False)
     compression_algo = models.CharField(max_length=1024, null=True)
+    # rusage and eusage reports original 0/x qgroup size
+    # and this has only current share content without snapshots
     rusage = models.BigIntegerField(default=0)
     eusage = models.BigIntegerField(default=0)
+    # Having Rockstor vol/subvols overriding btrfs standards
+    # with snapshots(subvols) not under their vols, we use qgroup sizes
+    # to report correct real vol sizes
+    pqgroup_rusage = models.BigIntegerField(default=0)
+    pqgroup_eusage = models.BigIntegerField(default=0)
 
     @property
     def size_gb(self):

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -13,8 +13,9 @@
         <th>Name</th>
         <th>Size</th>
         <th>Pool</th>
-        <th>Usage</th>
-	      <th>Compression algorithm</th>
+        <th>Usage <i class="fa fa-info-circle" title="Current share content"></th>
+		<th>Usage (Btrfs) <i class="fa fa-info-circle" title="Current share content considering snapshots too"></th>
+	    <th>Compression algorithm</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -24,7 +25,8 @@
         <td><a href="#shares/{{this.name}}"><i class="glyphicon glyphicon-folder-open"></i>  {{this.name}}</a></td>
         <td>{{humanize_size this.size}}</td>
         <td>{{this.pool.name}}</td>
-        <td>{{humanize_size this.eusage}}
+        <td>{{humanize_size this.rusage}}</td>
+		<td>{{humanize_size this.pqgroup_rusage}} {{checkUsage this.size this.pqgroup_rusage}}</td>
         <td>
         {{displayCompressionAlgo this.compression_algo this.name}}
         </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/top_shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/top_shares.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -95,7 +95,7 @@ TopSharesWidget = RockStorWidgetView.extend({
             var btrfs_size = (_this.data[index].get('pUsed') + _this.data[index].get('pOverUsed')).toFixed(2)
             $(this).text(btrfs_size + '%');
         });
-		var truncate = _this.maximized ? 100 : 12;
+        var truncate = _this.maximized ? 100 : 12;
         this.$('.progress-animate').not('.progress-bar-info').each(function(index) {
             $(this).find('span')
                 .text(humanize.truncatechars(_this.data[index].get('name'), truncate) +

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/top_shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/top_shares.js
@@ -62,11 +62,14 @@ TopSharesWidget = RockStorWidgetView.extend({
 
         var _this = this;
         _this.data = this.shares.sortBy(function(s) {
-            return ((s.get('rusage') / s.get('size')) * 100);
+            return ((s.get('pqgroup_rusage') / s.get('size')) * 100);
         }).reverse().slice(0, this.numTop);
         _this.data.map(function(d) {
             d.set({
                 'pUsed': ((d.get('rusage') / d.get('size')) * 100)
+            });
+            d.set({
+                'pOverUsed': (((d.get('pqgroup_rusage') - d.get('rusage')) / d.get('size')) * 100)
             });
         });
     },
@@ -89,20 +92,25 @@ TopSharesWidget = RockStorWidgetView.extend({
         });
 
         this.$('.pused').each(function(index) {
-            $(this).text(_this.data[index].get('pUsed').toFixed(2) + '%');
+            var btrfs_size = (_this.data[index].get('pUsed') + _this.data[index].get('pOverUsed')).toFixed(2)
+            $(this).text(btrfs_size + '%');
         });
 		var truncate = _this.maximized ? 100 : 12;
-        this.$('.progress-animate').each(function(index) {
+        this.$('.progress-animate').not('.progress-bar-info').each(function(index) {
             $(this).find('span')
                 .text(humanize.truncatechars(_this.data[index].get('name'), truncate) +
-                    '(' + humanize.filesize(_this.data[index].get('rusage') * 1024) +
+                    '(' + humanize.filesize(_this.data[index].get('pqgroup_rusage') * 1024) +
                     '/' + humanize.filesize(_this.data[index].get('size') * 1024) +
                     ')');
             $(this).animate({
                 width: _this.data[index].get('pUsed').toFixed(2) + '%'
             }, 1000);
         });
-
+        this.$('.progress-bar-info').each(function(index) {
+            $(this).animate({
+                width: _this.data[index].get('pOverUsed').toFixed(2) + '%'
+            }, 1000);
+        });
     },
 
     buildTitle: function() {
@@ -134,8 +142,11 @@ TopSharesWidget = RockStorWidgetView.extend({
         var html = '<div style="display: table;"><div class="' + percent_div['class'] + '" style="' + percent_div['style'] + '"></div>';
         html += '<div class="' + progressbar_container['class'] + '" style="' + progressbar_container['style'] + '">';
         html += '<div class="' + progressbars_defaults['class'] + '" style="' + progressbars_defaults['style'] + '" ';
-        html += 'role="' + progressbars_defaults['role'] + '">';
-        html += '<span style="' + progressbar_span['style'] + '"></span></div></div></div>';
+        html += 'role="' + progressbars_defaults['role'] + '">'
+        html += '<span style="' + progressbar_span['style'] + '"></span></div>';
+        html += '<div class="' + progressbars_defaults['class'] + ' progress-bar-info" style="' + progressbars_defaults['style'] + '" ';
+        html += 'role="' + progressbars_defaults['role'] + '"></div>';
+        html += '</div></div>';
 
         return html;
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -166,7 +166,7 @@ SharesView = RockstorLayoutView.extend({
             }
             if (warning !=='') {
                 html = '<i class="fa fa-warning fa-lg ' + warning;
-                html += '" title="Usage is ' + usage * 100 + '% os share size">';
+                html += '" title="Usage is ' + usage * 100 + '% of share size">';
                 return new Handlebars.SafeString(html);
             }
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -167,8 +167,8 @@ SharesView = RockstorLayoutView.extend({
             if (warning !=='') {
                 html = '<i class="fa fa-warning fa-lg ' + warning;
                 html += '" title="Usage is ' + usage * 100 + '% os share size">';
+                return new Handlebars.SafeString(html);
             }
-            return new Handlebars.SafeString(html);
         });
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -111,7 +111,7 @@ SharesView = RockstorLayoutView.extend({
 				enableButton(button);
 				_this.$('#delete-share-modal').modal('hide');
 				$('.modal-backdrop').remove();
-				app_router.navigate('shares', {trigger: true})
+				app_router.navigate('shares', {trigger: true});
 			},
 			error: function(xhr, status, error) {
 				enableButton(button);
@@ -120,7 +120,7 @@ SharesView = RockstorLayoutView.extend({
 	},
 	cancel: function(event) {
 		if (event) event.preventDefault();
-		app_router.navigate('shares', {trigger: true})
+		app_router.navigate('shares', {trigger: true});
 	},
 
 	initHandlebarHelpers: function(){
@@ -133,7 +133,7 @@ SharesView = RockstorLayoutView.extend({
 			var html = '';
 			if(shareCompression && shareCompression != 'no'){
 				html += shareCompression;
-			}else{
+			} else {
 				html += 'None(defaults to pool level compression, if any)   ' +
 				'<a href="#shares/' + shareName + '/?cView=edit"><i class="glyphicon glyphicon-pencil"></i></a>';
 			}
@@ -150,5 +150,25 @@ SharesView = RockstorLayoutView.extend({
             }
             return false;
         });
-	}
+
+        Handlebars.registerHelper('checkUsage', function(size, btrfs_usage) {
+
+            // We don't have share size enforcement with btrfs qgroup limit
+            // but with this we help users to start gettting used to it.
+            // Current warning levels are btrfs usage > 70% warning
+            // btrfs usage > 80% alert
+            var html, warning = '';
+            var usage = (btrfs_usage / size).toFixed(4);
+            if (usage >= 0.8) {
+                warning = 'text-danger';
+            } else if (usage >= 0.7){
+                warning = 'text-warning';
+            }
+            if (warning !=='') {
+                html = '<i class="fa fa-warning fa-lg ' + warning;
+                html += '" title="Usage is ' + usage * 100 + '% os share size">';
+            }
+            return new Handlebars.SafeString(html);
+        });
+    }
 });

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -23,7 +23,7 @@ from django.db import transaction
 from storageadmin.models import (Share, Pool, Snapshot, NFSExport, SambaShare,
                                  SFTP)
 from smart_manager.models import Replica
-from fs.btrfs import (add_share, remove_share, update_quota, share_usage,
+from fs.btrfs import (add_share, remove_share, update_quota, volume_usage,
                       set_property, mount_share, qgroup_id, qgroup_create)
 from system.osi import is_share_mounted
 from system.services import systemctl
@@ -210,7 +210,7 @@ class ShareDetailView(ShareMixin, rfc.GenericView):
             if ('size' in request.data):
                 new_size = self._validate_share_size(request, share.pool)
                 qid = qgroup_id(share.pool, share.subvol_name)
-                cur_rusage, cur_eusage = share_usage(share.pool, qid)
+                cur_rusage, cur_eusage = volume_usage(share.pool, qid)
                 if (new_size < cur_rusage):
                     e_msg = ('Unable to resize because requested new '
                              'size(%dKB) is less than current usage(%dKB)'

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -21,7 +21,7 @@ from django.db import transaction
 from django.conf import settings
 from storageadmin.models import (Snapshot, Share, NFSExport,
                                  NFSExportGroup, AdvancedNFSExport)
-from fs.btrfs import (add_snap, share_id, share_usage, remove_snap,
+from fs.btrfs import (add_snap, share_id, volume_usage, remove_snap,
                       umount_root, mount_snap, qgroup_assign)
 from system.osi import refresh_nfs_exports
 from storageadmin.serializers import SnapshotSerializer
@@ -121,7 +121,7 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         qgroup_id = ('0/%s' % snap_id)
         qgroup_assign(qgroup_id, share.pqgroup, ('%s/%s' % (settings.MNT_PT,
                                                             share.pool.name)))
-        snap_size, eusage = share_usage(share.pool, qgroup_id)
+        snap_size, eusage = volume_usage(share.pool, qgroup_id)
         s = Snapshot(share=share, name=snap_name, real_name=snap_name,
                      size=snap_size, qgroup=qgroup_id,
                      uvisible=uvisible, snap_type=snap_type,


### PR DESCRIPTION
Ref to #1412 

Please check comments under issue plus commits inline comments.

Some adds:
- Share lists page now returns 2 alerts if "btrfs usage" ( current content + snapshots ) > 70% share size (warning) or > 80% (danger)
- Same idea on top shares widget too, but only with a current size bar (blue) and a light-blue "btrfs overhead"

To @schakrava : ready for review/merge

Note: while testing found we really lack `btrfs quota rescan` #1624