### PR TITLE
Improve messaging re SMART refresh button. Fixes #1435

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disk_details_layout.jst
@@ -39,6 +39,8 @@
   <button id="smartinfo" class="btn btn-primary pull-right" title="Refresh for latest information"><i class="glyphicon glyphicon-refresh "></i>Refresh</button>
 </div>
 <span class="h2">S.M.A.R.T details for <strong>{{diskName}}</strong></span>
+<br>
+<span class="h4"><i>{{lastScannedOn}}<strong>(Refresh button to update)</strong></i></span>
 {{/if}}
 
 <ul class="nav nav-tabs">

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/disk_details_layout_view.js
@@ -174,6 +174,7 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
     },
 
     initHandlebarHelpers: function() {
+
         Handlebars.registerHelper('isAboveMinLength', function(minValue, target, options) {
             // check we have all the arguments we expect
             if (arguments.length != 3) {
@@ -186,6 +187,17 @@ DiskDetailsLayoutView = RockstorLayoutView.extend({
             } else {
                 return options.inverse(this);
             }
+        });
+
+        Handlebars.registerHelper('lastScannedOn', function () {
+            var html = '';
+            if (this.identity.scanned_on != null){
+                html += 'Information presented was manually scanned on: ' +
+                    this.identity.scanned_on + ' ';
+            } else {
+                html += 'No prior manual scan initiated: ';
+            }
+            return new Handlebars.SafeString(html);
         });
     }
 });


### PR DESCRIPTION
Adds a subtitle to the SMART details page that either indicates that no prior manual scan has been initiated, or indicates the date and time of the last recorded manual SMART scan. In both cases a "(Refresh button to update)" text element is included.

Fixes #1435 

Prior to this pull request no subtitle existed on this page, post pr the following text is displayed (as example):

    No prior manual scan initiated: (Refresh button to update)

and in the case of a prior manual scan:

    Information presented was manually scanned on: Mon Sep 4 17:21:50 2017 BST (Refresh button to update)

Ready for review.

It is acknowledged that in the future this info could be updated by a scheduled task; there after the word 'manually' could be removed from both messages and a link provided to the System - Scheduled Tasks page, or the "Schedule a new task" page, or to a specific SMART scheduler (more likely) page.

Test screen grabs to follow in comments.

