### PR TITLE
abstract by-id device path in a function

### DIFF
--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -20,7 +20,7 @@ import re
 from tempfile import mkstemp
 import shutil
 from system.exceptions import CommandException
-from system.osi import run_command, get_uuid_name_map
+from system.osi import run_command, get_uuid_name_map, get_device_path
 import logging
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def luks_format_disk(disk_byid, passphrase):
     :param passphrase: luks passphrase used to encrypt master key.
     :return: o, e, rc tuple as returned by cryptsetup luksFormat command.
     """
-    disk_byid_withpath = ('/dev/disk/by-id/%s' % disk_byid)
+    disk_byid_withpath = get_device_path(disk_byid)
     # Create a temp file to pass our passphrase to our cryptsetup command.
     tfo, npath = mkstemp()
     # Pythons _candidate_tempdir_list() should ensure our npath temp file is
@@ -483,7 +483,7 @@ def establish_keyfile(dev_byid, keyfile_withpath, passphrase):
         # keyfile has already been registered. UI will not ask for passphrase
         # as it is assumed that an existing keyfile is already registered.
         return True
-    dev_byid_withpath = '/dev/disk/by-id/%s' % dev_byid
+    dev_byid_withpath = get_device_path(dev_byid)
     tfo, npath = mkstemp()
     # Pythons _candidate_tempdir_list() should ensure our npath temp file is
     # in memory (tmpfs). From https://docs.python.org/2/library/tempfile.html

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import re
-from osi import run_command, get_base_device_byid
+from osi import run_command, get_base_device_byid, get_device_path
 from tempfile import mkstemp
 from shutil import move
 import logging
@@ -408,7 +408,7 @@ def get_dev_options(dev_byid, custom_options=''):
         # Empty custom_options or they have never been set so just return
         # full path to base device as nothing else to do.
         dev_options = [
-            '/dev/disk/by-id/%s' % get_base_device_byid(dev_byid, TESTMODE)]
+            get_device_path(get_base_device_byid(dev_byid, TESTMODE))]
     else:
         # Convert string of custom options into a list ready for run_command
         # TODO: think this ascii should be utf-8 as that's kernel standard
@@ -419,8 +419,7 @@ def get_dev_options(dev_byid, custom_options=''):
         if (re.search('/dev/tw|/dev/cciss/c|/dev/sg', custom_options) is None):
             # add full path to our custom options as we see no raid target dev
             dev_options += [
-                '/dev/disk/by-id/{}'.format(
-                    get_base_device_byid(dev_byid, TESTMODE))
+                get_device_path(get_base_device_byid(dev_byid, TESTMODE))
             ]
     # Note on raid controller target devices.  /dev/twe#, or /dev/twa#, or
     # /dev/twl# are 3ware controller targets devs respectively 3x-xxxx,


### PR DESCRIPTION
As discussed in PR #1704 this is an updated version of the patch there, reworked on top of current master.
This patch abstracts away the actual /dev/disk/by-id/ path substitution into a function, grouped with similar function in osi.py.
This would help us at Minebox to stay closer to upstream.