### PR TITLE
no drive name on custom smart options and spin down pages. Fixes #1756

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -53,9 +53,10 @@ SmartcustomDiskView = RockstorLayoutView.extend({
         });
         var serialNumber = disk_obj.get('serial');
         var currentSmartCustom = disk_obj.get('smart_options');
+        var disk_name = disk_obj.get('name');
 
         $(this.el).html(this.template({
-            diskName: this.diskName,
+            diskName: disk_name,
             serialNumber: serialNumber,
             currentSmartCustom: currentSmartCustom
         }));

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/spindown_disks.js
@@ -91,9 +91,10 @@ SpindownDiskView = RockstorLayoutView.extend({
         var serialNumber = diskObj.get('serial');
         var hdparmSetting = diskObj.get('hdparm_setting');
         var apmLevel = diskObj.get('apm_level');
+        var disk_name = diskObj.get('name');
 
         $(this.el).html(this.template({
-            diskName: diskObj.name,
+            diskName: disk_name,
             serialNumber: serialNumber,
             spindownTimes: spindownTimes,
             hdparmSetting: hdparmSetting,


### PR DESCRIPTION
Addresses cosmetic UI components identified as regressions from recent pr's:

#1747 (1746 disk api changes)
#1751 (minor disk api regression follow up. Fixes #1750)

Prior to pull request both "Drive name:" fields were empty, however the serial number on both pages was still displayed. After the pull request the "Drive name:" fields correctly indicated the associated drive.

Fixes #1756 

Ready for review.