### PR TITLE
inconsistent balance behaviour on single raid pool. Fixes #1894

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -191,7 +191,7 @@ AddPoolView = Backbone.View.extend({
         this.$('#raid_level').tooltip({
             html: true,
             placement: 'right',
-            title: 'Desired RAID level of the pool<br><strong>Single</strong>: No software raid. (Recommended while using hardware raid).<br><strong>Raid0</strong>, <strong>Raid1</strong>, <strong>Raid10</strong>, <strong>Raid5</strong>, and <strong>Raid6</strong> are similar to conventional raid levels. See documentation for more information.<br><strong>WARNING: Raid5 and Raid6 are not production-ready</strong>'
+            title: 'Software RAID level<br><strong>Single</strong>: No RAID - one or more devices (-m dup enforced).<br><strong>Raid0</strong>, <strong>Raid1</strong>, <strong>Raid10</strong>, and the parity based <strong>Raid5</strong> & <strong>Raid6</strong> levels are all similar to conventional raid but chunk based, not device based. See docs for more info.<br><strong>WARNING: Raid5 and Raid6 are not production-ready</strong>'
         });
 
         this.$('#compression').tooltip({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
@@ -143,7 +143,7 @@ PoolAddDisks = RockstorWizardPage.extend({
         Handlebars.registerHelper('display_raid_levels', function(){
             var html = '';
             var _this = this;
-            var levels = ['raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
             _.each(levels, function(level) {
                 if (_this.raidLevel != level) {
                     html += '<option value="' + level + '">' + level + '</option>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/raid_change.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/raid_change.js
@@ -77,7 +77,7 @@ PoolRaidChange = RockstorWizardPage.extend({
         Handlebars.registerHelper('display_raid_levels', function() {
             var html = '';
             var _this = this;
-            var levels = ['raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
             _.each(levels, function(level) {
                 if (_this.raidLevel != level) {
                     html += '<option value="' + level + '">' + level + '</option>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -113,7 +113,12 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         this.$('#ph-pool-usage').html(this.subviews['pool-usage'].render().el);
         this.$('#ph-pool-scrubs').html(this.subviews['pool-scrubs'].render().el);
         this.$('#ph-pool-rebalances').html(this.subviews['pool-rebalances'].render().el);
-        this.renderDataTables();
+        // Sort all SubView tables in descending order by initial column.
+        // This way we see the latest Scrub / Balance items at the top.
+        var customs = {
+            'order': [[0, 'desc']]
+        };
+        this.renderDataTables(customs);
 
 
         this.$('#ph-compression-info').html(this.compression_info_template({


### PR DESCRIPTION
Avoid failing attempt at -m dup to -m single metadata reduction when balancing a prior btrfs default compliant freshly created single device single level pool. Maintain single dev data/metadate levels even for multi-device single raid level pools (normally -m raid1). This is a remaining inconsistency with btrfs defaults for single level raid pools where dev count is > 1 but enables a simple approach to enabling single level pool support.

Summary:

1. Enforce -m dup for all dev count single level pools.
2. Enable pool conversion to single raid level, given (1), from all other raid levels.
3. Impose artificial block on single to raid10 conversions as a precautionary measure to help avoid "No space left on device" errors.
4. Blanket enable force option on all balances that involve a raid level change (allows for metadata reduction).
5. Info log (1).
6. Indicate (1) in tooltip during pool creation and further explain raid level function / sub categories in same tooltip.
7. Descend sort scrub and balance tables - on pool detail page tabs.
8. Remove currently redundant clause in pool raid level reporting code as per prior code review: see pr #1408 .

Fixes #1894
Please see issue text for more context.

@schakrava Ready for review.

N.B. It is important to note that by enforcing -m dup on single raid levels when there are > 1 pool members we are not adhering to btrfs defaults of -m raid1 in this scenario. This behaviour can be addresses, if desired, at a later date as the focus of this pr was to re-integrate and debug the single level availability for conversion. This was most simply done by initially enforcing -m dup irrespective of device count.

Testing:
2 cores, 4 GB RAM, 5 x 5 GB devices (min viable size per device given test data).

**Raid level	dev count**
single		1
created “rock-share” and populated via “cp -r /usr/* /mnt2/rock-share” (about 1.6 GB)
(optionally also disable quotas via “btrfs quota disable /mnt2/rock-pool”)
single		2
(here we test for metadata downgrade capability: -m dup to -m raid0)
raid0		2
raid0		3
raid1		3
raid1		4
raid5		4
raid5		5
raid6		5
raid10		5
raid10		4
raid6		4
raid6		3
raid5		3
raid5		2
raid1		2
raid0		2
single		2
single		1

All the above Web-UI initiated raid / dev count transitions completed successfully and without error, with and without quotas enabled. At each stage the UI reported raid level (of data) and all levels as reported by "btrfs fi usage /mnt2/rock-pool/" were confirmed to be as intended.

Disks were removed in the same order as they were added, so the last disk added was the only member of the final single level pool.



