### PR TITLE
minor disk api regression follow up. Fixes #1750

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -81,11 +81,11 @@
                                         <td>{{mathHelper @index}}</td>
                                         <td>{{this.name}}
                                             {{#if this.parted}}
-                                                <a href="#disks/role/{{this.name}}" class="user_role_part" data-disk-name="{{this.name}}" title="Partition (Redirect Role), click to edit. Capacity is for whole disk." rel="tooltip">
+                                                <a href="#disks/role/{{this.id}}" class="user_role_part" data-disk-id="{{this.id}}" title="Partition (Redirect Role), click to edit. Capacity is for whole disk." rel="tooltip">
                                                     <i class="glyphicon glyphicon-tags"></i></a>
                                             {{/if}}
                                             {{#if (isOpenLuks this.role)}}
-                                                <a href="#disks/luks/{{this.name}}" class="open_luks_drive" data-disk-name="{{this.name}}" title="Open LUKS Volume, click to review." rel="tooltip">
+                                                <a href="#disks/luks/{{this.id}}" class="open_luks_drive" data-disk-id="{{this.id}}" title="Open LUKS Volume, click to review." rel="tooltip">
                                                     <i class="glyphicon glyphicon-eye-open"></i></a>
                                             {{/if}}
                                         </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -269,7 +269,7 @@ SmartcustomDiskView = RockstorLayoutView.extend({
                 if (buttonDisabled(button)) return false;
                 disableButton(button);
                 var submitmethod = 'POST';
-                var posturl = '/api/disks/' + disk_name + '/smartcustom-drive';
+                var posturl = '/api/disks/' + disk_id + '/smartcustom-drive';
                 $.ajax({
                     url: posturl,
                     type: submitmethod,

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -388,7 +388,7 @@ class DiskDetailView(rfc.GenericView):
         try:
             return Disk.objects.get(id=did)
         except:
-            e_msg = ('Disk(%d) does not exist' % did)
+            e_msg = ('Disk(%s) does not exist' % did)
             handle_exception(Exception(e_msg), request)
 
     @staticmethod
@@ -463,11 +463,11 @@ class DiskDetailView(rfc.GenericView):
         try:
             disk = Disk.objects.get(id=did)
         except:
-            e_msg = ('Disk: %d does not exist' % did)
+            e_msg = ('Disk: %s does not exist' % did)
             handle_exception(Exception(e_msg), request)
 
         if (disk.offline is not True):
-            e_msg = ('Disk: %d is not offline. Cannot delete' % did)
+            e_msg = ('Disk: %s is not offline. Cannot delete' % did)
             handle_exception(Exception(e_msg), request)
 
         try:
@@ -519,10 +519,10 @@ class DiskDetailView(rfc.GenericView):
         reverse_name, isPartition = self._reverse_role_filter_name(disk_name,
                                                                    request)
         if reverse_name != disk.name:
-            e_msg = ('Wipe operation on whole or partition of device (%d) was '
+            e_msg = ('Wipe operation on whole or partition of device (%s) was '
                      'rejected as there was a discrepancy in device name '
                      'resolution. Wipe was called with device name (%s) which '
-                     'redirected to (%d) but a check on this redirection '
+                     'redirected to (%s) but a check on this redirection '
                      'returned device name (%s), which is not equal to the '
                      'caller name as was expected. A Disks page Rescan may '
                      'help.'
@@ -707,7 +707,7 @@ class DiskDetailView(rfc.GenericView):
                 import_snapshots(share)
             return Response(DiskInfoSerializer(disk).data)
         except Exception as e:
-            e_msg = ('Failed to import any pool on this device(%d). Error: %s'
+            e_msg = ('Failed to import any pool on this device(%s). Error: %s'
                      % (did, e.__str__()))
             handle_exception(Exception(e_msg), request)
 

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -42,7 +42,7 @@ class DiskSMARTDetailView(rfc.GenericView):
         try:
             return Disk.objects.get(id=did)
         except:
-            e_msg = ('Disk: %d does not exist' % did)
+            e_msg = ('Disk: %s does not exist' % did)
             handle_exception(Exception(e_msg), request)
 
     def get(self, *args, **kwargs):


### PR DESCRIPTION
Collection of follow-up fixes related to recent api url changes.

1. Partition 'tags' icon url update in Create Pool dialog.
2. Open LUKS volume 'eye-open' icon url update in Create Pool dialog
3. Exceptions containing disk id reporting were changed to %s as our 'did' is now unicode.
4. S.M.A.R.T custom option api url was update to use the new api format

All sub-issues above were first reproduced and then tested to work as expected after the relevant fix was applied. For (3) the 6 affected Exception messages were tested individually before and after relevant patches by the simple temporary addition of a raise in their respective 'try' blocks or by temporary inversion of their related if clauses.

Fixes #1750 

Ready for review.
