### PR TITLE
Rockstor Translations

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -126,9 +126,9 @@
     <script>
         var langs_folder = '/static/js/lib/jquery.i18n/langs/';
         $.i18n().load({
-            de: langs_folder + 'de.json'
-            es: langs_folder + 'es.json'
-            fr: langs_folder + 'fr.json'
+            de: langs_folder + 'de.json',
+            es: langs_folder + 'es.json',
+            fr: langs_folder + 'fr.json',
             it: langs_folder + 'it.json'
         });
     </script>

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <!--
     /**
@@ -115,7 +115,23 @@
     <script src="/static/js/lib/additional-methods.min.js"></script>
     <script src="/static/js/lib/bootstrap-editable.min.js"></script>
     <script src="/static/js/lib/Chart.min.js"></script>
+    <script src="/static/js/lib/jquery.i18n/CLDRPluralRuleParser.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.messagestore.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.fallbacks.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.parser.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.emitter.js"></script>
+    <script src="/static/js/lib/jquery.i18n/jquery.i18n.language.js"></script>
     <script src="/static/storageadmin/js/storageadmin.js"></script>
+    <script>
+        var langs_folder = '/static/js/lib/jquery.i18n/langs/';
+        $.i18n().load({
+            de: langs_folder + 'de.json'
+            es: langs_folder + 'es.json'
+            fr: langs_folder + 'fr.json'
+            it: langs_folder + 'it.json'
+        });
+    </script>
   </head>
 
   <body>

--- a/src/rockstor/storageadmin/templates/storageadmin/login.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
     <!--
     /**

--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <!--
     /**


### PR DESCRIPTION
Ref to #821
Hi @phillxnet @schakrava @priyaganti ,
we can merge this to have a starting point (had some tests).

Having translations over all Rockstor requires adding data apis to every *.rst file & define every language.json lib (en not required, Rockstor current default) :)

lang attr removed to avoid fixed en lang (jquery.i18n tests lang attr and use default lang only if that missing)

This requires jslib repo PR

Mirko