### PR TITLE
deleting stale pincard holding users fails. Fixes #1891

### DIFF
--- a/src/rockstor/system/pinmanager.py
+++ b/src/rockstor/system/pinmanager.py
@@ -97,6 +97,7 @@ def username_to_uid(username):
 
     # Convert from username to user uid
     try:
+        # retrieve the password database entry for a given username
         user_uid = getpwnam(username).pw_uid
     except KeyError:
         # user doesn't exist
@@ -173,8 +174,10 @@ def generate_pincard():
 def flush_pincard(uid):
 
     # Clear all Pincard entries for selected user
-    Pincard.objects.filter(user=int(uid)).delete()
-
+    # But only if we have a uid, see username_to_uid() which will return None
+    # if called when the given user no longer exists.
+    if uid is not None:
+        Pincard.objects.filter(user=int(uid)).delete()
 
 def save_pincard(uid):
 


### PR DESCRIPTION
Fail elegantly when attempting to delete stale pincard holding UI user entries who have already been removed via the command line. Please see issue text for more verbose context.

- Simply avoids a blocking error that occurs during a redundant user db entry delete via UI.

Fixes #1891 

@schakrava Ready for review.

Tested via:
- create user via UI
- activate user's pincard
- cli delete of user via 'userdel username'
- attempted delete of the now stale entry within the Users UI page.
Pre pr type error blocks stale user UI delete, post pr user is deleted as expected and as per non pincard holding users under the same scenario.

and via ongoing and as yet 'in-progress' unit test updates:

./bin/test -v 2 -p test_user.py

pre pr:
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
AssertionError: "int() argument must be a string or a number, not 'NoneType'" != 'A low level error occurred while deleting the user (admin2).'
post pr:
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
