### PR TITLE
config backup restore error exception isdir. Fixes #1765

### DIFF
--- a/src/rockstor/storageadmin/views/config_backup.py
+++ b/src/rockstor/storageadmin/views/config_backup.py
@@ -252,7 +252,7 @@ class ConfigBackupUpload(ConfigBackupMixin, rfc.GenericView):
                 filename=filename, config_backup=file_obj
             )
             cb_dir = ConfigBackup.cb_dir()
-            if (not os.path.isdir()):
+            if not os.path.isdir(cb_dir):
                 os.mkdir(cb_dir)
             fp = os.path.join(cb_dir, filename)
 


### PR DESCRIPTION
When attempting to upload a previously downloaded config backup file the mechanism used to assure that the config-backups directory exists was failing. It would appear that a code refactor inadvertently removed a required parameter causing this failure. This pr contains the following:

- fix config backup file upload dir check.

Tested as now able to upload a prior saved config file without error.
Thanks to @FroggyFlox for reporting the associated issue and assisting with testing the fix.

Ready for review.

Fixes #1765 

Note that an artefact of the issue that this pr addresses is that the uploaded file that was subject to the failure is left in place while it's expected db counterpart does not persist. There appears to be provision to account for this but the mechanism was not examined further as not falling within the remit of this pr.
