### PR TITLE
Add a script to toggle debug logging. Fixes #1478

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -203,6 +203,7 @@ PIPELINE = {
 # the site admins on every HTTP 500 error when DEBUG=False.
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
+LOG_LEVEL = 'DEBUG' if DEBUG else 'INFO'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -224,7 +225,7 @@ LOGGING = {
             'class': 'django.utils.log.AdminEmailHandler'
         },
         'file': {
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'class': 'logging.handlers.RotatingFileHandler',
             'filename': '${django-settings-conf:logfile}',
             'maxBytes': 1000000,
@@ -240,27 +241,27 @@ LOGGING = {
         },
         'storageadmin': {
             'handlers': ['file'],
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'propagate': True,
         },
         'smart_manager': {
             'handlers': ['file'],
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'propagate': True,
         },
         'system': {
             'handlers': ['file'],
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'propagate': True,
         },
         'scripts': {
             'handlers': ['file'],
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'propagate': True,
         },
         'fs': {
             'handlers': ['file'],
-            'level': 'DEBUG',
+            'level': LOG_LEVEL,
             'propagate': True,
         },
     }

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             'backup-plugin = backup.scheduler:main',
             'bootstrap = scripts.bootstrap:main',
             'data-collector = smart_manager.data_collector:main',
+            'debug-mode = scripts.debugmode:main',
             'delete-api-key = scripts.delete_api_key:main',
             'delete-rockon = scripts.rockon_delete:delete_rockon',
             'docker-wrapper = scripts.docker_wrapper:main',

--- a/src/rockstor/scripts/debugmode.py
+++ b/src/rockstor/scripts/debugmode.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os.path as path
+import re
+import shutil
+import sys
+
+
+from django.conf import settings
+from tempfile import mkstemp
+
+from system.osi import run_command
+
+
+SETTINGS_FILE = path.join(settings.ROOT_DIR, 'src/rockstor/settings.py')
+SUPERCTL_BIN = path.join(settings.ROOT_DIR, 'bin/supervisorctl')
+
+
+def update_settings(debug_flag):
+    fh, npath = mkstemp()
+    with open(SETTINGS_FILE) as sfo, open(npath, 'w') as tfo:
+        for line in sfo.readlines():
+            if re.match('DEBUG = ', line):
+                line = 'DEBUG = %s\n' % debug_flag
+            tfo.write(line)
+    shutil.move(npath, SETTINGS_FILE)
+
+
+def display_current():
+    print("currently debug flag is %s" % settings.DEBUG)
+
+
+def main():
+    hmsg = 'Usage: %s [-h] [ON|OFF]' % sys.argv[0]
+    if len(sys.argv) > 1:
+        log_level = sys.argv[1].upper()
+        if log_level not in ('ON', 'OFF'):
+            sys.exit(hmsg)
+
+        debug_flag = False
+        if log_level == 'ON':
+            debug_flag = True
+
+        if debug_flag == settings.DEBUG:
+            print('DEBUG flag already set to %s' % debug_flag)
+        else:
+            update_settings(debug_flag)
+            run_command([SUPERCTL_BIN, 'restart', 'gunicorn'])
+            print('DEBUG flag is now set to %s' % debug_flag)
+    else:
+        display_current()
+        sys.exit(hmsg)


### PR DESCRIPTION
Sample usage:
[root@rock-dev rock-dep]# ./bin/debug-mode off
[root@rock-dev rock-dep]# ./bin/debug-mode
currently debug flag is False
[root@rock-dev rock-dep]# ./bin/debug-mode -h
Usage: ./bin/debug-mode [-h] [ON|OFF]
[root@rock-dev rock-dep]# ./bin/debug-mode on
[root@rock-dev rock-dep]# ./bin/debug-mode
currently debug flag is True
Usage: ./bin/debug-mode [-h] [ON|OFF]
[root@rock-dev rock-dep]# ./bin/debug-mode -h
Usage: ./bin/debug-mode [-h] [ON|OFF]