### PR TITLE
insufficient use of btrfs device scan. Fixes #1547 

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -351,7 +351,8 @@ def mount_share(share, mnt_pt):
     if (is_mounted(mnt_pt)):
         return
     mount_root(share.pool)
-    pool_device = ('/dev/disk/by-id/%s' % share.pool.disk_set.first().name)
+    pool_device = ('/dev/disk/by-id/%s' %
+                   share.pool.disk_set.first().target_name)
     subvol_str = 'subvol=%s' % share.subvol_name
     create_tmp_dir(mnt_pt)
     toggle_path_rw(mnt_pt, rw=False)
@@ -360,7 +361,8 @@ def mount_share(share, mnt_pt):
 
 
 def mount_snap(share, snap_name, snap_mnt=None):
-    pool_device = ('/dev/disk/by-id/%s' % share.pool.disk_set.first().name)
+    pool_device = ('/dev/disk/by-id/%s' %
+                   share.pool.disk_set.first().target_name)
     share_path = ('%s%s' % (DEFAULT_MNT_DIR, share.name))
     rel_snap_path = ('.snapshots/%s/%s' % (share.name, snap_name))
     snap_path = ('%s%s/%s' %

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -240,21 +240,27 @@ def mount_root(pool):
     if (pool.compression is not None):
         if (re.search('compress', mnt_options) is None):
             mnt_options = ('%s,compress=%s' % (mnt_options, pool.compression))
+    # Prior to a mount by label attempt we call btrfs device scan on all
+    # members of our pool. This call ensures btrfs has up-to-date info on
+    # the relevant devices and avoids the potential overkill of a system wide
+    # call such as is performed in the rockstor-bootstrap service on boot.
+    # Disk.target_name ensures we observe any redirect roles.
+    device_scan([dev.target_name for dev in pool.disk_set.all()])
     if (os.path.exists(mnt_device)):
         if (len(mnt_options) > 0):
             mnt_cmd.extend(['-o', mnt_options])
         run_command(mnt_cmd)
         return root_pool_mnt
-
     # If we cannot mount by-label, let's try mounting by device; one by one
-    # until we get our first success.
+    # until we get our first success. All devices known to our pool object
+    # have already been scanned prior to our mount by label attempt above.
     if (pool.disk_set.count() < 1):
         raise Exception('Cannot mount Pool(%s) as it has no disks in it.'
                         % pool.name)
     last_device = pool.disk_set.last()
     logger.info('Mount by label failed.')
     for device in pool.disk_set.all():
-        mnt_device = ('/dev/disk/by-id/%s' % device.name)
+        mnt_device = ('/dev/disk/by-id/%s' % device.target_name)
         logger.info('Attempting mount by device (%s).' % mnt_device)
         if (os.path.exists(mnt_device)):
             mnt_cmd = [MOUNT, mnt_device, root_pool_mnt, ]
@@ -1002,8 +1008,39 @@ def balance_status(pool):
     return stats
 
 
-def device_scan():
-    return run_command([BTRFS, 'device', 'scan'])
+def device_scan(dev_byid_list=['all']):
+    """
+    When called with no parameters a 'btrfs device scan' is executed, ie a
+    system wide scan of all /dev block devices to update their btrfs status.
+    Otherwise the list of devices is iterated and a 'btrfs device scan dev'
+    is executed for each item in the passed list. Detached device names and
+    path names that don't exist are ignored.
+    :param dev_byid_list: list of byid device names (without paths) to perform
+    a 'btrfs device scan' on. If not supplied then a single element list
+    ['all'] is substituted and this flags a system wide scan request.
+    :return: (out, err, rc) of the first rc !=0 run or the last rc = 0 run.
+    """
+    out = err = ['']
+    # default to successful return code unless we find otherwise.
+    rc = 0
+    if len(dev_byid_list) > 0:
+        if dev_byid_list[0] == 'all':
+            return run_command([BTRFS, 'device', 'scan'])
+        for dev_byid in dev_byid_list:
+            if re.match('detached-', dev_byid) is not None:
+                # Skip detached devices as we know they don't exist.
+                # Potential log point for early detached device discovery.
+                continue
+            dev_byid_withpath = ('/dev/disk/by-id/%s' % dev_byid)
+            if os.path.exists(dev_byid_withpath):  # only scan existing devices
+                out, err, rc = run_command(
+                    [BTRFS, 'device', 'scan', dev_byid_withpath])
+                if rc != 0:
+                    # Return on first non zero return code.
+                    # Note that a drive specific device scan on a non btrfs
+                    # device returns 'Invalid argument'!! and rc=1.
+                    return out, err, rc
+    return out, err, rc
 
 
 def btrfs_uuid(disk):

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import json
 from django.db import models
 from storageadmin.models import Pool
 from system.osi import get_disk_power_status, read_hdparm_setting, \
@@ -92,6 +93,25 @@ class Disk(models.Model):
             return get_dev_temp_name(str(self.name))
         except:
             return None
+
+    @property
+    def target_name(self, *args, **kwargs):
+        """
+        Helper method to enable easier retrieval of a (re)direct role
+        name, if any. Allows for Disk.target_name which substitutes a
+        redirect role enforced name (eg to a partition) or fails over
+        to disk.name if no redirect role is in play or an exception is
+        encountered.
+        :return: role redirected name if any, otherwise return name.
+        """
+        try:
+            if self.role is not None:
+                disk_role_dict = json.loads(self.role)
+                if 'redirect' in disk_role_dict:
+                    return disk_role_dict.get('redirect', self.name)
+            return self.name
+        except:
+            return self.name
 
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -39,6 +39,7 @@ class DiskInfoSerializer(serializers.ModelSerializer):
     hdparm_setting = serializers.CharField()
     apm_level = serializers.CharField()
     temp_name = serializers.CharField()
+    target_name = serializers.CharField()
 
     class Meta:
         model = Disk

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -63,15 +63,8 @@ class CommandView(NFSExportMixin, APIView):
             try:
                 mount_root(p)
                 first_dev = p.disk_set.first()
-                first_dev_name = first_dev.name
-                # if we are looking at a device with a redirect role then
-                # redirect accordingly.
-                if first_dev.role is not None:
-                    disk_role_dict = json.loads(first_dev.role)
-                    if 'redirect' in disk_role_dict:
-                        # consider replacing None with first_dev.name
-                        first_dev_name = disk_role_dict.get('redirect', None)
-                pool_info = get_pool_info(first_dev_name)
+                # Observe any redirect role by using target_name.
+                pool_info = get_pool_info(first_dev.target_name)
                 p.name = pool_info['label']
                 p.raid = pool_raid('%s%s' % (settings.MNT_PT, p.name))['data']
                 p.size = p.usage_bound()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -398,10 +398,12 @@ class DiskDetailView(rfc.GenericView):
         If disk has a redirect role the redirect role value is substituted
         for that disk's name. This effects a device name re-direction:
         ie base dev to partition on base dev for example.
+        N.B. Disk model now has sister code under Disk.target_name property.
         :param disk:  disk object
         :param request:
         :return: by-id disk name (without path) post role filter processing
         """
+        # TODO: Consider revising to use new Disk.target_name property.
         try:
             disk_name = disk.name
             if disk.role is not None:

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -57,11 +57,13 @@ class PoolMixin(object):
         """
         Takes a series of disk objects and filters them based on their roles.
         For disk with a redirect role the role's value is substituted for that
-        disks name. This effects a name re-direction for redirect disks.
+        disks name. This effects a name re-direction for redirect role disks.
+        N.B. Disk model now has sister code under Disk.target_name property.
         :param disks:  list of disks object
         :param request:
         :return: list of disk names post role filter processing
         """
+        # TODO: Consider revising to use new Disk.target_name property.
         try:
             # Build dictionary of disks with roles
             role_disks = {d for d in disks if d.role is not None}


### PR DESCRIPTION
In some circumstances a multi-device pool can only be mounted by a sub set of it's member devices. This is a know issue referenced in 1: below. Please see #1547 for further details. This affects 'mount by label', the method we use, as this is essentially a symbolic link to a pool member, ie pool mount by a single member. The documented work around for this issue is to first execute a:

    btrfs device scan

However this will re-scan all block devices and was considered overkill by this pr's author. Consequently our existing 'btrfs device scan' wrapper was extended to accommodate single device scans. This wrapper was then called in it's single device mode for each pool member in turn just prior to pool mount from mount_root(pool). These changes required extending the Disk model to more easily account for devices with a redirect role.

While more closely examining the associated mount_share() / mount_snap() a bug was found and fixed, using the new model method, where bye these methods would fail if the first member of their respective pools also carried a redirect role. The fix was proved using a single redirect role device pool where share creation was the trigger. This was an over site of the authors in pull request #1622 .

To evaluate the effect of the device scan changes the reproducer was the same configuration as described in the issue text #1547. This involved a pool with 2 LUKS members, each backed by bcache. Prior to the changes within this pr, if the pool members were unlocked after Rockstor's initial mount attempts had finished, the pool would there after always fail to mount (unless a degraded mount option was specified) with the resulting logged error:

```
    mount: wrong fs type, bad option, bad superblock on /dev/mapper/luks-3efb3830-fee1-4a9e-a5c6-ea456bfc269e, missing codepage or helper program, or other error
```

The success of the degraded mount option in these scenarios confirmed that a member device was not 'registered' by the btrfs subsystems. A command line reproducer of this exact scenario was recorded in issue text in order to prove the effectiveness of a device specific 'btrfs device scan' on each pool member as a system wide scan had already been proved.

Post pull request changes resulted in 100% success in the above pool mount scenario.

These changes should assist with adopting a more dynamic disk capability going forward and help towards a more robust mount mechanism.

Fixes #1547 

1: Reference to btrfs wiki post sighted:
https://btrfs.wiki.kernel.org/index.php/Problem_FAQ#Filesystem_can.27t_be_mounted_by_label

A minor code tidy (reduced code duplication) enabled by the enhanced Disk model was also included as well as unit tests to prove the new btrfs device scan wrapper performed as expected:
```
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
```

Ready for review.