### PR TITLE
useradd error upon config restore. Fixes #1774

### DIFF
--- a/src/rockstor/storageadmin/models/user.py
+++ b/src/rockstor/storageadmin/models/user.py
@@ -38,6 +38,7 @@ class User(models.Model):
     homedir = models.CharField(max_length=1024, null=True)
     email = models.CharField(max_length=1024, null=True, blank=True,
                              validators=[validate_email])
+    # 'admin' field represents indicator of Rockstor web admin capability.
     admin = models.BooleanField(default=True)
     group = models.ForeignKey(Group, null=True, blank=True)
 

--- a/src/rockstor/storageadmin/views/user.py
+++ b/src/rockstor/storageadmin/views/user.py
@@ -138,6 +138,7 @@ class UserListView(UserMixin, rfc.GenericView):
                         invar['gid'] = g.gid
                         # Set the admin_group to our existing group object.
                         admin_group = g
+                        admin_group.save()
                         invar['group'] = g  # exchange name for db group item.
                         break
 

--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -157,16 +157,18 @@ def update_shell(username, shell):
 def useradd(username, shell, uid=None, gid=None):
     pw_entry = None
     try:
+        # Use unix password db to assess prior user status by name
         pw_entry = pwd.getpwnam(username)
     except:
         pass
     if (pw_entry is not None):
+        # If we have a prior user by name assess uid gid mismatches.
         if (uid is not None and uid != pw_entry.pw_uid):
             raise Exception('User({0}) already exists, but her uid({1}) is '
                             'different from the input({2}).'.format(
                                 username, pw_entry.pw_uid, uid))
         if (gid is not None and gid != pw_entry.pw_gid):
-            raise Exception('User({0}) already exists, but her git({1}) is '
+            raise Exception('User({0}) already exists, but her gid({1}) is '
                             'different from the input({2}).'.format(
                                 username, pw_entry.pw_gid, gid))
         if (shell != pw_entry.pw_shell):


### PR DESCRIPTION
The indicated failure as described in the issue text is as a result of 2 main elements. The first is that the current config backup format has db pk values for 'group' and our existing restore code does not cross reference these with the storageadmin.group entries to retrieve the group name. That issue, along with a proposed and under test fix/simplification, is detailed in #1781. The title issue of this pr #1774 concerns current config file format that only contains gid group info in user records, rather than both (as proposed in #1781). This means that our existing user create mechanism, shared between WebUI and restore systems, that is based on group names, fails when only a gid is presented. This is the essence of the second main element comprising the reported behaviour. This pr represents a fix for this second scenario: that of restoring from our existing config backup file.

Previously any gid passed when creating a user was filtered out by the validation mechanism. Once this was resolved the user create function required modification in order to be able to cope with pre-existing group matches by gid. Also note that a fix for issue #1780 is included in this pr as it was required for testing purposes:

Fixes #1774 
also:
Fixes #1780

Ready for review.

The manual test method used to ensure a fix is to be detailed in a comment to this pr.
