### PR TITLE
fix 'for' attributes on user_create_template labels

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/home/user_create_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/home/user_create_template.jst
@@ -16,7 +16,7 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-sm-2 control-label" for="hostnam">Hostname</label>
+      <label class="col-sm-2 control-label" for="hostname">Hostname</label>
       <div class="col-sm-3">
         <input class="form-control" type="text" id="hostname" name="hostname" placeholder="Hostname" required>
       </div>
@@ -28,13 +28,13 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-sm-2 control-label">Password</label>
+      <label class="col-sm-2 control-label" for="password">Password</label>
       <div class="col-sm-3">
 	<input class="form-control" type="password" id="password" name="password" placeholder="Password" required>
       </div>
     </div>
     <div class="form-group">
-      <label class="col-sm-2 control-label">Confirm Password</label>
+      <label class="col-sm-2 control-label" for="password_confirmation">Confirm Password</label>
       <div class="col-sm-3">
 	<input class="form-control" type="password" id="password_confirmation" name="password_confirmation" placeholder="Password" required>
       </div>


### PR DESCRIPTION
I stumbled over the <label>s in user_create_template having a typo and missing for="" attributes, so I created a patch to fix this. ;-)