### PR TITLE
allow import of ro,degraded cli mounted pool. Fixes #1890

### DIFF
--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -709,7 +709,6 @@ class DiskDetailView(rfc.GenericView):
             po.raid = pool_raid('%s%s' % (settings.MNT_PT, po.name))['data']
             po.size = po.usage_bound()
             po.save()
-            # TODO: enable_quota could well break an import from a ro pool.
             enable_quota(po)
             import_shares(po, request)
             for share in Share.objects.filter(pool=po):

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -119,8 +119,9 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         add_snap(share.pool, share.subvol_name, snap_name, writable)
         snap_id = share_id(share.pool, snap_name)
         qgroup_id = ('0/%s' % snap_id)
-        qgroup_assign(qgroup_id, share.pqgroup, ('%s/%s' % (settings.MNT_PT,
-                                                            share.pool.name)))
+        if share.pqgroup is not settings.MODEL_DEFS['pqgroup']:
+            pool_mnt_pt = '{}{}'.format(settings.MNT_PT, share.pool.name)
+            qgroup_assign(qgroup_id, share.pqgroup, pool_mnt_pt)
         snap_size, eusage = volume_usage(share.pool, qgroup_id)
         s = Snapshot(share=share, name=snap_name, real_name=snap_name,
                      size=snap_size, qgroup=qgroup_id,


### PR DESCRIPTION
Facilitates the import of a prior cli mounted pool, this enables the ability to use initial mount options that are currently not available via the Web-UI prior to an import. The focus here is to enable an import of a pool that requires, for example, ro,degraded mount options.

1. Fix import failure (prior TODO:) via Read-only quota enable attempt on import.
2. Fix failure on qgroup assign on ro fs and avoid these and related calls from higher level functions via (4) below.
3. Improves code consistency re PQGROUP_DEFAULT use.
4. Make additional use of the existing quota disabled mechanism to improve ro behaviour during import and subsequent share/snap refresh.
5. Avoid assigning pqgroups within db that failed creation due to ro fs.
6. Improve quota disabled robustness re redundant e.rc checks from btrfs command execution as per a previous pr code review (see pr #1874)
7. Improve / update code comments.
8. Improve pqgroup/quota management.

Fixes #1890
Please see issue text for further context.

@schakrava Ready for review.

Tested by creating a 2 disk "rock-pool" (raid1)
Shares:
- rock-share
- rock-share-clone
Snaps:
- rock-share-snap
- rock-share-snap-rw
- rock-share-clone-snap

System was power cycled during which both disks were removed. Upon boot both "detached-..." disk entries were removed and pool / share refresh to ensure all entries were removed.

One of the raid1 members was re-attached and the system booted up again.

All prior mount points were removed:
- chattr -i /mnt2/rock-{pool,share,share-clone}
- rm -rf /mnt2/rock-{pool,share,share-clone}

Cli mount to facilitate currently Web-UI impossible mount options prior to import:
N.B. as per Rockstor standard locations re vol label:

Make initial mount point either via UI attempted import or via:
- mkdir /mnt2/rock-pool
Mount ro,degraded via cli as per Rockstor expected location:
- /bin/mount -o ro,degraded /dev/disk/by-label/rock-pool /mnt2/rock-pool

An import via the Web-UI was enacted and pool, share, snap state verified to be as expected.

The above test method was also carried out with the addition of the rock-pool having quotas disabled prior to ro,degraded mount:
- btrfs quota disable /mnt2/rock-pool
to ensure that we have functional quota disabled ro,degraded import capability.



