### PR TITLE
share link regression on snapshots page. Fixes #1829

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
@@ -56,17 +56,17 @@
               </td>
               <td><i class="glyphicon glyphicon-camera"></i>&nbsp;{{this.name}}
                {{#if this.writable}}
-                    <a class="js-snapshot-clone" href="#" data-name="{{this.name}}" data-share-name="{{this.share}}">
+                    <a class="js-snapshot-clone" href="#" data-name="{{this.name}}" data-share-name="{{this.share_name}}">
                     <i rel="tooltip" title="Clone snapshot" class="glyphicon glyphicon-book"></i></a>
                {{/if}}
                 <a href="#" class="js-snapshot-delete" id="delete_snapshot_{{this.name}}" data-name="{{this.name}}" data-size="{{getSize this.eusage}}" 
-                data-share-name="{{this.share}}" data-action="delete" title="Delete snapshot">
+                data-share-name="{{this.share_name}}" data-action="delete" title="Delete snapshot">
                 <i rel="tooltip" title="Delete snapshot" class="glyphicon glyphicon-trash"></i></a>
               </td>
               <td>{{getSize this.rusage}}</td>
               <td>{{getSize this.eusage}}</td>
               <td>{{getToc this.toc}}</td>
-              <td><a href="#shares/{{this.share}}">{{this.share}}</a>
+              <td><a href="#shares/{{this.share}}">{{this.share_name}}</a>
                   {{#if this.share_is_mounted}}
                     ({{this.share_mount_status}})
                   {{else}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/snapshots.jst
@@ -56,11 +56,11 @@
               </td>
               <td><i class="glyphicon glyphicon-camera"></i>&nbsp;{{this.name}}
                {{#if this.writable}}
-                    <a class="js-snapshot-clone" href="#" data-name="{{this.name}}" data-share-name="{{this.share_name}}">
+                    <a class="js-snapshot-clone" href="#" data-name="{{this.name}}" data-share-name="{{this.share_name}}" data-share-id="{{this.share}}">
                     <i rel="tooltip" title="Clone snapshot" class="glyphicon glyphicon-book"></i></a>
                {{/if}}
                 <a href="#" class="js-snapshot-delete" id="delete_snapshot_{{this.name}}" data-name="{{this.name}}" data-size="{{getSize this.eusage}}" 
-                data-share-name="{{this.share_name}}" data-action="delete" title="Delete snapshot">
+                data-share-name="{{this.share_name}}" data-share-id="{{this.share}}" data-action="delete" title="Delete snapshot">
                 <i rel="tooltip" title="Delete snapshot" class="glyphicon glyphicon-trash"></i></a>
               </td>
               <td>{{getSize this.rusage}}</td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
@@ -77,7 +77,7 @@ SnapshotsView = SnapshotsCommonView.extend({
             var shareMatch = _this.shares.find(function(share) {
                 return share.get('id') == snapshots[i].share;
             });
-            snapshots[i].share = shareMatch.get('name');
+            snapshots[i].share_name = shareMatch.get('name');
             snapshots[i].share_is_mounted = shareMatch.get('is_mounted');
             snapshots[i].share_mount_status = shareMatch.get('mount_status');
         }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
@@ -103,10 +103,15 @@ SnapshotsView = SnapshotsCommonView.extend({
         return this;
     },
 
+    // may be redundant
     setShareName: function(shareName) {
         this.collection.setUrl(shareName);
     },
 
+    // it may be this method is redundant if, instead, we retrieve share id
+    // via added template attribute data-share-id sourced from snapshots array
+    // and move to shareID as value in share drop down (snapshot_add_template).
+    // See other TODOs in this file.
     getShareId: function(shareName) {
         var shareMatch = this.shares.find(function(share) {
             return share.get('name') == shareName;
@@ -147,6 +152,11 @@ SnapshotsView = SnapshotsCommonView.extend({
             },
             submitHandler: function() {
                 var button = _this.$('#js-snapshot-save');
+                // TODO: if handlebars helper show_shares_dropdown moves to
+                // passing value of shareId then the following line could be:
+                // var shareId = $('#shares').val();
+                // making the existing shareID def redundant and removes the
+                // need to call getShareID: assuming shareName is not needed.
                 var shareName = $('#shares').val();
                 var shareId = _this.getShareId(shareName);
                 if (buttonDisabled(button)) return false;
@@ -180,6 +190,8 @@ SnapshotsView = SnapshotsCommonView.extend({
         var _this = this;
         var name = $(event.currentTarget).attr('data-name');
         var shareName = $(event.currentTarget).attr('data-share-name');
+        // TODO: consider moving next line to:
+        // var shareId = $(event.currentTarget).attr('data-share-id');
         var shareId = _this.getShareId(shareName);
         var esize = $(event.currentTarget).attr('data-size');
         var button = $(event.currentTarget);
@@ -213,6 +225,8 @@ SnapshotsView = SnapshotsCommonView.extend({
         this.$('[rel=tooltip]').tooltip('hide');
         var name = $(event.currentTarget).attr('data-name');
         var shareName = $(event.currentTarget).attr('data-share-name');
+        // TODO: consider moving next line to:
+        // var shareId = $(event.currentTarget).attr('data-share-id');
         var shareId = this.getShareId(shareName);
         var url = 'shares/' + shareId + '/snapshots/' +
             name + '/create-clone';
@@ -335,6 +349,8 @@ SnapshotsView = SnapshotsCommonView.extend({
             var html = '';
             _this.shares.each(function(share, index) {
                 var shareName = share.get('name');
+                // var shareId = share.get('id');
+                // TODO: consider above shareId as value: avoids getShareId() use.
                 html += '<option value="' + shareName + '">' + shareName + '</option>';
             });
             return new Handlebars.SafeString(html);


### PR DESCRIPTION
Move share link in main snapshots page over to using the newly changed shares API. This is done by explicitly adding a share_name element to the existing UI snapshots array. This then 'uncovers' the existing share id value allowing for additional future enhancements / code simplifications. Todo's were added to this latter end.

Tested by applying included changes and ensuring share links within the snapshots table 'Shares' column then worked. Cloning and deleting snapshots via the first column icons was also tested to still work. The Create button function was also tested: though should not have been affected.

Fixes #1829 

Ready for review.