### PR TITLE
scrub task end time incorrectly updated. Fixes #1802

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
+++ b/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
@@ -77,7 +77,6 @@ def main():
             t.state = 'error'
             logger.exception(e)
         finally:
-            t.end = datetime.utcnow().replace(tzinfo=utc)
             t.save()
 
         while True:
@@ -85,6 +84,8 @@ def main():
             if (cur_state == 'error' or cur_state == 'finished'):
                 logger.debug('task(%d) finished with state(%s).' %
                              (tid, cur_state))
+                t.end = datetime.utcnow().replace(tzinfo=utc)
+                t.save()
                 break
             logger.debug('pending state(%s) for scrub task(%d). Will check '
                          'again in 60 seconds.' % (cur_state, tid))


### PR DESCRIPTION
Scrub task end times were incorrectly updated directly after scrub task initialization. They were not updated
there after. This resulted in premature end times of start time + 2 seconds.

The pull request moves the end time update and adds a db save to directly after current scrub state is assessed as terminal. This also results in an empty end time during scrub execution which is in keeping with the pool details scrub tab table.

Note that his patch is against master but was tested post pr #1801 which alters a line that lies between the moved line in this patch (within 5 lines each way). Please advise if this patch should be re-based on master once pr #1801 is merged.

Fixes #1802 

Ready for review.