### PR TITLE
Fix "Invalid environment variabled" error for multi-container rockons with "environment" section

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -712,7 +712,11 @@ RockonEnvironment = RockonCustomChoice.extend({
         }
         var env_map = {};
         var envars = this.custom_config.filter(function(cvar) {
-            env_map[cvar.get('key')] = this.$('#' + cvar.id).val();
+            co_id = cvar.get('container');
+            if(env_map[co_id] == undefined) {
+                env_map[co_id] = {};
+            }
+            env_map[co_id][cvar.get('key')] = this.$('#' + cvar.id).val();
             return cvar;
         }, this);
         this.model.set('env_map', env_map);

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -145,13 +145,11 @@ class RockOnIdView(rfc.GenericView):
                         cco.val = cc_map[c]
                         cco.save()
                     for e in env_map.keys():
-                        if (not DContainerEnv.objects.filter(
+                        if (DContainerEnv.objects.filter(
                                 container=co, key=e).exists()):
-                            e_msg = ('Invalid environment variabled(%s)' % e)
-                            handle_exception(Exception(e_msg), request)
-                        ceo = DContainerEnv.objects.get(container=co, key=e)
-                        ceo.val = env_map[e]
-                        ceo.save()
+                            ceo = DContainerEnv.objects.get(container=co, key=e)
+                            ceo.val = env_map[e]
+                            ceo.save()
                 install.async(rockon.id)
                 rockon.state = 'pending_install'
                 rockon.save()

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -94,6 +94,7 @@ class RockOnIdView(rfc.GenericView):
                 env_map = request.data.get('environment', {})
                 containers = DContainer.objects.filter(rockon=rockon)
                 for co in containers:
+                    co_id = str(co.id)
                     for sname in share_map.keys():
                         dest_dir = share_map[sname]
                         if (not Share.objects.filter(name=sname).exists()):
@@ -144,11 +145,14 @@ class RockOnIdView(rfc.GenericView):
                         cco = DCustomConfig.objects.get(rockon=rockon, key=c)
                         cco.val = cc_map[c]
                         cco.save()
-                    for e in env_map.keys():
-                        if (DContainerEnv.objects.filter(
-                                container=co, key=e).exists()):
+                    if (co_id in env_map):
+                        for e in env_map[co_id].keys():
+                            if (not DContainerEnv.objects.filter(
+                                    container=co, key=e).exists()):
+                                e_msg = ('Invalid environment variable(%s)' % e)
+                                handle_exception(Exception(e_msg), request)
                             ceo = DContainerEnv.objects.get(container=co, key=e)
-                            ceo.val = env_map[e]
+                            ceo.val = env_map[co_id][e]
                             ceo.save()
                 install.async(rockon.id)
                 rockon.state = 'pending_install'


### PR DESCRIPTION
Used to fix #1588.
env_map contains flat list of environment varialbes, so while looping through containers and checking for environment variables from that list there should not be any exception. Just ignore it and move on to the next container in loop.
Even if no such containers exists (just imagine), that would not be any problem, at least nothing worth an exception, but that's another story.