### PR TITLE
correct minor refactoring error on balance unit test. Fixes #1627

### DIFF
--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -287,7 +287,7 @@ class BTRFSTests(unittest.TestCase):
         pool = Pool(raid='raid0', name='test-pool')
         # run_command moc return values.
         out = ["Balance on '/mnt2/rock-pool' is running, cancel requested",
-               ('15 out of about 114 chunks balanced (16 considered),'
+               ('15 out of about 114 chunks balanced (16 considered),  '
                 '87% left'),
                '']
         err = ['']


### PR DESCRIPTION
Thanks to @MFlyer for highlighting this issue. Looks like we had a minor refactoring error in the expected output setup for the balance 'cancel requested' unit test in commit:

https://github.com/rockstor/rockstor-core/pull/1615/commits/e604691928be0cbd278bd88b6ba94b3aa122c95f

Fixes #1627 
