### PR TITLE
Samba share comment wrong model field name

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
@@ -95,7 +95,7 @@ AddSambaExportView = RockstorLayoutView.extend({
 		var configList = '',
 		smbShareName,
 		smbShadowCopy,
-		smbComments,
+		smbComment,
 		smbSnapPrefix = '';
 		if (this.sShares != null) {
 			var config = this.sShares.get('custom_config'),

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
@@ -101,7 +101,7 @@ AddSambaExportView = RockstorLayoutView.extend({
 			var config = this.sShares.get('custom_config'),
 			smbShareName = this.sShares.get('share'),
 			smbShadowCopy = this.sShares.get("shadow_copy"),
-			smbComments = this.sShares.get("comments"),
+			smbComment = this.sShares.get("comment"),
 			smbSnapPrefix = this.sShares.get("snapshot_prefix");
 
 			for(i=0; i<config.length; i++){
@@ -119,7 +119,7 @@ AddSambaExportView = RockstorLayoutView.extend({
 			smbShare: this.sShares,
 			smbShareName: smbShareName,
 			smbShareShadowCopy: smbShadowCopy,
-			smbShareComments: smbComments,
+			smbShareComment: smbComment,
 			smbShareSnapPrefix: smbSnapPrefix,
 			smbSnapshotPrefixRule: smbSnapshotPrefixBool,
 			users: this.users,


### PR DESCRIPTION
Ref to #1647 
We were fetching wrong model field (comments instead of comment), this causing samba export comment not rendered while on edit page

Ready to be merged

Mirko