### PR TITLE
surface pool missing disk info in UI. Fixes #1897

### DIFF
--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.db import models
 from django.conf import settings
 from fs.btrfs import pool_usage, usage_bound, \
-    are_quotas_enabled
+    are_quotas_enabled, is_pool_missing_dev
 from system.osi import mount_status
 
 RETURN_BOOLEAN = True
@@ -38,6 +38,23 @@ class Pool(models.Model):
     mnt_options = models.CharField(max_length=4096, null=True)
     """optional aux info. eg: role = root for OS Pool"""
     role = models.CharField(max_length=256, null=True)
+
+    def __init__(self, *args, **kwargs):
+        super(Pool, self).__init__(*args, **kwargs)
+        self.update_missing_dev()
+
+    def update_missing_dev(self, *args, **kwargs):
+        # Establish an instance variable to track missing device status.
+        # Currently Boolean and may be updated during instance life by
+        # calling this method again or directly setting the field.
+        try:
+            self.missing_dev = is_pool_missing_dev(self.name)
+        except:
+            self.missing_dev = False
+
+    @property
+    def has_missing_dev(self, *args, **kwargs):
+        return self.missing_dev
 
     @property
     def free(self, *args, **kwargs):

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -52,6 +52,7 @@ class PoolInfoSerializer(serializers.ModelSerializer):
     mount_status = serializers.CharField()
     is_mounted = serializers.BooleanField()
     quotas_enabled = serializers.BooleanField()
+    has_missing_dev = serializers.BooleanField()
 
     class Meta:
         model = Pool

--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -797,13 +797,13 @@ label.error { font-size: 12px; color: #b94a48; }
 
 #breadcrumbs h3 { color: #005580; padding: 0; margin: 0;}
 
-#appliance-name, #local-time, #direct-shell, #shutdown-status {
+#appliance-name, #local-time, #direct-shell, #shutdown-status, #pool-degraded-status {
     color: #FFFFFF;
     font-family: Roboto-Light;
     font-size: 12px;
 }
 
-#local-time, #direct-shell, #shutdown-status {
+#local-time, #direct-shell, #shutdown-status, #pool-degraded-status {
     padding-left: 20px;
     display: inline-block;
 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -1048,6 +1048,22 @@ $(document).ready(function() {
         }
     };
 
+    var displayPoolDegradedStatus = function (data) {
+        var html = '';
+        if (data.status === 'degraded') {
+            html += '<i class="fa fa-warning fa-inverse" style="color: red;"> Pool Degraded Alert </i>';
+            $('#pool-degraded-status').fadeOut(1500, function(){
+                $('#pool-degraded-status').attr('title', data.message);
+                $('#pool-degraded-status').html(html).fadeIn(1500);
+            });
+        } else {
+            $('#pool-degraded-status').fadeOut(1500, function() {
+                $('#pool-degraded-status').attr('title', '');
+                $('#pool-degraded-status').empty();
+            });
+        }
+    };
+
     var displayLoadAvg = function(data) {
         var n = parseInt(data);
         var mins = Math.floor(n / 60) % 60;
@@ -1162,6 +1178,7 @@ $(document).ready(function() {
     RockStorSocket.addListener(kernelError, this, 'sysinfo:kernel_error');
     RockStorSocket.addListener(displayUpdate, this, 'sysinfo:software_update');
     RockStorSocket.addListener(displayShutdownStatus, this, 'sysinfo:shutdown_status');
+    RockStorSocket.addListener(displayPoolDegradedStatus, this, 'sysinfo:pool_degraded_status');
 
     //insert pagination partial helper functions here
     Handlebars.registerHelper('pagination', function() {

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -105,6 +105,9 @@
                     "&nbsp;
                     {{/each}}
                 {{/if}}
+                {{#if this.has_missing_dev}}
+                    <strong><span style="color:red">SOME MISSING</span></strong>
+                {{/if}}
             </td>
             <td>{{#if (isRoot this.role)}}
                     N/A

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
@@ -1,4 +1,8 @@
-<h3>Disks</h3>
+<h3>Disks
+    {{#if pool.has_missing_dev}}
+    &nbsp;(<strong><span style="color:red">Some Missing</span></strong>)
+    {{/if}}
+</h3>
 
 <table id="pool-disk-table"
        class="table table-condensed table-bordered table-hover">

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -167,6 +167,7 @@
       <div id="local-time"><i class="fa fa-clock-o fa-inverse"></i>&nbsp;Local Time:&nbsp;<span/></div>
       <a id="direct-shell" href="#shell"><i class="fa fa-desktop fa-inverse"></i>&nbsp;System Shell</a>
       <div id="shutdown-status"></div>
+      <div id="pool-degraded-status"></div>
       <div id="uptime"></div>
       <div id="appliance-loadavg"></div>
       <div id="yum-msg"><a id="yumupdates"></a></div>

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -70,11 +70,13 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                              p.name)
                 continue
             try:
-                mount_root(p)
+                # Get and save what info we can prior to mount.
                 first_attached_dev = p.disk_set.attached().first()
                 # Observe any redirect role by using target_name.
                 pool_info = get_pool_info(first_attached_dev.target_name)
                 p.name = pool_info['label']
+                p.save()
+                mount_root(p)
                 p.raid = pool_raid('%s%s' % (settings.MNT_PT, p.name))['data']
                 p.size = p.usage_bound()
                 p.save()

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -316,6 +316,7 @@ class DiskMixin(object):
             # the attached disk is our root disk (flagged by scan_disks)
             if (dob.pool is None and d.root is True):
                 # setup our special root disk db entry in Pool
+                # TODO: call get_pool_info() & pool_raid() for following TODOs.
                 # TODO: dynamically retrieve raid level.
                 # TODO: dynamically retrieve compression level.
                 p = Pool(name=d.label, raid='single', role='root',


### PR DESCRIPTION
By adding a lighweight 'has_missing_dev' property to the Pool object we can conveniently surface pool degraded status within the UI. The pools overview and detail pages can then be informed by this property and consequently display red "Some Missing" indicators within the pool's respective disks section. In addition another mechanism linked to a new gevent is used to inform system wide pool degraded status to the Web-UI header, so that no page refresh is required. This second mechanism can also report on the number of non managed / pre-imported degraded pools. The extraction of pool labels for un-managed pools is purposefully avoided in order to keep the initial detection algorithm as light as possible. On systems with no degraded pools the detection is down to a single system call. Pool Object creation for the header gevent notifications is avoided until at least one degraded pool is detected.

Summary:

- Add serialized 'has_missing_dev' boolean property to Pool Object.
- Add lightweight pool degraded detection to inform above.
- Add red "SOME MISSING" UI element to Disks column in Pool overview.
- Add red "Some Missing" UI element to Disks title in subsection of Pool details view.
- Add system wide pool degraded detection to inform Web-UI header, via a gevent, so that even on a freshly installed system, unimported pools can be indicated. This system does not require a Web-UI refresh and is modeled after the existing 'shutdown-status' indicator.
- Add a unit test to prove the function of the above system wide pool degraded sensor.
- Extend the existing back-end pool-info system to encompass degraded state along with expected total disk count and missing disk count. These additional facilities are not employed in this pr but will serve as a double check on Pool object info to inform future mechanisms before enacting on such operations as delete missing.
- Add TODO on informing system pool's status.

Fixes #1897 
Please see comment section for context and UI element images.

@schakrava Ready for review.

Tested in KVM by removing select virtio disks to 'degrade' one or more system pools. Both imported and non imported. The system wide, rather than individual pool, degrade detection mechanism was also developed along side a unit test included with this pr:

test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok

All 3 degraded indicators were tested via development logging to reflect the observed pool degraded status as per 'btrfs fi show'.

Caveat: In some specific instances 'btrfs fi show' would indicate a degraded state that would then not be evident when a normal mount was attempted (as it succeeded without the degrade option). The system wide degrade detection algorithm does not report this instance (test case included for this caveat with relevant comments) but the pool specific degrade detection does indicate this. It was thought that this diversification was healthy and would help to inform future development on this issue. The 3rd pool degrade detection mechanism, added to get_pool_info(), is as yet unused but is intended to acts as a low level validation mechanism for future pool actions such as are indicated in:
"Implement a delete missing disk in pool UI #1700"
for which this pr is considered a prerequisite.
