### PR TITLE
improve user messaging re system disk no serial. Fixes #1866

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -109,7 +109,8 @@
       <td>
         {{#checkSerialStatus this.serial this.name}}
         <div class="alert alert-danger"><h4>Warning! Disk unusable as pool member - serial number is not legitimate or unique.</h4>Disk names may change unfavourably upon reboot leading to inadvertent drive reallocation and potential data loss. This error is caused by the source of these disks such as your Hypervisor or SAN.
-          Please ensure that disks are provided with unique serial numbers before proceeding further.</div>
+          Please ensure that disks are provided with unique serial numbers before proceeding further.
+          See our <a href="http://rockstor.com/docs/quickstart.html#minimum-system-requirements" target="_blank">Minimum system requirements</a> for VMware config.</div>
         {{else if this.serial}}
         {{this.serial}}
         &nbsp;&nbsp;&nbsp;&nbsp;<a href="#disks/blink/{{this.id}}" title="A tool to physically identify the hard drive with this serial number." rel="tooltip">

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -20,7 +20,7 @@ import re
 from rest_framework.response import Response
 from django.db import transaction
 from storageadmin.models import (Disk, Pool, Share)
-from fs.btrfs import (enable_quota, btrfs_uuid, mount_root,
+from fs.btrfs import (enable_quota, mount_root,
                       get_pool_info, pool_raid)
 from storageadmin.serializers import DiskInfoSerializer
 from storageadmin.util import handle_exception
@@ -325,7 +325,9 @@ class DiskMixin(object):
                 dob.save()
                 p.size = p.usage_bound()
                 enable_quota(p)
-                p.uuid = btrfs_uuid(dob.name)
+                # scan_disks() has already acquired our fs uuid so inherit it.
+                # We have already established btrfs as the fs type.
+                p.uuid = d.uuid
                 p.save()
             # save our updated db disk object
             dob.save()


### PR DESCRIPTION
By using the already acquired fs (btrfs) uuid from scan_disks() we can avoid a system call that fails when there are no by-id names (no dev serial) this removes a dev scan block and allows for the initial creation of the system pool and subsequent scans via pool / share updates (btrfs_uuid import removed). These later mechanisms can in turn deal more elegantly with failed dev calls and as an initial dev db then exists the existing mechanisms that communicate the serial issues can do so via the Disk page warnings.

pr components:
- avoid unnecessary and dev scan blocking call to btrfs_uuid()
- removed now redundant import of btrfs_uuid() in views.py _update_disk_state()
- add link to doc's 'Minimum system requirements' along with VMware config teaser to Disk page serial warning.

Fixes #1866 

Please see issue comments for dev notes and images of the resulting UI Disk page serial warning changes.

@schakrava Ready for review.

Limitations: we will still fail to import the system disk's subvols but as we are not responsible for their mounts it is a far less severe affect than having all device scanning blocked. Plus we are now able to communicate the 'short fall' in config along with the min sys requirements link to indicate this further and provide a config solution for at least VMware.

Testing was achieved by hand editing the main functional change (avoiding the early call to btrfs_uuid()) on a clean install of 3.9.1-0 that had been installed on a 3 disk system where no disks had any serials. This was achieved in KVM by installing to virtio devices and removing the ks= option on the installer command line. A full rebuild of master + patch was also tested on the same system (no serials present) in order to ensure the blocking issue was avoided. Initial hostname / admin user setup was achieved and all disks were appropriately flagged as having a serial issue within the Disks page. Adding a serial to each disk in turn resulted in expected behaviour of by-id name substitution within the db and consequent system pool subvol imports.
