### PR TITLE
change share and snapshot endpoints to by id and not by name. Fixes #…

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -130,7 +130,7 @@ var PoolCollection = RockStorPaginatedCollection.extend({
 
 var Share = Backbone.Model.extend({
     url: function() {
-        return '/api/shares/' + this.get('shareName');
+        return '/api/shares/' + this.get('sid');
     }
 });
 
@@ -185,7 +185,7 @@ var ContainerCollection = RockStorPaginatedCollection.extend({
 
 var Snapshot = Backbone.Model.extend({
     url: function() {
-        return '/api/shares/' + this.get('shareName') + '/' + this.get('snapName');
+        return '/api/shares/' + this.get('shareId') + '/' + this.get('snapName');
     }
 });
 
@@ -197,8 +197,8 @@ var SnapshotCollection = RockStorPaginatedCollection.extend({
             this.snapType = options.snapType;
         }
     },
-    setUrl: function(shareName) {
-        this.baseUrl = '/api/shares/' + shareName + '/snapshots';
+    setUrl: function(shareId) {
+        this.baseUrl = '/api/shares/' + shareId + '/snapshots';
     },
     extraParams: function() {
         var p = this.constructor.__super__.extraParams.apply(this, arguments);

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -48,11 +48,11 @@ var AppRouter = Backbone.Router.extend({
         'shares': 'showShares',
         'add_share?poolName=:poolName': 'addShare',
         'add_share': 'addShare',
-        'shares/:shareName': 'showShare',
-        'shares/:shareName/create-clone': 'createCloneFromShare',
-        'shares/:shareName/snapshots/:snapName/create-clone': 'createCloneFromSnapshot',
-        'shares/:shareName/rollback': 'rollbackShare',
-        'shares/:shareName/?cView=:cView': 'showShare',
+        'shares/:shareId': 'showShare',
+        'shares/:shareId/create-clone': 'createCloneFromShare',
+        'shares/:shareId/snapshots/:snapName/create-clone': 'createCloneFromSnapshot',
+        'shares/:shareId/rollback': 'rollbackShare',
+        'shares/:shareId/?cView=:cView': 'showShare',
         'snapshots': 'showSnapshots',
         'services': 'showServices',
         'services/:serviceName/edit': 'configureService',
@@ -298,13 +298,13 @@ var AppRouter = Backbone.Router.extend({
 
     },
 
-    showShare: function(shareName, cView) {
+    showShare: function(shareId, cView) {
         this.renderSidebar('storage', 'shares');
         $('#maincontent').empty();
         this.cleanup();
         this.currentLayout = new ShareDetailsLayoutView({
-            shareName: shareName,
-            cView: cView,
+            shareId: shareId,
+            cView: cView
         });
         $('#maincontent').append(this.currentLayout.render().el);
     },
@@ -536,34 +536,34 @@ var AppRouter = Backbone.Router.extend({
         $('#maincontent').append(this.currentLayout.render().el);
     },
 
-    createCloneFromShare: function(shareName) {
+    createCloneFromShare: function(shareId) {
         this.renderSidebar('storage', 'shares');
         this.cleanup();
         this.currentLayout = new CreateCloneView({
             sourceType: 'share',
-            shareName: shareName
+            shareId: shareId
         });
         $('#maincontent').empty();
         $('#maincontent').append(this.currentLayout.render().el);
     },
 
-    createCloneFromSnapshot: function(shareName, snapName) {
+    createCloneFromSnapshot: function(shareId, snapName) {
         this.renderSidebar('storage', 'shares');
         this.cleanup();
         this.currentLayout = new CreateCloneView({
             sourceType: 'snapshot',
-            shareName: shareName,
+            shareId: shareId,
             snapName: snapName
         });
         $('#maincontent').empty();
         $('#maincontent').append(this.currentLayout.render().el);
     },
 
-    rollbackShare: function(shareName) {
+    rollbackShare: function(shareId) {
         this.renderSidebar('storage', 'shares');
         this.cleanup();
         this.currentLayout = new RollbackView({
-            shareName: shareName,
+            shareId: shareId
         });
         $('#maincontent').empty();
         $('#maincontent').append(this.currentLayout.render().el);

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_details_layout.jst
@@ -21,7 +21,7 @@
 <div class="messages"></div>
 <div class="pull-right">
   <span id="rollback-btn-ph"></span>
-    <a id="js-clone" class="btn btn-primary" href="#shares/{{shareName}}/create-clone"><i class="glyphicon glyphicon-book "></i> Clone</a>
+    <a id="js-clone" class="btn btn-primary" href="#shares/{{shareId}}/create-clone"><i class="glyphicon glyphicon-book "></i> Clone</a>
 	{{#unless isSystemShare}}
         <button id="js-delete" class="btn btn-danger" type="button" type="button"><i class="glyphicon glyphicon-trash "></i> Delete </button>
 	{{/unless}}
@@ -51,8 +51,8 @@
         <div class="messages"></div>
 
         <p>By deleting <strong><em>{{shareName}}</em></strong>, all it's data (<strong>{{shareUsage}}</strong>) will be lost. Are you sure?</p>
-      
-      <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg" 
+
+      <label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"
     title="Forces the deletion of undetected Snapshots and then deletes the Share. Useful to forcefully delete the Rock-on root share, for example." rel="tooltip"></i></label>
       </div>
       <div class="modal-footer">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_details_rollback_btn.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_details_rollback_btn.jst
@@ -1,7 +1,7 @@
 <a id="js-rollback" class="btn btn-primary"
     {{#if rollbackBtnDisabler}}
         disabled="disabled" title="At least one writable snapshot must exist to rollback to.">
-    {{else}} 
-        href="#shares/{{shareName}}/rollback">
+    {{else}}
+        href="#shares/{{shareId}}/rollback">
     {{/if}}
 <i class="glyphicon glyphicon-repeat "></i> Rollback</a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -23,7 +23,7 @@
     <tbody>
     {{#each shares}}
     <tr>
-        <td><a href="#shares/{{this.name}}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;&nbsp;{{this.name}}</a></td>
+        <td><a href="#shares/{{this.id}}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;&nbsp;{{this.name}}</a></td>
         <td>{{humanize_size this.size}}</td>
         <td>{{humanize_size this.rusage}}</td>
         <td>{{humanize_size this.pqgroup_rusage}} {{checkUsage this.size this.pqgroup_rusage}}</td>
@@ -42,12 +42,12 @@
             {{/if}}
         </td>
         <td>
-        {{displayCompressionAlgo this.compression_algo this.name}}
+        {{displayCompressionAlgo this.compression_algo this.id}}
         </td>
         <td>{{#if (isSystemShare this.id this.pool.role)}}
                 N/A
             {{else}}
-                <a id="delete_share_{{this.name}}" data-name="{{this.name}}" data-action="delete"
+                <a id="delete_share_{{this.name}}" data-id="{{this.id}}" data-name="{{this.name}}" data-action="delete"
                 data-pool="{{this.pool.name}}" data-size="{{humanize_size this.size}}" data-usage="{{humanize_size this.eusage}}" rel="tooltip" title="Delete share"><i class="glyphicon glyphicon-trash"></i></a>
             {{/if}}
 		</td>
@@ -72,7 +72,7 @@
       <div class="modal-body">
         <div class="messages"></div>
         <p>Deleting <strong><em><span class="pass-share-name"></span></em></strong> will destroy all of it's data (<strong><span id="pass-share-usage"></span></strong>). Are you sure?</p>
-	<label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg" 
+	<label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"
 	title="Forces the deletion of undetected Snapshots and then deletes the Share. Useful to forcefully delete the Rock-on root share, for example." rel="tooltip"></i></label>
       </div>
       <div class="modal-footer">

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/create_clone.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/create_clone.js
@@ -1,27 +1,27 @@
 /*
  *
- * @licstart  The following is the entire license notice for the 
+ * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
- * 
+ *
  * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
- * 
+ *
  * RockStor is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published
  * by the Free Software Foundation; either version 2 of the License,
  * or (at your option) any later version.
- * 
+ *
  * RockStor is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * @licend  The above is the entire license notice
  * for the JavaScript code in this page.
- * 
+ *
  */
 
 CreateCloneView = RockstorLayoutView.extend({
@@ -33,11 +33,21 @@ CreateCloneView = RockstorLayoutView.extend({
         this.constructor.__super__.initialize.apply(this, arguments);
         this.template = window.JST.share_create_clone;
         this.sourceType = this.options.sourceType;
-        this.shareName = this.options.shareName;
+        this.shareId = this.options.shareId;
         this.snapName = this.options.snapName;
+
+        this.share = new Share({
+            sid: this.shareId
+        });
+        this.dependencies.push(this.share);
     },
 
     render: function() {
+        this.fetch(this.renderSubViews, this);
+        return this;
+    },
+
+    renderSubViews: function() {
         var _this = this,
             sourceTypeIsShare = false;
         if (this.sourceType == 'share') {
@@ -45,16 +55,16 @@ CreateCloneView = RockstorLayoutView.extend({
         }
         $(this.el).html(this.template({
             sourceType: this.sourceType,
-            shareName: this.shareName,
+            shareName: this.share.get('name'),
             snapName: this.snapName,
-            sourceTypeIsShare: sourceTypeIsShare,
+            sourceTypeIsShare: sourceTypeIsShare
         }));
         this.$('#create-clone-form :input').tooltip();
         this.$('#create-clone-form').validate({
             onfocusout: false,
             onkeyup: false,
             rules: {
-                name: 'required',
+                name: 'required'
             },
             submitHandler: function() {
                 var button = _this.$('#create-clone');
@@ -62,9 +72,9 @@ CreateCloneView = RockstorLayoutView.extend({
                 disableButton(button);
                 var url;
                 if (_this.sourceType == 'share') {
-                    url = '/api/shares/' + _this.shareName + '/clone';
+                    url = '/api/shares/' + _this.shareId + '/clone';
                 } else if (_this.sourceType == 'snapshot') {
-                    url = '/api/shares/' + _this.shareName + '/snapshots/' +
+                    url = '/api/shares/' + _this.shareId + '/snapshots/' +
                         _this.snapName + '/clone';
                 }
                 $.ajax({
@@ -92,11 +102,11 @@ CreateCloneView = RockstorLayoutView.extend({
     cancel: function(event) {
         event.preventDefault();
         if (this.sourceType == 'share') {
-            app_router.navigate('#shares/' + this.shareName, {
+            app_router.navigate('#shares/' + this.shareId, {
                 trigger: true
             });
         } else if (this.sourceType == 'snapshot') {
-            app_router.navigate('#shares/' + this.shareName, {
+            app_router.navigate('#shares/' + this.shareId, {
                 trigger: true
             });
         }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rollback.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rollback.js
@@ -37,11 +37,11 @@ RollbackView = RockstorLayoutView.extend({
         this.snapshot_list_template = window.JST.share_rollback_snapshot_list;
         // Dependencies
         this.share = new Share({
-            shareName: this.options.shareName
+            sid: this.options.shareId
         });
         this.collection = new SnapshotCollection();
         this.collection.pageSize = 10;
-        this.collection.setUrl(this.options.shareName);
+        this.collection.setUrl(this.options.shareId);
         this.dependencies.push(this.share);
         this.dependencies.push(this.collection);
         this.collection.on('reset', this.renderSnapshotList, this);
@@ -57,14 +57,14 @@ RollbackView = RockstorLayoutView.extend({
         var _this = this;
         $(this.el).html(this.template({
             collection: this.collection,
-            shareName: this.share.get('name'),
+            shareName: this.share.get('name')
         }));
         this.renderSnapshotList();
         this.$('#rollback-form').validate({
             onfocusout: false,
             onkeyup: false,
             rules: {
-                snapshot: 'required',
+                snapshot: 'required'
             },
             submitHandler: function() {
                 var button = _this.$('#rollback-share');
@@ -83,7 +83,7 @@ RollbackView = RockstorLayoutView.extend({
         this.$('#ph-snapshot-list').html(this.snapshot_list_template({
             rollbackSnaps: this.collection.toJSON(),
             collection: this.collection,
-            collectionNotEmpty: !this.collection.isEmpty(),
+            collectionNotEmpty: !this.collection.isEmpty()
         }));
     },
 
@@ -94,7 +94,7 @@ RollbackView = RockstorLayoutView.extend({
         disableButton(button);
         var snapName = this.$('input:radio[name=snapshot]:checked').val();
         $.ajax({
-            url: '/api/shares/' + _this.share.get('name') + '/rollback',
+            url: '/api/shares/' + _this.share.get('id') + '/rollback',
             type: 'POST',
             dataType: 'json',
             contentType: 'application/json',
@@ -105,7 +105,7 @@ RollbackView = RockstorLayoutView.extend({
                 enableButton(button);
                 _this.$('#confirm-rollback').modal('hide');
                 $('.modal-backdrop').remove();
-                app_router.navigate('shares/' + _this.share.get('name'), {
+                app_router.navigate('shares/' + _this.share.get('id'), {
                     trigger: true
                 });
 
@@ -114,12 +114,11 @@ RollbackView = RockstorLayoutView.extend({
                 enableButton(button);
             },
         });
-
     },
 
     cancel: function(event) {
         if (event) event.preventDefault();
-        app_router.navigate('shares/' + this.share.get('name'), {
+        app_router.navigate('shares/' + this.share.get('id'), {
             trigger: true
         });
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
@@ -35,13 +35,13 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         'click #js-submit-compression': 'updateCompression',
         'click #js-delete': 'deleteShare',
         'click #js-cancel': 'cancel',
-        'click #js-confirm-share-delete': 'confirmShareDelete',
+        'click #js-confirm-share-delete': 'confirmShareDelete'
     },
 
     initialize: function() {
         // call initialize of base
         this.constructor.__super__.initialize.apply(this, arguments);
-        this.shareName = this.options.shareName;
+        this.shareId = this.options.shareId;
         this.template = window.JST.share_share_details_layout;
         this.rollback_btn_template = window.JST.share_share_details_rollback_btn;
         this.shareAclTemplate = window.JST.share_share_acl;
@@ -53,10 +53,10 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
 
         // create models
         this.share = new Share({
-            shareName: this.shareName
+            sid: this.shareId
         });
         this.snapshots = new SnapshotCollection([]);
-        this.snapshots.setUrl(this.shareName);
+        this.snapshots.setUrl(this.shareId);
 
         this.users = new UserCollection();
         this.users.pageSize = RockStorGlobals.maxPageSize;
@@ -67,7 +67,6 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.dependencies.push(this.snapshots);
         this.dependencies.push(this.users);
         this.dependencies.push(this.groups);
-        //this.dependencies.push(this.iscsi_target);
         this.dependencies.push(this.appliances);
         this.modify_choices = [{
             name: 'ro',
@@ -131,6 +130,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         $(this.el).html(this.template({
             share: this.share,
             shareName: this.share.get('name'),
+            shareId: this.share.get('id'),
             shareUsage: humanize.filesize(this.share.get('rusage') * 1024),
             snapshots: this.snapshots,
             permStr: this.parsePermStr(this.share.get('perms')),
@@ -157,7 +157,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             this.$('#ph-compression-info').html(this.compression_info_template({
                 share: this.share,
                 shareCompression: this.share.get('compression_algo'),
-                shareCompressionNull: this.shareCompressBool,
+                shareCompressionNull: this.shareCompressBool
             }));
         }
         this.$('ul.nav.nav-tabs').tabs('div.css-panes > div');
@@ -177,8 +177,8 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         }
         this.$('#rollback-btn-ph').html(this.rollback_btn_template({
             foundWritableSnapshot: foundWritableSnapshot,
-            shareName: this.share.get('name'),
-            rollbackBtnDisabler: rollbackBtnDisabler,
+            shareId: this.share.get('id'),
+            rollbackBtnDisabler: rollbackBtnDisabler
         }));
 
     },
@@ -193,7 +193,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             if (buttonDisabled(button)) return false;
             disableButton(button);
             $.ajax({
-                url: '/api/shares/' + _this.share.get('name') + '/snapshots/' + $('#snapshot-name').val(),
+                url: '/api/shares/' + _this.share.get('id') + '/snapshots/' + $('#snapshot-name').val(),
                 type: 'POST',
                 dataType: 'json'
             }).done(function() {
@@ -221,7 +221,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
         disableButton(button);
-        var url = '/api/shares/' + _this.share.get('name');
+        var url = '/api/shares/' + _this.share.get('id');
         if ($('#force-delete').prop('checked')) {
             url += '/force';
         }
@@ -242,6 +242,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             }
         });
     },
+
     cancel: function(event) {
         if (event) event.preventDefault();
         app_router.navigate('shares', {
@@ -255,7 +256,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             shareOwner: this.share.get('owner'),
             shareGroup: this.share.get('group'),
             sharePerms: this.share.get('perms'),
-            permStr: this.parsePermStr(this.share.get('perms')),
+            permStr: this.parsePermStr(this.share.get('perms'))
         }));
     },
 
@@ -266,7 +267,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             permStr: this.parsePermStr(this.share.get('perms')),
             users: this.users.toJSON(),
             groups: this.groups.toJSON(),
-            sharePerms: this.share.get('perms'),
+            sharePerms: this.share.get('perms')
         }));
     },
 
@@ -283,7 +284,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
             perms: permStr
         };
         $.ajax({
-            url: '/api/shares/' + this.share.get('name') + '/acl',
+            url: '/api/shares/' + this.share.get('id') + '/acl',
             type: 'POST',
             data: data,
             dataType: 'json',
@@ -305,7 +306,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         event.preventDefault();
         this.$('#ph-access-control').html(this.shareAclTemplate({
             share: this.share,
-            permStr: this.parsePermStr(this.share.get('perms')),
+            permStr: this.parsePermStr(this.share.get('perms'))
         }));
     },
 
@@ -370,7 +371,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.$('#ph-compression-info').html(this.compression_info_template({
             share: this.share,
             shareCompression: this.share.get('compression_algo'),
-            shareCompressionNull: this.shareCompressBool,
+            shareCompressionNull: this.shareCompressBool
         }));
     },
 
@@ -381,11 +382,11 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         if (buttonDisabled(button)) return false;
         disableButton(button);
         $.ajax({
-            url: '/api/shares/' + this.share.get('name'),
+            url: '/api/shares/' + this.share.get('id'),
             type: 'PUT',
             dataType: 'json',
             data: {
-                'compression': this.$('#compression').val(),
+                'compression': this.$('#compression').val()
             },
             success: function() {
                 _this.hideCompressionTooltips();

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
@@ -28,8 +28,7 @@ ShareUsageModule = RockstorModuleView.extend({
     events: {
         'click #js-resize': 'edit',
         'click #js-resize-save': 'save',
-        'click #js-resize-cancel': 'cancel',
-
+        'click #js-resize-cancel': 'cancel'
     },
 
     initialize: function() {
@@ -51,10 +50,9 @@ ShareUsageModule = RockstorModuleView.extend({
             share_is_mounted: this.share.get('is_mounted'),
             share_mount_status: this.share.get('mount_status'),
             pid: this.share.get('pool').id,
-            shareCreatedDate: moment(this.share.get('toc')).format(RS_DATE_FORMAT),
+            shareCreatedDate: moment(this.share.get('toc')).format(RS_DATE_FORMAT)
         }));
         this.renderGraph();
-        //this.renderBar();
         return this;
     },
 
@@ -70,7 +68,6 @@ ShareUsageModule = RockstorModuleView.extend({
         free = total - used;
         var dataSet = [used, free];
         var data = [Math.round((used / total) * 100), Math.round((free / total) * 100)];
-        //var data = [70,30]; //convert to percentages
         var dataLabels = ['used', 'free'];
         var colors = {
             used: {
@@ -170,7 +167,7 @@ ShareUsageModule = RockstorModuleView.extend({
         event.preventDefault();
         $(this.el).html(this.editTemplate({
             share: this.share,
-            newSizeVal: humanize.filesize(this.share.get('size') * 1024).replace(/[^0-9\.]+/g, ''),
+            newSizeVal: humanize.filesize(this.share.get('size') * 1024).replace(/[^0-9\.]+/g, '')
         }));
     },
 
@@ -193,7 +190,7 @@ ShareUsageModule = RockstorModuleView.extend({
             size = size * 1024 * 1024 * 1024;
         }
         $.ajax({
-            url: '/api/shares/' + this.share.get('name'),
+            url: '/api/shares/' + this.share.get('id'),
             type: 'PUT',
             dataType: 'json',
             data: {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -92,6 +92,7 @@ SharesView = RockstorLayoutView.extend({
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
         shareName = button.attr('data-name');
+        sid = button.attr('data-id');
         shareUsage = button.attr('data-usage');
 		// set share name in confirm dialog
         _this.$('.pass-share-name').html(shareName);
@@ -106,7 +107,7 @@ SharesView = RockstorLayoutView.extend({
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
         disableButton(button);
-        var url = '/api/shares/' + shareName;
+        var url = '/api/shares/' + sid;
         if($('#force-delete').prop('checked')){
             url += '/force';
         }
@@ -137,14 +138,14 @@ SharesView = RockstorLayoutView.extend({
             return humanize.filesize(num * 1024);
         });
 
-        Handlebars.registerHelper('displayCompressionAlgo', function(shareCompression,shareName) {
+        Handlebars.registerHelper('displayCompressionAlgo', function(shareCompression,shareId) {
             var html = '';
             if (shareCompression && shareCompression != 'no') {
                 html += shareCompression + ' ';
             } else {
                 html += 'Same as Pool ';
             }
-            html += '<a href="#shares/' + shareName + '/?cView=edit"' +
+            html += '<a href="#shares/' + shareId + '/?cView=edit"' +
                 'title="Edit share compression setting" rel="tooltip">' +
                 '<i class="glyphicon glyphicon-pencil"></i></a>';
             return new Handlebars.SafeString(html);
@@ -182,4 +183,3 @@ SharesView = RockstorLayoutView.extend({
         });
     }
 });
-

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
@@ -84,7 +84,7 @@ SnapshotsView = SnapshotsCommonView.extend({
         $(this.el).append(_this.template({
             snapshots: snapshots,
             snapshotsNotEmpty: !_this.collection.isEmpty(),
-            collection: _this.collection,
+            collection: _this.collection
         }));
 
         this.$('[rel=tooltip]').tooltip({
@@ -107,11 +107,18 @@ SnapshotsView = SnapshotsCommonView.extend({
         this.collection.setUrl(shareName);
     },
 
+    getShareId: function(shareName) {
+        var shareMatch = this.shares.find(function(share) {
+            return share.get('name') == shareName;
+        });
+        return shareMatch.get('id');
+    },
+
     add: function(event) {
         var _this = this;
         event.preventDefault();
         $(this.el).html(this.addTemplate({
-            snapshots: this.collection,
+            snapshots: this.collection
         }));
         this.$('#shares').select2();
         var err_msg = '';
@@ -141,10 +148,11 @@ SnapshotsView = SnapshotsCommonView.extend({
             submitHandler: function() {
                 var button = _this.$('#js-snapshot-save');
                 var shareName = $('#shares').val();
+                var shareId = _this.getShareId(shareName);
                 if (buttonDisabled(button)) return false;
                 disableButton(button);
                 $.ajax({
-                    url: '/api/shares/' + shareName + '/snapshots/' + _this.$('#snapshot_name').val(),
+                    url: '/api/shares/' + shareId + '/snapshots/' + _this.$('#snapshot_name').val(),
                     type: 'POST',
                     dataType: 'json',
                     contentType: 'application/json',
@@ -172,13 +180,14 @@ SnapshotsView = SnapshotsCommonView.extend({
         var _this = this;
         var name = $(event.currentTarget).attr('data-name');
         var shareName = $(event.currentTarget).attr('data-share-name');
+        var shareId = _this.getShareId(shareName);
         var esize = $(event.currentTarget).attr('data-size');
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
         if (confirm('Deleting snapshot(' + name + ') deletes ' + esize + ' of data permanently. Do you really want to delete it?')) {
             disableButton(button);
             $.ajax({
-                url: '/api/shares/' + shareName + '/snapshots/' + name,
+                url: '/api/shares/' + shareId + '/snapshots/' + name,
                 type: 'DELETE',
                 success: function() {
                     enableButton(button);
@@ -204,7 +213,8 @@ SnapshotsView = SnapshotsCommonView.extend({
         this.$('[rel=tooltip]').tooltip('hide');
         var name = $(event.currentTarget).attr('data-name');
         var shareName = $(event.currentTarget).attr('data-share-name');
-        var url = 'shares/' + shareName + '/snapshots/' +
+        var shareId = this.getShareId(shareName);
+        var url = 'shares/' + shareId + '/snapshots/' +
             name + '/create-clone';
         app_router.navigate(url, {
             trigger: true
@@ -250,9 +260,9 @@ SnapshotsView = SnapshotsCommonView.extend({
 
                     _this.shares.each(function(share, index) {
                         if (s.get('share') == share.get('id')) {
-                            var shareName = share.get('name');
+                            var shareId = share.get('id');
                             $.ajax({
-                                url: '/api/shares/' + shareName + '/snapshots/' + name,
+                                url: '/api/shares/' + shareId + '/snapshots/' + name,
                                 type: 'DELETE',
                                 success: function() {
                                     enableButton(button);
@@ -273,7 +283,6 @@ SnapshotsView = SnapshotsCommonView.extend({
                     });
                 });
             }
-
         }
     },
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots_table.js
@@ -56,7 +56,7 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
             collection: this.collection,
             collectionNotEmpty: !this.collection.isEmpty(),
             selectedSnapshots: this.selectedSnapshots,
-            share: this.share,
+            share: this.share
         }));
         this.$('[rel=tooltip]').tooltip({
             placement: 'bottom'
@@ -110,7 +110,7 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
                 if (buttonDisabled(button)) return false;
                 disableButton(button);
                 $.ajax({
-                    url: '/api/shares/' + _this.share.get('name') + '/snapshots/' + _this.$('#snapshot-name').val(),
+                    url: '/api/shares/' + _this.share.get('id') + '/snapshots/' + _this.$('#snapshot-name').val(),
                     type: 'POST',
                     dataType: 'json',
                     contentType: 'application/json',
@@ -139,13 +139,13 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
         var _this = this;
         var name = $(event.currentTarget).attr('data-name');
         var esize = $(event.currentTarget).attr('data-size');
-        var share_name = this.share.get('name');
+        var share_id = this.share.get('id');
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
         if (confirm('Deleting snapshot(' + name + ') deletes ' + esize + ' of data permanently. Do you really want to delete it?')) {
             disableButton(button);
             $.ajax({
-                url: '/api/shares/' + share_name + '/snapshots/' + name,
+                url: '/api/shares/' + share_id + '/snapshots/' + name,
                 type: 'DELETE',
                 success: function() {
                     enableButton(button);
@@ -171,7 +171,7 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
         // even after new page has loaded.
         this.$('[rel=tooltip]').tooltip('hide');
         var name = $(event.currentTarget).attr('data-name');
-        var url = 'shares/' + this.share.get('name') + '/snapshots/' +
+        var url = 'shares/' + this.share.get('id') + '/snapshots/' +
             name + '/create-clone';
         app_router.navigate(url, {
             trigger: true
@@ -184,7 +184,7 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
         event.preventDefault();
         var button = $(event.currentTarget);
         if (buttonDisabled(button)) return false;
-        var share_name = this.share.get('name');
+        var share_id = this.share.get('id');
         if (this.selectedSnapshots.length == 0) {
             alert('Select at least one snapshot to delete');
         } else {
@@ -209,7 +209,7 @@ SnapshotsTableModule = SnapshotsCommonView.extend({
             if (confirm(confirmMsg + snapNames + ' deletes ' + totalSizeStr + ' of data. Are you sure?')) {
                 disableButton(button);
                 $.ajax({
-                    url: '/api/shares/' + share_name + '/snapshots?id=' + snapIds,
+                    url: '/api/shares/' + share_id + '/snapshots?id=' + snapIds,
                     type: 'DELETE',
                     success: function() {
                         enableButton(button);

--- a/src/rockstor/storageadmin/urls/share.py
+++ b/src/rockstor/storageadmin/urls/share.py
@@ -30,24 +30,20 @@ share_command = 'rollback|clone'
 urlpatterns = patterns(
     '',
     url(r'^$', ShareListView.as_view(), name='share-view'),
-    url(r'^/(?P<sname>%s)$' % share_regex, ShareDetailView.as_view(),
-        name='share-view'),
-    url(r'^/(?P<sname>%s)/(?P<command>force)$'
-        % share_regex, ShareDetailView.as_view(),),
+    url(r'^/(?P<sid>\d+)$', ShareDetailView.as_view(), name='share-view'),
+    url(r'^/(?P<sid>\d+)/(?P<command>force)$', ShareDetailView.as_view(),),
 
     # Individual snapshots don't have detailed representation in the web-ui. So
     # thre is no need for SnapshotDetailView.
-    url(r'^/(?P<sname>%s)/snapshots$' % share_regex,
+    url(r'^/(?P<sid>\d+)/snapshots$', SnapshotView.as_view(),
+        name='snapshot-view'),
+    url(r'^/(?P<sid>\d+)/snapshots/(?P<snap_name>%s)$' % snap_regex,
         SnapshotView.as_view(), name='snapshot-view'),
-    url(r'^/(?P<sname>%s)/snapshots/(?P<snap_name>%s)$' % (share_regex,
-                                                           snap_regex),
-        SnapshotView.as_view(), name='snapshot-view'),
-    url(r'^/(?P<sname>%s)/snapshots/(?P<snap_name>%s)/(?P<command>%s)$' %
-        (share_regex, snap_regex, snap_command), SnapshotView.as_view()),
+    url(r'^/(?P<sid>\d+)/snapshots/(?P<snap_name>%s)/(?P<command>%s)$' %
+        (snap_regex, snap_command), SnapshotView.as_view()),
 
-    url(r'^/(?P<sname>%s)/acl$' % share_regex, ShareACLView.as_view(),
-        name='acl-view'),
+    url(r'^/(?P<sid>\d+)/acl$', ShareACLView.as_view(), name='acl-view'),
 
-    url(r'^/(?P<sname>%s)/(?P<command>%s)$' % (share_regex, share_command),
+    url(r'^/(?P<sid>\d+)/(?P<command>%s)$' % share_command,
         ShareCommandView.as_view()),
 )

--- a/src/rockstor/storageadmin/views/share_acl.py
+++ b/src/rockstor/storageadmin/views/share_acl.py
@@ -29,9 +29,9 @@ from system.acl import (chown, chmod)
 class ShareACLView(ShareListView):
 
     @transaction.atomic
-    def post(self, request, sname):
+    def post(self, request, sid):
         with self._handle_exception(request):
-            share = Share.objects.get(name=sname)
+            share = Share.objects.get(id=sid)
             options = {
                 'owner': 'root',
                 'group': 'root',


### PR DESCRIPTION
…1807

ids don't change during the lifecycle of the resource and let's us rename
shares easily.