### PR TITLE
Fix replication regression re share api change. Fixes #1853

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -314,7 +314,7 @@ SCHEDULER = ('127.0.0.1', ${django-settings-conf:schedulerport})
 REPLICATION = {
 	    'ipc_socket': '/var/run/replication.sock',
 	    'max_send_attempts': 10,
-	    'max_snap_retain': 5,
+	    'max_snap_retain': 2,
 	    'listener_port': 10002,
 }
 

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -301,7 +301,7 @@ SCHEDULER = ('127.0.0.1', ${django-settings-conf:schedulerport})
 REPLICATION = {
     'ipc_socket': '/var/run/replication.sock',
     'max_send_attempts': 10,
-    'max_snap_retain': 5,
+    'max_snap_retain': 2,
     'listener_port': 10002,
 }
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -351,6 +351,9 @@ def add_share(pool, share_name, qid):
 
 
 def mount_share(share, mnt_pt):
+    # TODO: Consider making mnt_pt optional as per helper_mount_share() as then
+    # TODO: we could remove almost system wide many duplicates of temp mnt_pt
+    # TODO: created just prior and only for this methods call.
     if (is_mounted(mnt_pt)):
         return
     mount_root(share.pool)
@@ -560,6 +563,7 @@ def remove_share(pool, share_name, pqgroup, force=False):
     mount root pool
     btrfs subvolume delete root_mnt/vol_name
     umount root pool
+    :param pool: pool object
     """
     if (is_share_mounted(share_name)):
         mnt_pt = ('%s%s' % (DEFAULT_MNT_DIR, share_name))
@@ -1292,8 +1296,20 @@ def set_property(mnt_pt, name, val, mount=True):
         return run_command(cmd)
 
 
-def get_snap(subvol_path, oldest=False, num_retain=None, regex=None):
-    if (not os.path.isdir(subvol_path)):
+def get_snap(subvol_path, oldest=False, num_retain=None, regex=None,
+             test_mode=False):
+    """
+    If the supplied path is a directory, it's last element after delimiter (/)
+    it taken and used as the share name. A subvol list is then generated via
+    "btrfs subvol list -o subvol_path" command.
+    :param subvol_path:
+    :param oldest:
+    :param num_retain:
+    :param regex:
+    :param test_mode:
+    :return:
+    """
+    if (not os.path.isdir(subvol_path)) and not test_mode:
         return None
     share_name = subvol_path.split('/')[-1]
     cmd = [BTRFS, 'subvol', 'list', '-o', subvol_path]

--- a/src/rockstor/storageadmin/models/snapshot.py
+++ b/src/rockstor/storageadmin/models/snapshot.py
@@ -25,6 +25,8 @@ class Snapshot(models.Model):
     """display name of the snapshot"""
     name = models.CharField(max_length=4096)
     """real name of the snapshot"""
+    # TODO: Is real_name an equivalent to the Share model subvol-name, and
+    # TODO; if so should it contain the full path.
     real_name = models.CharField(max_length=4096, default='unknownsnap')
     """read-only by default"""
     writable = models.BooleanField(default=False)

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/receive_trails.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/receive_trails.jst
@@ -26,7 +26,7 @@
   <div class="row">
     <div class="col-md-12">
       <div class="messages"></div>
-      <table id="receive-trails-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="Replica trails">
+      <table id="receive-trails-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="Receive trails">
         <thead>
           <tr>
             <th scope="col" abbr="ID">ID</th>
@@ -35,7 +35,7 @@
             <th scope="col" abbr="Start Time">End Time</th>
             <th scope="col" abbr="Start Time">Status</th>
             <th scope="col" abbr="Start Time">Duration</th>
-            <th scope="col" abbr="Start Time">Data transferred / Transfer rate (KB)</th>
+            <th scope="col" abbr="Start Time">Data transferred at rate</th>
           </tr>
         </thead>
         <tbody>
@@ -58,7 +58,7 @@
                     {{getDuration this.end_ts receive_pending}}
                     {{/if}}
                 </td>
-                <td>{{humanReadableSize this.kb_received}} at {{getRate this.end_ts this.receive_pending this.kb_received}} /sec.</td>
+                <td>{{humanReadableSize this.kb_received}} at {{getRate this.end_ts this.receive_pending this.kb_received}}/sec</td>
             </tr>
           {{/each}}
         </tbody>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replica_trails.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replica_trails.jst
@@ -24,16 +24,16 @@
   <div class="row">
     <div class="col-md-12">
       <div class="messages"></div>
-      <table id="replica-trails-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="Replica trails">
+      <table id="replica-trails-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="Replica trails">
         <thead>
           <tr>
             <th scope="col" abbr="ID">ID</th>
-	    <th scope="col" abbr="Snapshot">Snapshot</th>
+            <th scope="col" abbr="Snapshot">Snapshot</th>
             <th scope="col" abbr="Start Time">Start Time</th>
             <th scope="col" abbr="Start Time">End Time</th>
             <th scope="col" abbr="Start Time">Status</th>
             <th scope="col" abbr="Start Time">Duration</th>
-            <th scope="col" abbr="Start Time">Data transferred / Transfer rate (KB)</th>
+            <th scope="col" abbr="Start Time">Data transferred at rate</th>
           </tr>
         </thead>
         <tbody>
@@ -56,12 +56,11 @@
                     {{getDuration this.end_ts this.snapshot_created}}
                     {{/if}}
                 </td>
-                <td>{{humanReadableSize this.kb_sent}} at {{getRate this.end_ts this.snapshot_created this.kb_sent}} /sec.</td>
+                <td>{{humanReadableSize this.kb_sent}} at {{getRate this.end_ts this.snapshot_created this.kb_sent}}/sec</td>
             </tr>
           {{/each}}
         </tbody>
       </table>
-      <div>{{pagination}}</div>
     </div>
   </div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replication.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replication.jst
@@ -83,7 +83,7 @@
     <a href="#add_replication_task" class="btn btn-primary">Add Replication Task</a>
 {{else}}
     {{#if noOtherAppliances}}
-        <div class="alert alert-warning"><h4>No other RockStor appliances have been connected. At least one other appliance must be connected to setup a replication task. You can connect to an appliance on the <a href=#appliances>Appliances</a> page.</h4></div>
+        <div class="alert alert-warning"><h4>No other Rockstor appliances have been connected. At least one other appliance must be connected to setup a replication task. You can connect to an appliance on the <a href=#appliances>Appliances</a> page.</h4></div>
     {{/if}}
     {{#if noFreeShares}}
         <div class="alert alert-warning"><h4>All existing shares have replication tasks setup. Create a new share to setup a new replication task.</h4>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replication_receive.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/replication/replication_receive.jst
@@ -62,7 +62,7 @@
             </td>
             <td>{{this.appliance}}</td>
             <td>{{this.src_share}}</td>
-            <td><a href="#pools/{{this.pool}}">{{this.pool}}</a></td>
+            <td>{{this.pool}}</td>
             <td>{{this.share}}</td>
             <td>{{lastReceived this.id}}</td>
         </tr>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/replica_receive_trails.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/replica_receive_trails.js
@@ -67,8 +67,22 @@ ReplicaReceiveTrailsView = RockstorLayoutView.extend({
         this.$('[rel=tooltip]').tooltip({
             placement: 'bottom'
         });
-
-        this.renderDataTables();
+        //Added columns definition for sorting purpose
+        var customs = {
+            'iDisplayLength': 15,
+            'aLengthMenu': [
+                [15, 30, 45, -1],
+                [15, 30, 45, 'All']
+            ],
+            'order': [[0, 'desc']],
+            'columns': [
+                null, null, null, null, null, null,
+                {
+                    'orderDataType': 'dom-checkbox'
+                }
+            ]
+        };
+        this.renderDataTables(customs);
     },
 
     initHandlebarHelpers: function() {
@@ -89,12 +103,17 @@ ReplicaReceiveTrailsView = RockstorLayoutView.extend({
         });
 
         Handlebars.registerHelper('humanReadableSize', function(size) {
-            return humanize.filesize(size * 1024);
+            if (size === 0){
+                return '0 or < 1KB'
+            } else {
+                return humanize.filesize(size * 1024);
+            }
         });
 
         Handlebars.registerHelper('getRate', function(endTime, startTime, kbReceived) {
+            if (kbReceived === 0) return 'N/A'
             var d;
-            if (kbReceived) {
+            if (endTime != null) {
                 d = moment(endTime).diff(moment(startTime)) / 1000;
             } else {
                 d = moment().diff(moment(startTime)) / 1000;
@@ -104,6 +123,3 @@ ReplicaReceiveTrailsView = RockstorLayoutView.extend({
     }
 
 });
-
-//Add pagination
-Cocktail.mixin(ReplicaReceiveTrailsView, PaginationMixin);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/replica_trails.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/replica_trails.js
@@ -41,7 +41,6 @@ ReplicaTrailsView = RockstorLayoutView.extend({
         this.collection = new ReplicaTrailCollection(null, {
             replicaId: this.replicaId
         });
-        this.collection.pageSize = 10;
         this.dependencies.push(this.collection);
         this.collection.on('reset', this.renderReplicaTrails, this);
         // has the replica been fetched? prevents renderReplicaTrails executing
@@ -76,6 +75,22 @@ ReplicaTrailsView = RockstorLayoutView.extend({
         this.$('[rel=tooltip]').tooltip({
             placement: 'bottom'
         });
+        //Added columns definition for sorting purpose
+        var customs = {
+            'iDisplayLength': 15,
+            'aLengthMenu': [
+                [15, 30, 45, -1],
+                [15, 30, 45, 'All']
+            ],
+            'order': [[0, 'desc']],
+            'columns': [
+                null, null, null, null, null, null,
+                {
+                    'orderDataType': 'dom-checkbox'
+                }
+            ]
+        };
+        this.renderDataTables(customs);
     },
 
     initHandlebarHelpers: function() {
@@ -96,12 +111,17 @@ ReplicaTrailsView = RockstorLayoutView.extend({
         });
 
         Handlebars.registerHelper('humanReadableSize', function(size) {
-            return humanize.filesize(size * 1024);
+            if (size === 0){
+                return '0 or < 1KB'
+            } else {
+                return humanize.filesize(size * 1024);
+            }
         });
 
         Handlebars.registerHelper('getRate', function(endTime, startTime, kbSent) {
+            if (kbSent === 0) return 'N/A'
             var d;
-            if (kbSent) {
+            if (endTime != null) {
                 d = moment(endTime).diff(moment(startTime)) / 1000;
             } else {
                 d = moment().diff(moment(startTime)) / 1000;
@@ -112,6 +132,3 @@ ReplicaTrailsView = RockstorLayoutView.extend({
 
 
 });
-
-//Add pagination
-Cocktail.mixin(ReplicaTrailsView, PaginationMixin);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/replication.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/replication.js
@@ -346,6 +346,3 @@ ReplicationView = RockstorLayoutView.extend({
     }
 
 });
-
-//Add pagination
-Cocktail.mixin(ReplicationView, PaginationMixin);

--- a/src/rockstor/storageadmin/urls/share.py
+++ b/src/rockstor/storageadmin/urls/share.py
@@ -24,7 +24,7 @@ from django.conf import settings
 
 share_regex = settings.SHARE_REGEX
 snap_regex = share_regex
-snap_command = 'clone'
+snap_command = 'clone|repclone'
 share_command = 'rollback|clone'
 
 urlpatterns = patterns(

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -105,9 +105,11 @@ class ShareListView(ShareMixin, rfc.GenericView):
             # If this box is receiving replication backups, the first full-send
             # is interpreted as a Share(because it does not have a parent
             # subvol/snapshot) It is a transient subvolume that gets rolled
-            # into a proper Share after 5 incremental-sends. Until then, keep
-            # such transient shares hidden from the UI, mostly for costmetic
-            # and UX reasons.
+            # into a proper Share after max_snap_retain + 1 incremental-sends.
+            # Until then, keep such transient shares hidden from the UI, mostly
+            # for cosmetic and UX reasons.
+            # TODO: This currently fails to work, needs investigating, leaving
+            # TODO: for now as good for indicting the initial rep phases.
             return Share.objects.exclude(
                 name__regex=r'^\.snapshots/.*/.*_replication_').order_by('-id')
 


### PR DESCRIPTION
Prior function was restore by updating the relevant api urls in the replication system. But in one, non critical check this was not managed. As a result the non critical but desirable internal sanity check was, for the time being, remarked out and TODOs added to signify required future attention. Also includes a number of replication UI fix ups including table formatting, sort capability, appropriate ordering, and consistency with the rest of the UI.

A core mechanic of the replication system was also abstracted such that it could benefit from the existing share / snapshot management system. This alteration made more explicit, in code, a quirk involving the initial subvol transferred and how it requires a special treatment given it's unique nature in the context of the existing share / snapshot / clone / import structures.

Summary:
- Update internal replication api urls to fit new share by id scheme.
- Remove problematic non critical internal check (TODO added for later).
- Create new repclone command to improve replication share / snap handling, ie more transactional by using existing structures via api.
- Minor improvements were added in the new repclone system, ie sys refresh qgroup transfer, auto mounting etc.
- Ensure we import initial btrfs receive quirk subvol with replica flag and add logging to indicate it's quirk nature.
- Improve replication tables formatting, text, sort ability / order.
- Reduce and mirror (between send and receive) rep-snap-count.
- Fix bugs in receive status update, includes utilising the pending state.
- Improve user communication re data transferred / rate table cell text.
- Remove broken pool link in replication overview table.
- Improve debug logging re share / snap import.
- Minor steps / TODOs towards future share name/subvol_name seperation.
- TODOs towards centralising mount path creation.
- Various TODO added for future consideration.

N.B. this pr assumes the prior application of the following (currently pending) pull request:
"remove immutable flag prior to share delete. Fixes #1882" pr #1883 
As that fix also addresses an observed breakage during replication runs and was used (pre-applied) during all testing of this pr's code.

Fixes #1853 (if #1883 in pre-applied)

@schakrava Ready for review.

Testing included several hundred individual replication events (btrfs send receive hosts) with runs up to 150 ish. A real hardware arrangement was also tested where the source machine's (sender) share had more data than could be replicated in the chosen scheduled replication interval (10 mins). Additional send receive pairs were not activated and all data was successfully transferred.

Note that with the in pr rep-snap-count change to 2, 3 snapshots are stored both on the sender and against the receivers share counterpart. And that for a replication cycle to reach it's final state, which will in turn there after be maintained by rotation, 5 replication events must be completed: the initial full-send followed by 4 incremental sends.

There are still known limitations and bugs in the replication code post pr but these can be addressed more specifically in pending issues to be opened in due course: and depend on review outcome of this pr.