### PR TITLE
version and date incorrectly reported re update info. Fixes #1870

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -94,14 +94,15 @@ def current_version():
 def rpm_build_info(pkg):
     version = None
     date = None
-    o, e, rc = run_command([YUM, 'info', pkg])
+    o, e, rc = run_command([YUM, 'info', 'installed', '-v', pkg])
     for l in o:
-        if (re.match('Build Date', l) is not None):
-            # eg: Build Date  : Tue 11 Aug 2015 02:25:24 PM PDT
-            # we return 2015-Aug-11
+        if (re.match('Buildtime', l) is not None):
+            # eg: "Buildtime   : Tue Dec  5 13:34:06 2017"
+            # we return 2017-Dec-06
+            # Note the one day on from retrieved Buildtime with zero padding.
             dfields = l.strip().split()
-            dstr = ' '.join(dfields[3:7])
-            bdate = datetime.strptime(dstr, '%a %d %b %Y')
+            dstr = dfields[6] + ' ' + dfields[3] + ' ' + dfields[4]
+            bdate = datetime.strptime(dstr, '%Y %b %d')
             bdate += timedelta(days=1)
             date = bdate.strftime('%Y-%b-%d')
         if (re.match('Version ', l) is not None):


### PR DESCRIPTION
A recent move to yum from rpm inadvertently caused a miss reporting of installed version for that of available version. This was due to the differing outputs and the inclusion of both installed and available in the newer yum format. The command switch set was revised to output only the installed version and to include the previously missing and required build date/time info. Consequent parsing adjustments were made to accommodate for the now changed date format.

Time info was excluded as it is not used.

@schakrava Ready for review.

Fixes #1870 

Please see issue text for stable package test / validation procedure.

As there are currently existing anomalies in package change log dates and contents re recently added minor version numbers this must be resolved in future package releases for the intended function of the "List of changes in this update" to correctly populate. See issue text for details. Currently it will be blank for the more recent stable package releases but should work as intended when the date anomalies are resolved in future package releases (ie when package changelogs indicate the time of release).

Also tested by applying to a fresh 3.9.1-0 install pre and post testing channel subscription and thereafter then updating via command line to 3.9.1-15. In all instances installed and available were displayed correctly. An update from 3.9.1-15 to 3.9.1-16 was then successfully completed via the command line.

