### PR TITLE
improve mount status reporting capability. Fixes #1763 

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -227,7 +227,7 @@ def mount_root(pool):
     indicates 'no disks in pool' or 'Unknown Reason'
     """
     root_pool_mnt = DEFAULT_MNT_DIR + pool.name
-    if (is_share_mounted(pool.name)):
+    if pool.is_mounted:
         return root_pool_mnt
     # Creates a directory to act as the mount point.
     create_tmp_dir(root_pool_mnt)

--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -24,7 +24,7 @@ from base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from django.conf import settings
 from storageadmin.models import Share
-from fs.btrfs import (mount_share, is_share_mounted)
+from fs.btrfs import mount_share
 import re
 import shutil
 
@@ -63,7 +63,7 @@ class DockerServiceView(BaseServiceDetailView):
 
             share = self._validate_root(request, config['root_share'])
             mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
-            if (not is_share_mounted(share.name)):
+            if not share.is_mounted:
                 mount_share(share, mnt_pt)
 
             inf = ('%s/docker.service' % (settings.CONFROOT))

--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -19,6 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.db import models
 from django.conf import settings
 from fs.btrfs import pool_usage, usage_bound
+from system.osi import mount_status
+
+RETURN_BOOLEAN = True
 
 
 class Pool(models.Model):
@@ -53,6 +56,23 @@ class Pool(models.Model):
                       .values_list('size', flat=True)
                       .order_by('-size')]
         return usage_bound(disk_sizes, len(disk_sizes), self.raid)
+
+    @property
+    def mount_status(self, *args, **kwargs):
+        # Presents raw string of active mount options akin to mnt_options field
+        try:
+            return mount_status('%s%s' % (settings.MNT_PT, self.name))
+        except:
+            return None
+
+    @property
+    def is_mounted(self, *args, **kwargs):
+        # Calls mount_status in return boolean mode.
+        try:
+            return mount_status('%s%s' % (settings.MNT_PT, self.name),
+                                RETURN_BOOLEAN)
+        except:
+            return False
 
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -22,8 +22,11 @@ from django.db.models.signals import (post_save, post_delete)
 from django.dispatch import receiver
 
 from storageadmin.models import Pool
+from system.osi import mount_status
 from .netatalk_share import NetatalkShare
 from system.services import (systemctl, refresh_afp_config)
+
+RETURN_BOOLEAN = True
 
 
 class Share(models.Model):
@@ -60,6 +63,23 @@ class Share(models.Model):
     @property
     def size_gb(self):
         return self.size / (1024.0 * 1024.0)
+
+    @property
+    def mount_status(self, *args, **kwargs):
+        # Presents raw string of active mount options
+        try:
+            return mount_status('%s%s' % (settings.MNT_PT, self.name))
+        except:
+            return None
+
+    @property
+    def is_mounted(self, *args, **kwargs):
+        # Calls mount_status in return boolean mode.
+        try:
+            return mount_status('%s%s' % (settings.MNT_PT, self.name),
+                                RETURN_BOOLEAN)
+        except:
+            return False
 
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -49,6 +49,8 @@ class PoolInfoSerializer(serializers.ModelSerializer):
     disks = DiskInfoSerializer(many=True, source='disk_set')
     free = serializers.IntegerField()
     reclaimable = serializers.IntegerField()
+    mount_status = serializers.CharField()
+    is_mounted = serializers.BooleanField()
 
     class Meta:
         model = Pool
@@ -139,6 +141,8 @@ class ShareSerializer(serializers.ModelSerializer):
     snapshots = SnapshotSerializer(many=True, source='snapshot_set')
     pool = PoolInfoSerializer()
     nfs_exports = NFSExportSerializer(many=True, source='nfsexport_set')
+    mount_status = serializers.CharField()
+    is_mounted = serializers.BooleanField()
 
     class Meta:
         model = Share

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
@@ -22,7 +22,14 @@
 <!-- Content -->
 <div class="module-content">
   <h3>Details</h3>
-  Created on <strong>{{getPoolCreationDate model.toc}}</strong><br/>
-  Raid Configuration: <strong>{{model.raid}}</strong>
+  Created on: <strong>{{getPoolCreationDate model.toc}}</strong><br/>
+  Raid configuration: <strong>{{model.raid}}</strong><br/>
+  Active mount options / Status: <strong>
+  {{#if model.is_mounted}}
+    {{model.mount_status}}
+  {{else}}
+    <span style="color:red">{{model.mount_status}}</span>
+  {{/if}}
+  </strong>
 </div> <!-- module-content -->
  

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -6,6 +6,7 @@
       <th>Size</th>
       <th>Usage</th>
       <th>Raid</th>
+      <th>Active mount options / Status</th>
       <th>Compression</th>
       <th>Extra mount options</th>
       <th>Disks</th>
@@ -36,6 +37,12 @@
                 {{#unless (isRoot this.role)}}
                       &nbsp;<a href="#pools/{{this.id}}/?cView=resize"><i class="fa fa-pencil-square-o"></i></a>
                 {{/unless}}
+            </td>
+            <td>{{#if this.is_mounted}}
+                    {{this.mount_status}}
+                {{else}}
+                    <strong><span style="color:red">{{this.mount_status}}</span></strong>
+                {{/if}}
             </td>
             <td>
             {{#if (isRoot this.role)}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
@@ -20,8 +20,8 @@
 </script>
 
 <div id="ph-share-info">
-  Created on {{shareCreatedDate}} <br>
-  Pool: <a href="#pools/{{poolName}}">{{poolName}}</a> 
+  Created on: <strong>{{shareCreatedDate}}</strong><br>
+  Pool: <a href="#pools/{{pid}}">{{poolName}}</a>
 </div>
 <br><br>
 <div id="chart"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
@@ -21,7 +21,21 @@
 
 <div id="ph-share-info">
   Created on: <strong>{{shareCreatedDate}}</strong><br>
-  Pool: <a href="#pools/{{pid}}">{{poolName}}</a>
+  Pool (Active mount options / Status): <a href="#pools/{{pid}}">{{poolName}}</a>
+  {{#if pool_is_mounted}}
+    ({{pool_mount_status}})
+  {{else}}
+    (<strong><span style="color:red">{{pool_mount_status}}</span></strong>)
+  {{/if}}
+  <br>
+  Active mount options / Status:
+  <strong>
+  {{#if share_is_mounted}}
+    {{share_mount_status}}
+  {{else}}
+    <span style="color:red">{{share_mount_status}}</span>
+  {{/if}}
+  </strong>
 </div>
 <br><br>
 <div id="chart"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -12,21 +12,35 @@
       <tr>
         <th>Name</th>
         <th>Size</th>
-        <th>Pool</th>
         <th>Usage <i class="fa fa-info-circle" title="Current share content"></th>
-		<th>Usage (Btrfs) <i class="fa fa-info-circle" title="Current share content considering snapshots too"></th>
-	    <th>Compression algorithm</th>
+        <th>Btrfs Usage <i class="fa fa-info-circle" title="Current share content including snapshots"></th>
+        <th>Active mount options / Status</th>
+        <th>Pool (Active mount options / Status)</th>
+        <th>Compression <i class="fa fa-info-circle" title="Inherits pool setting if not specified on share"></th>
         <th>Actions</th>
       </tr>
     </thead>
     <tbody>
     {{#each shares}}
     <tr>
-        <td><a href="#shares/{{this.name}}"><i class="glyphicon glyphicon-folder-open"></i>  {{this.name}}</a></td>
+        <td><a href="#shares/{{this.name}}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;&nbsp;{{this.name}}</a></td>
         <td>{{humanize_size this.size}}</td>
-        <td>{{this.pool.name}}</td>
         <td>{{humanize_size this.rusage}}</td>
-		<td>{{humanize_size this.pqgroup_rusage}} {{checkUsage this.size this.pqgroup_rusage}}</td>
+        <td>{{humanize_size this.pqgroup_rusage}} {{checkUsage this.size this.pqgroup_rusage}}</td>
+        <td>
+            {{#if this.is_mounted}}
+                {{this.mount_status}}
+            {{else}}
+                <strong><span style="color:red">{{this.mount_status}}</span></strong>
+            {{/if}}
+        </td>
+        <td><a href="#pools/{{this.pool.id}}">{{this.pool.name}}</a>
+            {{#if this.pool.is_mounted}}
+                ({{this.pool.mount_status}})
+            {{else}}
+                (<strong><span style="color:red">{{this.pool.mount_status}}</span></strong>)
+            {{/if}}
+        </td>
         <td>
         {{displayCompressionAlgo this.compression_algo this.name}}
         </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
@@ -40,12 +40,12 @@
         <input class="js-snapshot-select-all inline" type="checkbox" name="snapshot-select-all" ></input>
       </th>
       <th>Snapshot Name</th>
-      <th>Created on</th>
-      <th>Share</th>
-      <th>Visibility to user</th>
-      <th>Writable</th>
       <th>Total Size</th>
       <th>Exclusive Size</th>
+      <th>Created on</th>
+      <th>Share (Active mount options / Status)</th>
+      <th>Visibility</th>
+      <th>Writable</th>
     </tr>
   </thead>
   <tbody>
@@ -54,7 +54,7 @@
               <td><input class="js-snapshot-select inline" type="checkbox" name="snapshot-select" 
               data-name="{{this.name}}" data-id='{{this.id}}' {{checkboxValue this.name}}></input>
               </td>
-              <td><i class="glyphicon glyphicon-camera"></i> {{this.name}} &nbsp;&nbsp;&nbsp;&nbsp;
+              <td><i class="glyphicon glyphicon-camera"></i>&nbsp;{{this.name}}
                {{#if this.writable}}
                     <a class="js-snapshot-clone" href="#" data-name="{{this.name}}" data-share-name="{{this.share}}">
                     <i rel="tooltip" title="Clone snapshot" class="glyphicon glyphicon-book"></i></a>
@@ -62,9 +62,17 @@
                 <a href="#" class="js-snapshot-delete" id="delete_snapshot_{{this.name}}" data-name="{{this.name}}" data-size="{{getSize this.eusage}}" 
                 data-share-name="{{this.share}}" data-action="delete" title="Delete snapshot">
                 <i rel="tooltip" title="Delete snapshot" class="glyphicon glyphicon-trash"></i></a>
-               </td>
+              </td>
+              <td>{{getSize this.rusage}}</td>
+              <td>{{getSize this.eusage}}</td>
               <td>{{getToc this.toc}}</td>
-              <td><a href="#shares/{{this.share}}">{{this.share}}</a></td>
+              <td><a href="#shares/{{this.share}}">{{this.share}}</a>
+                  {{#if this.share_is_mounted}}
+                    ({{this.share_mount_status}})
+                  {{else}}
+                    (<strong><span style="color:red">{{this.share_mount_status}}</span></strong>)
+                  {{/if}}
+              </td>
                <td>
                {{#if this.uvisible}}
                     Visible
@@ -79,8 +87,6 @@
                     No
                {{/if}}
                </td>
-               <td>{{getSize this.rusage}}</td>
-               <td>{{getSize this.eusage}}</td>
           </tr>
   {{/each}}
   </tbody> 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
@@ -46,6 +46,7 @@ ShareUsageModule = RockstorModuleView.extend({
             module_name: this.module_name,
             share: this.share,
             poolName: this.share.get('pool').name,
+            pid: this.share.get('pool').id,
             shareCreatedDate: moment(this.share.get('toc')).format(RS_DATE_FORMAT),
         }));
         this.renderGraph();

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
@@ -46,6 +46,10 @@ ShareUsageModule = RockstorModuleView.extend({
             module_name: this.module_name,
             share: this.share,
             poolName: this.share.get('pool').name,
+            pool_is_mounted: this.share.get('pool').is_mounted,
+            pool_mount_status: this.share.get('pool').mount_status,
+            share_is_mounted: this.share.get('is_mounted'),
+            share_mount_status: this.share.get('mount_status'),
             pid: this.share.get('pool').id,
             shareCreatedDate: moment(this.share.get('toc')).format(RS_DATE_FORMAT),
         }));

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -139,12 +139,14 @@ SharesView = RockstorLayoutView.extend({
 
         Handlebars.registerHelper('displayCompressionAlgo', function(shareCompression,shareName) {
             var html = '';
-            if(shareCompression && shareCompression != 'no'){
-                html += shareCompression;
+            if (shareCompression && shareCompression != 'no') {
+                html += shareCompression + ' ';
             } else {
-                html += 'None(defaults to pool level compression, if any)   ' +
-				'<a href="#shares/' + shareName + '/?cView=edit"><i class="glyphicon glyphicon-pencil"></i></a>';
+                html += 'Same as Pool ';
             }
+            html += '<a href="#shares/' + shareName + '/?cView=edit"' +
+                'title="Edit share compression setting" rel="tooltip">' +
+                '<i class="glyphicon glyphicon-pencil"></i></a>';
             return new Handlebars.SafeString(html);
         });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
@@ -78,6 +78,8 @@ SnapshotsView = SnapshotsCommonView.extend({
                 return share.get('id') == snapshots[i].share;
             });
             snapshots[i].share = shareMatch.get('name');
+            snapshots[i].share_is_mounted = shareMatch.get('is_mounted');
+            snapshots[i].share_mount_status = shareMatch.get('mount_status');
         }
         $(this.el).append(_this.template({
             snapshots: snapshots,

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -30,7 +30,7 @@ from fs.btrfs import (mount_share, mount_root, qgroup_create, get_pool_info,
                       pool_raid, mount_snap)
 from system.ssh import (sftp_mount_map, sftp_mount)
 from system.services import systemctl
-from system.osi import (is_share_mounted, system_shutdown, system_reboot,
+from system.osi import (system_shutdown, system_reboot,
                         system_suspend, set_system_rtc_wake)
 from storageadmin.models import (Share, NFSExport, SFTP, Pool, Snapshot,
                                  UpdateSubscription, AdvancedNFSExport)
@@ -101,7 +101,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                     if (share.pqgroup == settings.MODEL_DEFS['pqgroup']):
                         share.pqgroup = qgroup_create(share.pool)
                         share.save()
-                    if (not is_share_mounted(share.name)):
+                    if not share.is_mounted:
                         mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
                         mount_share(share, mnt_pt)
                 except Exception as e:

--- a/src/rockstor/storageadmin/views/netatalk.py
+++ b/src/rockstor/storageadmin/views/netatalk.py
@@ -23,7 +23,7 @@ from storageadmin.models import NetatalkShare
 from storageadmin.util import handle_exception
 from storageadmin.serializers import NetatalkShareSerializer
 from storageadmin.exceptions import RockStorAPIException
-from fs.btrfs import (mount_share, is_share_mounted)
+from fs.btrfs import mount_share
 from system.services import (systemctl, refresh_afp_config)
 import rest_framework_custom as rfc
 from share_helpers import validate_share
@@ -129,7 +129,7 @@ class NetatalkListView(rfc.GenericView):
                                      description=cur_description,
                                      time_machine=time_machine)
                 afpo.save()
-                if (not is_share_mounted(share.name)):
+                if not share.is_mounted:
                     mount_share(share, mnt_pt)
             refresh_afp_config(list(NetatalkShare.objects.all()))
             systemctl('netatalk', 'reload-or-restart')

--- a/src/rockstor/storageadmin/views/nfs_exports.py
+++ b/src/rockstor/storageadmin/views/nfs_exports.py
@@ -23,7 +23,7 @@ from storageadmin.models import (NFSExport, NFSExportGroup, AdvancedNFSExport)
 from storageadmin.util import handle_exception
 from storageadmin.serializers import (NFSExportGroupSerializer,
                                       AdvancedNFSExportSerializer)
-from fs.btrfs import (mount_share, is_share_mounted)
+from fs.btrfs import mount_share
 from system.osi import (refresh_nfs_exports, nfs4_mount_teardown)
 from share_helpers import validate_share
 import rest_framework_custom as rfc
@@ -64,7 +64,7 @@ class NFSExportMixin(object):
             share = fields[0].split('/')[-1]
             s = validate_share(share, request)
             mnt_pt = ('%s%s' % (settings.MNT_PT, s.name))
-            if (not is_share_mounted(s.name)):
+            if not s.is_mounted:
                 mount_share(s, mnt_pt)
             exports_d[fields[0]] = []
             for f in fields[1:]:
@@ -240,7 +240,7 @@ class NFSExportGroupDetailView(NFSExportMixin, rfc.GenericView):
             for s in shares:
                 mnt_pt = ('%s%s' % (settings.MNT_PT, s.name))
                 export_pt = ('%s%s' % (settings.NFS_EXPORT_ROOT, s.name))
-                if (not is_share_mounted(s.name)):
+                if not s.is_mounted:
                     mount_share(s, mnt_pt)
                 export = NFSExport(export_group=eg, share=s, mount=export_pt)
                 export.full_clean()

--- a/src/rockstor/storageadmin/views/samba.py
+++ b/src/rockstor/storageadmin/views/samba.py
@@ -27,7 +27,7 @@ from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
 from share import ShareMixin
 from system.samba import (refresh_smb_config, status, restart_samba)
-from fs.btrfs import (mount_share, is_share_mounted)
+from fs.btrfs import mount_share
 
 import logging
 logger = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ class SambaListView(SambaMixin, ShareMixin, rfc.GenericView):
                     cco = SambaCustomConfig(smb_share=smb_share,
                                             custom_config=cc)
                     cco.save()
-                if (not is_share_mounted(share.name)):
+                if not share.is_mounted:
                     mount_share(share, mnt_pt)
 
                 admin_users = request.data.get('admin_users', [])
@@ -218,7 +218,7 @@ class SambaDetailView(SambaMixin, rfc.GenericView):
                 cco = SambaCustomConfig(smb_share=smbo, custom_config=cc)
                 cco.save()
             for smb_o in SambaShare.objects.all():
-                if (not is_share_mounted(smb_o.share.name)):
+                if not smb_o.share.is_mounted:
                     mnt_pt = ('%s%s' % (settings.MNT_PT, smb_o.share.name))
                     try:
                         mount_share(smb_o.share, mnt_pt)

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -25,7 +25,6 @@ from storageadmin.models import (Share, Pool, Snapshot, NFSExport, SambaShare,
 from smart_manager.models import Replica
 from fs.btrfs import (add_share, remove_share, update_quota, volume_usage,
                       set_property, mount_share, qgroup_id, qgroup_create)
-from system.osi import is_share_mounted
 from system.services import systemctl
 from storageadmin.serializers import ShareSerializer, SharePoolSerializer
 from storageadmin.util import handle_exception
@@ -177,7 +176,7 @@ class ShareListView(ShareMixin, rfc.GenericView):
                       compression_algo=compression)
             s.save()
             mnt_pt = '%s%s' % (settings.MNT_PT, sname)
-            if (not is_share_mounted(sname)):
+            if not s.is_mounted:
                 mount_share(s, mnt_pt)
             if (compression != 'no'):
                 set_property(mnt_pt, 'compression', compression)

--- a/src/rockstor/storageadmin/views/share_acl.py
+++ b/src/rockstor/storageadmin/views/share_acl.py
@@ -21,7 +21,7 @@ from django.db import transaction
 from django.conf import settings
 from storageadmin.models import Share
 from storageadmin.serializers import ShareSerializer
-from fs.btrfs import (mount_share, is_share_mounted, umount_root)
+from fs.btrfs import (mount_share, umount_root)
 from storageadmin.views import ShareListView
 from system.acl import (chown, chmod)
 
@@ -53,7 +53,7 @@ class ShareACLView(ShareListView):
 
             mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
             force_mount = False
-            if (not is_share_mounted(share.name)):
+            if not share.is_mounted:
                 mount_share(share, mnt_pt)
                 force_mount = True
             chown(mnt_pt, options['owner'], options['group'],

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -21,7 +21,7 @@ from django.utils.timezone import utc
 from django.conf import settings
 from storageadmin.models import (Share, Snapshot, SFTP)
 from smart_manager.models import ShareUsage
-from fs.btrfs import (mount_share, mount_snap, is_share_mounted, is_mounted,
+from fs.btrfs import (mount_share, mount_snap, is_mounted,
                       umount_root, shares_info, volume_usage, snaps_info,
                       qgroup_create, update_quota)
 from storageadmin.util import handle_exception
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 def helper_mount_share(share, mnt_pt=None):
-    if (not is_share_mounted(share.name)):
-        if(mnt_pt is None):
+    if not share.is_mounted:
+        if mnt_pt is None:
             mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
         mount_share(share, mnt_pt)
 


### PR DESCRIPTION
Adds a ‘Mount Status’ reporting capability by resourcing /proc/mount via a Pool and Share model property extension. Consequently the pool ForeignKey relationship held by the Share model can inherit this status and be informed by it. An additional column in the Pools table, Shares table, and Snapshots overview table, reflects the current mount status. As a consequence the user experience re Pool / Share status awareness is improved; along with surfacing many of the ‘auto’ applied mount options such as ‘ssd’ and ‘space_cache’.

This pull request includes the following changes:

- Create mount_status() osi component to return current mount options / state.
- Extend Pool model to include current mount options.
- Extend Pool model to allow Pool.is_mounted boolean.
- Extend Share model to include current mount options.
- Extend Share model to allow Share.is_mounted boolean.
- Add "Active mount options / Status" column to Pools table.
- Add Pool 'mount status' / info to Pool column contents in Shares table.
- Add "Active mount options / Status" column to Shares table.
- Make Pool names in Shares table into links to those Pools details page.
- Add "Active mount options / Status" info to Pools details page
- Add "Active mount options / Status" entry against Pool link on Share details page.
- Add "Active mount options / Status" entry against Share link on Snapshots overview page.
- Add Active mount options / Status entry on Shares details page.
- Use Pool.is_mounted or Share.pool.is_mounted where this can simplify code.
- Substitute code in is_mounted & is_share_mounted with calls to mount_status() boolean personality.
- Reorder Shares table columns to reflect those in Pools table by grouping Size, Usage, and Btrfs usage.
- Repair regression in Pool link on Share detail pages. #1764 
- Fix edit icon not appearing in Shares table once a share specific compression is set. #1766 

Note that the last 2 items (first 2 commits) in the above were included to ease merging and represent trivial but related fixes for the following issues:
Fixes #1764 "pool link regression on share details page"
Fixes #1766 "custom share compression removes edit icon"

All other changes pertain to issue:

Fixes #1763 "improve mount status reporting capability"

Ready for review.
