### PR TITLE
improve rebooted dialog message. Fixes #1584

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -117,7 +117,7 @@
 	  <div id="reboot-time-left"></div>
 	</div>
 	<div id="reboot-user-msg" style="display: none"><h4> System reboot still not complete. Connect to the console for current status of the system.</h4> </div>
-	<div id="reboot-user-msg2" style="display: none"><h3> Rockstor is now up and running.</h3></div>
+	<div id="reboot-user-msg2" style="display: none"><h3> Rockstor is now up and running. Please refresh your browser window.</h3></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Simple pr to change the rebooted message that under certain circumstances reads:
"Rockstor is now up and running."
to
"Rockstor is now up and running. Please refresh your browser window"
This message is rarely displayed as it depends on quite specific system and browser timings and will often only appear transiently; but just for the instances when it does 'stick' this change makes it more user friendly.

Fixes #1584 

Ready for review.