### PR TITLE
regression in 'force' option - scrub and balance. Fixes #1790

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -928,7 +928,7 @@ def usage_bound(disk_sizes, num_devices, raid_level):
 
 def scrub_start(pool, force=False):
     mnt_pt = mount_root(pool)
-    p = PoolScrub(mnt_pt)
+    p = PoolScrub(mnt_pt, force)
     p.start()
     return p.pid
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
@@ -83,6 +83,7 @@ PoolRebalanceTableModule = RockstorModuleView.extend({
                 $.ajax({
                     url: '/api/pools/' + _this.pool.get('id') + '/balance',
                     type: 'POST',
+                    contentType: 'application/json',
                     data: postdata,
                     success: function() {
                         _this.$('#pool-rebalance-form :input').tooltip('hide');

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
@@ -83,6 +83,7 @@ PoolScrubTableModule = RockstorModuleView.extend({
                 $.ajax({
                     url: '/api/pools/' + _this.pool.get('id') + '/scrub',
                     type: 'POST',
+                    contentType: 'application/json',
                     data: postdata,
                     success: function() {
                         _this.$('#pool-scrub-form :input').tooltip('hide');


### PR DESCRIPTION
The intention with the force option for scrubs and balances is two fold:

1. change the status of the last listed job (if currently 'started' or 'running') to 'terminated'.
2. pass the -f option to the respective btrfs commands and monitor this under a new job.

It is surmised that a recent Django or related update altered the requirement by which the existing 'force' option was passed from the Web-UI front end to the backend balance/scrub command wrappers. The result was that the force option was ineffectual in both 1. and 2. above. However in the case of a scrub there existed an additional bug that prevented 2. as well. This is also addressed in this pr.

Elements of this pull request:

- Fix 'force' UI option transition to backend - scrub/balance
- Fix -f addition to scrub command with force option.

Logging was used to identify the failure of the force option to successfully propagate to the back-end as expected and the scrub and balance commands were confirmed to have received their '-f' options post pr.

Fixes #1790 

Ready for review.



