### PR TITLE
Samba config restore, missing checks over configuration origin (WebUI or config restore system)

### DIFF
--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -56,19 +56,23 @@ class SambaServiceView(BaseServiceDetailView):
             try:
                 config = request.data.get('config', {})
                 global_config = {}
-                gc_lines = config['global_config'].split('\n')
-                for l in gc_lines:
-                    gc_param = l.strip().split(' = ')
-                    if (len(gc_param) == 2):
-                        if '=' in gc_param[0]:
-                            raise Exception(
-                                'Syntax error, one param has wrong spaces '
-                                'around equal signs, please check syntax of '
-                                '\'%s\'' % ''.join(gc_param))
-                        global_config[gc_param[0].strip().lower()] = gc_param[1].strip()  # noqa
-                # #E501 Default set current workgroup to one got via samba
-                # config page
-                global_config['workgroup'] = config['workgroup']
+                if 'global_config' in config:
+                    gc_lines = config['global_config'].split('\n')
+                    for l in gc_lines:
+                        gc_param = l.strip().split(' = ')
+                        if (len(gc_param) == 2):
+                            if '=' in gc_param[0]:
+                                raise Exception(
+                                    'Syntax error, one param has wrong '
+                                    'spaces around equal signs, '
+                                    'please check syntax of '
+                                    '\'%s\'' % ''.join(gc_param))
+                            global_config[gc_param[0].strip().lower()] = gc_param[1].strip()  # noqa
+                    # #E501 Default set current workgroup to one got via samba
+                    # config page
+                    global_config['workgroup'] = config['workgroup']
+                else:
+                    global_config = config
                 # Check Active Directory config and status if AD configured and
                 # ON set workgroup to AD retrieved workgroup else AD not
                 # running and leave workgroup to one choosen by user


### PR DESCRIPTION
#1585 issue by @phillxnet ,
added control over config origin (samba config page or system config restore) with if...else to handle data

Ready to be merged, tested with:
- config saving over WebUI -> OK
- config backup and restore -> OK

Mirko