### PR TITLE
support full disk luks. Fixes #550

### DIFF
--- a/base-buildout.cfg
+++ b/base-buildout.cfg
@@ -61,7 +61,7 @@ command =
 	postgresql-server postgresql-devel kernel-ml btrfs-progs rsync \
 	nfs-utils avahi netatalk smartmontools net-tools sos hdparm \
 	postfix cyrus-sasl-plain yum-cron nano usbutils pciutils shellinabox \
-	epel-release
+	epel-release cryptsetup
 
 [rpm-deps-nut]
 recipe = plone.recipe.command

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -252,8 +252,10 @@ def mount_root(pool):
         raise Exception('Cannot mount Pool(%s) as it has no disks in it.'
                         % pool.name)
     last_device = pool.disk_set.last()
+    logger.info('Mount by label failed.')
     for device in pool.disk_set.all():
         mnt_device = ('/dev/disk/by-id/%s' % device.name)
+        logger.info('Attempting mount by device (%s).' % mnt_device)
         if (os.path.exists(mnt_device)):
             mnt_cmd = [MOUNT, mnt_device, root_pool_mnt, ]
             if (len(mnt_options) > 0):
@@ -265,11 +267,13 @@ def mount_root(pool):
                 if (device.name == last_device.name):
                     # exhausted mounting using all devices in the pool
                     raise e
-                logger.error('Error mouting: %s. '
+                logger.error('Error mounting: %s. '
                              'Will try using another device.' % mnt_cmd)
                 logger.exception(e)
-    raise Exception('Failed to mount Pool(%s) due to an unknown reason.'
-                    % pool.name)
+        else:
+            logger.error('Device (%s) was not found' % mnt_device)
+    raise Exception('Failed to mount Pool(%s) due to an unknown reason. '
+                    'Command used %s' % (pool.name, mnt_cmd))
 
 
 def umount_root(root_pool_mnt):

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -39,6 +39,7 @@ var AppRouter = Backbone.Router.extend({
         'disks/smartcustom/:diskName': 'smartcustomDrive',
         'disks/spindown/:diskName': 'spindownDrive',
         'disks/role/:diskName': 'roleDrive',
+        'disks/luks/:diskName': 'luksDrive',
         'disks/:diskName': 'showDisk',
         'pools': 'showPools',
         'pools/:poolName': 'showPool',
@@ -207,6 +208,14 @@ var AppRouter = Backbone.Router.extend({
         this.renderSidebar('storage', 'disks');
         this.cleanup();
         this.currentLayout = new SetroleDiskView({diskName: diskName});
+        $('#maincontent').empty();
+        $('#maincontent').append(this.currentLayout.render().el);
+    },
+
+    luksDrive: function(diskName) {
+        this.renderSidebar('storage', 'disks');
+        this.cleanup();
+        this.currentLayout = new LuksDiskView({diskName: diskName});
         $('#maincontent').empty();
         $('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
@@ -16,6 +16,10 @@
       <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition (Redirect Role), click to review. Note: Capacity is for whole disk when adding so may be inaccurate." rel="tooltip">
         <i class="glyphicon glyphicon-tags"></i></a>
       {{/if}}
+      {{#if (isOpenLuks this.role)}}
+      <a href="#disks/luks/{{this.name}}" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Volume, click to review." rel="tooltip">
+        <i class="glyphicon glyphicon-eye-open"></i></a>
+      {{/if}}
     </td>
     <td>{{humanReadableSize this.size}}</td>
     <td><input type="checkbox" name="diskname" id="{{this.name}}" value="{{this.name}}" class="diskname"></td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -29,8 +29,13 @@
             {{#if this.parted}}
                 <i class="glyphicon glyphicon-lock" title="Disk contains at least one partition hosting a LUKS Container. LUKS in partition is only supported for the Rockstor system drive." rel="tooltip"></i>
             {{else}}
-                <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (UI pending)." rel="tooltip">
-                <i class="glyphicon glyphicon-lock"></i></a>
+                {{#if (isLuksContainerUnlocked this.role)}}
+                    <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (unlocked) (UI pending)." rel="tooltip">
+                    <i class="fa fa-unlock"></i></a>
+                {{else}}
+                    <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (locked) (UI pending)." rel="tooltip">
+                    <i class="fa fa-lock"></i></a>
+                {{/if}}
             {{/if}}
         {{else if (isMdraidMember this.role)}}
             <a href="#" class="raid_member" data-disk-name="{{this.name}}" title="Mdraid member (UI pending)." rel="tooltip">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -83,8 +83,13 @@
                     {{#if this.pool_name}}
                         <i class="glyphicon glyphicon-map-marker" title="Whole drive is mapped to a Pool" rel="tooltip"></i>
                     {{else}}
-                        <a href="#disks/role/{{this.name}}" class="no_user_role_whole" data-disk-name="{{this.name}}" title="Assign an optional Whole Disk Role (ie LUKS/bcache etc), click to edit." rel="tooltip">
-                        <i class="glyphicon glyphicon-question-sign"></i></a>
+                        {{#if (isOpenLuks this.role)}}
+                            <a href="#disks/role/{{this.name}}" class="no_user_role_whole" data-disk-name="{{this.name}}" title="Assign an optional Whole Disk Role (Excluding LUKS container or bcache), click to edit." rel="tooltip">
+                            <i class="glyphicon glyphicon-question-sign"></i></a>
+                        {{else}}
+                            <a href="#disks/role/{{this.name}}" class="no_user_role_whole" data-disk-name="{{this.name}}" title="Assign an optional Whole Disk Role (ie LUKS/bcache etc), click to edit." rel="tooltip">
+                            <i class="glyphicon glyphicon-question-sign"></i></a>
+                        {{/if}}
                     {{/if}}
                 {{/if}}
             {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -27,7 +27,11 @@
               <i class="glyphicon glyphicon-registration-mark" title="Rockstor System Drive." rel="tooltip"></i>
         {{else if (isLuksContainer this.role)}}
             {{#if this.parted}}
-                <i class="glyphicon glyphicon-lock" title="Disk contains at least one partition hosting a LUKS Container. LUKS in partition is only supported for the Rockstor system drive." rel="tooltip"></i>
+                {{#if (isLuksContainerUnlocked this.role)}}
+                    <i class="fa fa-unlock" title="Disk contains at least one partition hosting a LUKS Container (unlocked). LUKS in partition is only supported for the Rockstor system drive." rel="tooltip"></i>
+                {{else}}
+                    <i class="fa fa-lock" title="Disk contains at least one partition hosting a LUKS Container (locked). LUKS in partition is only supported for the Rockstor system drive." rel="tooltip"></i>
+                {{/if}}
             {{else}}
                 {{#if (isLuksContainerUnlocked this.role)}}
                     <a href="#disks/luks/{{this.name}}" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (unlocked)." rel="tooltip">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -30,10 +30,10 @@
                 <i class="glyphicon glyphicon-lock" title="Disk contains at least one partition hosting a LUKS Container. LUKS in partition is only supported for the Rockstor system drive." rel="tooltip"></i>
             {{else}}
                 {{#if (isLuksContainerUnlocked this.role)}}
-                    <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (unlocked) (UI pending)." rel="tooltip">
+                    <a href="#disks/luks/{{this.name}}" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (unlocked)." rel="tooltip">
                     <i class="fa fa-unlock"></i></a>
                 {{else}}
-                    <a href="#" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (locked) (UI pending)." rel="tooltip">
+                    <a href="#disks/luks/{{this.name}}" class="luks_drive" data-disk-name="{{this.name}}" title="Full Disk LUKS Container (locked)." rel="tooltip">
                     <i class="fa fa-lock"></i></a>
                 {{/if}}
             {{/if}}
@@ -89,8 +89,8 @@
           they are found independently and in addition to other roles.
           Ie the root fs (flagged above) on an open LUKS container. -->
           {{#if (isOpenLuks this.role)}}
-          <a href="#" class="open_luks_drive" data-disk-name="{{this.name}}"
-             title="Open LUKS Container (UI pending)." rel="tooltip">
+          <a href="#disks/luks/{{this.name}}" class="open_luks_drive" data-disk-name="{{this.name}}"
+             title="Open LUKS Volume." rel="tooltip">
               <i class="glyphicon glyphicon-eye-open"></i></a>
           {{/if}}
       </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -9,7 +9,41 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
  virtual device. It will remain detached until it's parent LUKS container is
  unlocked again.
 </p>
-
+<h4>Boot up Configuration:</h4>
+<ul>
+ <li>
+  <strong>No auto unlock</strong> The container will remain locked during and
+  after boot. Any filesystem or data on the device will be inaccessible until
+  it is manually unlocked via the command line.
+  <p class="text-warning">
+   As Rockstor currently mounts all pools during boot this configuration is
+   for advanced users. Only single device pools are recommended.
+  </p>
+   </li>
+ <li>
+   <strong>Manual passphrase via local console</strong> Every time Rockstor is
+  booted or restarted it will wait indefinitely for the passphrase to be
+  entered (at the local console) before unlocking the container and
+  continuing on with a normal boot.
+  <p class="text-warning">
+   The system will not be functional until the passphrase has been entered.
+  </p>
+ </li>
+ <li>
+  <strong>Auto unlock via keyfile</strong> Unlock on every boot by using
+  a keyfile on the system drive. Unless Rockstor was installed using the
+  "Encrypt my data" option the system drive will not be encrypted and so
+  all keyfiles will also not be encrypted. This still cater for protecting
+  data if a drive has to be returned to a supplier or for when the drive
+  reaches end-of-life so long as it is not accompanied by the System Drive.
+  <p class="text-warning">
+   Rockstor generated keyfile example:
+   "/root/keyfile-fd168e30-5386-43b2-9f15-353b9ecff803". The characters
+   after '-' are the uuid of the LUKS container and the key is 2048 bytes
+   sourced from /dev/urandom (2^14 bit equivalent).
+  </p>
+ </li>
+</ul>
 <div class="row">
  <div class="col-md-8">
   <label class="control-label"></label>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -34,18 +34,21 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
    <strong>Manual passphrase via local console</strong> Every time Rockstor is
   booted or restarted it will wait indefinitely for the passphrase to be
   entered (at the local console) before unlocking the container and
-  continuing on with a normal boot.
+  continuing on with a normal boot. A passphrase must also be entered (via:
+  <i>systemd-tty-ask-password-agent</i> as root) after wiping a LUKS Volume.
   <p class="text-warning">
    The system will not be functional until the passphrase has been entered.
+   Failure to enter the passphrase after a LUKS Volume wipe will result in a
+   locked container and detached volume.
   </p>
  </li>
  <li>
-  <strong>Auto unlock via keyfile</strong> Unlock on every boot by using
-  a keyfile on the system drive. Unless Rockstor was installed using the
-  "Encrypt my data" option the system drive will not be encrypted and so
+  <strong>Auto unlock via keyfile (Recommended)</strong> Unlock on every boot
+  by using a keyfile on the system drive. Unless Rockstor was installed using
+  the "Encrypt my data" option the system drive will not be encrypted and so
   all keyfiles will also not be encrypted. This still protects against data
-  exposure if a drive has to be returned to a supplier or for when the drive
-  reaches end-of-life; so long as it is not accompanied by the System Drive.
+  exposure if a drive is returned to a supplier, or for end-of-life scenarios;
+  so long as it is not accompanied by the system drive.
   <p class="text-warning">
    Rockstor generated keyfile example:
    "/root/keyfile-fd168e30-5386-43b2-9f15-353b9ecff803". The characters

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -22,6 +22,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
      <div class="col-sm-offset-4 col-sm-8">
       <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
       <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+      {{display_luks_container_wipe_link}}
      </div>
     </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -52,7 +52,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
        <input type="checkbox" name="create_keyfile_tick"
               id="create_keyfile_tick">
        <i class="fa fa-key"></i><i class="fa fa-file-o"></i>
-       Create the above keyfile.
+       {{display_create_keyfile_text}}
       </div>
      </div>
      <div class="form-group" id="luks_passphrase_group">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -9,6 +9,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
  virtual device. It will remain detached until it's parent LUKS container is
  unlocked again.
 </p>
+<div id="crypttab_text">
 <h4>Boot up Configuration:</h4>
 <ul>
  <li>
@@ -44,6 +45,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
   </p>
  </li>
 </ul>
+</div>
 <div class="row">
  <div class="col-md-8">
   <label class="control-label"></label>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -44,6 +44,28 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
      </div>
     </div>
 
+    <!-- Display Create Keyfile -->
+    <div class="form-group" id="create_keyfile_group">
+     <div class="checkbox">
+      <label class="col-sm-4 control-label" for="create_keyfile_tick"></label>
+      <div class="col-sm-4">
+       <input type="checkbox" name="create_keyfile_tick"
+              id="create_keyfile_tick">
+       <i class="fa fa-key"></i><i class="fa fa-file-o"></i>
+       Create the above keyfile.
+      </div>
+     </div>
+     <div class="form-group" id="luks_passphrase_group">
+      <label class="col-sm-4 control-label" for="luks_passphrase">LUKS
+       Passphrase<span class="required"> *</span></label>
+      <div class="col-sm-4">
+       <input class="form-control shorten-input" type="password"
+              name="luks_passphrase" id="luks_passphrase"
+              title="Enter any Key Slot passphrase for this device to authorize the above action.">
+      </div>
+     </div>
+    </div>
+
     <div class="form-group">
      <div class="col-sm-offset-4 col-sm-8">
       <a id="cancel" class="btn btn-default">Cancel</a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -66,7 +66,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
      </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" id="cancel_submit_buttons_group">
      <div class="col-sm-offset-4 col-sm-8">
       <a id="cancel" class="btn btn-default">Cancel</a>
       <input type="Submit" id="luks-disk" class="btn btn-primary"

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -37,6 +37,13 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
      </div>
     </div>
 
+    <!-- Display current keyfile -->
+    <div class="form-group" id="current_keyfile_group">
+     <div class="col-sm-offset-4 col-sm-8">
+      <h5>{{display_keyfile_path}}</h5>
+     </div>
+    </div>
+
     <div class="form-group">
      <div class="col-sm-offset-4 col-sm-8">
       <a id="cancel" class="btn btn-default">Cancel</a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -1,7 +1,7 @@
 <h3>{{display_luks_container_or_volume}}</h3>
 LUKS Containers are encrypted block devices. Once a LUKS container is unlocked
 it's otherwise encrypted and invisible filesystem (if any) is made available
-via a second virtual block device. This unlocked counterpart is knows as an
+via a second virtual block device. This unlocked counterpart is known as an
 Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
 <p></p>
 <p class="text-warning">
@@ -9,8 +9,17 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
  virtual device. It will remain detached until it's parent LUKS container is
  unlocked again.
 </p>
+<p class="bg-info">
+ <strong>Note:</strong> Custom LUKS Volume names are not supported; only
+ canonical names of the form <i>luks-uuid</i>; resulting in auto generated
+ by-id names: <i>dm-name-luks-uuid</i> (uuid from hosting container format).
+</p>
 <div id="crypttab_text">
 <h4>Boot up Configuration:</h4>
+ <p class="bg-info">
+  <strong>WARNING:</strong> Custom LUKS Volume names will be overridden by
+  any <i>Boot up Configuration</i> submission.
+ </p>
 <ul>
  <li>
   <strong>No auto unlock</strong> The container will remain locked during and
@@ -34,14 +43,20 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
   <strong>Auto unlock via keyfile</strong> Unlock on every boot by using
   a keyfile on the system drive. Unless Rockstor was installed using the
   "Encrypt my data" option the system drive will not be encrypted and so
-  all keyfiles will also not be encrypted. This still cater for protecting
-  data if a drive has to be returned to a supplier or for when the drive
-  reaches end-of-life so long as it is not accompanied by the System Drive.
+  all keyfiles will also not be encrypted. This still protects against data
+  exposure if a drive has to be returned to a supplier or for when the drive
+  reaches end-of-life; so long as it is not accompanied by the System Drive.
   <p class="text-warning">
    Rockstor generated keyfile example:
    "/root/keyfile-fd168e30-5386-43b2-9f15-353b9ecff803". The characters
    after '-' are the uuid of the LUKS container and the key is 2048 bytes
    sourced from /dev/urandom (2^14 bit equivalent).
+  </p>
+  <p class="bg-info">
+   Non native or manually configured keyfiles are reported as "(custom)" and
+   left 'as is'. But once a non keyfile config option is submitted a return
+   to keyfile config will yield a default Rockstor native keyfile generation
+   and registration. <i>No keyfile is currently deleted: custom or native.</i>
   </p>
  </li>
 </ul>
@@ -64,7 +79,7 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
 
     <!-- Table displaying info for Open LUKS Volume -->
     <div class="form-group" id="open_vol_status_table_group">
-     <label class="col-sm-4 control-label">Last Known Attributes:</label>
+     <label class="col-sm-4 control-label">Last Known Attached Attributes:</label>
      <div class="col-sm-6">
       <div class="openLuksVolTable">
        <table id="open_luks_vol_table" class="table table-condensed table-bordered share-table tablesorter" summary="Open LUKS Volume Status">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -1,4 +1,4 @@
-<h3>LUKS Container or Open LUKS Volume.</h3>
+<h3>{{display_luks_container_or_volume}}</h3>
 LUKS Containers are encrypted block devices. Once a LUKS container is unlocked
 it's otherwise encrypted and invisible filesystem (if any) is made available
 via a second virtual block device. This unlocked counterpart is knows as an
@@ -24,6 +24,19 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
       <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
      </div>
     </div>
+
+    <!-- /etc/crypttab entry selection -->
+    <div class="form-group" id="crypttab_selection_group">
+     <label class="col-sm-4 control-label" for="crypttab_selection">Boot up
+      configuration<span class="required"> *</span></label>
+     <div class="col-sm-4">
+      <select class="form-control" id="crypttab_selection"
+              name="crypttab_selection">
+       {{display_crypttab_entry}}
+      </select>
+     </div>
+    </div>
+
     <div class="form-group">
      <div class="col-sm-offset-4 col-sm-8">
       <a id="cancel" class="btn btn-default">Cancel</a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -62,6 +62,24 @@ Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
      </div>
     </div>
 
+    <!-- Table displaying info for Open LUKS Volume -->
+    <div class="form-group" id="open_vol_status_table_group">
+     <label class="col-sm-4 control-label">Last Known Attributes:</label>
+     <div class="col-sm-6">
+      <div class="openLuksVolTable">
+       <table id="open_luks_vol_table" class="table table-condensed table-bordered share-table tablesorter" summary="Open LUKS Volume Status">
+        <thead>
+        <tr>
+         <th>Attribute</th>
+         <th>Value</th>
+        </tr>
+        </thead>
+         {{display_luks_volume_status_table}}
+        </table>
+      </div>
+     </div>
+    </div><!--open_vol_status_table_group-->
+
     <!-- /etc/crypttab entry selection -->
     <div class="form-group" id="crypttab_selection_group">
      <label class="col-sm-4 control-label" for="crypttab_selection">Boot up

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/luks_disk.jst
@@ -1,0 +1,38 @@
+<h3>LUKS Container or Open LUKS Volume.</h3>
+LUKS Containers are encrypted block devices. Once a LUKS container is unlocked
+it's otherwise encrypted and invisible filesystem (if any) is made available
+via a second virtual block device. This unlocked counterpart is knows as an
+Open LUKS Volume and only exists whilst the LUKS Container remains unlocked.
+<p></p>
+<p class="text-warning">
+ Closing an Open LUKS Volume is the equivalent of unplugging or detaching that
+ virtual device. It will remain detached until it's parent LUKS container is
+ unlocked again.
+</p>
+
+<div class="row">
+ <div class="col-md-8">
+  <label class="control-label"></label>
+  <div class="form-box">
+   <form class="form-horizontal" id="luks-disk-form" name="luksform">
+    <div class="messages"></div>
+
+    <!-- Form Header Info -->
+    <div class="form-group">
+     <div class="col-sm-offset-4 col-sm-8">
+      <h4>Drive name:&nbsp;&nbsp;<strong>{{diskName}}</strong></h4>
+      <h4>Serial number:&nbsp;&nbsp;<strong>{{serialNumber}}</strong></h4>
+     </div>
+    </div>
+    <div class="form-group">
+     <div class="col-sm-offset-4 col-sm-8">
+      <a id="cancel" class="btn btn-default">Cancel</a>
+      <input type="Submit" id="luks-disk" class="btn btn-primary"
+             value="Submit"></input>
+     </div>
+    </div>
+
+   </form>
+  </div>
+ </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -69,8 +69,9 @@ not remember or record the associated passphrase.</strong><br>
 <strong>Passphrase Notes</strong> (Only use 7-bit ASCII(32-126) characters <strong>!"#$%&'()*+,-./0-9:;<=>?@A-Z[\]^_`a-z{|}~</strong> )
 <ul>
     <li>
-        Must be entered on every power up using a locally connected keyboard
-        and monitor (unless a keyfile is created).
+        Must be entered on every boot (using local console) unless 'Auto unlock via keyfile" is configured via the
+        Disks page lock icon (<i class="fa fa-lock" title="Full Disk LUKS Container (locked)." rel="tooltip"></i> /
+        <i class="fa fa-unlock" title="Full Disk LUKS Container (unlocked)." rel="tooltip"></i>).
     </li>
     <li>
         Commonly shared across a systems drives: a single power on

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -111,7 +111,7 @@ LUKS equivalent of system root password: initially the only way to unlock the di
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" id="delete_tick_group">
           <div class="checkbox">
             <label class="col-sm-4 control-label" for="delete_tick"></label>
             <div class="col-sm-4">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -136,35 +136,34 @@
                 <input type="checkbox" name="luks_tick" id="luks_tick">
                 <i class="fa fa-eye"></i>
                 Tick to enable Whole Disk LUKS on the above device. Once
-                enabled
-                the password entered below will be required every time Rockstor
-                is powered up or restarted. This requires a local console and
-                monitor but ensures that Rockstor box theft does not compromise
-                your data.
+                enabled the passphrase entered below will be required every
+                time Rockstor is powered up or restarted. This requires a
+                local console and monitor but ensures that Rockstor box theft
+                does not compromise your data.
               </div>
             </div>
           </div>
 
-          <!-- LUKS Master Passwords Group -->
+          <!-- LUKS Master Passphrase Group -->
           <div class="form-group" id="luks_passwords">
-            <!--  LUKS Master Password one  -->
+            <!--  LUKS Master Passphrase one  -->
             <div class="form-group" id="luks_pass_one_group">
               <label class="col-sm-4 control-label" for="luks_pass_one">LUKS
-                Master Password<span class="required"> *</span></label>
+                Master Passphrase<span class="required"> *</span></label>
               <div class="col-sm-4">
                 <input class="form-control shorten-input" type="text"
                        name="luks_pass_one" id="luks_pass_one"
-                       title="The Master Password to enable Full Disk LUKS encryption. This password is not recorded by Rockstor.">
+                       title="The Master Passphrase to enable Full Disk LUKS encryption. This passphrase is not recorded by Rockstor.">
               </div>
             </div>
-            <!--  LUKS Master Password Two  -->
+            <!--  LUKS Master Passphrase Two  -->
             <div class="form-goup" id="luks_pass_two_group">
               <label class="col-sm-4 control-label" for="luks_pass_two">
                 Please Retype to Verify<span class="required"> *</span></label>
               <div class="col-sm-4">
                 <input class="form-control shorten-input" type="text"
                        name="luks_pass_two" id="luks_pass_two"
-                       title="The Master Password to enable Full Disk LUKS encryption. This password is not recorded by Rockstor.">
+                       title="The Master Passphrase to enable Full Disk LUKS encryption. This passphrase is not recorded by Rockstor.">
               </div>
             </div>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,13 +1,12 @@
 <h3>Configure drive Role or Wipe an existing Filesystem.</h3>
-  Drive Roles inform Rockstor of how to treat a specific drive. They can
-  drastically alter a devices options within Rockstor. Below is a list of
-  disk roles and their intended use. Not all roles can be combined. Please see:
+  Drive Roles inform Rockstor of specific drive treatment and can drastically
+  alter a devices available options: not all roles are compatible. Please see:
 <a href="http://rockstor.com/docs/disks.html#disk-role-configuration"
-   target="_blank">Disk Role Configuration</a> in our official online docs.
+   target="_blank">Disk Role Configuration</a> in our online docs.
 <p></p>
 <p class="text-warning">
   Changing a disk role can result in loss of data, please take care when
-  making any changes on this page.
+  making changes on this page.
 </p>
 <p class="bg-info">
   <strong>Note: </strong> No drive role is required for general purpose use.
@@ -29,42 +28,42 @@
     including on the initial import device. <strong>Only one Redirect role
     (partition) per device is supported.</strong>
     <p class="text-warning">
-      A drive's <i>Redirect</i> role defines the <i>wipe</i> action. An
-      active redirect + wipe erases a partitions data and filesystem.
-      No redirect role + wipe erases the entire drive and all it's partitions.
+      A drive's <a href="http://rockstor.com/docs/disks.html#the-disk-redirect-role"
+      target="_blank">Redirect role</a> defines the
+      <a href="http://rockstor.com/docs/disks.html#wiping-a-partition-or-whole-disk" target="_blank">Wipe</a>
+      action. A Redirect + Wipe erases a partitions data and filesystem.
+      No Redirect + Wipe erases the entire drive and all it's partitions.
       The wipe command used is "wipefs -a devname".
     </p>
   </li>
   <li>
-    The <strong>Archive</strong> role is intended to be used by a single
-    external drive (eg USB).
+    The <strong>Archive</strong> role: intended for single external drive use
+    (eg USB).
     <br>
-    The <i>Archive</i> role can be combined with the <i>Redirect</i> role.
+    Compatible with the <i>Redirect</i> role.
     <br>
     <i>N.B. Not currently implemented</i>
     <p></p>
   </li>
   <li>
-    The <strong>External Import</strong> role is, like the <i>Archive</i> role
-    above, intended to be used by a single external drive (eg USB) and is
-    primarily aimed at sync type use where you wish for an external drives data
-    to be imported onto a specifically designated internal Rockstor share.
+    The <strong>External Import</strong> role: intended for single external
+    drive use (eg USB). A data synchronization role where an external drive's
+    data is to be imported onto a designated internal share.
     <br>
-    The <i>External Import</i> role can be combined with the <i>Redirect</i> role.
+    Compatible with the <i>Redirect</i> role.
     <br>
     <i>N.B. Not currently implemented</i>
     <p class="text-warning">
-      Please note: With the <i>External Import</i> role the external drive is
-      considered to be the master source of truth. If a file is changed on the
-      external drive and the drive is then re-attached to Rockstor then the
-      next sync operation will update Rockstor's version of that file.
-      Not the other way around.
+      Note: The external drive is the master source of truth. If a file is
+      changed on the external drive and the drive is then re-attached, the
+      next sync operation will update the designated share's version. Not
+      the other way around.
     </p>
   </li>
 </ul>
 <h4>LUKS Full Disk Encryption:</h4>
-Empty or freshly wiped devices can be LUKS encrypted. Rockstor does
-not remember or record the associated passphrase.<br>
+Blank or freshly wiped devices can be LUKS encrypted. <strong>Rockstor does
+not remember or record the associated passphrase.</strong><br>
 <i> A pool is only encrypted if all it's members are LUKS formatted.</i>
 <br>
 Passphrase Notes:
@@ -141,7 +140,7 @@ LUKS equivalent of system root password: initially the only way to unlock the di
               <div class="col-sm-4">
                 <input type="checkbox" name="luks_tick" id="luks_tick">
                 <i class="fa fa-eye"></i>
-                    Tick to enable Whole Disk LUKS. Please see LUKS notes above.
+                    Tick to enable Whole Disk Encryption (LUKS Format). Please see LUKS notes above.
               </div>
             </div>
           </div>
@@ -153,9 +152,9 @@ LUKS equivalent of system root password: initially the only way to unlock the di
               <label class="col-sm-4 control-label" for="luks_pass_one">LUKS
                 Master Passphrase<span class="required"> *</span></label>
               <div class="col-sm-4">
-                <input class="form-control shorten-input" type="text"
+                <input class="form-control shorten-input" type="password"
                        name="luks_pass_one" id="luks_pass_one"
-                       title="The Master Passphrase to enable Full Disk LUKS encryption. This passphrase is not recorded by Rockstor.">
+                       title="Suggested character length = 14-18 if random, 108-140 if english words.">
               </div>
             </div>
             <!--  LUKS Master Passphrase Two  -->
@@ -163,9 +162,9 @@ LUKS equivalent of system root password: initially the only way to unlock the di
               <label class="col-sm-4 control-label" for="luks_pass_two">
                 Please Retype to Verify<span class="required"> *</span></label>
               <div class="col-sm-4">
-                <input class="form-control shorten-input" type="text"
+                <input class="form-control shorten-input" type="password"
                        name="luks_pass_two" id="luks_pass_two"
-                       title="The Master Passphrase to enable Full Disk LUKS encryption. This passphrase is not recorded by Rockstor.">
+                       title="Suggested character length = 14-18 if random, 108-140 if english words.">
               </div>
             </div>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -36,12 +36,11 @@
     require the user to manually set the desired partition, including the
     initial btrfs import device; only additional devices within the imported
     pool will automatically have a redirect role set if required.
-    <p>
-      N.B.Rockstor only supports the use of one partition (redirect role) per
+    <i>Note: Rockstor only supports the use of one partition (redirect role) per
       device. Although other partitions may exist they will be ignored.
-    </p>
+    </i>
     <p class="text-warning">
-      Please note that a drive's <i>Redirect</i> role will affect the action
+      A drive's <i>Redirect</i> role will affect the action
       taken when it is wiped from within the Rockstor interface. If a valid
       redirect to an existing partition exists then the contents of that
       partition will be deleted. But if there is no redirect role then the
@@ -67,7 +66,6 @@
     The <i>External Import</i> role can be combined with the <i>Redirect</i> role.
     <br>
     <i>N.B. Not currently implemented</i>
-    <p></p>
     <p class="text-warning">
       Please note: With the <i>External Import</i> role the external drive is
       considered to be the master source of truth. If a file is changed on the
@@ -76,6 +74,27 @@
       Not the other way around.
     </p>
   </li>
+</ul>
+<h4>LUKS Full Disk Encryption:</h4>
+Empty or freshly wiped devices can be LUKS encrypted. Rockstor does
+not remember or record the associated passphrase.<br>
+<i> A pool is only encrypted if all it's members are LUKS formatted.</i>
+<br>
+Passphrase Notes:
+<ul>
+    <li>
+        Must be entered on every power up using a locally connected keyboard
+        and monitor (unless a keyfile is created).
+    </li>
+    <li>
+        Commonly shared across a systems drives: a single power on
+        entry then unlocks all drives.
+    </li>
+    <li>
+        <p class="text-warning">
+The LUKS equivalent of the system root password: initially the only way to unlock the disks contents.
+        </p>
+    </li>
 </ul>
 
 <div class="row">
@@ -135,11 +154,7 @@
               <div class="col-sm-4">
                 <input type="checkbox" name="luks_tick" id="luks_tick">
                 <i class="fa fa-eye"></i>
-                Tick to enable Whole Disk LUKS on the above device. Once
-                enabled the passphrase entered below will be required every
-                time Rockstor is powered up or restarted. This requires a
-                local console and monitor but ensures that Rockstor box theft
-                does not compromise your data.
+                    Tick to enable Whole Disk LUKS. Please see LUKS notes above.
               </div>
             </div>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,4 +1,4 @@
-<h3>Configure drive Role or Wipe an existing Filesystem.</h3>
+<h3>Configure drive Role / Wipe existing Filesystem / LUKS Format Whole Disk.</h3>
   Drive Roles inform Rockstor of specific drive treatment and can drastically
   alter a devices available options: not all roles are compatible. Please see:
 <a href="http://rockstor.com/docs/disks.html#disk-role-configuration"

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -117,9 +117,8 @@ LUKS equivalent of system root password: initially the only way to unlock the di
             <div class="col-sm-4">
               <input type="checkbox" name="delete_tick" id="delete_tick">
               <i class="fa fa-eraser"></i>
-              Tick to wipe the contents of the above 'active' device (including
-              it's filesystem). Note 'Whole Disk' removes all partitions as
-              well.
+              Tick to wipe the data and filesystem on the above 'active' device.
+              Whole Disk removes all partitions.
             </div>
           </div>
         </div>
@@ -140,7 +139,7 @@ LUKS equivalent of system root password: initially the only way to unlock the di
               <div class="col-sm-4">
                 <input type="checkbox" name="luks_tick" id="luks_tick">
                 <i class="fa fa-eye"></i>
-                    Tick to enable Whole Disk Encryption (LUKS Format). Please see LUKS notes above.
+                    Tick to enable Whole Disk Encryption (LUKS Format). See LUKS notes above.
               </div>
             </div>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -66,7 +66,7 @@ Blank or freshly wiped devices can be LUKS encrypted. <strong>Rockstor does
 not remember or record the associated passphrase.</strong><br>
 <i> A pool is only encrypted if all it's members are LUKS formatted.</i>
 <br>
-Passphrase Notes:
+<strong>Passphrase Notes</strong> (Only use 7-bit ASCII(32-126) characters <strong>!"#$%&'()*+,-./0-9:;<=>?@A-Z[\]^_`a-z{|}~</strong> )
 <ul>
     <li>
         Must be entered on every power up using a locally connected keyboard
@@ -153,17 +153,17 @@ LUKS equivalent of system root password: initially the only way to unlock the di
               <div class="col-sm-4">
                 <input class="form-control shorten-input" type="password"
                        name="luks_pass_one" id="luks_pass_one"
-                       title="Suggested character length = 14-18 if random, 108-140 if english words.">
+                       title="Suggested character length = 14(min)-18 if random, 108-140 if english words.">
               </div>
             </div>
             <!--  LUKS Master Passphrase Two  -->
             <div class="form-goup" id="luks_pass_two_group">
               <label class="col-sm-4 control-label" for="luks_pass_two">
-                Please Retype to Verify<span class="required"> *</span></label>
+                Retype to Verify<span class="required"> *</span></label>
               <div class="col-sm-4">
                 <input class="form-control shorten-input" type="password"
                        name="luks_pass_two" id="luks_pass_two"
-                       title="Suggested character length = 14-18 if random, 108-140 if english words.">
+                       title="Suggested character length = 14(min)-18 if random, 108-140 if english words.">
               </div>
             </div>
           </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/setrole_disks.jst
@@ -1,51 +1,38 @@
 <h3>Configure drive Role or Wipe an existing Filesystem.</h3>
-  Drive specific Roles are a way for Rockstor to know how you want to use this
-  specific drive and can drastically alter the options associated with a device.
-  Below is a list of disk roles and their intended use. Note that not
-  all roles can be combined.
+  Drive Roles inform Rockstor of how to treat a specific drive. They can
+  drastically alter a devices options within Rockstor. Below is a list of
+  disk roles and their intended use. Not all roles can be combined. Please see:
+<a href="http://rockstor.com/docs/disks.html#disk-role-configuration"
+   target="_blank">Disk Role Configuration</a> in our official online docs.
 <p></p>
 <p class="text-warning">
   Changing a disk role can result in loss of data, please take care when
   making any changes on this page.
 </p>
 <p class="bg-info">
-  <strong>Note: </strong> No drive role is required for general purpose
-  data drives. Roles are intended primarily for specific <strong>single</strong>
-  drive use and not recommended for multi device pool members.
-  <br>
-  "Whole Disk" is the default and recommended setting for general purpose use.
-  <br>
-  A device must first be wiped before it can take part as a pool member. Unless
-  a btrfs import is desired, in which case select the (btrfs) labeled device
-  and Submit. An import icon will then be offered on the Disk Page.
+  <strong>Note: </strong> No drive role is required for general purpose use.
+  <strong>Roles are for single drive use</strong> and not advised for multi
+  device pool members. <strong>"Whole Disk" is the default and recommended
+  setting.</strong>
+  For <a href="http://rockstor.com/docs/disks.html#import-btrfs-pool"
+  target="_blank">btrfs import</a> select the (btrfs) labeled device and
+  'Submit'. An import icon will then be offered on the Disk Page. Otherwise
+  intended new pool members must first be wiped.
 </p>
 <h4>Roles and their use:</h4>
 <ul>
   <li>
-    The <strong>Redirect</strong> role. This role is always required for any
-    drive that is partitioned. Without it Rockstor cannot be sure which of the
-    partitions on a drive you wish to use. It is required even if there is only
-    one partition found. Without the addition of this role the only way a
-    partitioned drive can be used is for it's entire contents to first be wiped,
-    including any and all partitions and all date there in: resulting in the
-    drive no longer being partitioned. The drive can then be used in the
-    Rockstor default <i>Whole Disk</i> configuration: no partitions and no roles.
-    The only time Rockstor will add the <i>redirect</i> role itself is when a
-    user imports a
-    multi device pool that has a btrfs in partition member. All other cases
-    require the user to manually set the desired partition, including the
-    initial btrfs import device; only additional devices within the imported
-    pool will automatically have a redirect role set if required.
-    <i>Note: Rockstor only supports the use of one partition (redirect role) per
-      device. Although other partitions may exist they will be ignored.
-    </i>
+    The <strong>Redirect</strong> role is <strong>always required for
+    partitioned drives</strong>. Rockstor will only add the <i>redirect</i>
+    role itself when importing a multi device pool with 'btrfs in partition'
+    members. All other cases require user selection of the desired partition,
+    including on the initial import device. <strong>Only one Redirect role
+    (partition) per device is supported.</strong>
     <p class="text-warning">
-      A drive's <i>Redirect</i> role will affect the action
-      taken when it is wiped from within the Rockstor interface. If a valid
-      redirect to an existing partition exists then the contents of that
-      partition will be deleted. But if there is no redirect role then the
-      entire drive and all it's partitions and associated data will be wiped.
-      The command used internally to accomplish the wipe is "wipefs -a devname".
+      A drive's <i>Redirect</i> role defines the <i>wipe</i> action. An
+      active redirect + wipe erases a partitions data and filesystem.
+      No redirect role + wipe erases the entire drive and all it's partitions.
+      The wipe command used is "wipefs -a devname".
     </p>
   </li>
   <li>
@@ -92,7 +79,7 @@ Passphrase Notes:
     </li>
     <li>
         <p class="text-warning">
-The LUKS equivalent of the system root password: initially the only way to unlock the disks contents.
+LUKS equivalent of system root password: initially the only way to unlock the disk's data.
         </p>
     </li>
 </ul>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -84,6 +84,10 @@
                                                 <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition (Redirect Role), click to edit. Capacity is for whole disk." rel="tooltip">
                                                     <i class="glyphicon glyphicon-tags"></i></a>
                                             {{/if}}
+                                            {{#if (isOpenLuks this.role)}}
+                                                <a href="#disks/luks/{{this.name}}" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Volume, click to review." rel="tooltip">
+                                                    <i class="glyphicon glyphicon-eye-open"></i></a>
+                                            {{/if}}
                                         </td>
                                         <td>{{humanReadableSize this.size}}</td>
                                         <td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -52,7 +52,16 @@
             </td>
             <td>
                 {{#if (isRoot this.role)}}
-                    {{#each this.disks}}"{{this.name}}"&nbsp;{{/each}}
+                    {{#each this.disks}}
+                    "{{this.name}}
+                    {{#if (isOpenLuks this.role)}}
+                        <a href="#disks/luks/{{this.name}}" class="open_luks_drive"
+                           data-disk-name="{{this.name}}"
+                           title="Open LUKS Volume, click to review." rel="tooltip">
+                        <i class="glyphicon glyphicon-eye-open"></i></a>
+                    {{/if}}
+                    "&nbsp;
+                    {{/each}}
                 {{else}}
                     {{#each this.disks}}
                     "{{this.name}}
@@ -61,6 +70,12 @@
                             data-disk-name="{{this.name}}"
                             title="Partition (Redirect Role), click to review."
                             rel="tooltip"><i class="glyphicon glyphicon-tags"></i></a>
+                    {{/if}}
+                    {{#if (isOpenLuks this.role)}}
+                        <a href="#disks/luks/{{this.name}}" class="open_luks_drive"
+                           data-disk-name="{{this.name}}"
+                           title="Open LUKS Volume, click to review." rel="tooltip">
+                        <i class="glyphicon glyphicon-eye-open"></i></a>
                     {{/if}}
                     "&nbsp;
                     {{/each}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
@@ -12,7 +12,14 @@
     {{#if (isRoot pool.role)}}
     {{#each pool.disks}}
     <tr>
-        <td>{{this.name}}</td>
+        <td>{{this.name}}
+            {{#if (isOpenLuks this.role)}}
+            <a href="#disks/luks/{{this.name}}" class="open_luks_drive"
+               data-disk-name="{{this.name}}"
+               title="Open LUKS Volume, click to review." rel="tooltip">
+                <i class="glyphicon glyphicon-eye-open"></i></a>
+            {{/if}}
+        </td>
         <td>{{humanReadableSize this.size}}</td>
     </tr>
     {{/each}}
@@ -26,6 +33,12 @@
                title="Partition (Redirect Role), click to review."
                rel="tooltip">
                 <i class="glyphicon glyphicon-tags"></i></a>
+            {{/if}}
+            {{#if (isOpenLuks this.role)}}
+            <a href="#disks/luks/{{this.name}}" class="open_luks_drive"
+               data-disk-name="{{this.name}}"
+               title="Open LUKS Volume, click to review." rel="tooltip">
+                <i class="glyphicon glyphicon-eye-open"></i></a>
             {{/if}}
         </td>
         <td>{{humanReadableSize this.size}}</td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -329,6 +329,38 @@ AddPoolView = Backbone.View.extend({
     },
 
     initHandlebarHelpers: function () {
+
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
+        // Identify Open LUKS container by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isRootDevice'
+        Handlebars.registerHelper('isOpenLuks', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('openLUKS')) {
+                // Once a LUKS container is open it has a type of crypt
+                // and we attribute it the role of 'openLUKS' as a result.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('mathHelper', function (value, options) {
             return parseInt(value) + 1;
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -333,6 +333,25 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
+        // Works by examining the Disk.role field and if a LUKS role is found
+        // we examine the roles value to see if it reports having an open
+        // counterpart ie is this container mapped to an OpenLuks volume
+        // which is expressed as unlocked having a true value.
+        Handlebars.registerHelper('isLuksContainerUnlocked', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('LUKS')) {
+                // here we deviate from isLuksContainer by unpacking
+                // our LUKS role's value:
+                if (roleAsJson['LUKS'].hasOwnProperty('unlocked') == true) {
+                    return roleAsJson['LUKS']['unlocked'];
+                }
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         // Identify Open LUKS container by return of true / false.
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isRootDevice'

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -224,10 +224,6 @@ DisksView = RockstorLayoutView.extend({
     },
 
     initHandlebarHelpers: function () {
-        // Helper to display APM value after merger with upstream changes
-        // where the above helper is replaced by many smaller ones like this.
-        // N.B. untested. Presumably we do {{humanReadableAPM this.apm_level}}
-        // in upstream disks_table.jst
 
         asJSON = function (role) {
             // Simple wrapper to test for not null and JSON compatibility,
@@ -244,6 +240,7 @@ DisksView = RockstorLayoutView.extend({
             }
         };
 
+        // Helper to display APM value
         Handlebars.registerHelper('humanReadableAPM', function (apm) {
             var apmhtml = '';
             if (apm == 0 || apm == null) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -183,9 +183,9 @@ LuksDiskView = RockstorLayoutView.extend({
                 if (crypttab_selection !== 'false' && crypttab_selection !== 'none') {
                     // auto unlock via keyfile selected
                     if (!create_keyfile_tick.prop('checked')) {
-                        err_msg = 'Auto unlock via keyfile selected when ' +
+                        err_msg = '"Auto unlock via keyfile" selected when ' +
                             'the indicated keyfile does not exist. ' +
-                            'Tick "Create the above keyfile" below.';
+                            'Tick "Create keyfile" below.';
                         return false;
                     }
                 }
@@ -301,6 +301,23 @@ LuksDiskView = RockstorLayoutView.extend({
                 html += 'Open LUKS Volume information page.'
             } else {
                 html += 'Warning: Non LUKS Device, please report bug on forum.'
+            }
+            return new Handlebars.SafeString(html);
+        });
+        Handlebars.registerHelper('display_create_keyfile_text', function () {
+            // Customize our "create_keyfile_tick" user facing text.
+            // Ie "Create the above keyfile if we don't have a custom keyfile
+            // If we have a custom keyfile config that doesn't exist then we
+            // must be clear that we create our native /root/keyfile-<uuid>
+            // and alter the crypttab to match.
+            // This is in lue of a fully configurable custom config option.
+            var current_crypttab_status = this.current_crypttab_status;
+            var html = '';
+            var native_keyfile = '/root/keyfile-' + this.luks_container_uuid;
+            if (current_crypttab_status !== native_keyfile) {
+                html += 'Create keyfile (native)'
+            } else {
+                html += 'Create keyfile (as above)';
             }
             return new Handlebars.SafeString(html);
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -31,7 +31,7 @@ LuksDiskView = RockstorLayoutView.extend({
         'click #create_keyfile_tick': 'create_keyfile_tick_toggle'
     },
 
-        initialize: function () {
+    initialize: function () {
         var _this = this;
         this.constructor.__super__.initialize.apply(this, arguments);
         this.template = window.JST.disk_luks_disk;
@@ -296,11 +296,11 @@ LuksDiskView = RockstorLayoutView.extend({
         Handlebars.registerHelper('display_luks_container_or_volume', function () {
             var html = '';
             if (this.is_luks) {
-                html += 'LUKS container configuration.'
+                html += 'LUKS container configuration.';
             } else if (this.is_open_luks) {
-                html += 'Open LUKS Volume information page.'
+                html += 'Open LUKS Volume information page.';
             } else {
-                html += 'Warning: Non LUKS Device, please report bug on forum.'
+                html += 'Warning: Non LUKS Device, please report bug on forum.';
             }
             return new Handlebars.SafeString(html);
         });
@@ -315,7 +315,7 @@ LuksDiskView = RockstorLayoutView.extend({
             var html = '';
             var native_keyfile = '/root/keyfile-' + this.luks_container_uuid;
             if (current_crypttab_status !== native_keyfile) {
-                html += 'Create keyfile (native)'
+                html += 'Create keyfile (native)';
             } else {
                 html += 'Create keyfile (as above)';
             }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -258,10 +258,12 @@ LuksDiskView = RockstorLayoutView.extend({
         if (this.is_luks) {
             // LUKS Container mode so show crypttab selection and buttons.
             this.$('#crypttab_selection_group').show();
+            this.$('#crypttab_text').show();
             this.$('#cancel_submit_buttons_group').show();
         } else {
             // Open LUKS volume mode assumed so hide crypttab and buttons.
             this.$('#crypttab_selection_group').hide();
+            this.$('#crypttab_text').hide();
             this.$('#cancel_submit_buttons_group').hide();
         }
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -78,6 +78,8 @@ LuksDiskView = RockstorLayoutView.extend({
             role_obj = null;
         }
         // extract our partitions obj from the role_obj if there is one.
+        // @todo Could be used in the future to add js validation against
+        // @todo partitioned LUKS containers, ie we leave them alone.
         var partitions;
         if (role_obj != null && role_obj.hasOwnProperty('partitions')) {
             partitions = role_obj.partitions;
@@ -106,7 +108,7 @@ LuksDiskView = RockstorLayoutView.extend({
         var current_crypttab_status = false;
         // Likewise we can also retrieve keyfile existence
         var keyfile_exists = false;
-        if (role_obj != null && role_obj.hasOwnProperty('LUKS')) {
+        if (role_obj !== null && role_obj.hasOwnProperty('LUKS')) {
             is_luks = true;
             if (role_obj['LUKS'].hasOwnProperty('uuid')) {
                 luks_container_uuid = role_obj['LUKS']['uuid'];
@@ -133,7 +135,7 @@ LuksDiskView = RockstorLayoutView.extend({
         };
         // additional convenience flag if device is an open LUKS volume.
         var is_open_luks;
-        if (role_obj != null && role_obj.hasOwnProperty('openLUKS')) {
+        if (role_obj !== null && role_obj.hasOwnProperty('openLUKS')) {
             is_open_luks = true;
         } else {
             is_open_luks = false;
@@ -173,16 +175,12 @@ LuksDiskView = RockstorLayoutView.extend({
 
         $.validator.addMethod('validateCrypttab_selection', function (value) {
             var crypttab_selection = $('#crypttab_selection').val();
-            var crypttab_selection_changed = false;
             var create_keyfile_tick = $('#create_keyfile_tick');
-            if (crypttab_selection != current_crypttab_status) {
-                crypttab_selection_changed = true;
-            }
             // Check to see if we are attempting to configure an auto unlock
             // via a non existent keyfile and not also requesting the creation
             // of that keyfile: ie ticked "create_keyfile_tick"
-            if (!this.keyfile_exists) {
-                if (crypttab_selection != 'false' && crypttab_selection != 'none') {
+            if (!keyfile_exists) {
+                if (crypttab_selection !== 'false' && crypttab_selection !== 'none') {
                     // auto unlock via keyfile selected
                     if (!create_keyfile_tick.prop('checked')) {
                         err_msg = 'Auto unlock via keyfile selected when ' +
@@ -199,7 +197,7 @@ LuksDiskView = RockstorLayoutView.extend({
             var create_keyfile_tick = $('#create_keyfile_tick');
             var luks_passphrase = $('#luks_passphrase').val();
             if (create_keyfile_tick.prop('checked')) {
-                if (luks_passphrase == '') {
+                if (luks_passphrase === '') {
                     err_msg = 'Keyfile creation requested but no passphrase ' +
                         'entered';
                     return false;
@@ -258,7 +256,6 @@ LuksDiskView = RockstorLayoutView.extend({
 
     crypttab_selection_changed: function () {
         var crypttab_selected = this.$('#crypttab_selection').val();
-        var current_crypttab_status = this.current_crypttab_status;
         if (crypttab_selected !== 'false' && crypttab_selected !== 'none') {
             // Assuming not false and not none is keyfile entry.
             this.show_keyfile_options(true);
@@ -271,8 +268,7 @@ LuksDiskView = RockstorLayoutView.extend({
         var keyfile_exists = this.keyfile_exists;
         if (show) {
             this.$('#current_keyfile_group').show();
-            // this.$('#create_keyfile_group').show();
-            if (keyfile_exists == false) {
+            if (!keyfile_exists) {
                 this.$('#create_keyfile_group').show();
             }
         } else {
@@ -319,7 +315,7 @@ LuksDiskView = RockstorLayoutView.extend({
                 // cycle through the available known entries and construct our
                 // drop down html; using 'selected' to indicate current value.
                 html += '<option value="' + this.crypttab_options[entry];
-                if (current_crypttab_status == this.crypttab_options[entry]) {
+                if (current_crypttab_status === this.crypttab_options[entry]) {
                     // we have found our current setting so indicate this by
                     // pre-selecting it. N.B. exact matches only ie keyfile
                     // match in this case uses native naming ie:
@@ -327,8 +323,8 @@ LuksDiskView = RockstorLayoutView.extend({
                     html += '" selected="selected">';
                     html += entry + ' - active</option>';
                 } else if ((current_crypttab_status !== false) &&
-                    (current_crypttab_status.substring(0, 1) == '/') &&
-                    (entry == 'Auto unlock via keyfile')) {
+                    (current_crypttab_status.substring(0, 1) === '/') &&
+                    (entry === 'Auto unlock via keyfile')) {
                     // @todo - the above clause is clumsy and could later be
                     // @todo - replaced with a custom cryptab file entry
                     // @todo - option in crypttab_options.
@@ -357,7 +353,7 @@ LuksDiskView = RockstorLayoutView.extend({
             // Redefine local keyfile_entry value to represent the native
             // keyfile if false (no cyrpttab entry) or 'none' manual. Slightly
             // unclean but we are done with it otherwise.
-            if (keyfile_entry == false || keyfile_entry == 'none') {
+            if (keyfile_entry === false || keyfile_entry === 'none') {
                 keyfile_entry = '/root/keyfile-' + this.luks_container_uuid;
             }
             if (this.keyfile_exists) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -1,0 +1,177 @@
+/*
+ *
+ * @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * Rockstor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * Rockstor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+
+LuksDiskView = RockstorLayoutView.extend({
+    events: {
+        'click #cancel': 'cancel'
+    },
+
+        initialize: function () {
+        var _this = this;
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.template = window.JST.disk_luks_disk;
+        this.disks = new DiskCollection();
+        this.diskName = this.options.diskName;
+        this.dependencies.push(this.disks);
+        this.initHandlebarHelpers();
+    },
+
+    render: function () {
+        this.fetch(this.renderDisksForm, this);
+        return this;
+    },
+
+
+    renderDisksForm: function () {
+        if (this.$('[rel=tooltip]')) {
+            this.$('[rel=tooltip]').tooltip('hide');
+        }
+        var _this = this;
+        var disk_name = this.diskName;
+        // retrieve local copy of disk serial number
+        var serialNumber = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('serial');
+        // retrieve local copy of current disk role
+        var diskRole = this.disks.find(function (d) {
+            return (d.get('name') == disk_name);
+        }).get('role');
+        // get the btrfsuuid for this device
+        var disk_btrfs_uuid = this.disks.find(function(d) {
+            return (d.get('name') == disk_name);
+        }).get('btrfs_uuid');
+        // get the pool for this device
+        var disk_pool = this.disks.find(function(d) {
+            return (d.get('name') == disk_name);
+        }).get('pool');
+        // parse the diskRole json to a local object
+        try {
+            var role_obj = JSON.parse(diskRole);
+        } catch (e) {
+                // as we can't convert this drives role to json we assume
+                // it's isRoleUsable status by false
+            role_obj = null;
+        }
+        // extract our partitions obj from the role_obj if there is one.
+        var partitions;
+        if (role_obj != null && role_obj.hasOwnProperty('partitions')) {
+            partitions = role_obj.partitions;
+        } else {
+            // else we set our partitions to be an empty object
+            partitions = {};
+        }
+        // extract any existing redirect role value.
+        var current_redirect;
+        if (role_obj != null && role_obj.hasOwnProperty('redirect')) {
+            // if there is a redirect role then set our current role to it
+            current_redirect = role_obj['redirect'];
+        } else {
+            current_redirect = '';
+        }
+        // set local convenience flag if device is a LUKS container.
+        var is_luks;
+        if (role_obj != null && role_obj.hasOwnProperty('LUKS')) {
+            is_luks = true;
+        } else {
+            is_luks = false;
+        }
+
+        this.current_redirect = current_redirect;
+        this.partitions = partitions;
+        this.disk_btrfs_uuid = disk_btrfs_uuid;
+
+        $(this.el).html(this.template({
+            diskName: this.diskName,
+            serialNumber: serialNumber,
+            diskRole: diskRole,
+            role_obj: role_obj,
+            partitions: partitions,
+            current_redirect: current_redirect,
+            disk_btrfs_uuid: disk_btrfs_uuid,
+            is_luks: is_luks
+        }));
+
+        this.$('#luks-disk-form :input').tooltip({
+            html: true,
+            placement: 'right'
+        });
+
+        var err_msg = '';
+        var luks_err_msg = function () {
+            return err_msg;
+        };
+
+        this.$('#luks-disk-form').validate({
+            onfocusout: false,
+            onkeyup: false,
+            rules: {
+
+            },
+
+            submitHandler: function () {
+                var button = $('#role-disk');
+                if (buttonDisabled(button)) return false;
+                disableButton(button);
+                var submitmethod = 'POST';
+                var posturl = '/api/disks/' + disk_name + '/luks-drive';
+                $.ajax({
+                    url: posturl,
+                    type: submitmethod,
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    data: JSON.stringify(_this.$('#luks-disk-form').getJSON()),
+                    success: function () {
+                        enableButton(button);
+                        _this.$('#luks-disk-form :input').tooltip('hide');
+                        app_router.navigate('disks', {trigger: true});
+                    },
+                    error: function (xhr, status, error) {
+                        enableButton(button);
+                    }
+                });
+                return false;
+            }
+        });
+    },
+
+    initHandlebarHelpers: function () {
+        Handlebars.registerHelper('display_luks_container_or_volume', function () {
+            var html = '';
+            return new Handlebars.SafeString(html);
+        });
+    },
+
+    cancel: function (event) {
+        event.preventDefault();
+        this.$('#luks-disk-form :input').tooltip('hide');
+        app_router.navigate('disks', {trigger: true});
+    }
+
+});
+
+
+
+

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -259,11 +259,13 @@ LuksDiskView = RockstorLayoutView.extend({
             // LUKS Container mode so show crypttab selection and buttons.
             this.$('#crypttab_selection_group').show();
             this.$('#crypttab_text').show();
+            this.$('#open_vol_status_table_group').hide();
             this.$('#cancel_submit_buttons_group').show();
         } else {
             // Open LUKS volume mode assumed so hide crypttab and buttons.
             this.$('#crypttab_selection_group').hide();
             this.$('#crypttab_text').hide();
+            this.$('#open_vol_status_table_group').show();
             this.$('#cancel_submit_buttons_group').hide();
         }
     },
@@ -385,6 +387,30 @@ LuksDiskView = RockstorLayoutView.extend({
                     // construct non current entry
                     html += '">' + entry + '</option>';
                 }
+            }
+            return new Handlebars.SafeString(html);
+        });
+        Handlebars.registerHelper('display_luks_volume_status_table', function () {
+            // Build a table body <tbody> containing the openLUKS role
+            // dict value entries.
+            var rows = ['status','type', 'cipher', 'keysize', 'device', 'offset', 'sizemode'];
+            var html = '';
+            var _this = this;
+            if (this.is_open_luks) {
+                //so we are assured of an 'openLUKS' role.
+                html += '<tbody>';
+                rows.forEach(function(item) {
+                    if (_this.role_obj['openLUKS'].hasOwnProperty(item)) {
+                        html += '<tr>';
+                        // fill out index column
+                        html += '<td>' + item + '</td>';
+                        // fill out value column
+                        html += '<td>' + _this.role_obj['openLUKS'][item] + '</td>';
+                        html += '</tr>';
+                    }
+                });
+                html += '</tr>';
+                html += '</tbody>';
             }
             return new Handlebars.SafeString(html);
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -246,11 +246,13 @@ LuksDiskView = RockstorLayoutView.extend({
 
     container_or_volume_mode: function () {
         if (this.is_luks) {
-            // LUKS Container mode so show crypttab selection
+            // LUKS Container mode so show crypttab selection and buttons.
             this.$('#crypttab_selection_group').show();
+            this.$('#cancel_submit_buttons_group').show();
         } else {
-            // Open LUKS volume mode assumed.
+            // Open LUKS volume mode assumed so hide crypttab and buttons.
             this.$('#crypttab_selection_group').hide();
+            this.$('#cancel_submit_buttons_group').hide();
         }
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/luks_disk.js
@@ -124,6 +124,8 @@ LuksDiskView = RockstorLayoutView.extend({
         // Populate our crypttab_selection text object along with values.
         // A value of false is used to indicate no crypttab entry exists.
         // see display_crypttab_entry handlebar helper below.
+        // @todo In the future these options could be extended with a custom
+        // @todo keyfile option to allow users to specify a keyfile with path.
         var crypttab_options = {
             'No auto unlock': false,
             'Manual passphrase via local console': 'none',
@@ -258,14 +260,28 @@ LuksDiskView = RockstorLayoutView.extend({
             for (var entry in this.crypttab_options) {
                 // cycle through the available known entries and construct our
                 // drop down html; using 'selected' to indicate current value.
-                if (this.crypttab_options[entry] == current_crypttab_status){
+                html += '<option value="' + this.crypttab_options[entry];
+                if (current_crypttab_status == this.crypttab_options[entry]) {
                     // we have found our current setting so indicate this by
-                    // pre-selecting it
-                    html += '<option value="' + this.crypttab_options[entry] + '" selected="selected">';
+                    // pre-selecting it. N.B. exact matches only ie keyfile
+                    // match in this case uses native naming ie:
+                    // /root/keyfile-<uuid>.
+                    html += '" selected="selected">';
                     html += entry + ' - active</option>';
+                } else if ((current_crypttab_status !== false) &&
+                    (current_crypttab_status.substring(0, 1) == '/') &&
+                    (entry == 'Auto unlock via keyfile')) {
+                    // @todo - the above clause is clumsy and could later be
+                    // @todo - replaced with a custom cryptab file entry
+                    // @todo - option in crypttab_options.
+                    // We have a path entry (ie keyfile type) but not one
+                    // using the native naming ie a non /root/keyfile-<uuid>.
+                    // Indicate the selection type and "custom" nature.
+                    html += '" selected="selected">';
+                    html += entry + ' (custom) - active</option>';
                 } else {
                     // construct non current entry
-                    html += '<option value="' + this.crypttab_options[entry] + '">' + entry + '</option>';
+                    html += '">' + entry + '</option>';
                 }
             }
             return new Handlebars.SafeString(html);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
@@ -108,6 +108,38 @@ PoolAddDisks = RockstorWizardPage.extend({
     },
 
     initHandlebarHelpers: function () {
+
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
+        // Identify Open LUKS container by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isRootDevice'
+        Handlebars.registerHelper('isOpenLuks', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('openLUKS')) {
+                // Once a LUKS container is open it has a type of crypt
+                // and we attribute it the role of 'openLUKS' as a result.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('display_raid_levels', function(){
             var html = '';
             var _this = this;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/remove_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/remove_disks.js
@@ -84,6 +84,38 @@ PoolRemoveDisks = RockstorWizardPage.extend({
     },
 
     initHandlebarHelpers: function() {
+
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
+        // Identify Open LUKS container by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isRootDevice'
+        Handlebars.registerHelper('isOpenLuks', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('openLUKS')) {
+                // Once a LUKS container is open it has a type of crypt
+                // and we attribute it the role of 'openLUKS' as a result.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('mathHelper', function(value, options) {
             return parseInt(value) + 1;
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -361,6 +361,36 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
 
     initHandlebarHelpers: function() {
 
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
+        // Identify Open LUKS container by return of true / false.
+        // Works by examining the Disk.role field.
+        Handlebars.registerHelper('isOpenLuks', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('openLUKS')) {
+                // Once a LUKS container is open it has a type of crypt
+                // and we attribute it the role of 'openLUKS' as a result.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('getPoolCreationDate', function(date) {
             return moment(date).format(RS_DATE_FORMAT);
         });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -198,6 +198,37 @@ PoolsView = RockstorLayoutView.extend({
     },
 
     initHandlebarHelpers: function(){
+
+        asJSON = function (role) {
+            // Simple wrapper to test for not null and JSON compatibility,
+            // returns the json object if both tests pass, else returns false.
+            if (role == null) { // db default
+                return false;
+            }
+            // try json conversion and return false if it fails
+            // @todo not sure if this is redundant?
+            try {
+                return JSON.parse(role);
+            } catch (e) {
+                return false;
+            }
+        };
+
+        // Identify Open LUKS container by return of true / false.
+        // Works by examining the Disk.role field.
+        Handlebars.registerHelper('isOpenLuks', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('openLUKS')) {
+                // Once a LUKS container is open it has a type of crypt
+                // and we attribute it the role of 'openLUKS' as a result.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         Handlebars.registerHelper('humanReadableSize', function(type, size, poolReclaim, poolFree) {
             var html = '';
             if(type == 'size'){

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -208,7 +208,7 @@ SetroleDiskView = RockstorLayoutView.extend({
                 // to include DEL (delete) char increase range to 7F.
                 if (/^[\x20-\x7E]+$/.test(luks_pass_one) == false) {
                     err_msg = 'Invalid non ASCII(32-126) 7-bit character entered';
-                    return false
+                    return false;
                 }
             }
             return true;
@@ -267,7 +267,7 @@ SetroleDiskView = RockstorLayoutView.extend({
             this.$('#delete_tick_warning').hide();
             // show LUKS options if appropriate
             // this.$('#luks_options').show();
-            this.luks_options_show_hide()
+            this.luks_options_show_hide();
         }
     },
 
@@ -390,7 +390,7 @@ SetroleDiskView = RockstorLayoutView.extend({
 
     cancel: function (event) {
         event.preventDefault();
-        this.$('#add-spindown-disk-form :input').tooltip('hide');
+        this.$('#add-role-disk-form :input').tooltip('hide');
         app_router.navigate('disks', {trigger: true});
     }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -95,7 +95,7 @@ SetroleDiskView = RockstorLayoutView.extend({
         }
         // set local convenience flag if device is a LUKS container and note
         // if it's unlocked or not.
-        var is_luks;
+        var is_luks = false;
         // Default to appearing as if we are unlocked if we fail for
         // some reason to retrieve the obligatory unlocked flag. This
         // way we fail safe as unlocked containers can't be deleted.
@@ -113,8 +113,6 @@ SetroleDiskView = RockstorLayoutView.extend({
             if (role_obj['LUKS'].hasOwnProperty('crypttab')) {
                 current_crypttab_status = role_obj['LUKS']['crypttab'];
             }
-        } else {
-            is_luks = false;
         }
         // additional convenience flag if device is an open LUKS volume.
         var is_open_luks;
@@ -207,7 +205,7 @@ SetroleDiskView = RockstorLayoutView.extend({
                             'filesystem.';
                         return false;
                     }
-                    if (is_unlocked) {
+                    if (is_luks && is_unlocked) {
                         // We block attempts to wipe unlocked LUKS containers
                         // as a safe guard, we have no direct way to know if
                         // they are backing any pool members but they are

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -238,9 +238,18 @@ SetroleDiskView = RockstorLayoutView.extend({
     delete_tick_toggle: function () {
         var delete_tick = this.$('#delete_tick');
         if (delete_tick.prop('checked')) {
+            // show delete warning
             this.$('#delete_tick_warning').show();
+            // un-tick and hide LUKS tick and passwords
+            this.$('#luks_tick').removeAttr('checked');
+            this.$('#luks_passwords').hide();
+            this.$('#luks_options').hide();
         } else {
+            // hide delete warning
             this.$('#delete_tick_warning').hide();
+            // show LUKS options if appropriate
+            // this.$('#luks_options').show();
+            this.luks_options_show_hide()
         }
     },
 
@@ -268,9 +277,18 @@ SetroleDiskView = RockstorLayoutView.extend({
     luks_tick_toggle: function () {
         var luks_tick = this.$('#luks_tick');
         if (luks_tick.prop('checked')) {
+            // un-tick delete and hide it
+            this.$('#delete_tick').removeAttr('checked');
+            this.$('#delete_tick_group').hide();
+            // show password entry and delete warning
             this.$('#luks_passwords').show();
+            this.$('#delete_tick_warning').show();
         } else {
+            // show delete tick
+            this.$('#delete_tick_group').show();
+            // hide password entry and delete warning
             this.$('#luks_passwords').hide();
+            this.$('#delete_tick_warning').hide();
         }
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -202,6 +202,14 @@ SetroleDiskView = RockstorLayoutView.extend({
                         'again.';
                     return false;
                 }
+                // Reject non ASCII 7-bit & control characters ie only accept:
+                // !"#$%&'()*+,-./0-9:;<=>?@A-Z[\]^_`a-z{|}~ plus space.
+                // Equates to Decimal (32-126) or Hex (0x20-0x7E)
+                // to include DEL (delete) char increase range to 7F.
+                if (/^[\x20-\x7E]+$/.test(luks_pass_one) == false) {
+                    err_msg = 'Invalid non ASCII(32-126) 7-bit character entered';
+                    return false
+                }
             }
             return true;
         }, role_err_msg);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -112,6 +112,7 @@ SetroleDiskView = RockstorLayoutView.extend({
         this.partitions = partitions;
         this.disk_btrfs_uuid = disk_btrfs_uuid;
         this.is_open_luks = is_open_luks;
+        this.is_luks = is_luks;
 
         $(this.el).html(this.template({
             diskName: this.diskName,
@@ -327,9 +328,12 @@ SetroleDiskView = RockstorLayoutView.extend({
         // Also guard against creating a LUKS container within an open LUKS
         // volume as this is both redundant and not supported as we would then
         // have a device that was both a LUKS volume and a LUKS container.
-        // Confusing and unnecessary.
+        // Confusing and unnecessary. Likewise we only show LUKS format
+        // options is we are not already a LUKS container (is_luks). This
+        // helps to avoid some potential confusion when re-formatting a LUKS
+        // container as it forces a traditional wipe first.
         if (_.isEmpty(this.partitions) && this.disk_btrfs_uuid == null
-            && this.is_open_luks !== true) {
+            && this.is_open_luks !== true && this.is_luks !== true) {
             luks_tick.removeAttr('disabled');
             this.$('#luks_options').show();
         } else {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -173,13 +173,36 @@ SetroleDiskView = RockstorLayoutView.extend({
             return true;
         }, role_err_msg);
 
+        $.validator.addMethod('validateLuksPassphrases', function (value) {
+            var luks_tick = $('#luks_tick');
+            var luks_pass_one = $('#luks_pass_one').val();
+            var luks_pass_two = $('#luks_pass_two').val();
+            if (luks_tick.prop('checked')) {
+                if (luks_pass_one == '') {
+                    err_msg = 'An empty LUKS passphrase is not supported';
+                    return false;
+                }
+                if (luks_pass_one.length < 14) {
+                    err_msg = 'LUKS passphrase should be at least 14 ' +
+                        'characters long.';
+                    return false;
+                }
+                if (luks_pass_one != luks_pass_two) {
+                    err_msg = 'LUKS passphrases do not match, please try ' +
+                        'again.';
+                    return false;
+                }
+            }
+            return true;
+        }, role_err_msg);
+
         this.$('#add-role-disk-form').validate({
             onfocusout: false,
             onkeyup: false,
             rules: {
-                // redirect_part: 'required',
                 redirect_part: 'validateRedirect',
-                delete_tick: 'validateDeleteTick'
+                delete_tick: 'validateDeleteTick',
+                luks_pass_one: 'validateLuksPassphrases'
             },
 
             submitHandler: function () {

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -673,8 +673,10 @@ class DiskDetailView(rfc.GenericView):
                         e_msg = ('LUKS passphase empty. Aborting. Please try '
                                  'again')
                         raise Exception(e_msg)
-                    # TODO: Consider checking on min length also ie akin to
-                    # TODO: front end validation of < 14 chars.
+                    if len(luks_pass_one) < 14:
+                        e_msg = ('LUKS passphrase of less then 14 characters'
+                                 'is not supported. Please re-enter.')
+                        raise Exception(e_msg)
                     return self._luks_format(dname, request, luks_pass_one)
             return Response(DiskInfoSerializer(disk).data)
         except Exception as e:

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -677,6 +677,12 @@ class DiskDetailView(rfc.GenericView):
                         e_msg = ('LUKS passphrase of less then 14 characters'
                                  'is not supported. Please re-enter.')
                         raise Exception(e_msg)
+                    if re.search('[^\x20-\x7E]', luks_pass_one) is not None:
+                        e_msg = ('A LUKS passphrase containing non 7-bit '
+                                 'ASCII(32-126) characters is not supported '
+                                 'as boot entry character codes may differ. '
+                                 'Please re-enter.')
+                        raise Exception(e_msg)
                     return self._luks_format(dname, request, luks_pass_one)
             return Response(DiskInfoSerializer(disk).data)
         except Exception as e:

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -738,6 +738,13 @@ class DiskDetailView(rfc.GenericView):
                                  'identified as an Open LUKS volume. This '
                                  'configuration is not supported.')
                         raise Exception(e_msg)
+                    if 'LUKS' in roles:
+                        e_msg = ('LUKS format requested but device is '
+                                 'already LUKS formatted. If you wish to '
+                                 're-deploy as a different LUKS container '
+                                 'please select wipe first then return and '
+                                 're-select LUKS format.')
+                        raise Exception(e_msg)
                     return self._luks_format(dname, request, luks_pass_one)
             return Response(DiskInfoSerializer(disk).data)
         except Exception as e:

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -733,6 +733,11 @@ class DiskDetailView(rfc.GenericView):
                                  'as boot entry character codes may differ. '
                                  'Please re-enter.')
                         raise Exception(e_msg)
+                    if 'openLUKS' in roles:
+                        e_msg = ('LUKS format requested but device is '
+                                 'identified as an Open LUKS volume. This '
+                                 'configuration is not supported.')
+                        raise Exception(e_msg)
                     return self._luks_format(dname, request, luks_pass_one)
             return Response(DiskInfoSerializer(disk).data)
         except Exception as e:

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -29,7 +29,8 @@ from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
 from system.luks import luks_format_disk, get_unlocked_luks_containers_uuids, \
-    get_crypttab_entries, update_crypttab, native_keyfile_exists, add_keyfile
+    get_crypttab_entries, update_crypttab, native_keyfile_exists, \
+    establish_keyfile
 from system.osi import set_disk_spindown, enter_standby, get_dev_byid_name, \
     wipe_disk, blink_disk, scan_disks
 from copy import deepcopy
@@ -793,10 +794,11 @@ class DiskDetailView(rfc.GenericView):
             # None 'none' and None 'false' is assumed to be keyfile config.
             # We ensure / create our keyfile and register it using
             # cryptsetup luksAddKeyfile via the following wrapper function:
-            if not add_keyfile(disk.name, crypttab_selection, luks_passphrase):
-                e_msg = ('There was an unknown problem with add_key when '
-                         'called by _luks_disk() for Disk(%s). Keyfile '
-                         'registration may have failed.' % dname)
+            if not establish_keyfile(disk.name, crypttab_selection,
+                                     luks_passphrase):
+                e_msg = ('There was an unknown problem with establish_keyfile '
+                         'when called by _luks_disk() for Disk(%s). Keyfile '
+                         'may not have been established.' % dname)
                 handle_exception(Exception(e_msg), request)
         # In all cases we try to ensure /etc/crypttab is updated:
         if not update_crypttab(disk_uuid, crypttab_selection):

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # and the post processing present in scan_disks()
 # LUKS currently stands for full disk crypto container.
 SCAN_DISKS_KNOWN_ROLES = ['mdraid', 'root', 'LUKS', 'openLUKS', 'bcache',
-                          'bcache-cdev', 'partitions']
+                          'bcachecdev', 'partitions']
 WHOLE_DISK_FORMAT_ROLES = ['LUKS', 'bcache', 'bcachecdev']
 
 
@@ -251,7 +251,7 @@ class DiskMixin(object):
                 # here we tag our backing device with it's virtual counterparts
                 # serial number.
                 disk_roles_identified['bcache'] = 'bcache-%s' % d.uuid
-            if d.fstype == 'bcache-cdev':
+            if d.fstype == 'bcachecdev':
                 # BCACHE: continued; here we use the scan_disks() added info
                 # of this bcache device being a cache device not a backing
                 # device, so it will have no virtual block device counterpart

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -310,6 +310,9 @@ class PoolListView(PoolMixin, rfc.GenericView):
             p.size = p.usage_bound()
             p.uuid = btrfs_uuid(dnames[0])
             p.save()
+            # Now we ensure udev info is updated via system wide trigger
+            # as per pool resize add, only here it is for a new pool.
+            trigger_udev_update()
             return Response(PoolInfoSerializer(p).data)
 
 

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -15,8 +15,9 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-
+import os
 import re
+from tempfile import mkstemp
 from system.osi import run_command
 import logging
 
@@ -68,3 +69,40 @@ def get_luks_container_dev(mapped_device_name, test=None):
             return line_fields[1]
     return container_dev
 
+
+def luks_format_disk(disk_byid, passphrase):
+    """
+    Formats disk_byid using supplied passphrase for master key encryption.
+    Simple run_command wrapper to execute 'cryptsetup luksFormat <dev> path'
+    Care is taken to immediately remove our temporary key-file (in ram) even 
+    in the event of an Exception.
+    :param disk_byid: by-id type name without path as found in db Disks.name.
+    :param passphrase: luks passphrase used to encrypt master key.
+    :return: o, e, rc tuple as returned by cryptsetup luksFormat command.
+    """
+    disk_byid_withpath = ('/dev/disk/by-id/%s' % disk_byid)
+    # Create a temp file to pass our passphrase to our cryptsetup command.
+    tfo, npath = mkstemp()
+    # Pythons _candidate_tempdir_list() should ensure our npath temp file is
+    # in memory (tmpfs). From https://docs.python.org/2/library/tempfile.html
+    # we have "Creates a temporary file in the most secure manner possible."
+    # Populate this file with our passphrase and use as cryptsetup keyfile.
+    try:
+        with open(npath, 'w') as passphrase_file_object:
+            passphrase_file_object.write(passphrase)
+        cmd = [CRYPTSETUP, 'luksFormat', disk_byid_withpath, npath]
+        out, err, rc = run_command(cmd)
+    except Exception as e:
+        msg = ('Exception while running command(%s): %s' %
+               (cmd, e.__str__()))
+        raise Exception(msg)
+    finally:
+        passphrase_file_object.close()
+        if os.path.exists(npath):
+            try:
+                os.remove(npath)
+            except Exception as e:
+                msg = ('Exception while removing temp file %s' %
+                       (npath, e.__str__()))
+                raise Exception(msg)
+    return out, err, rc

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 CRYPTSETUP = '/usr/sbin/cryptsetup'
 
 
-def get_luks_container_dev(device_name, test=None):
+def get_luks_container_dev(mapped_device_name, test=None):
     """
     Returns the parent device of an open LUKS container, ie if passed:
     /dev/mapper/luks-b8f89d97-f135-450f-9620-80a9fb421403
@@ -33,19 +33,18 @@ def get_luks_container_dev(device_name, test=None):
     /dev/sda3
     So /dev/sda3 is the LUKS container that once opened is mapped as our
     device_name in /dev/mapper
-    :param device_name: any mapped device name accepted by cryptsetup,
+    :param mapped_device_name: any mapped device name accepted by cryptsetup,
     ie starting with "/dev/mapper/"
     :param test: if not None then it's contents is considered as substitute
     for the output of the cryptsetup command that is otherwise executed.
     :return: Empty string on any error or a device with path
     """
     # if non luks device then return empty string
-    logger.debug('get_luks_container_dev passed device_name = %s' % device_name)
-    if re.match('/dev/mapper/luks-', device_name) is None:
+    if re.match('/dev/mapper/luks-', mapped_device_name) is None:
         return ''
     container_dev = ''
     if test is None:
-        out, err, rc = run_command([CRYPTSETUP, 'status' + device_name],
+        out, err, rc = run_command([CRYPTSETUP, 'status' + mapped_device_name],
                                    throw=False)
     else:
         # test mode so process test instead of cryptsetup output

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -26,10 +26,11 @@ logger = logging.getLogger(__name__)
 CRYPTSETUP = '/usr/sbin/cryptsetup'
 
 
-def get_luks_container_dev(mapped_device_name, test=None):
+def get_open_luks_container_dev(mapped_device_name, test=None):
     """
     Returns the parent device of an open LUKS container, ie if passed:
-    /dev/mapper/luks-b8f89d97-f135-450f-9620-80a9fb421403
+    luks-b8f89d97-f135-450f-9620-80a9fb421403
+    (with or without a leading /dev/mapper/)
     it would return the following example device name string:
     /dev/sda3
     So /dev/sda3 is the LUKS container that once opened is mapped as our
@@ -38,14 +39,11 @@ def get_luks_container_dev(mapped_device_name, test=None):
     ie starting with "/dev/mapper/"
     :param test: if not None then it's contents is considered as substitute
     for the output of the cryptsetup command that is otherwise executed.
-    :return: Empty string on any error or a device with path
+    :return: Empty string on any error or a device with path type /dev/vdd
     """
-    # if non luks device then return empty string
-    if re.match('/dev/mapper/luks-', mapped_device_name) is None:
-        return ''
     container_dev = ''
     if test is None:
-        out, err, rc = run_command([CRYPTSETUP, 'status' + mapped_device_name],
+        out, err, rc = run_command([CRYPTSETUP, 'status', mapped_device_name],
                                    throw=False)
     else:
         # test mode so process test instead of cryptsetup output
@@ -65,7 +63,6 @@ def get_luks_container_dev(mapped_device_name, test=None):
             continue
         if re.match('device:', line_fields[0]) is not None:
             # we have our line match so return it's second member
-            logger.debug('get_luks_container_dev return = %s' % line_fields[1])
             return line_fields[1]
     return container_dev
 

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -494,7 +494,6 @@ def create_keyfile(keyfile_withpath):
             cmd = [DD, 'bs=512', 'count=4', 'if=/dev/urandom', 'of=%s' % npath]
             out, err, rc = run_command(cmd, throw=False)
         if rc != 0:
-            logger.debug('create_keyfile failed cmd=%s' % cmd)
             return False
         # shutil.copy2 is equivalent to cp -p (preserver attributes).
         # This preserves the secure defaults of the temp file without having

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -106,7 +106,7 @@ def luks_format_disk(disk_byid, passphrase):
     return out, err, rc
 
 
-def get_open_luks_containers_uuids():
+def get_unlocked_luks_containers_uuids():
     """
     Returns a list of LUKS container uuids backing open LUKS volumes. 
     The method used is to first run:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -429,8 +429,8 @@ def scan_disks(min_size):
                 elif bcache_dev_type == 'cdev':
                     # We have a bcache caching device, not a backing device.
                     # Change fstype as an indicator to _update_disk_state()
-                    # role system. N.B. fstype bcache-cdev is fictitious.
-                    dmap['FSTYPE'] = 'bcache-cdev'
+                    # role system. N.B. fstype bcachecdev is fictitious.
+                    dmap['FSTYPE'] = 'bcachecdev'
             else:
                 # we are a non bcache bdev but we might be the virtual device
                 # if we are listed directly after a bcache bdev.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -56,6 +56,7 @@ NMCLI = '/usr/bin/nmcli'
 RMDIR = '/bin/rmdir'
 SHUTDOWN = '/usr/sbin/shutdown'
 SYSTEMCTL_BIN = '/usr/bin/systemctl'
+SYSTEMD_ESCAPE = '/usr/bin/systemd-escape'
 UDEVADM = '/usr/sbin/udevadm'
 UMOUNT = '/bin/umount'
 WIPEFS = '/usr/sbin/wipefs'
@@ -1995,3 +1996,27 @@ def trigger_systemd_update():
     :return: o, e, rc as returned by run_command
     """
     return run_command([SYSTEMCTL_BIN, 'daemon-reload'])
+
+
+def systemd_name_escape(original_sting, template=''):
+    """Wrapper around systemd-escape unit name pre-processor. Used to escape
+    stings ready for use as systemd unit or service names. Eg (shortened):
+    passed sting = 'luks-5037b320-95d6-4c74-94e7'
+    output:
+    'luks\x2d5037b320\x2d95d6\x2d4c74\x2d94e7'
+    With optional template='systemd-cryptsetup@.service' the output would be:
+    systemd-cryptsetup@luks\x2d5037b320\x2d95d6\x2d4c74\x2d94e7.service
+    :param template: if supplied passed as parameter to --template
+    :param original_sting: pre-escaped  string for systemd service name use.
+    :return: post-escaped string ie '\x2d' instead of '-' etc or '' if a non
+    zero return code was encountered.
+    """
+    if template == '':
+        out, err, rc = run_command([SYSTEMD_ESCAPE, original_sting])
+    else:
+        out, err, rc = run_command(
+            [SYSTEMD_ESCAPE, '--template=%s' % template, original_sting])
+    if rc == 0 and len(out) > 0:
+        return out[0]
+    else:
+        return ''

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -298,21 +298,19 @@ def scan_disks(min_size):
                         dnames[dname][8] = dmap['FSTYPE']
                     if dmap['FSTYPE'] == 'crypto_LUKS' \
                             and (dnames[dname][8] is None):
-                        # N.B. although this if clause has identical treatment
-                        # to the mdraid partition treatment it is intentionally
-                        # kept independent to aid in clarity and maintenance
-                        # as it may be that the treatments diverge.
-                        # As per mdraid we we backport to the base device LUKS
+                        # As per mdraid we backport to the base device LUKS
                         # containers that live in partitions as the base device
                         # will have an FSTYPE="" and as per mdraid we classify
                         # the entire device as a LUKS container member even if
-                        # it is only a in part (ie this partition). But we only
+                        # it is only in part (ie this partition). But we only
                         # backport this information if there currently exists
                         # no FSTYPE on the base device, there by protecting
                         # against fstype information loss on the base device.
                         # Please see mdraid partition treatment for additional
                         # comments on index number used.
                         dnames[dname][8] = dmap['FSTYPE']
+                        # and uuid backport
+                        dnames[dname][10] = dmap['UUID']
                     # Akin to back porting a partitions FSTYPE to it's base
                     # device, as with 'linux_raid_member' above, we can do the
                     # same for btrfs if found in a partition.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1977,3 +1977,21 @@ def trigger_udev_update():
     :return: o, e, rc as returned by run_command
     """
     return run_command([UDEVADM, 'trigger'])
+
+
+def trigger_systemd_update():
+    """Reruns all systemd generators (see man systemd.generator 7).
+    In some instances systemd managed resources can be out of date with 
+    associated configuration file changes which can lead to a confusion via
+    prior configurations being still current. An example of this is when
+    /etc/crypttab is changed and it's systemd generated service files no
+    longer reflect the 'source of truth' that /etc/crypttab represents.
+    The systemd-cryptsetup-generator scans the contents of /etc/crypttab
+    and establishes service files for each (eg LUKS) mapped device. An 
+    example of one of these generated files is:
+    /var/run/systemd/generator/systemd-cryptsetup@<mapped-name>.service
+    Running 'systemctl daemon-reload' requests that all such resources be
+    updated to freshly represent the new state of the associated config files.
+    :return: o, e, rc as returned by run_command
+    """
+    return run_command([SYSTEMCTL_BIN, 'daemon-reload'])

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -2006,17 +2006,35 @@ def systemd_name_escape(original_sting, template=''):
     'luks\x2d5037b320\x2d95d6\x2d4c74\x2d94e7'
     With optional template='systemd-cryptsetup@.service' the output would be:
     systemd-cryptsetup@luks\x2d5037b320\x2d95d6\x2d4c74\x2d94e7.service
+    # N.B. there is currently an issue with the --template option:
+    https://bugs.centos.org/view.php?id=13262
     :param template: if supplied passed as parameter to --template
     :param original_sting: pre-escaped  string for systemd service name use.
     :return: post-escaped string ie '\x2d' instead of '-' etc or '' if a non
     zero return code was encountered.
     """
-    if template == '':
-        out, err, rc = run_command([SYSTEMD_ESCAPE, original_sting])
-    else:
-        out, err, rc = run_command(
-            [SYSTEMD_ESCAPE, '--template=%s' % template, original_sting])
+    # future version when upstream --template bug fixed:
+    # if template == '':
+    #     out, err, rc = run_command([SYSTEMD_ESCAPE, original_sting])
+    # else:
+    #     out, err, rc = run_command(
+    #         [SYSTEMD_ESCAPE, '--template=%s' % template, original_sting])
+    # if rc == 0 and len(out) > 0:
+    #     return out[0]
+    # else:
+    #     return ''
+    # future version end
+    # temp --template bug workaround version:
+    out, err, rc = run_command([SYSTEMD_ESCAPE, original_sting])
     if rc == 0 and len(out) > 0:
-        return out[0]
+        if template == '':
+            return out[0]
+        else:
+            dot_index = template.find('.')
+            if dot_index == -1:
+                return ''
+            # Put our command output into our template at position dot_index.
+            out = template[:dot_index] + out[0] + template[dot_index:]
+            return out
     else:
         return ''


### PR DESCRIPTION
Abstract:
Adds full disk LUKS UI components to perform initial LUKS format and set boot up configuration for the resulting container; with integral keyfile generation and registration where required. The consequent LUKS volumes also gain an ‘information only’ UI component to display their last recorded status which includes their backing container device. Further enhancements were required to the disk role improvements established in pr #1622 in order to meet the requirements of the UI components added. And to meet the expected pairing of LUKS data disk capability with encrypted system disk installs (via the “Encrypt my data” install option) the disk scan subsystem was improved to correctly propagate the otherwise incompatible LUKS in partition arrangement. Disk table view iconography was extended to indicate the open/closed status of LUKS containers.

Changes made:
- Add capability to appropriately indicate system disk use on encrypted installs.
- Improve iconic disk identification / tool tip info on disks page re LUKS.
- Add LUKS format tick to role/wipe page with relevant text and title changes.
- Add dual mode LUKS config/info page: Used for both containers and volumes.
- Report/configure /etc/crypttab config (boot up config) for LUKS containers/volumes.
- Partially account for existing udev sane LUKS config arrangements.
- Report last known status of LUKS volumes, including their container device.
- Enhance role and disk scan subsystems to accommodate the above.
- Add generic ‘mapped to pool’ icon to further clarify device state re btrfs.
- Add iconic indicator of pool member’s LUKS status on all main pool tables.
- Add in context explanatory text re LUKS passphrase, boot up config, and container / volume relationship.

Existing Pathologies:
- Removing a luks volume from an existing pool results in a detached device for up to 30mins after the end of a balance. Cause is as per commit: https://github.com/phillxnet/rockstor-core/commit/085e3871b4c51ccf16067f4ae19e5d9d7c0c67dc , however as a balance is often a long running process this artifact is less crucial and given the additional anticipated complexities of the same approach as per commit only applied directly after the end of a balance it was deemed worthy of it’s own issue / pr.
- When using a non keyfile boot up configuration the system has no way to authenticate reattachment of an auto detached LUKS volume (such as when a full volume fs is wiped). And so for the time being systemd-tty-ask-password-agent is a required at the console to enable reattachment prior to redeployment. Or a reboot as the name and user text presented against the relevant options suggests. To address this inelegance only the “Auto unlock via keyfile” option is recommended via user text. This could be addressed in the future when adding manual immediate container unlock UI components.
- Due to the extended use of the role field and it’s combined use to identify partitions and their filesystem, the existing 256 character db field limit can be exceeded upon encountering partitioned Open LUKS Volumes. However this is not a supported configuration. The existing issue #1709 will address this lack of robustness by way of quadrupling the disk.role maximum field length.

Configuration caveats:
- The only recognized way to identify which device is referenced in /etc/crypttab is via the containers uuid ie 2nd column must be of the form: UUID=3efb3830-fee1-4a9e-a5c6-ea456bfc269e however this is a commonly used and robust option.
- Keyfile location is non configurable via UI: all auto generated keyfiles will be placed in /root.
- No account is made for keyslot availability or configuration. However appropriate error messages should be surfaced.
- Only locked containers can be wiped and only if they also have no current boot up configuration (ie the “No auto unlock” selection). This is a safety measure and it is enforced by backend validation and front end function (ie the “Wipe locked LUKS container” link is otherwise hidden).

Noteworthy anticipated exclamations:
- It is assumed that existing LUKS configurations, identified as custom, will experience difficulties where the chosen mapped name for the resulting LUKS volume (first column in /etc/crypttab) does not begin with “luks-”. This is not recognized by udev in the same way and so does not receive a LUKS class of by-id naming: ie will not receive a “dm-name-” prefix in /dev/disk/by-id. In this case it is advised to proceed such names with “luks-” to attain on next reboot, a udev assigned dm-name-luks- by-id name. Or have Rockstor assert the luks-{uuid} type name by way of “Boot up configuration” reconfiguration.

Testing methods employed are to follow in additional comments to this pr.

Fixes #550
Please see #550 for development history.

Ready for review.
