### PR TITLE
Add option to disable BTRFS quota-qgroups. Fixes #1592

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
@@ -34,6 +34,19 @@
             {{/if}}
         </td>
     </tr>
+    <tr>
+        <td>Quotas</td>
+        <td>&nbsp;&nbsp;
+            <strong>
+                  <a href="#" id="editQuota" data-type="select" data-title="<strong>Enabled: </strong> (Rockstor default) - Used to track and limit
+                  (pending feature) pool share usage.<br><strong>Disabled: </strong> (optional) - significant performance benefits with
+                  high snapshot count (>200/share) and when balancing large pools (double digit TB).<br>Note: when quotas are
+                  disabled share usage is (currently) not tracked and can show <strong><i>0 bytes.</i></strong>">
+                      {{isEnabledDisabled pool.quotas_enabled}}
+                  </a>
+            </strong>
+        </td>
+    </tr>
 </table>
 
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -54,7 +54,7 @@
             <div id="ph-pool-info"></div>
         </div> <!-- col-md-6 -->
         <div class="col-md-6">
-            <h3>Compression and extra mount options</h3>
+            <h3>Compression / Extra mount options / Quotas</h3>
             <div id="ph-compression-info"></div>
         </div> <!-- col-md-6 -->
       </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
@@ -30,13 +30,6 @@
   {{else}}
     <span style="color:red">{{model.mount_status}}</span>
   {{/if}}
-  </strong><br/>
-  Quotas: <strong>
-  {{#if model.quotas_enabled}}
-    Enabled
-  {{else}}
-    <span style="color:red">Disabled</span>
-  {{/if}}
   </strong>
 </div> <!-- module-content -->
  

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -33,11 +33,18 @@
             <td>{{humanReadableSize 'usage' this.size this.reclaimable this.free}}
                 <strong>({{humanReadableSize 'usagePercent' this.size this.reclaimable this.free}} %)</strong>
             </td>
-            <td>{{#if this.quotas_enabled}}
-                    Enabled
-                {{else}}
-                    <strong><span style="color:red">Disabled</span></strong>
-                {{/if}}
+            <td>
+                <strong>
+                    <a href="#" class="editQuotaOverview" data-name="editQuotaOverview" data-type="select"
+                       data-value="{{isEnabledDisabled this.quotas_enabled}}" data-pid="{{this.id}}"
+                       data-title="<strong>Enabled: </strong> (Rockstor default) - Used to track and limit
+                       (pending feature) pool share usage.<br><strong>Disabled: </strong> (optional) - significant
+                       performance benefits with high snapshot count (>200/share) and when balancing large
+                       pools (double digit TB).<br>Note: when quotas are disabled share usage is (currently)
+                       not tracked and can show <strong><i>0 bytes.</i></strong>">
+                        {{isEnabledDisabled this.quotas_enabled}}
+                    </a>
+                </strong>
             </td>
             <td>{{this.raid}}
                 {{#unless (isRoot this.role)}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -191,6 +191,32 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
             placement: 'right'
         });
 
+        var url_quotas = '/api/pools/' + this.pool.get('id') + '/quotas';
+        $('#editQuota').editable({
+            // emptyclass: 'editable-empty-custom',
+            source: [
+                {value: 'Enabled', text: 'Enabled'},
+                {value: 'Disabled', text: 'Disabled'}
+            ],
+            success: function(response, quotasEditVal) {
+                $.ajax({
+                    url: url_quotas,
+                    type: 'PUT',
+                    dataType: 'json',
+                    data: {
+                        'quotas': quotasEditVal
+                    },
+                });
+            }
+        });
+
+        // Attempt to colour "Disabled" red. Non functional currently.
+        // https://vitalets.github.io/bootstrap-editable/
+        $('#editQuota').on('render', function (e, editable) {
+            // colour #EB6841 is our default for links.
+            var colors = {'Enabled': '#EB6841', 'Disabled': 'red'};
+            $(this).css("color", colors[editable.value]);
+        });
     },
 
     deletePool: function(event) {
@@ -400,6 +426,13 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
                 return true;
             }
             return false;
+        });
+        // Simple Boolean to Text converter for use with Pool.quotas_enabled.
+        Handlebars.registerHelper('isEnabledDisabled', function (q_enabled) {
+            if (q_enabled) {
+                return 'Enabled';
+            }
+            return 'Disabled'
         });
     }
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -132,6 +132,34 @@ PoolsView = RockstorLayoutView.extend({
             }
         });
 
+        $('.editQuotaOverview').editable({
+            // emptyclass: 'editable-empty-custom',
+            source: [
+                {value: 'Enabled', text: 'Enabled'},
+                {value: 'Disabled', text: 'Disabled'}
+            ],
+            success: function(response, quotasEditVal) {
+                var pid = $(this).data('pid');
+                $.ajax({
+                    url: '/api/pools/' + pid + '/quotas',
+                    type: 'PUT',
+                    dataType: 'json',
+                    data: {
+                        'quotas': quotasEditVal
+                    },
+                });
+            }
+        });
+
+        // Attempt to colour "Disabled" red. Non functional currently.
+        // https://vitalets.github.io/bootstrap-editable/
+        $('.editQuotaOverview').on('render', function (e, editable) {
+            // colour #EB6841 is our default for links.
+            var colors = {'Enabled': '#EB6841', 'Disabled': 'red'};
+            $(this).css("color", colors[editable.value]);
+        });
+
+
         $('#pools-table').tooltip({
             selector: '[data-title]',
             html: true,
@@ -261,6 +289,14 @@ PoolsView = RockstorLayoutView.extend({
                 return true;
             }
             return false;
+        });
+
+        // Simple Boolean to Text converter for use with Pool.quotas_enabled.
+        Handlebars.registerHelper('isEnabledDisabled', function (q_enabled) {
+            if (q_enabled) {
+                return 'Enabled';
+            }
+            return 'Disabled'
         });
     }
 });


### PR DESCRIPTION
Adds pool api command to enable / disable quotas. Upon enabling a quota rescan is initiated. In some instances this scan is redundant but is robust to those instances and simply info logs the prior existence of an ongoing quota rescan and skips the rescan requested. Similarly provision is made to deal elegantly with quota rescan requests on read only filesystems. UI is by way of bootstrap inline editable as per current compression and custom mount options settings.

Summary:
- Add backend pool quota enable/disable command.
- Change existing quota status displays for inline editable elements.
- Move pool details page quota element from "Details" section to "Compression and extra mount options" section as then all inline edit elements are grouped.
- Rename compression / extra mount options header to indicate quotas.
- Allowed quotas enable/disable on the system pool.
- Initiate a quota rescan when re enabling via the inline edit UI element / api command.
- Improve user messaging (via tool tips) re 0 usage indication on Shares as a consequence of quotas disabled (currently).
- Indicate that the default quote state is enabled but provide the performance related argument for them being disabled (via tool tips).

Fixes #1592 
Additionally as we initiate a rescan upon enabling quotas on a given pool this pr also:
Fixes #1785 

@schakrava Ready for review.

This pr represents the enable/disable api and front end to the work done for issue:
"improve quotas not enabled behaviour #1869"
and it's pr:
"improve quotas not enabled behaviour. Fixes #1869" #1874
re quota groups management / recreation through quota disabled / enabled cycles.

Tested in KVM systems and on a number of small real hw installs in the low TB range of pool size.

Caveats / future enhancements: we currently give no indication of ongoing rescans, this could properly be addressed against it's own issue. The consequence of not surfacing an ongoing quota rescan is potential user confusion re share size reporting which will periodically adjust for a number of minutes after re enabling quotas (with quotas disabled shares are reported as taking 0 space (currently)).