### PR TITLE
ensure restored group membership is name based. Fixes #1783

### DIFF
--- a/src/rockstor/storageadmin/models/group.py
+++ b/src/rockstor/storageadmin/models/group.py
@@ -22,6 +22,9 @@ from django.db import models
 class Group(models.Model):
     gid = models.IntegerField(unique=True)
     groupname = models.CharField(max_length=1024, null=True)
+    # 'admin' field represents indicator of Rockstor managed group;
+    # ie pre-existing group (eg audio) will be False. Rockstor created groups
+    # are admin=True.
     admin = models.BooleanField(default=False)
 
     class Meta:


### PR DESCRIPTION
This pr addresses issue #1783 by in-line processing the config backup file during the restore process such that when it's relevant contents are presented to the restore user mechanism the prior group name is made available. The existing mechanism is then able to match prior group membership to existing groups ‘by name’, the preferred method, rather than by the fail over ‘by gid’ method that resulted from no group name being presented (the essence of the bug).

The same test procedure as was used in the issue text was repeated as proof of fix:

### Initial user group setup prior to config backup:

Create ‘group1’, managed, and ‘Autogenerate’ gid.
Create ‘group2’, managed, and ‘Autogenerate’ gid.
Create ‘user1’ with ‘group1’ membership
Create ‘user2’ with ‘group2’ membership

### Backup current config.

delete ‘user1’, ‘user2’, ‘group1’, ‘group2’.

Create ‘group2’, managed, and ‘Autogenerate’ gid.
Create ‘group1’, managed, and ‘Autogenerate’ gid.

(we have re-established the same group names; but their gid’s are now reversed)

### Restoring the saved config post pull request patches results in:

‘user1’ has ‘group1’ membership.
‘user2’ has ‘group2’ membership.

As expected.

Fixes #1783

Ready for review.

This pr and it's referenced issue and testing procedure assume the prior merge of the following pull requests:
#1773 “config backup restore error exception isdir. Fixes #1765” (already merged in current master but not yet released in testing channel update.)
#1782 “useradd error upon config restore. Fixes #1774” (awaiting merge as of this pr's submission)
