### PR TITLE
improve quotas not enabled behaviour. Fixes #1869

### DIFF
--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -18,7 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from django.conf import settings
-from fs.btrfs import pool_usage, usage_bound
+from fs.btrfs import pool_usage, usage_bound, \
+    are_quotas_enabled
 from system.osi import mount_status
 
 RETURN_BOOLEAN = True
@@ -71,6 +72,14 @@ class Pool(models.Model):
         try:
             return mount_status('%s%s' % (settings.MNT_PT, self.name),
                                 RETURN_BOOLEAN)
+        except:
+            return False
+
+    @property
+    def quotas_enabled(self, *args, **kwargs):
+        # Calls are_quotas_enabled for boolean response
+        try:
+            return are_quotas_enabled('%s%s' % (settings.MNT_PT, self.name))
         except:
             return False
 

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -21,6 +21,7 @@ from django.db import models
 from django.db.models.signals import (post_save, post_delete)
 from django.dispatch import receiver
 
+from fs.btrfs import qgroup_exists
 from storageadmin.models import Pool
 from system.osi import mount_status
 from .netatalk_share import NetatalkShare
@@ -78,6 +79,19 @@ class Share(models.Model):
         try:
             return mount_status('%s%s' % (settings.MNT_PT, self.name),
                                 RETURN_BOOLEAN)
+        except:
+            return False
+
+    @property
+    def pqgroup_exist(self, *args, **kwargs):
+        # Returns boolean status of pqgroup existence
+        try:
+            if str(self.pqgroup) == '-1/-1':
+                return False
+            else:
+                return qgroup_exists(
+                    '%s%s' % (settings.MNT_PT, self.pool.name),
+                    '%s' % self.pqgroup)
         except:
             return False
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -51,6 +51,7 @@ class PoolInfoSerializer(serializers.ModelSerializer):
     reclaimable = serializers.IntegerField()
     mount_status = serializers.CharField()
     is_mounted = serializers.BooleanField()
+    quotas_enabled = serializers.BooleanField()
 
     class Meta:
         model = Pool
@@ -145,6 +146,7 @@ class ShareSerializer(serializers.ModelSerializer):
     nfs_exports = NFSExportSerializer(many=True, source='nfsexport_set')
     mount_status = serializers.CharField()
     is_mounted = serializers.BooleanField()
+    pqgroup_exist = serializers.BooleanField()
 
     class Meta:
         model = Share

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
@@ -30,6 +30,13 @@
   {{else}}
     <span style="color:red">{{model.mount_status}}</span>
   {{/if}}
+  </strong><br/>
+  Quotas: <strong>
+  {{#if model.quotas_enabled}}
+    Enabled
+  {{else}}
+    <span style="color:red">Disabled</span>
+  {{/if}}
   </strong>
 </div> <!-- module-content -->
  

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -5,6 +5,7 @@
       <th>Name</th>
       <th>Size</th>
       <th>Usage</th>
+      <th>Quotas</th>
       <th>Raid</th>
       <th>Active mount options / Status</th>
       <th>Compression</th>
@@ -32,7 +33,12 @@
             <td>{{humanReadableSize 'usage' this.size this.reclaimable this.free}}
                 <strong>({{humanReadableSize 'usagePercent' this.size this.reclaimable this.free}} %)</strong>
             </td>
-
+            <td>{{#if this.quotas_enabled}}
+                    Enabled
+                {{else}}
+                    <strong><span style="color:red">Disabled</span></strong>
+                {{/if}}
+            </td>
             <td>{{this.raid}}
                 {{#unless (isRoot this.role)}}
                       &nbsp;<a href="#pools/{{this.id}}/?cView=resize"><i class="fa fa-pencil-square-o"></i></a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/share_usage_module.jst
@@ -28,6 +28,13 @@
     (<strong><span style="color:red">{{pool_mount_status}}</span></strong>)
   {{/if}}
   <br>
+  Pool Quotas:&nbsp;
+  {{#if pool_quotas_enabled}}
+    Enabled
+  {{else}}
+    <strong><span style="color:red">Disabled</span></strong>
+  {{/if}}
+  <br>
   Active mount options / Status:
   <strong>
   {{#if share_is_mounted}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -12,11 +12,11 @@
       <tr>
         <th>Name</th>
         <th>Size</th>
-        <th>Usage <i class="fa fa-info-circle" title="Current share content"></th>
-        <th>Btrfs Usage <i class="fa fa-info-circle" title="Current share content including snapshots"></th>
+        <th>Usage <i class="fa fa-info-circle" title="Share content - uses Quotas" /></th>
+        <th>Btrfs Usage <i class="fa fa-info-circle" title="Share content inc snapshots - uses Quotas" /></th>
         <th>Active mount options / Status</th>
-        <th>Pool (Active mount options / Status)</th>
-        <th>Compression <i class="fa fa-info-circle" title="Inherits pool setting if not specified on share"></th>
+        <th>Pool (Active mount options / Status) Quotas</th>
+        <th>Compression <i class="fa fa-info-circle" title="Inherits pool setting if not specified on share" /></th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -39,6 +39,11 @@
                 ({{this.pool.mount_status}})
             {{else}}
                 (<strong><span style="color:red">{{this.pool.mount_status}}</span></strong>)
+            {{/if}}
+            {{# if this.pool.quotas_enabled}}
+                Enabled
+            {{else}}
+                <strong><span style="color:red">Disabled</span></strong>
             {{/if}}
         </td>
         <td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_usage_module.js
@@ -47,6 +47,7 @@ ShareUsageModule = RockstorModuleView.extend({
             poolName: this.share.get('pool').name,
             pool_is_mounted: this.share.get('pool').is_mounted,
             pool_mount_status: this.share.get('pool').mount_status,
+            pool_quotas_enabled: this.share.get('pool').quotas_enabled,
             share_is_mounted: this.share.get('is_mounted'),
             share_mount_status: this.share.get('mount_status'),
             pid: this.share.get('pool').id,

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -26,7 +26,7 @@ from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
 from storageadmin.views import DiskMixin
 from system.osi import (uptime, kernel_info)
-from fs.btrfs import (mount_share, mount_root, qgroup_create, get_pool_info,
+from fs.btrfs import (mount_share, mount_root, get_pool_info,
                       pool_raid, mount_snap)
 from system.ssh import (sftp_mount_map, sftp_mount)
 from system.services import systemctl
@@ -92,15 +92,13 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
             for p in Pool.objects.all():
                 if p.disk_set.attached().count() == 0:
                     continue
+                # Import / update db shares counterpart for managed pool.
                 import_shares(p, request)
 
             for share in Share.objects.all():
                 if share.pool.disk_set.attached().count() == 0:
                     continue
                 try:
-                    if (share.pqgroup == settings.MODEL_DEFS['pqgroup']):
-                        share.pqgroup = qgroup_create(share.pool)
-                        share.save()
                     if not share.is_mounted:
                         mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
                         mount_share(share, mnt_pt)

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -707,6 +707,7 @@ class DiskDetailView(rfc.GenericView):
             po.raid = pool_raid('%s%s' % (settings.MNT_PT, po.name))['data']
             po.size = po.usage_bound()
             po.save()
+            # TODO: enable_quota could well break an import from a ro pool.
             enable_quota(po)
             import_shares(po, request)
             for share in Share.objects.filter(pool=po):


### PR DESCRIPTION
Uses the existing -1/-1 default for pqgoups to represent an unset state for the share.pqgroup and adds an active return to this value whenever quotas are deemed to be disabled. Pqgroup setup is moved from the bootstrap process into the import_shares / shares refresh section. This allows for live setting / resetting of pqgroups via the regular share re-fresh process. Pool.quotas_enabled and share.pqgroup_exist properties are added and all used low level quota actions are adjusted to catch, log, and ignore a quota disabled state. Additionally active pqgroup assignment is added to share
resize and share refresh procedures which aid in returning to existence the expected native 2015/n pqgroups and their relationship to the auto generated 0/n qgroups as whenever quotas are disabled all this info (var the 0/n) is lost. UI elements are added in pool and share focused pages to indicate a live status for the associated pool quotas enabled status.

Fixes #1869 

@schakrava ready for review

Please see linked issue for images of the resulting UI components within this pr.

This pr aims to improve robustness to a quotas disabled state and, with some limitations, is able to re-establish full quota group relationships upon quotas becoming re-enabled. Although a share re-scan is required for this to take place.

Know limitations:
- When importing a pool via the disk page there is a failure to assert pqgroup ggroup relationships, this is intentional as adding the additional potential quota scans is currently an unknown load on what is already a fairly intense process. This short fall can be addressed separately in another issue/pr.
- when making a clone that clone's pqgroup is not immediately established, however there also exist a potentially related bug where clones are also not mounted: again this can be addressed separately and is in time resolved by future share scans anyway.
- Long term pqgroup to share identity is not maintained over quota disabled enabled cycles. This does not look to affect any current function, but given all pqgroups are deleted whenever quotas are disabled it would require additional complexity whenever reconstructing, ie split brain between db and pool: hence the defaulting to -1/-1 in unknown / quota disabled states for all shares associated with the pool in question.

