### PR TITLE
improve redirect role input validation. Fixes #1651

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -114,14 +114,29 @@ SetroleDiskView = RockstorLayoutView.extend({
 
         $.validator.addMethod('validateRedirect', function (value) {
             var redirect_role = $('#redirect_part').val();
+            var redirect_changed = false;
+            if (redirect_role != current_redirect) {
+                redirect_changed = true;
+            }
+            var redirect_support_msg = 'Redirection is only supported to ' +
+                'a non btrfs partition when no btrfs partition exists on ' +
+                'the same device.';
             // check to see if we are attempting to change an existing btrfs
             // redirect, if so refuse the action and explain why.
-            if ((partitions[current_redirect] == 'btrfs') && (redirect_role != current_redirect)) {
+            if ((partitions[current_redirect] == 'btrfs') && redirect_changed) {
+                err_msg = 'Active btrfs partition redirect found; if you ' +
+                    'wish to change this redirect role first wipe the ' +
+                    'partition and then re-assign. ' + redirect_support_msg;
+                return false;
+            }
+            // check to see if an exiting btrfs partition exists and is not
+            // the selected option after a change. As we default to whole disk
+            // the 'after a change' clause allows for whole disk wipe.
+            if ((disk_btrfs_uuid != null) && (partitions[redirect_role] != 'btrfs') && redirect_changed) {
                 err_msg = 'Existing btrfs partition found; if you wish to ' +
                     'use the redirect role either select this btrfs partition ' +
-                    'or wipe it or the whole disk and re-assign.' +
-                    'Redirecting is only supported to a non btrfs partition when ' +
-                    'no btrfs partition exists on the same device.';
+                    'and import/use it, or wipe it (or the whole disk) and ' +
+                    'then re-assign. ' + redirect_support_msg;
                 return false;
             }
             return true;


### PR DESCRIPTION
Prior to this pr it was found that a non btrfs redirect role could be set on a device that also contained a btrfs partition. This was not intended behaviour and results in an import option that is non functional. This pr adds additional redirect role input validation to reject non btrfs partition redirection when a device also contains a btrfs partition. The check is only made when a role change is requested. This allows for the default whole disk wipe option.

As this is a bug fix for (my) code contributed in pr #1622 I have provided the additional manual testing steps required to identify and confirm the fix for this issue. These steps are additional to those detailed in #1622 .

Initial test drive partition setup(using sata bus this time):
```
yum install dosfstools
# 4GB virtual sata device (50% partitions give bare min of 2GB each) serial number "serial3"
parted -a optimal /dev/disk/by-id/ata-QEMU_HARDDISK_serial3
mklabel msdos
mkpart primary fat32 1 50%
mkpart primary ext2 50% 100%
quit
mkfs.fat -s2 -F 32 /dev/disk/by-id/ata-QEMU_HARDDISK_serial3-part1
mkfs.btrfs -f -L btrfs-in-partition /dev/disk/by-id/ata-QEMU_HARDDISK_serial3-part2
# the following command is required to ensure udev ‘sees’ the partition and fs changes.
udevadm trigger
```

Pre pr test failure:

status - no active redirect (default)
- attempt to redirect to vfat partition - Allowed
*This is a FAIL as it is not intended behaviour.*

Post pr test procedure:

status - no active redirect (default)
- attempt to redirect to vfat partition - Blocked
- resubmit whole disk selection - OK (no change)
- wipe whole disk - OK

*repeat above “Initial test drive partition setup” as disk is now blank.*

status - no active redirect (default)
- attempt to redirect to btrfs partition - OK

*leading to the next series of tests:*

status - active btrfs redirect:
- attempt to redirect to vfat partition - Blocked
- attempt to remove redirect (whole disk) - Blocked
- wipe active btrfs partition - OK

*leading to the next series of tests:*

status - active non btrfs redirect (wiped in previous step):
- attempt to redirect to vfat partition - OK
- wipe active (vfat) redirect partition - OK
(disk rescan required to update fs info)
- attempt to remove redirect (whole disk) - OK
- wipe whole disk - OK

During all of the "Post pr test procedure" steps above, the disk page 'flag' icons and their tool-tips, as well as any role config page warning messages, were as intended. Given the know issue identified in #1623 .

All manual tests detailed in pr #1622 were also re run and no regression was observed.

Fixes #1651 