### PR TITLE
improve scrub status reporting resolution. Fixes #1786

### DIFF
--- a/src/rockstor/storageadmin/models/scrub.py
+++ b/src/rockstor/storageadmin/models/scrub.py
@@ -23,6 +23,7 @@ from storageadmin.models import Pool
 class PoolScrub(models.Model):
 
     pool = models.ForeignKey(Pool)
+    # with a max of 10 chars we use 'halted' to indicated 'interrupted'
     status = models.CharField(max_length=10, default='started')
     pid = models.IntegerField()
     start_time = models.DateTimeField(auto_now=True)

--- a/src/rockstor/storageadmin/views/pool_scrub.py
+++ b/src/rockstor/storageadmin/views/pool_scrub.py
@@ -53,7 +53,9 @@ class PoolScrubView(rfc.GenericView):
             return Response()
         if (ps.status == 'started' or ps.status == 'running'):
             cur_status = scrub_status(pool)
-            if (cur_status['status'] == 'finished'):
+            if cur_status['status'] == 'finished' \
+                    or cur_status['status'] == 'halted' \
+                    or cur_status['status'] == 'cancelled':
                 duration = int(cur_status['duration'])
                 cur_status['end_time'] = (ps.start_time +
                                           timedelta(seconds=duration))


### PR DESCRIPTION
Prior to this pr scrub_status() reported only 'unknow', 'running', and 'finished'. The scrub halted (interrupted) state was misreported as running which lead to buggy behaviour. This pr improves scrub status reporting resolution to address the consequent buggy behaviour and improve user experience re scrub status.

Elements of this pull request:

- Fix portability bug in fs unit tests. Fixes #1787
- Add unit tests to account for current expected behaviour of scrub_status().
- Add unit test to indicate current suspected false positive for 'running' status on 'interrupted' scrubs.
- improve scrub status reporting resolution to include halted (interrupted), conn-reset (Connection reset by peer), and cancelled (aborted).
- Pool scrub job monitoring was also extended to include 'halted' and 'cancelled' as 'non running' jobs.

Fixes #1786

And as #1786 was essentially a duplicate of #1640 (with more specificity) we also have:
Fixes #1640

Note that this pr also includes a trivial fix for:
issue #1787 "fix portability bug in fs unit tests" so adding the also fixes:
Fixes #1787 

```
./bin/test --settings=test-settings -v 3 -p test_btrfs*
```
results in:
```
...
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
...
```
All scrub states were reproduced on real hardware and their UI reflection confirmed. Note that to reproduce the halted ('interrupted') state the test machine was shutdown 'mid scrub'. Upon next boot the halted ('interrupted') state was in effect. And to reproduce 'conn_reset' / time out warning state a second scrub with the -f option was enacted over and existing running one. This caused interactivity issues and upon the first scrub finishing the conn_reset status was observed on an active (and waiting) btrfs scrub status command.

A trivial amount of code duplication was created but was highlighted with a "TODO:" and is very local in nature: within the same if-else block.

Ready for review.

