### PR TITLE
rock-ons-root host pool quota disabled by docker-ce. Fixes #1872

### DIFF
--- a/src/rockstor/scripts/docker_wrapper.py
+++ b/src/rockstor/scripts/docker_wrapper.py
@@ -34,4 +34,5 @@ def main():
         sys.exit('Failed to mount Docker root(%s). Exception: %s' %
                  (mnt_pt, e.__str__()))
     run_command([DOCKERD, '--log-driver=journald', '--storage-driver',
-                 'btrfs', '--data-root', mnt_pt])
+                 'btrfs', '--storage-opt', 'btrfs.min_space=1G', '--data-root',
+                 mnt_pt])


### PR DESCRIPTION
It was found that the unwanted and currently unsupported behaviour of docker-ce disabling quotas, pre this commit, whenever systemd initiated this dockerd wrapper was partially circumvented by the addition of the: btrfs.min_space storage drive option. In this case, although qoutas were still disabled they were then re-enabled shortly there after; once the dockerd deamon had settled: returning the pool's quotas to the supported enabled status. Note however that disabling the docker service still disables quotas on the associated host pool and the state is persistent.

Fixes #1872 

Please see issue text for context.

@schakrava I'm pretty sure this is good on it's own to alleviate the consequences of quotas disabled that we currently see in 3.9.2-3 (post reboot) onward (currently 3.9.2-5) and as such could be considered as the second fix to the same with 3.9.2-5's #1868 (applied and release) being the first.

An initial approach to dealing with quotas disabled is to be presented shortly against #1869 (almost done). However those changes will necessitate greater scrutiny, hence my splitting this change out.

Ready for review.

A reference for this additional option is available at:
https://github.com/moby/moby/blob/67fdf574d5acd6ddccb6ece0ffe0ace1c1608712/docs/reference/commandline/dockerd.md#btrfsmin_space
It is currently the only documented btrfs specific storage-opt.