### PR TITLE
increase max_length of disk.role db field. Fixes #1709

### DIFF
--- a/src/rockstor/storageadmin/migrations/0004_auto_20170523_1140.py
+++ b/src/rockstor/storageadmin/migrations/0004_auto_20170523_1140.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0003_auto_20170114_1332'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='disk',
+            name='role',
+            field=models.CharField(max_length=1024, null=True),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -56,7 +56,7 @@ class Disk(models.Model):
     {"mdraid": "linux_raid_member"}.
     role can be Null if no flags are in use.
     """
-    role = models.CharField(max_length=256, null=True)
+    role = models.CharField(max_length=1024, null=True)
 
     @property
     def pool_name(self, *args, **kwargs):


### PR DESCRIPTION
This pr extends the disk.role model and consequent db field from it's prior length of 256 characters to 1024 characters. The reported examples of overflow were related to the partitions role and triggered by prior use disks containing an unusual, but not rare, number of partitions. Calculations available in issue #1709 detail the current and future limit. Essentially before this pr we have a failure point in the 4-5 existing partition range for a reported case but if using the longest observed device name then in the 2-3 partition count range: depending on if an additional redirect role is required. Post pr our failure point would be 14-15 prior existing partitions: assuming the longest observed device name of 50 characters and the requirement or otherwise of an additional redirect role.

The procedure used to create the migration file was as per the documentation at:
http://rockstor.com/docs/contribute.html#database-migrations

The output of the commands executed were as follows:
```
/opt/rockstor-dev/bin/django makemigrations storageadmin
Migrations for 'storageadmin':
  0004_auto_20170523_1140.py:
    - Alter field role on disk
```
and when the created migration file was applied:
```
/opt/rockstor-dev/bin/django migrate storageadmin
Operations to perform:
  Apply all migrations: storageadmin
Running migrations:
  Rendering model states... DONE
  Applying storageadmin.0004_auto_20170523_1140... OK
The following content types are stale and need to be deleted:

    storageadmin | networkinterface
    storageadmin | poolstatistic
    storageadmin | sharestatistic

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

    Type 'yes' to continue, or 'no' to cancel: no
```
@schakrava I am a little concerned with the latter commands output re confirmation of stale type removal. As can be seen I answered 'no' here. Noting here in case this results in an error that may be interpreted by controlling code as a failure to migrate.
```
echo $?
0
```
However this was with my 'no' answer.

Prior to the generated migration file's application we have:
```
SELECT column_name, data_type, character_maximum_length FROM information_schema.columns WHERE table_name = 'storageadmin_disk' AND column_name = 'role';
 column_name |     data_type     | character_maximum_length 
-------------+-------------------+--------------------------
 role        | character varying |                      256
(1 row)
```
post application we have:
```
SELECT column_name, data_type, character_maximum_length FROM information_schema.columns WHERE table_name = 'storageadmin_disk' AND column_name = 'role';
 column_name |     data_type     | character_maximum_length 
-------------+-------------------+--------------------------
 role        | character varying |                     1024
(1 row)
```

Fixes #1709

Ready for review.