### PR TITLE
Fixing max count for snapshots on snapshot task edit page

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/add_task.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/add_task.jst
@@ -116,7 +116,7 @@ $(document).ready(function() {
           <div class="form-group">
             <label class="control-label col-sm-4" for="share">Task type: </label>
             <div class="col-sm-6">
-              <input type="text" class="form-control" value="{{taskObj.type}}" disabled />
+              <input type="text" class="form-control" id="task_type" name="task_type" value="{{taskObj.type}}" disabled />
             </div>
           </div>
           <!-- Type dependent fields -->


### PR DESCRIPTION
Ref to #1645

Fixed by adding missing id and name html attrs: backbone view already has its validator to check max count if task_type is snapshot (check was missing on edit page)

Ready to be merged @schakrava 