### PR TITLE
scrubs 'show entries' selector ineffectual. Fixes #1799

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -36,7 +36,6 @@
       {{display_poolRebalance_table}}
     </tbody>
   </table>
-<div>{{pagination}}</div>
 {{else}}
   <div class="alert alert-warning"><h4>There are no balances to display</h4></div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -36,6 +36,7 @@
       {{display_poolRebalance_table}}
     </tbody>
   </table>
+<div>{{pagination}}</div>
 {{else}}
   <div class="alert alert-warning"><h4>There are no balances to display</h4></div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolscrub_table_template.jst
@@ -36,7 +36,6 @@
     {{display_poolScrub_table}}
     </tbody>
   </table>
-<div>{{pagination}}</div>
 {{else}}
   <div class="alert alert-warning"><h4>There are no scrubs to display</h4></div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -41,13 +41,11 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         this.poolscrubs = new PoolScrubCollection([], {
             snapType: 'admin'
         });
-        this.poolscrubs.pageSize = 5;
         this.poolscrubs.setUrl(this.pid);
         // create pool re-balance models
         this.poolrebalances = new PoolRebalanceCollection([], {
             snapType: 'admin'
         });
-        this.poolrebalances.pageSize = 5;
         this.poolrebalances.setUrl(this.pid);
 
         this.dependencies.push(this.pool);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
@@ -133,6 +133,3 @@ PoolRebalanceTableModule = RockstorModuleView.extend({
     }
 
 });
-
-//Add pagination
-Cocktail.mixin(PoolRebalanceTableModule, PaginationMixin);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_scrub_table.js
@@ -133,6 +133,3 @@ PoolScrubTableModule = RockstorModuleView.extend({
     }
 
 });
-
-//Add pagination
-Cocktail.mixin(PoolScrubTableModule, PaginationMixin);


### PR DESCRIPTION
The Pool details page Scrubs and Balances tab tables are limited to displaying the last 5 entries. This is not consistent with elsewhere within the UI and renders the Show entries selector ineffectual. This pr removes the relevant page limits and also removes the now redundant pagination template element and the PaginationMixins definitions.

Fixes #1799 

@schakrava Ready for review.
