### PR TITLE
scrub feedback feature. Fixes #1243 

### DIFF
--- a/src/rockstor/storageadmin/models/scrub.py
+++ b/src/rockstor/storageadmin/models/scrub.py
@@ -25,6 +25,7 @@ class PoolScrub(models.Model):
     pool = models.ForeignKey(Pool)
     # with a max of 10 chars we use 'halted' to indicated 'interrupted'
     status = models.CharField(max_length=10, default='started')
+    # pid is the process id of a scrub job
     pid = models.IntegerField()
     start_time = models.DateTimeField(auto_now=True)
     end_time = models.DateTimeField(null=True)

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -219,7 +219,8 @@ var SnapshotsCollection = RockStorPaginatedCollection.extend({
 
 var PoolScrub = Backbone.Model.extend({
     url: function() {
-        return '/api/pools/' + this.get('poolName') + '/scrub';
+        // retrieve pool specific scrubs by pool id.
+        return '/api/pools/' + this.get('pid') + '/scrub';
     }
 });
 
@@ -231,8 +232,9 @@ var PoolScrubCollection = RockStorPaginatedCollection.extend({
             this.snapType = options.snapType;
         }
     },
-    setUrl: function(poolName) {
-        this.baseUrl = '/api/pools/' + poolName + '/scrub';
+    // pid = Pool database id
+    setUrl: function(pid) {
+        this.baseUrl = '/api/pools/' + pid + '/scrub';
     },
     extraParams: function() {
         var p = this.constructor.__super__.extraParams.apply(this, arguments);

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -44,6 +44,7 @@ var AppRouter = Backbone.Router.extend({
         'pools': 'showPools',
         'pools/:pid': 'showPool',
         'pools/:pid/?cView=:cView': 'showPool',
+        'pools/:pid/:scrubId': 'showScrub',
         'add_pool': 'addPool',
         'shares': 'showShares',
         'add_share?poolName=:poolName': 'addShare',
@@ -253,6 +254,17 @@ var AppRouter = Backbone.Router.extend({
         this.currentLayout = new PoolDetailsLayoutView({
             pid: pid,
             cView: cView
+        });
+        $('#maincontent').append(this.currentLayout.render().el);
+    },
+
+    showScrub: function(pid, scrubId) {
+        this.renderSidebar('storage', 'pools');
+        $('#maincontent').empty();
+        this.cleanup();
+        this.currentLayout = new ScrubDetailsView({
+            pid: pid,
+            scrubId: scrubId
         });
         $('#maincontent').append(this.currentLayout.render().el);
     },

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_details_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_details_template.jst
@@ -1,0 +1,73 @@
+<script>
+/*
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+</script>
+<span class="h2">Scrub Details page.</span>
+<br>
+Formatted output from: <strong> btrfs scrub status -R /mnt2/{{poolName}} </strong>
+for the given job ID. If job is running then browser refresh for
+update.
+<br>
+<span class="h4">Scrub Status values:</span>
+<ul>
+ <li><strong>running:</strong> Ongoing, <strong>finished:</strong> Completed,
+  <strong> terminated:</strong> Job open when force scrub initiated.</li>
+ <li><strong>halted:</strong> Interrupted e.g. reboot,
+  <strong>cancelled:</strong> btrfs scrub cancel /mnt2/{{poolName}} executed.</li>
+ <li><strong>conn-reset:</strong> Forced scrub encountered running scrub.</li>
+</ul>
+
+
+<div class="row">
+ <div class="col-md-8">
+  <label class="control-label"></label>
+  <div class="form-box">
+   <form class="form-horizontal" id="scrub-detail-form" name="scrubdetailform">
+    <div class="messages"></div>
+
+    <!-- Form Header Info -->
+    <div class="form-group">
+     <div class="col-sm-offset-4 col-sm-8">
+      <h4>Pool name:&nbsp;&nbsp;<strong>{{poolName}}</strong></h4>
+      <h4>Scrub Status:&nbsp;&nbsp;<strong>{{scrubStatus}}</strong></h4>
+     </div>
+    </div>
+
+    <!-- Table displaying Scrub Detail -->
+    <div class="form-group" id="pool_scrub_detail_table_group">
+     <label class="col-sm-4 control-label">Scrub Statistics</label>
+     <div class="col-sm-6">
+      <div class="poolScrubDetailsTable">
+       <table id="pool_scrub_details_table" class="table table-condensed table-bordered share-table tablesorter" summary="Pool Scrub Details Table">
+        <thead>
+        <tr>
+         <th>Attribute</th>
+         <th>Value</th>
+        </tr>
+        </thead>
+         {{display_pool_scrub_details_table}}
+        </table>
+      </div>
+     </div>
+    </div><!-- pool_scrub_detail_table_group -->
+
+    </form>
+  </div>
+ </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_table_template.jst
@@ -25,7 +25,7 @@
   <table id="poolscrubs-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of poolscrubs">
     <thead>
       <tr>
-        <th scope="col" abbr="Id">Id</th>
+        <th scope="col" abbr="Id">ID</th>
         <th scope="col" abbr="Status">Status</th>
         <th scope="col" abbr="STime">Start Time</th>
         <th scope="col" abbr="ETime">End Time</th>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/tasks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/scheduled_tasks/tasks.jst
@@ -19,9 +19,8 @@
  */
 </script>
 
-<h4>Task history for {{taskName}} &nbsp;
-( {{display_snapshot_scrub}} )
-</h4>
+<span class="h2">Task history for {{taskName}}</span><br>
+{{display_snapshot_scrub}}
 {{#if collectionNotEmpty}}
   <div class="row">
     <div class="col-md-12">
@@ -30,21 +29,21 @@
         <thead>
           <tr>
             <th scope="col" abbr="ID">ID</th>
+            <th scope="col" abbr="Status">Status</th>
             <th scope="col" abbr="Start Time">Start Time</th>
             <th scope="col" abbr="End Time">End Time</th>
-            <th scope="col" abbr="Status">Status</th>
           </tr>
         </thead>
         <tbody>
           {{#each taskColl}}
             <tr>
                 <td>{{this.id}}</td>
+                <td>{{this.state}}</td>
                 <td>{{dateFormat this.start}}</td>
                 <td>{{#if this.end}} 
                         {{dateFormat this.end}}
                     {{/if}}
                 </td>
-                <td>{{this.state}}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
@@ -107,13 +107,35 @@ PoolScrubTableModule = RockstorModuleView.extend({
         this.render();
     },
 
-    initHandlebarHelpers: function() {
-        Handlebars.registerHelper('display_poolScrub_table', function() {
+    initHandlebarHelpers: function () {
+        Handlebars.registerHelper('display_poolScrub_table', function () {
+            var _this = this;
             var html = '';
-            this.collection.each(function(poolscrub, index) {
+            var errorStats = ['read_errors', 'csum_errors', 'verify_errors',
+                'super_errors', 'malloc_errors', 'uncorrectable_errors',
+                'unverified_errors', 'corrected_errors'];
+            var errorStatsLen = errorStats.length;
+            this.collection.each(function (poolscrub, index) {
+                var errorMarks = '';
+                // Tally number of non zero error stats
+                // (no forEach available in Handlebars helper context.)
+                for (var i = 0; i < errorStatsLen; i++) {
+                    if (poolscrub.get(errorStats[i]) !== 0) {
+                        errorMarks += '!';
+                    }
+                }
                 html += '<tr>';
                 html += '<td>' + poolscrub.get('id') + '</td>';
-                html += '<td>' + poolscrub.get('status') + '</td>';
+                // construct our href as pools/pid/scrubId for Scrub Details.
+                html += '<td><a href="#pools/' + _this.pool.get('id') + '/';
+                html += poolscrub.get('id') + '">';
+                html += poolscrub.get('status') + '</a>';
+                if (errorMarks !== '') {
+                    html += '<span style="color:darkred"><strong>';
+                    html += ' ' + 'ERRORS FOUND' + errorMarks;
+                    html += '</strong></span>';
+                }
+                html += '</td>';
                 html += '<td>';
                 if (poolscrub.get('start_time')) {
                     html += moment(poolscrub.get('start_time')).format(RS_DATE_FORMAT);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
@@ -167,7 +167,7 @@ ScheduledTasksView = RockstorLayoutView.extend({
                         var task = taskMapId[0],
                             taskState = task.get('state');
 
-                        if (taskState != 'scheduled' && taskState != 'pending' && taskState != 'running' && taskState != 'finished') {
+                        if (taskState != 'started' && taskState != 'running' && taskState != 'finished') {
                             html += '<a href="#scheduled-tasks/' + tId + '/log" class="task-log"><i class="glyphicon glyphicon-warning-sign"></i> ' + taskState + '</a>';
                         } else if (taskState == 'finished') {
                             html += '<a href="#scheduled-tasks/' + tId + '/log" class="task-log">' + moment(task.get('end')).fromNow() + '</a>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
@@ -57,7 +57,7 @@ ScheduledTasksView = RockstorLayoutView.extend({
                 return moment(task.get('start')).valueOf();
             }).reverse();
         });
-		// remove existing tooltips
+        // remove existing tooltips
         if (this.$('[rel=tooltip]')) {
             this.$('[rel=tooltip]').tooltip('hide');
         }
@@ -143,9 +143,13 @@ ScheduledTasksView = RockstorLayoutView.extend({
                 html += '<td><a href="#edit-scheduled-task/' + taskId + '">' + taskName + '</a></td>';
                 html += '<td>' + taskType + '&nbsp;';
                 if (taskType == 'snapshot') {
+                    // TODO: once we have snapshot task moved to new API
+                    // TODO: add link to share details page akin to pool below.
                     html += '(' + JSON.parse(jsonMeta).share_name + ')';
                 } else if (taskType == 'scrub') {
-                    html += '(' + JSON.parse(jsonMeta).pool_name + ')';
+                    // TODO: make pool name link to pool details page
+                    html += '(<a href="#pools/' + JSON.parse(jsonMeta).pool + '">';
+                    html += JSON.parse(jsonMeta).pool_name + '</a>)';
                 }
                 html += '</td>';
                 html += '<td>' + prettyCron.toString(t.get('crontab')) + '</td>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scheduled_tasks.js
@@ -143,11 +143,11 @@ ScheduledTasksView = RockstorLayoutView.extend({
                 html += '<td><a href="#edit-scheduled-task/' + taskId + '">' + taskName + '</a></td>';
                 html += '<td>' + taskType + '&nbsp;';
                 if (taskType == 'snapshot') {
-                    // TODO: once we have snapshot task moved to new API
-                    // TODO: add link to share details page akin to pool below.
-                    html += '(' + JSON.parse(jsonMeta).share_name + ')';
+                    // TODO: fix this to go direct to Snapshots tab.
+                    html += '(<a href="#shares/' + JSON.parse(jsonMeta).share + '">';
+                    html += JSON.parse(jsonMeta).share_name + '</a>)';
                 } else if (taskType == 'scrub') {
-                    // TODO: make pool name link to pool details page
+                    // TODO: fix this to go direct to Scrubs tab.
                     html += '(<a href="#pools/' + JSON.parse(jsonMeta).pool + '">';
                     html += JSON.parse(jsonMeta).pool_name + '</a>)';
                 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/scrub_details_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/scrub_details_view.js
@@ -1,0 +1,138 @@
+/*
+ *
+ * @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+
+ScrubDetailsView = RockstorLayoutView.extend({
+    events: {},
+
+    initialize: function () {
+        // call initialize of base
+        this.constructor.__super__.initialize.apply(this, arguments);
+        this.pid = this.options.pid;
+        this.scrubId = this.options.scrubId;
+        this.template = window.JST.pool_poolscrub_details_template;
+        this.pool = new Pool({
+            pid: this.pid
+        });
+        // create poolscrub models
+        this.poolscrubs = new PoolScrubCollection([], {
+            snapType: 'admin'
+        });
+        // If we experience problems with retrieving the entire scrub history
+        // then we should limit the pageSize as follows:
+        // this.poolscrubs.pageSize = 50;
+        this.poolscrubs.setUrl(this.pid);
+        // ensure dependencies
+        this.dependencies.push(this.pool);
+        this.dependencies.push(this.poolscrubs);
+        this.initHandlebarHelpers();
+    },
+
+    render: function () {
+        this.fetch(this.renderScrubForm, this);
+        return this;
+    },
+
+    renderScrubForm: function () {
+        if (this.$('[rel=tooltip]')) {
+            this.$('[rel=tooltip]').tooltip('hide');
+        }
+        var pid = this.pid;
+        var pool = this.pool;
+        // extract the specified scrub via id
+        var _this = this;
+        var scrub_details = this.poolscrubs.find(function(scrub) {
+            return (scrub.get('id') == _this.scrubId)
+        });
+
+        $(this.el).html(this.template({
+            pool: pool,
+            poolName: pool.get('name'),
+            scrubStatus: scrub_details.get('status'),
+            scrubDetails: scrub_details
+        }));
+    },
+
+    initHandlebarHelpers: function () {
+        var _this = this;
+
+        Handlebars.registerHelper('display_pool_scrub_details_table', function () {
+            // Build a table body <tbody> containing the end scrub state
+            // PoolScrub model has kb_scrubbed for data_bytes_scrubbed.
+            var elements = {"id": "ID",
+                "start_time": "Start Time",
+                "end_time": "End Time",
+                "kb_scrubbed": "Data Scrubbed",
+                "data_extents_scrubbed": "Data Extents Scrubbed",
+                "tree_extents_scrubbed": "Tree Extents Scrubbed",
+                "tree_bytes_scrubbed": "Tree Bytes Scrubbed",
+                "read_errors": "Read Errors",
+                "csum_errors": "Csum Errors",
+                "verify_errors": "Verify Errors",
+                "no_csum": "No Csum",
+                "csum_discards": "Csum Discards",
+                "super_errors": "Super Errors",
+                "malloc_errors": "Malloc Errors",
+                "uncorrectable_errors": "Uncorrectable Errors",
+                "unverified_errors": "Unverified Errors",
+                "corrected_errors": "Corrected Errors",
+                "last_physical": "Last Physical"
+            };
+            var html = '<tbody>';
+            for (var item in elements) {
+                html += '<tr>';
+                // fill out index column
+                html += '<td>' + elements[item] + '</td>';
+                // fill out value column
+                if (item == 'kb_scrubbed') {
+                    html += '<td>';
+                    if (this.scrubDetails.get(item)) {
+                        html += humanize.filesize(this.scrubDetails.get(item) * 1024);
+                    } else {
+                        html += 'Not available'
+                    }
+                    html += '</td>';
+                } else if (item == 'start_time' || item == 'end_time') {
+                    html += '<td>';
+                    if (this.scrubDetails.get(item)) {
+                        html += moment(this.scrubDetails.get(item)).format(RS_DATE_FORMAT);
+                    } else {
+                        html += 'Not available'
+                    }
+                    html += '</td>';
+                } else if (item.indexOf('errors') !== -1 && this.scrubDetails.get(item) !== 0) {
+                    // item has errors substing and != 0 value so mark as red
+                    html += '<td><span style="color:darkred"><strong>';
+                    html += this.scrubDetails.get(item);
+                    html += '</strong></span></td>';
+                } else {
+                    html += '<td>' + this.scrubDetails.get(item) + '</td>';
+                }
+            }
+            html += '</tbody>';
+            return new Handlebars.SafeString(html);
+        });
+    }
+});

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
@@ -80,15 +80,17 @@ TasksView = RockstorLayoutView.extend({
         Handlebars.registerHelper('display_snapshot_scrub', function() {
             var html = '';
             if (this.taskDef.get('task_type') == 'snapshot') {
-                // TODO: once snapshot task moved to new share api change this
-                // TODO: to a share details page link akin to Scrubs below.
-                html += 'Snapshot of Share [' + JSON.parse(this.taskDef.get('json_meta')).share_name + ']';
+                html += 'Snapshot of Share (<a href="#shares/';
+                // TODO: fix this to go direct to Snapshots tab.
+                html += JSON.parse(this.taskDef.get('json_meta')).share + '">';
+                html += JSON.parse(this.taskDef.get('json_meta')).share_name;
+                html += '</a>): see "Snapshots" tab for details.';
             } else if (this.taskDef.get('task_type') == 'scrub'){
                 html += 'Scrub of Pool (<a href="#pools/';
-                // TODO: fix this to go direct to Scrubs tab
+                // TODO: fix this to go direct to Scrubs tab.
                 html += JSON.parse(this.taskDef.get('json_meta')).pool + '">';
                 html += JSON.parse(this.taskDef.get('json_meta')).pool_name;
-                html += '</a>) See "Scrubs" tab for details.';
+                html += '</a>): see "Scrubs" tab for details.';
             } else {
                 html += this.taskDef.get('task_type');
             }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
@@ -41,7 +41,6 @@ TasksView = RockstorLayoutView.extend({
         this.collection = new TaskCollection(null, {
             taskDefId: this.taskDefId
         });
-        this.collection.pageSize = 10;
         this.dependencies.push(this.collection);
         this.collection.on('reset', this.renderTasks, this);
         // has the replica been fetched? prevents renderReplicaTrails executing

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/tasks.js
@@ -81,9 +81,15 @@ TasksView = RockstorLayoutView.extend({
         Handlebars.registerHelper('display_snapshot_scrub', function() {
             var html = '';
             if (this.taskDef.get('task_type') == 'snapshot') {
+                // TODO: once snapshot task moved to new share api change this
+                // TODO: to a share details page link akin to Scrubs below.
                 html += 'Snapshot of Share [' + JSON.parse(this.taskDef.get('json_meta')).share_name + ']';
             } else if (this.taskDef.get('task_type') == 'scrub'){
-                html += 'Scrub of Pool [' + JSON.parse(this.taskDef.get('json_meta')).pool_name + ']';
+                html += 'Scrub of Pool (<a href="#pools/';
+                // TODO: fix this to go direct to Scrubs tab
+                html += JSON.parse(this.taskDef.get('json_meta')).pool + '">';
+                html += JSON.parse(this.taskDef.get('json_meta')).pool_name;
+                html += '</a>) See "Scrubs" tab for details.';
             } else {
                 html += this.taskDef.get('task_type');
             }


### PR DESCRIPTION
To date we do not surface the details already collected of scrub jobs, this pr adds a "Scrub Details page" linked to from the entries within the "Status" column of the Scrubs tab table on the Pools details page to address this. A quick abstraction, in the event of errors found, is also presented.

Elements of this pr:

- Add a "Scrubs Details page."
- Link to above page from Status column entries in Pool details page - Scrubs tab.
- Surface errors found during a scrub via additional "ERRORS FOUND" + !+ status column entries.
- Cosmetic / readability updates concerning recent pool api changes in models.js.
- Normalise use of "ID", to be dual capitalised, in table column headers.
- Improve formatting of "Task history" page title.
- Re-order "Task history" table to be in keeping with the more developed Pool details page Scrubs and Balances tabs tables.
- Improve utility / clarity of subtitle on "Task history" page for both snapshots and shares.
- Add links to snapshot's share and scrub's pool on scheduled tasks overview table.

Fixes #1243 

@schakrava Ready for review.

Images of the resulting "Scrubs Details page" and the surfaced errors within Pools details page - Scrubs tab table entries are available in the associated issue comments.