### PR TITLE
substitute smart attribute threshold '---' with '999'. Fixes #1725

### DIFF
--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -108,6 +108,10 @@ def extended_info(device, custom_options='', test_mode=TESTMODE):
                         fields = o[j].strip().split()
                         if (len(fields) > 10):
                             fields[9] = ' '.join(fields[9:])
+                        # Some drives return "---" as a Threshold value, in
+                        # this case substitute 999 as an integer equivalent.
+                        if fields[5] == '---':
+                            fields[5] = '999'
                         attributes[fields[1]] = fields[0:10]
     return attributes
 


### PR DESCRIPTION
Some drives return "---" as a threshold value where as the
vast majority report an integer. To preserve this info we
substitute 999 in these cases given this is a more obvious
substitution than '0' which is a very common threshold value.

Fixes #1725 

Please see the issue text for further information.

Thanks to forum member amtuannguyen for reporting the consequent parsing failure and submitting the required smart output upon request within the following forum thread:

https://forum.rockstor.com/t/invalid-literal-for-int-with-base-10/3342

These changes were tested on the supplied smart output and found to effectively work around this anomaly. The substitution is also very specific so should not affect any other working systems.