### PR TITLE
mark whole disk LVM members as unusable. Fixes #1710

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -50,6 +50,9 @@
         {{else if (isBcacheCdev this.role)}}
             <a href="#" class="bcache_caching_drive" data-disk-id="{{this.id}}" title="Bcache Caching Drive (UI pending)." rel="tooltip">
             <i class="glyphicon glyphicon-link"></i><i class="glyphicon glyphicon-link"></i></a>
+        {{else if (isLVM2member this.role)}}
+            <a href="#disks/role/{{this.id}}" class="LVM2_member" data-disk-id="{{this.id}}" title="Disk is unusable as it is an LVM2 member (Physical Volume). Click to wipe." rel="tooltip">
+            <i class="glyphicon glyphicon-cog"></i></a>
         {{else if this.parted}}
             {{#if (hasUserRole this.role)}}
                 <a href="#disks/role/{{this.id}}" class="user_role_part" data-disk-id="{{this.id}}" title="User Assigned Role found on partitioned disk, click to edit." rel="tooltip">

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disks.js
@@ -398,6 +398,22 @@ DisksView = RockstorLayoutView.extend({
             return false;
         });
 
+        // Identify LVM2_member devices by return of true / false.
+        // Works by examining the Disk.role field. Based on sister handlebars
+        // helper 'isBcache'
+        Handlebars.registerHelper('isLVM2member', function (role) {
+            var roleAsJson = asJSON(role);
+            if (roleAsJson == false) return false;
+            // We have a json string ie non legacy role info so we can examine:
+            if (roleAsJson.hasOwnProperty('LVM2member')) {
+                // We have an LVM2 member (Physical Volume) which we tag to
+                // avoid it's accidental re-use / delete.
+                return true;
+            }
+            // In all other cases return false.
+            return false;
+        });
+
         // Identify User assigned role disks by return of true / false.
         // Works by examining the Disk.role field. Based on sister handlebars
         // helper 'isBcache'

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/setrole_disks.js
@@ -113,6 +113,11 @@ SetroleDiskView = RockstorLayoutView.extend({
         } else {
             is_open_luks = false;
         }
+        // convenience flag to indicate if a device is an LVM2 member.
+        var is_lvm2member;
+        if (role_obj !== null && role_obj.hasOwnProperty('LVM2member')) {
+            is_lvm2member = true;
+        }
 
         this.current_redirect = current_redirect;
         this.partitions = partitions;
@@ -121,6 +126,7 @@ SetroleDiskView = RockstorLayoutView.extend({
         this.is_luks = is_luks;
         this.is_unlocked = is_unlocked;
         this.current_crypttab_status = current_crypttab_status;
+        this.is_lvm2member = is_lvm2member;
 
         $(this.el).html(this.template({
             diskName: diskName,
@@ -133,7 +139,8 @@ SetroleDiskView = RockstorLayoutView.extend({
             is_luks: is_luks,
             is_open_luks: is_open_luks,
             is_unlocked: is_unlocked,
-            current_crypttab_status: current_crypttab_status
+            current_crypttab_status: current_crypttab_status,
+            is_lvm2member: is_lvm2member
         }));
 
         this.$('#add-role-disk-form :input').tooltip({
@@ -366,7 +373,8 @@ SetroleDiskView = RockstorLayoutView.extend({
         // helps to avoid some potential confusion when re-formatting a LUKS
         // container as it forces a traditional wipe first.
         if (_.isEmpty(this.partitions) && this.disk_btrfs_uuid == null
-            && this.is_open_luks !== true && this.is_luks !== true) {
+            && this.is_open_luks !== true && this.is_luks !== true
+            && this.is_lvm2member !== true) {
             luks_tick.removeAttr('disabled');
             this.$('#luks_options').show();
         } else {
@@ -389,6 +397,8 @@ SetroleDiskView = RockstorLayoutView.extend({
                 whole_disk_fstype = 'btrfs';
             } else if (this.is_luks) {
                 whole_disk_fstype = 'LUKS';
+            } else if (this.is_lvm2member) {
+                whole_disk_fstype = 'LVM2_member';
             } else {
                 whole_disk_fstype = 'None';
             }


### PR DESCRIPTION
Prior to this pull request whole disk LVM2 physical volumes are not recognised and are incorrectly identified as blank disks. By introducing an 'LVM2member' whole disk role, keyed from fstype, we automatically exclude these devices from pool participation selection by our existing white list on roles approach. Once assigned the role informs a handelbars helper and both front and back end logic to enhance UI feedback accordingly.

Fixes #1710 

Ready for review.