### PR TITLE
Consolidate db migration logic into initrock. Fixes #1332

### DIFF
--- a/base-buildout.cfg
+++ b/base-buildout.cfg
@@ -90,32 +90,6 @@ command = mkdir -p ${buildout:directory}/var/log &&
           systemctl disable nginx
 update-command = ${extra-stuff:command}
 
-[db-migrate-fakeinit]
-recipe = plone.recipe.command
-command = export DJANGO_SETTINGS_MODULE=settings &&
-        for app in storageadmin smart_manager; do
-            db="default"
-            if [ $app == "smart_manager" ]; then
-                db="smart_manager"
-            fi
-            ${buildout:directory}/bin/django migrate --list --database=$db $app | grep "^ \[X\] 0001_initial";
-            if [ $? -ne 0 ]; then
-                ${buildout:directory}/bin/django migrate --noinput --fake --database=$db $app 0001_initial
-            fi
-        done
-update-command = ${db-migrate-fakeinit:command}
-
-[db-migrate]
-recipe = plone.recipe.command
-command = export DJANGO_SETTINGS_MODULE=settings &&
-      ${buildout:directory}/bin/django migrate --noinput storageadmin &&
-      ${buildout:directory}/bin/django migrate --noinput --database=smart_manager smart_manager &&
-      ${buildout:directory}/bin/django migrate --noinput auth &&
-   	  ${buildout:directory}/bin/django migrate --noinput django_ztask &&
-          ${buildout:directory}/bin/prep_db
-update-command = ${db-migrate:command}
-stop-on-error = true
-
 [myvar]
 nginx_websocket_port = 7999
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -39,8 +39,6 @@ parts =
       gulp-eslint
       supervisor
       supervisord-conf
-      db-migrate-fakeinit
-      db-migrate
       create-cert
       docker-conf
       rockstor-pre-systemd-conf


### PR DESCRIPTION
* run db-migration logic in initrock(one place) instead of in rpm post script
  and buildout steps.
* the logic runs a fake initial migration if it hasn't been already
  applied. this applies to new installs or if db is wiped.
* legit migrations are run on each run of initrock, and since that process is
  idempotent, it works smoothly.