### PR TITLE
failure in share import prep re duplicate name and usage. Fixes 1828

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -406,8 +406,15 @@ def snapshot_list(mnt_pt):
 
 
 def shares_info(pool):
-    # return a list of share names under this mount_point.
-    # useful to gather names of all shares in a pool
+    """
+    Returns a list of share/subvol names by retrieving the mount point of the
+    passed pool and using this to run "btrfs subvol list -s mnt_point".
+    N.B. Child snapshots and subvolumes are ignored but writable snapshots that
+    are immediate children of a pool (vol) are not ignored and regarded as
+    shares in their own right.
+    :param pool: Pool object
+    :return: list of share/subvol names found under Pool.name
+    """
     try:
         mnt_pt = mount_root(pool)
     except CommandException as e:

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -407,13 +407,16 @@ def snapshot_list(mnt_pt):
 
 def shares_info(pool):
     """
-    Returns a list of share/subvol names by retrieving the mount point of the
-    passed pool and using this to run "btrfs subvol list -s mnt_point".
+    Returns a dictionary of share/subvol names via passed pool mount point
+    lookup and using this to run "btrfs subvol list -s mnt_point" for snapshots
+    and "btrfs subvol list -p mnt_point" for all subvols including parent id.
     N.B. Child snapshots and subvolumes are ignored but writable snapshots that
     are immediate children of a pool (vol) are not ignored and regarded as
-    shares in their own right.
+    shares in their own right (a Share 'clone' in Rockstor parlance).
     :param pool: Pool object
-    :return: list of share/subvol names found under Pool.name
+    :return: dictionary indexed by share/subvol names found directly under
+    Pool.name. Indexed values are share/subvol qgroup ie "0/266" see
+    Share.qgroup model definition.
     """
     try:
         mnt_pt = mount_root(pool)

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -81,6 +81,7 @@ def import_shares(pool, request):
             Share.objects.get(pool=pool, name=s_in_pool_db).delete()
     # Check if each share in pool also has a db counterpart.
     for s_in_pool in shares_in_pool:
+        logger.debug('Share name = {}.'.format(s_in_pool))
         if s_in_pool in shares_in_pool_db:
             logger.debug('Updating pre-existing same pool db share entry.')
             # We have a pool db share counterpart so retrieve and update it.
@@ -113,7 +114,6 @@ def import_shares(pool, request):
             continue
         try:
             logger.debug('No prior entries in scanned pool trying all pools.')
-            logger.debug('Share name = {}.'.format(s_in_pool))
             # Test (Try) for an existing system wide Share db entry.
             cshare = Share.objects.get(name=s_in_pool)
             # Get a list of Rockstor relevant subvols (ie shares and clones)

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -84,7 +84,7 @@ def import_shares(pool, request):
         if s_in_pool in shares_in_pool_db:
             logger.debug('Updating pre-existing same pool db share entry.')
             # We have a pool db share counterpart so retrieve and update it.
-            share = Share.objects.get(name=s_in_pool)
+            share = Share.objects.get(name=s_in_pool, pool=pool)
             share.qgroup = shares_in_pool[s_in_pool]
             rusage, eusage, pqgroup_rusage, pqgroup_eusage = \
                 volume_usage(pool, share.qgroup, share.pqgroup)

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -109,8 +109,7 @@ def import_shares(pool, request):
             continue
         try:
             cshare = Share.objects.get(name=s_on_disk)
-            cshares_d = shares_info('%s%s' % (settings.MNT_PT,
-                                              cshare.pool.name))
+            cshares_d = shares_info(cshare.pool)
             if (s_on_disk in cshares_d):
                 e_msg = ('Another pool(%s) has a Share with this same '
                          'name(%s) as this pool(%s). This configuration '

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -150,7 +150,7 @@ def import_shares(pool, request):
             nso = Share(pool=pool, qgroup=shares_in_pool[s_in_pool], pqgroup=pqid, name=s_in_pool,
                         size=pool.size, subvol_name=s_in_pool)
             nso.save()
-        mount_share(nso, '%s%s' % (settings.MNT_PT, s_in_pool))
+            mount_share(nso, '%s%s' % (settings.MNT_PT, s_in_pool))
 
 
 def import_snapshots(share):

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -109,7 +109,6 @@ def import_shares(pool, request):
             continue
         try:
             cshare = Share.objects.get(name=s_on_disk)
-            logger.debug('######## cshare.pool.name={}'.format(cshare.pool.name))
             cshares_d = shares_info('%s%s' % (settings.MNT_PT,
                                               cshare.pool.name))
             if (s_on_disk in cshares_d):

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -137,9 +137,9 @@ def import_shares(pool, request):
                 cshare.qgroup = shares_in_pool[s_in_pool]
                 cshare.size = pool.size
                 cshare.subvol_name = s_in_pool
-                cshare.rusage, cshare.eusage,
-                cshare.pqgroup_rusage, cshare.pqgroup_eusage = \
-                    volume_usage(pool, cshare.qgroup, cshare.pqgroup)
+                (cshare.rusage, cshare.eusage, cshare.pqgroup_rusage,
+                 cshare.pqgroup_eusage) = volume_usage(pool, cshare.qgroup,
+                                                       cshare.pqgroup)
                 cshare.save()
         except Share.DoesNotExist:
             logger.debug('Db share entry does not exist - creating.')

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -111,12 +111,14 @@ def import_shares(pool, request):
             cshare = Share.objects.get(name=s_on_disk)
             cshares_d = shares_info(cshare.pool)
             if (s_on_disk in cshares_d):
-                e_msg = ('Another pool(%s) has a Share with this same '
-                         'name(%s) as this pool(%s). This configuration '
+                e_msg = ('Another pool ({}) has a Share with this same '
+                         'name ({}) as this pool ({}). This configuration '
                          'is not supported. You can delete one of them '
-                         'manually with this command: '
-                         'btrfs subvol delete %s[pool name]/%s' %
-                         (cshare.pool.name, s_on_disk, pool.name, settings.MNT_PT, s_on_disk))
+                         'manually with the following command: '
+                         '"btrfs subvol delete {}[pool name]/{}" WARNING this '
+                         'will remove the entire contents of that subvolume.'
+                         .format(cshare.pool.name, s_on_disk, pool.name,
+                                 settings.MNT_PT, s_on_disk))
                 handle_exception(Exception(e_msg), request)
             else:
                 cshare.pool = pool


### PR DESCRIPTION
When attempting to import a pool that has a subvol by the same name as an existing subvol on another pool known to the system the intended warning explaining the lack of support for this arrangement (ie unique subvol names across an install) failed to log as expected. This was down to a prior exception in the same try clause preventing the intended log action: a call to share_info() using it's prior parameter type.

A caveat of the related fix (share_info() parameter fix) was that an intended call to volume_usage(), introduced during the existence of the share_info() parameter bug, was also blocked from ever running. And this code, in turn, had a syntactic anomaly.

Elements of this pull request:

1. Update misleading docstring on share_info().
2. Refactor import_shares() via var name changes to aid maintenance / readability.
3. Update the call to share_info() to use the new parameter type.
4. Improve 'duplicate name' during import log message wording and update format method of same.
5. Correct syntactic anomaly to the now live code concerning the intended volume_usage() call.
6. Tighten db retrieval filter to more exactly represent our required search: ie specify the desired pool rather than the existing system wide subvol search.
7. Confine explicit mount to the intended setup - avoiding a silent variable scope issue that would prevent this mount's execution anyway.
8. Add 'bare bones' debug level logging to aid in debugging future import issues.
9. Abstract db update pertaining to smart_manager_shareusage db table, aids readability / maintenance.
10. Use newly abstracted smart_manager_shareusage update mechanism to do the same on import for prior unknown, or moved (between pools) subvols. This was previously neglected.
11. Ensure that when we create a new share db entry we specify rusage, eusage, pqgroup_rusage, and pqgroup_eusage.

Please see pr issue #1828 text for a reproduction of the reported issue and a consequent proof of fix re duplicate subvol name element of this issue.

Fixes #1828 

Ready for review.

This pr does not change the essential mechanism used by share_import() but does, by way of bug fixes, extend the work done. Especially where the db in concerned: specifically smart_manager_shareusage and the additional calls to volume_usage. In the comments I will detail a basic test procedure used to establish existing function remained intact.