### PR TITLE
Print actionable error upon autorization failure. Fixes #1843

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -94,7 +94,7 @@ def current_version():
 def rpm_build_info(pkg):
     version = None
     date = None
-    o, e, rc = run_command([RPM, '-qi', pkg])
+    o, e, rc = run_command([YUM, 'info', pkg])
     for l in o:
         if (re.match('Build Date', l) is not None):
             # eg: Build Date  : Tue 11 Aug 2015 02:25:24 PM PDT


### PR DESCRIPTION
* Don't print stack trace as it's unnecessary
* Improve error message to be more actionable
* Use yum to get the rpm metadata for consistent behavior when using source builds.