### PR TITLE
fix snapshot scheduled task regression re share api change #1809

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -68,7 +68,7 @@ def delete(aw, share, snap_type, prefix, max_count):
         name__startswith=prefix).order_by('-id')
     for snap in snapshots[max_count:]:
         try:
-            url = ('shares/%s/snapshots/%s' % (share.id, snap.name))
+            url = ('shares/{}/snapshots/{}'.format(share.id, snap.name))
             aw.api_call(url, data=None, calltype='delete', save_error=False)
         except Exception as e:
             logger.error('Failed to delete old snapshots exceeding the '
@@ -105,7 +105,7 @@ def main():
             name = ('%s_%s'
                     % (meta['prefix'],
                        datetime.now().strftime(settings.SNAP_TS_FORMAT)))
-            url = ('shares/%s/snapshots/%s' % (share.id, name))
+            url = ('shares/{}/snapshots/{}'.format(share.id, name))
             # only create a new snap if there's no overflow situation. This
             # prevents runaway snapshot creation beyond max_count+1.
             if(delete(aw, share, stype, prefix, max_count)):

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -34,10 +34,15 @@ def validate_snap_meta(meta):
         raise Exception('meta must be a dictionary, not %s' % type(meta))
     if ('prefix' not in meta):
         raise Exception('prefix missing from meta. %s' % meta)
+    if ('share_name' not in meta):
+        raise Exception('share_name missing from meta. {}'.format(meta))
     if ('share' not in meta):
         raise Exception('share missing from meta. %s' % meta)
-    if (not Share.objects.filter(name=meta['share']).exists()):
-        raise Exception('Non-existent Share(%s) in meta. %s' %
+    if not meta['share'].isdigit():
+        raise Exception('Non-digit share element ({}) in meta {}'
+                        .format(meta['share'], meta))
+    if (not Share.objects.filter(id=meta['share']).exists()):
+        raise Exception('Non-existent Share id (%s) in meta. %s' %
                         (meta['share'], meta))
     if ('max_count' not in meta):
         raise Exception('max_count missing from meta. %s' % meta)
@@ -63,7 +68,7 @@ def delete(aw, share, snap_type, prefix, max_count):
         name__startswith=prefix).order_by('-id')
     for snap in snapshots[max_count:]:
         try:
-            url = ('shares/%s/snapshots/%s' % (share.name, snap.name))
+            url = ('shares/%s/snapshots/%s' % (share.id, snap.name))
             aw.api_call(url, data=None, calltype='delete', save_error=False)
         except Exception as e:
             logger.error('Failed to delete old snapshots exceeding the '
@@ -87,7 +92,7 @@ def main():
             return
         meta = json.loads(tdo.json_meta)
         validate_snap_meta(meta)
-        share = Share.objects.get(name=meta['share'])
+        share = Share.objects.get(id=meta['share'])
         max_count = int(float(meta['max_count']))
         prefix = ('%s_' % meta['prefix'])
 
@@ -100,7 +105,7 @@ def main():
             name = ('%s_%s'
                     % (meta['prefix'],
                        datetime.now().strftime(settings.SNAP_TS_FORMAT)))
-            url = ('shares/%s/snapshots/%s' % (share.name, name))
+            url = ('shares/%s/snapshots/%s' % (share.id, name))
             # only create a new snap if there's no overflow situation. This
             # prevents runaway snapshot creation beyond max_count+1.
             if(delete(aw, share, stype, prefix, max_count)):

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -518,6 +518,12 @@ var TaskDef = Backbone.Model.extend({
         }
         return '';
     },
+    share_name: function() {
+        if (this.get('json_meta') != null) {
+            return JSON.parse(this.get('json_meta')).share_name;
+        }
+        return '';
+    },
     prefix: function() {
         if (this.get('json_meta') != null) {
             return JSON.parse(this.get('json_meta')).prefix;

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/snapshot_fields.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/snapshot_fields.jst
@@ -6,14 +6,14 @@
     </div>
     <div class="row">
         <div class="col-sm-4">
-	        <select class="form-control" id="share" name="meta.share">
+            <select class="form-control" id="share" name="meta.share">
             {{#each shares}}
-                <option value="{{this.name}}">{{this.name}}</option>
+                <option value="{{this.id}}">{{this.name}}</option>
             {{/each}}
-	        </select>
+            </select>
         </div>
         <div class="col-sm-4">
-	        <input class="form-control" type="text" id="prefix" name="meta.prefix" placeholder="Prefix" title="Snapshots will be named with this prefix. The format is prefix_YYYYMMDDHHMM">
+            <input class="form-control" type="text" id="prefix" name="meta.prefix" placeholder="Prefix" title="Snapshots will be named with this prefix. The format is prefix_YYYYMMDDHHMM">
         </div>
     </div>
 </div>
@@ -39,9 +39,9 @@
 </div>
 {{else}}
 <div class="form-group">
-    <label class="control-label col-sm-4" for="share">Share: </label>
+    <label class="control-label col-sm-4" for="share">Share name: </label>
     <div class="col-sm-6">
-        <input type="text" class="form-control" value="{{> taskObj.share}}" disabled />
+        <input type="text" class="form-control" value="{{> taskObj.share_name}}" disabled />
     </div>
 </div>
 <div class="form-group">
@@ -61,8 +61,8 @@
     <div class="col-sm-offset-4 col-sm-6">
         <div class="checkbox">
             <label>
-			    <input class="checkbox" type="checkbox" id="writable" name="meta.writable" {{> taskObj.writable}} title="Make snapshots writable"> Make snapshots writable?
-			</label>
+                <input class="checkbox" type="checkbox" id="writable" name="meta.writable" {{> taskObj.writable}} title="Make snapshots writable"> Make snapshots writable?
+            </label>
         </div>
     </div>
 </div>
@@ -71,8 +71,8 @@
     <div class="col-sm-offset-4 col-sm-6">
         <div class="checkbox">
             <label>
-			    <input class="checkbox" type="checkbox" id="visible" name="meta.visible" {{> taskObj.visible}} title="Make snapshots visible to the end user"> Make snapshots visible?
-			</label>
+                <input class="checkbox" type="checkbox" id="visible" name="meta.visible" {{> taskObj.visible}} title="Make snapshots visible to the end user"> Make snapshots visible?
+            </label>
         </div>
     </div>
 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
@@ -76,6 +76,7 @@ AddScheduledTaskView = RockstorLayoutView.extend({
                 name: this.taskDef.get('name'),
                 type: this.taskDef.get('task_type'),
                 share: this.taskDef.share(),
+                share_name: this.taskDef.share_name(),
                 prefix: this.taskDef.prefix(),
                 pool: this.taskDef.pool(),
                 pool_name: this.taskDef.pool_name(),
@@ -149,6 +150,13 @@ AddScheduledTaskView = RockstorLayoutView.extend({
                     min: 1
                 },
                 share: {
+                    required: {
+                        depends: function(element) {
+                            return (_this.$('#task_type').val() == 'snapshot');
+                        }
+                    }
+                },
+                'meta.share_name': {
                     required: {
                         depends: function(element) {
                             return (_this.$('#task_type').val() == 'snapshot');

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
@@ -143,7 +143,7 @@ ScheduledTasksView = RockstorLayoutView.extend({
                 html += '<td><a href="#edit-scheduled-task/' + taskId + '">' + taskName + '</a></td>';
                 html += '<td>' + taskType + '&nbsp;';
                 if (taskType == 'snapshot') {
-                    html += '(' + JSON.parse(jsonMeta).share + ')';
+                    html += '(' + JSON.parse(jsonMeta).share_name + ')';
                 } else if (taskType == 'scrub') {
                     html += '(' + JSON.parse(jsonMeta).pool_name + ')';
                 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
@@ -81,7 +81,7 @@ TasksView = RockstorLayoutView.extend({
         Handlebars.registerHelper('display_snapshot_scrub', function() {
             var html = '';
             if (this.taskDef.get('task_type') == 'snapshot') {
-                html += 'Snapshot of Share [' + JSON.parse(this.taskDef.get('json_meta')).share + ']';
+                html += 'Snapshot of Share [' + JSON.parse(this.taskDef.get('json_meta')).share_name + ']';
             } else if (this.taskDef.get('task_type') == 'scrub'){
                 html += 'Scrub of Pool [' + JSON.parse(this.taskDef.get('json_meta')).pool_name + ']';
             } else {


### PR DESCRIPTION
Update UI input to pass share id not name as per new api. Also adds share_name to meta field and backbone model of snapshot tasks to enable scheduled task interfaces to report the share name.

Update cron activated snapshot script to use the new share id based api, including the removal of > max snapshot removal elements.

Includes some minor tab char removal.

Fixes #1809 

@schakrava  Ready for review

Tested by establishing a share snapshot task to run every 5 mins with a 4 snapshot limit. All tasks ran and a max of 4 snapshots were observed on the share's details page. Email notifications indicated no errors with the associated snapshot cron jobs.
