### PR TITLE
create SHA256 certs so browser devtools don't complain all the time

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -148,9 +148,9 @@ recipe = plone.recipe.command
 cert_loc = ${buildout:directory}/certs
 command = if [[ ! -d ${create-cert:cert_loc} ]]; then
 	mkdir ${create-cert:cert_loc};
-	openssl req -nodes -newkey rsa:2048 -keyout ${create-cert:cert_loc}/first.key -out ${create-cert:cert_loc}/rockstor.csr -subj "/C=US/ST=Rockstor user's state/L=Rockstor user's city/O=Rockstor user/OU=Rockstor dept/CN=rockstor.user" &&
+	openssl req -nodes -newkey rsa:2048 -keyout ${create-cert:cert_loc}/first.key -out ${create-cert:cert_loc}/rockstor.csr -sha256 -subj "/C=US/ST=Rockstor user's state/L=Rockstor user's city/O=Rockstor user/OU=Rockstor dept/CN=rockstor.user" &&
 	openssl rsa -in ${create-cert:cert_loc}/first.key -out ${create-cert:cert_loc}/rockstor.key &&
-        openssl x509 -in ${create-cert:cert_loc}/rockstor.csr -out ${create-cert:cert_loc}/rockstor.cert -req -signkey ${create-cert:cert_loc}/rockstor.key -days 3650
+        openssl x509 -in ${create-cert:cert_loc}/rockstor.csr -out ${create-cert:cert_loc}/rockstor.cert -sha256 -req -signkey ${create-cert:cert_loc}/rockstor.key -days 3650
 	fi
 update-command = ${create-cert:command}
 


### PR DESCRIPTION
When developing things with Rocktor UI, I noticed a lot of warning about SHA1 certs in my browser's developer tools. Here's a patch that moves to SHA256, which does away with those warnings.