### PR TITLE
make hdparm systemd service template more robust. Fixes #1752

### DIFF
--- a/conf/rockstor-hdparm.service
+++ b/conf/rockstor-hdparm.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Rockstor hdparm settings
 After=suspend.target
-# Rockstor-hdparm - the automated maintenance of this file requires a clear line
-# at the end of both the Unit and Service sections, but no other clear lines.
+Requires=systemd-udev-settle.service
+# N.B. Requires a clear line after Unit & Service sections. No others permitted.
 # The line count of the template file in <rockstorroot>/conf is used to evaluate
 # if an 'all entries removed' scenario has been reached. If any modification are
 # made to the template file please also delete the generated file,


### PR DESCRIPTION
The existing template did not ensure that the by-id names used to identify devices were available. The fail condition was only seen on some systems but resulted in custom spin down times and APM configurations, entered via the GUI on the affected systems, not be applied.

The proposed fix in this pr is to make use of the:

    Requires=systemd-udev-settle.service

entry in the template used to create the:

/etc/systemd/system/rockstor-hdparm.service

Care was taken to keep the existing line count the same as the previous template which allows for existing configurations to make use of the new template by simply removing all of their existing Spin Down and APM settings (to cause the in place rockstor-hdparm.service file to be remove) and then re-apply the same settings. This re-applying from scratch (after first removing all existing Spin Down and APM configs) will ensure the new template, complete with fix, is put into play.

Note that there is a hardware combination component to expressing the noted failed state (in the related issue text #1752): that of the device's by-id name not being available when systemd attempts the rockstor-hdparm.service. The exact same system disk (installed on USB) was transferred to a system that, with it's own msata boot system disk did not exhibit the failure, continued to not exhibit the failure when booted from the USB system disk that previously did (on other hardware) exhibit a failed hdparm service start. However when transferring the msata based system disk from the non failing system to the previously failing system the fault was not expressed. Hence the exact trigger of this fault was not established but no regression was observed on any of the systems trialled and all previously failing systems were fixed. For this test procedure 2 previously failing systems and 2 previously working systems were used, ranging from 1 to 4 cores and 2 - 4 GB RAM; in all cases at least 2 concurrent and relevant hdparm entries were included in the rockstor-hdparm.service file.

Fixes #1752 

Ready for review.