### PR TITLE
detached disks used in mount command. Fixes #1422

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -352,7 +352,7 @@ def mount_share(share, mnt_pt):
         return
     mount_root(share.pool)
     pool_device = ('/dev/disk/by-id/%s' %
-                   share.pool.disk_set.first().target_name)
+                   share.pool.disk_set.attached().first().target_name)
     subvol_str = 'subvol=%s' % share.subvol_name
     create_tmp_dir(mnt_pt)
     toggle_path_rw(mnt_pt, rw=False)
@@ -362,7 +362,7 @@ def mount_share(share, mnt_pt):
 
 def mount_snap(share, snap_name, snap_mnt=None):
     pool_device = ('/dev/disk/by-id/%s' %
-                   share.pool.disk_set.first().target_name)
+                   share.pool.disk_set.attached().first().target_name)
     share_path = ('%s%s' % (DEFAULT_MNT_DIR, share.name))
     rel_snap_path = ('.snapshots/%s/%s' % (share.name, snap_name))
     snap_path = ('%s%s/%s' %
@@ -648,7 +648,7 @@ def rollback_snap(snap_name, sname, subvol_name, pool):
     shutil.move(snap_fp, '%s/%s/%s' % (DEFAULT_MNT_DIR, pool.name, sname))
     create_tmp_dir(mnt_pt)
     subvol_str = 'subvol=%s' % sname
-    dpath = '/dev/disk/by-id/%s' % pool.disk_set.first().target_name
+    dpath = '/dev/disk/by-id/%s' % pool.disk_set.attached().first().target_name
     mnt_cmd = [MOUNT, '-t', 'btrfs', '-o', subvol_str, dpath, mnt_pt]
     run_command(mnt_cmd)
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -648,7 +648,7 @@ def rollback_snap(snap_name, sname, subvol_name, pool):
     shutil.move(snap_fp, '%s/%s/%s' % (DEFAULT_MNT_DIR, pool.name, sname))
     create_tmp_dir(mnt_pt)
     subvol_str = 'subvol=%s' % sname
-    dpath = '/dev/disk/by-id/%s' % pool.disk_set.first().name
+    dpath = '/dev/disk/by-id/%s' % pool.disk_set.first().target_name
     mnt_cmd = [MOUNT, '-t', 'btrfs', '-o', subvol_str, dpath, mnt_pt]
     run_command(mnt_cmd)
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -245,7 +245,7 @@ def mount_root(pool):
     # the relevant devices and avoids the potential overkill of a system wide
     # call such as is performed in the rockstor-bootstrap service on boot.
     # Disk.target_name ensures we observe any redirect roles.
-    device_scan([dev.target_name for dev in pool.disk_set.all()])
+    device_scan([dev.target_name for dev in pool.disk_set.attached()])
     if (os.path.exists(mnt_device)):
         if (len(mnt_options) > 0):
             mnt_cmd.extend(['-o', mnt_options])
@@ -257,9 +257,9 @@ def mount_root(pool):
     if (pool.disk_set.count() < 1):
         raise Exception('Cannot mount Pool(%s) as it has no disks in it.'
                         % pool.name)
-    last_device = pool.disk_set.last()
-    logger.info('Mount by label failed.')
-    for device in pool.disk_set.all():
+    last_device = pool.disk_set.attached().last()
+    logger.info('Mount by label (%s) failed.' % mnt_device)
+    for device in pool.disk_set.attached():
         mnt_device = ('/dev/disk/by-id/%s' % device.target_name)
         logger.info('Attempting mount by device (%s).' % mnt_device)
         if (os.path.exists(mnt_device)):

--- a/src/rockstor/scripts/bootstrap.py
+++ b/src/rockstor/scripts/bootstrap.py
@@ -52,6 +52,7 @@ def main():
     while True:
         try:
             aw = APIWrapper()
+            time.sleep(2)
             aw.api_call('network')
             aw.api_call('commands/bootstrap', calltype='post')
             break

--- a/src/rockstor/storageadmin/urls/commands.py
+++ b/src/rockstor/storageadmin/urls/commands.py
@@ -19,10 +19,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.conf.urls import patterns, url
 from storageadmin.views import CommandView
 
-valid_commands = ('uptime|bootstrap|utcnow|update-check|update|'
-                  'current-version|shutdown|reboot|kernel|current-user|auto-update-status'  # noqa E501
-                  '|enable-auto-update|disable-auto-update|refresh-pool-state'
-                  '|refresh-share-state|refresh-snapshot-state')
+valid_commands = ('uptime|bootstrap|utcnow|update-check|update|current-version'
+                  '|shutdown|reboot|kernel|current-user|auto-update-status'
+                  '|enable-auto-update|disable-auto-update|refresh-disk-state'
+                  '|refresh-pool-state|refresh-share-state'
+                  '|refresh-snapshot-state')
 
 urlpatterns = patterns(
     '',

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -24,6 +24,7 @@ from rest_framework.authentication import (BasicAuthentication,
                                            SessionAuthentication)
 from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
+from storageadmin.views import DiskMixin
 from system.osi import (uptime, kernel_info)
 from fs.btrfs import (mount_share, mount_root, qgroup_create, get_pool_info,
                       pool_raid, mount_snap)
@@ -47,7 +48,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CommandView(NFSExportMixin, APIView):
+class CommandView(DiskMixin, NFSExportMixin, APIView):
     authentication_classes = (DigestAuthentication, SessionAuthentication,
                               BasicAuthentication,
                               RockstorOAuth2Authentication,)
@@ -78,7 +79,7 @@ class CommandView(NFSExportMixin, APIView):
     @transaction.atomic
     def post(self, request, command, rtcepoch=None):
         if (command == 'bootstrap'):
-
+            self._update_disk_state()
             self._refresh_pool_state()
             for p in Pool.objects.all():
                 import_shares(p, request)
@@ -291,6 +292,10 @@ class CommandView(NFSExportMixin, APIView):
                 msg = ('Failed to disable auto update due to this exception:  '
                        '%s' % e.__str__())
                 handle_exception(Exception(msg), request)
+
+        if (command == 'refresh-disk-state'):
+            self._update_disk_state()
+            return Response()
 
         if (command == 'refresh-pool-state'):
             self._refresh_pool_state()


### PR DESCRIPTION
To avoid the unintended use of detached devices the Disk model was extended with a custom manager to return a query set that excluded Disk.name__startswith='detached-'. This mechanism was then used to replace Pool.disk_set.all() where appropriate. The manager was made default to facilitate it's use via the related fields/Disk.pool ForeignKey relationship.

Components of this pr:

1. Disk Model extension as above.
2. Use of the above model extension to replace Pool.disk_set.all() and Pool.disk_set.first() with Pool.disk_set.attached() and Pool.disk_set.attached().first() respectively.
3. Bootstrap command (called up to 17 times from src/rockstor/scripts/bootstrap.py via /etc/systemd/system/rockstor-bootstrap.service upon encountering any exception in bootstrap) was modified via DiskMixin inheritance to be able to update disk state prior to pool state. This was also added as an external command capability.
4. Bootstrap command, as in (3) above, was also enhanced via the model extension in (1) to avoid all attempts at refreshing Pool and Share info via detached disks, including skipping pool updates whose members are all detached.
5. An essentially unrelated but minor bug fix where partitioned devices could cause snapshot rollback to fail (a simple replacement of Disk.name with Disk.target_name) which was found on a line also altered in (2) above.
6. During final testing of the above it was noticed that the api calls 'try' block executed by the rockstor-bootstrap service would always fail on the first attempt “Exception while setting access_token”. Adding an additional 2 second delay directly after APIWrapper() setup resulted in no similar exceptions on the same configuration. A 1 second delay was trialled and found to be insufficient. Testing was carried out on a clean build which included this pr’s other patches.

Besides the:
Fixes #1422 
this pr also contributes towards degraded mount capability by avoiding the use of detached members of a pool in all device queries. It also improves the bootstrap behaviour re pools whose members are all detached. There by enabling greater flexibility re scenarios such as external drive use where a device is the only member of a pool and is not permanently attached.

Ready for review.