### PR TITLE
fix scheduled scrub regression re pool api changes. Fixes #1759

### DIFF
--- a/src/rockstor/smart_manager/views/task_scheduler.py
+++ b/src/rockstor/smart_manager/views/task_scheduler.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from smart_manager.models import TaskDefinition
-from storageadmin.models import EmailClient
+from storageadmin.models import (Pool, EmailClient)
 from smart_manager.serializers import TaskDefinitionSerializer
 from django.db import transaction
 from django.conf import settings
@@ -40,12 +40,20 @@ class TaskSchedulerMixin(object):
         crontab = request.data.get('crontab')
         crontabwindow = request.data.get('crontabwindow')
         meta = request.data.get('meta', {})
-        if 'rtc_hour' in meta:
-            meta['rtc_hour'] = int(meta['rtc_hour'])
-            meta['rtc_minute'] = int(meta['rtc_minute'])
+        # "if 'rtc_hour'" block moved to below dictionary type check on meta.
         if (type(meta) != dict):
             e_msg = ('meta must be a dictionary, not %s' % type(meta))
             handle_exception(Exception(e_msg), request)
+        if 'pool' in meta:
+            if not Pool.objects.filter(id=meta['pool']).exists():
+                raise Exception('Non-existent Pool(%s) in meta. %s' %
+                                (meta['pool'], meta))
+            # Add pool_name to task meta dictionary
+            pool = Pool.objects.get(id=meta['pool'])
+            meta['pool_name'] = pool.name
+        if 'rtc_hour' in meta:
+            meta['rtc_hour'] = int(meta['rtc_hour'])
+            meta['rtc_minute'] = int(meta['rtc_minute'])
         return crontab, crontabwindow, meta
 
     @staticmethod

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -530,6 +530,12 @@ var TaskDef = Backbone.Model.extend({
         }
         return '';
     },
+    pool_name: function() {
+        if (this.get('json_meta') != null) {
+            return JSON.parse(this.get('json_meta')).pool_name;
+        }
+        return '';
+    },
     visible: function() {
         if (this.get('json_meta') != null) {
             return JSON.parse(this.get('json_meta')).visible;

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/scrub_fields.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/scrub_fields.jst
@@ -9,7 +9,7 @@
         <div class="col-md-4">
             <select class="form-control" id="pool" name="meta.pool">
             {{#each pools}}
-                <option value="{{this.name}}">{{this.name}}</option>
+                <option value="{{this.id}}">{{this.name}}</option>
             {{/each}}
             </select>
         </div><!--col-md-4-->
@@ -17,9 +17,9 @@
 </div><!--row -->
 {{else}}
 <div class="form-group">
-    <label class="control-label col-sm-4" for="share">Pool: </label>
+    <label class="control-label col-sm-4" for="share">Pool name: </label>
     <div class="col-sm-6">
-        <input type="text" class="form-control" value="{{> taskObj.pool}}" disabled />
+        <input type="text" class="form-control" value="{{> taskObj.pool_name}}" disabled />
     </div>    
 </div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/tasks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/tasks.jst
@@ -20,7 +20,7 @@
 </script>
 
 <h4>Task history for {{taskName}} &nbsp;
-({{display_snapshot_scrub}})
+( {{display_snapshot_scrub}} )
 </h4>
 {{#if collectionNotEmpty}}
   <div class="row">

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
@@ -78,6 +78,7 @@ AddScheduledTaskView = RockstorLayoutView.extend({
                 share: this.taskDef.share(),
                 prefix: this.taskDef.prefix(),
                 pool: this.taskDef.pool(),
+                pool_name: this.taskDef.pool_name(),
                 maxCount: this.taskDef.max_count(),
                 visible: this.taskDef.visible(),
                 writable: this.taskDef.writable(),
@@ -172,6 +173,13 @@ AddScheduledTaskView = RockstorLayoutView.extend({
                     }
                 },
                 pool: {
+                    required: {
+                        depends: function(element) {
+                            return (_this.$('#task_type').val() == 'scrub');
+                        }
+                    }
+                },
+                'meta.pool_name': {
                     required: {
                         depends: function(element) {
                             return (_this.$('#task_type').val() == 'scrub');

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
@@ -145,7 +145,7 @@ ScheduledTasksView = RockstorLayoutView.extend({
                 if (taskType == 'snapshot') {
                     html += '(' + JSON.parse(jsonMeta).share + ')';
                 } else if (taskType == 'scrub') {
-                    html += '(' + JSON.parse(jsonMeta).pool + ')';
+                    html += '(' + JSON.parse(jsonMeta).pool_name + ')';
                 }
                 html += '</td>';
                 html += '<td>' + prettyCron.toString(t.get('crontab')) + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
@@ -81,9 +81,9 @@ TasksView = RockstorLayoutView.extend({
         Handlebars.registerHelper('display_snapshot_scrub', function() {
             var html = '';
             if (this.taskDef.get('task_type') == 'snapshot') {
-                html += 'Snapshot of Share[' + JSON.parse(this.taskDef.get('json_meta')).share + ']';
+                html += 'Snapshot of Share [' + JSON.parse(this.taskDef.get('json_meta')).share + ']';
             } else if (this.taskDef.get('task_type') == 'scrub'){
-                html += 'Scrub of Pool[' + JSON.parse(this.taskDef.get('json_meta')).pool + ']';
+                html += 'Scrub of Pool [' + JSON.parse(this.taskDef.get('json_meta')).pool_name + ']';
             } else {
                 html += this.taskDef.get('task_type');
             }


### PR DESCRIPTION
Thanks to @kbogert, @MFlyer, and KarstenV on the forum for helping to diagnose the associated issue.
Update UI input to pass pool id not name as per new api. Also adds pool_name to meta field and backbone model of scrub tasks to enable scheduled task interfaces to report the associated pool name.

Some minor cosmetic spacing adjustments were also included in UI pool name display elements.

Fixes #1759 

@schakrava Ready for review

Please see the associated issue text and the following forum thread for historical context:
https://forum.rockstor.com/t/scheduled-scrub-throws-an-error/3448