### PR TITLE
add share detail links to export tables + rewording #1830

### DIFF
--- a/src/rockstor/storageadmin/models/netatalk_share.py
+++ b/src/rockstor/storageadmin/models/netatalk_share.py
@@ -37,6 +37,9 @@ class NetatalkShare(models.Model):
     def share_name(self, *args, **kwargs):
         return self.share.name
 
+    def share_id(self, *args, **kwargs):
+        return self.share.id
+
     @property
     def vol_size(self):
         return self.share.size

--- a/src/rockstor/storageadmin/models/nfs_export.py
+++ b/src/rockstor/storageadmin/models/nfs_export.py
@@ -32,5 +32,8 @@ class NFSExport(models.Model):
     def share_name(self, *args, **kwargs):
         return self.share.name
 
+    def share_id(self, *args, **kwargs):
+        return self.share.id
+
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/models/samba_share.py
+++ b/src/rockstor/storageadmin/models/samba_share.py
@@ -47,5 +47,8 @@ class SambaShare(models.Model):
     def share_name(self, *args, **kwargs):
         return self.share.name
 
+    def share_id(self, *args, **kwargs):
+        return self.share.id
+
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/models/sftp.py
+++ b/src/rockstor/storageadmin/models/sftp.py
@@ -35,5 +35,8 @@ class SFTP(models.Model):
     def share_name(self, *args, **kwargs):
         return self.share.name
 
+    def share_id(self, *args, **kwargs):
+        return self.share.id
+
     class Meta:
         app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -63,6 +63,7 @@ class SnapshotSerializer(serializers.ModelSerializer):
 
 class NFSExportSerializer(serializers.ModelSerializer):
     share = serializers.CharField(source='share_name')
+    share_id = serializers.CharField()
 
     class Meta:
         model = NFSExport
@@ -117,6 +118,7 @@ class SambaCustomConfigSerializer(serializers.ModelSerializer):
 
 class SambaShareSerializer(serializers.ModelSerializer):
     share = serializers.CharField(source='share_name')
+    share_id = serializers.CharField()
     admin_users = SUserSerializer(many=True)
     custom_config = SambaCustomConfigSerializer(many=True,
                                                 source='sambacustomconfig_set')
@@ -199,6 +201,7 @@ class SetupSerializer(serializers.ModelSerializer):
 
 class SFTPSerializer(serializers.ModelSerializer):
     share = serializers.CharField(source='share_name')
+    share_id = serializers.CharField()
 
     class Meta:
         model = SFTP
@@ -214,6 +217,7 @@ class OauthAppSerializer(serializers.ModelSerializer):
 
 class NetatalkShareSerializer(serializers.ModelSerializer):
     share = serializers.CharField(source='share_name')
+    share_id = serializers.CharField()
 
     class Meta:
         model = NetatalkShare

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/add_afp_share.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/add_afp_share.jst
@@ -14,7 +14,7 @@
 
         <!-- Shares -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="shares">Shares to export via afp<span class="required">*</span></label>
+          <label class="col-sm-4 control-label" for="shares">Shares to export<span class="required">*</span></label>
           <div class="col-sm-4">
             <select class="form-control" name="shares" id="shares" size="10" class='required' data-placeholder="Select shares to export" multiple="multiple">
             {{display_shares_dropdown}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
@@ -28,7 +28,7 @@
         <tbody>
           {{#each afpShare}}
             <tr>
-                <td>{{this.share}}</td>
+                <td><a href="#shares/{{this.share_id}}">{{this.share}}</a></td>
                 <td>{{this.time_machine}}</td>
                 <td><a href="#afp/edit/{{this.id}}"><i class="glyphicon glyphicon-pencil"></i></a>&nbsp;
                 <a href="#" class="delete-afp-share" data-share="{{this.share}}" data-id="{{this.id}}">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/nfs/nfs_exports.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/nfs/nfs_exports.jst
@@ -42,9 +42,9 @@
       <table id="nfs-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of nfs exports">
         <thead>
           <tr>
-            <th scope="col" abbr="Host String">Host String</th>
             <th scope="col" abbr="Shares">Shares</th>
-            <th scope="col" abbr="Writable">Writable</th>
+            <th scope="col" abbr="Host String">Host String</th>
+            <th scope="col" abbr="Read only">Read only</th>
             <th scope="col" abbr="Sync">Sync / Async</th>
             <th scope="col" abbr="Actions">Actions</th>
           </tr>
@@ -52,15 +52,15 @@
         <tbody>
           {{#each nfsCollection}}
             <tr>
-                <td>{{this.host_str}}</td>
                 <td>
                 {{#each this.exports}}
-                    {{this.share}} {{showNfsShares @index ../this.exports}}
+                    <a href="#shares/{{this.share_id}}">{{this.share}}</a> {{showNfsShares @index ../this.exports}}
                 {{/each}}
                 </td>
+                <td>{{this.host_str}}</td>
                 <td>{{showWritableOption this.editable}}</td>
                 <td>{{this.syncable}}</td>
-                <td><a href="#nfs-exports/edit/{{this.id}}"><i class="glyphicon glyphicon-edit"></i></a>&nbsp;
+                <td><a href="#nfs-exports/edit/{{this.id}}"><i class="glyphicon glyphicon-pencil"></i></a>&nbsp;
                 <a href="#" class="delete-nfs-export" data-id="{{this.id}}"><i class="glyphicon glyphicon-trash"></i></a>
                 </td>
             </tr>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/add_samba_export.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/add_samba_export.jst
@@ -45,7 +45,7 @@
         </div>
 
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="guest_ok">Guest Ok<span class="required"> *</span></label>
+          <label class="col-sm-4 control-label" for="guest_ok">Guest OK<span class="required"> *</span></label>
           <div class="col-sm-4">
           {{display_options "guest_ok"}}
            </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/samba.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/samba.jst
@@ -33,7 +33,7 @@
         <tbody>
           {{#each samba}}
             <tr>
-                <td>{{this.share}}</td>
+                <td><a href="#shares/{{this.share_id}}">{{this.share}}</a></td>
                 <td>{{this.browsable}}</td>
                 <td>{{this.guest_ok}}</td>
                 <td>{{this.read_only}}</td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/add_sftp_share.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/add_sftp_share.jst
@@ -8,7 +8,7 @@
 
         <!-- Shares -->
         <div class="form-group">
-          <label class="col-sm-4 control-label" for="shares">Shares to export via sftp<span class="required">*</span></label>
+          <label class="col-sm-4 control-label" for="shares">Shares to export<span class="required">*</span></label>
 	      <div class="col-sm-4">
               <select class="form-control" name="shares" id="shares" size="10" data-placeholder="Select shares" multiple="multiple">
         		{{#each shares}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
@@ -18,15 +18,15 @@
       <table id="sftp-shares-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of sftp shares">
         <thead>
           <tr>
-            <th scope="col" abbr="Host String">Share name</th>
-            <th scope="col" abbr="Access type">Read only</th>
+            <th scope="col" abbr="Host String">Share</th>
+            <th scope="col" abbr="Read only">Read only</th>
             <th scope="col" abbr="Actions">Actions</th>
           </tr>
         </thead>
         <tbody>
           {{#each sftpShare}}
             <tr>
-                <td>{{this.share}}</td>
+                <td><a href="#shares/{{this.share_id}}">{{this.share}}</a></td>
                 <td>{{displaySftpPermission this.editable}}</td>
                 <td><a href="#" class="delete-sftp-share" data-id="{{this.id}}">
                 <i class="glyphicon glyphicon-trash"></i></a></td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/edit_nfs_export.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/edit_nfs_export.js
@@ -51,7 +51,7 @@ EditNFSExportView = RockstorLayoutView.extend({
             value: 'rw'
         },
         {
-            name: 'Read-only',
+            name: 'Read only',
             value: 'ro'
         },
         ];

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/nfs_exports.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/nfs_exports.js
@@ -184,7 +184,7 @@ NFSExportsView = RockstorLayoutView.extend({
         });
 
         Handlebars.registerHelper('showWritableOption', function(editable) {
-            return editable == 'rw' ? 'Writable' : 'Read-only';
+            return editable == 'rw' ? 'no' : 'yes';
         });
     }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/samba.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/samba.js
@@ -56,7 +56,7 @@ SambaView = RockstorLayoutView.extend({
 
     renderSamba: function() {
         this.freeShares = this.shares.reject(function(share) {
-            s = this.collection.find(function(sambaShare) {
+            var s = this.collection.find(function(sambaShare) {
                 return (sambaShare.get('share') == share.get('name'));
             });
             return !_.isUndefined(s);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/sftp.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/sftp.js
@@ -55,7 +55,7 @@ SFTPView = RockstorLayoutView.extend({
 
     renderSFTP: function() {
         this.freeShares = this.shares.reject(function(share) {
-            s = this.collection.find(function(sftpShare) {
+            var s = this.collection.find(function(sftpShare) {
                 return (sftpShare.get('share') == share.get('name'));
             });
             return !_.isUndefined(s);
@@ -201,9 +201,9 @@ SFTPView = RockstorLayoutView.extend({
         Handlebars.registerHelper('displaySftpPermission', function(sftpEditable) {
             var html = '';
             if (sftpEditable == 'ro') {
-                html += 'Read only';
+                html += 'yes';
             } else {
-                html += 'Writable';
+                html += 'no';
             }
             return new Handlebars.SafeString(html);
         });


### PR DESCRIPTION
Also includes NFS export table re-order to normalise share as first column in all export tables. Normalise "Read only" column header in all export tables with contents as yes/no. 2 minor implicit to explicit js var declarations.

Please see issue text for initial reasoning and context.
Fixes #1830 

All subsequent links tested to affect share detail page display.
