### PR TITLE
don't raise exception on quota not enabled. Fixes #1867

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -832,7 +832,7 @@ def volume_usage(pool, volume_id, pvolume_id=None):
     current real size we can indistinctly use one of them.
     """
     cmd = [BTRFS, 'qgroup', 'show', volume_dir]
-    out, err, rc = run_command(cmd, log=True)
+    out, err, rc = run_command(cmd, log=True, throw=False)
     volume_id_sizes = [0, 0]
     pvolume_id_sizes = [0, 0]
     for line in out:


### PR DESCRIPTION
We already log the state of quota not enabled via run_command log=True on the line relating to this pr and given a failure / exception here (pre pr) breaks mounts we should simply log and move on. Our parent function already deals with this scenario by returning vol / pvol sizes of 0.

This is akin to the treatment we give to command lines involved in the following functions withing the same file: is_subvol, subvol_info, add_share, balance_status, device_scan.

Although this pr does address a failure to mount shares due to 'quota not enabled' it does not address the reason for the quota not being enabled in the first place. This however can be addressed in a future pr, along with it's various ramifications ie 0 usage against shares and an inability to change share sizes etc.

Fixes #1867 

Proof of fix re shares unmounted was accomplished by re-producing the issue (fresh 3.9.2-3 install setup with an example plex config as per:
http://rockstor.com/docs/docker-based-rock-ons/plex-media-server.html#plex-server-rock-on
Then rebooting.

There after every reboot failed with exceptions as noted in the issue text (quota not enabled).

Post pr every reboot thus far successfully remounted all shares and started the plex rock-on but with the above noted caveats re shares.

@schakrava Ready for review.


