### PR TITLE
On GUI only 5000 user show up. Fixes #1915

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -36,7 +36,6 @@ parts =
       js-sync
       collectstatic
       gulp-install
-      gulp-eslint
       supervisor
       supervisord-conf
       create-cert

--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -426,7 +426,7 @@ RockStorGlobals = {
     navbarLoaded: false,
     applianceNameSet: false,
     currentAppliance: null,
-    maxPageSize: 5000,
+    maxPageSize: 9000,
     browserChecked: false,
     kernel: null
 };

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -2004,17 +2004,22 @@ def hostid():
     There's a lazy vendor problem where uuid is not set and defaults to
     03000200-0400-0500-0006-000700080009 or
     00020003-0004-0005-0006-000700080009. I don't know how these values are
-    populated, but emperically it seems to be just these
-    two. non-persistent uuid is generated even in this case.
+    populated, but empirically it seems to be just these
+    two. A non-persistent uuid is also generated in this case.
 
+    Observed motherboards with these fake non unique puuids:
+    ASRock N3700-ITX
+    ASRock C2550D4I
+    ASRock J3455 ITX - Thanks to forum member adworacz for reporting this one.
     """
+
     fake_puuids = ('03000200-0400-0500-0006-000700080009',
                    '00020003-0004-0005-0006-00070008000')
     try:
         with open("/sys/class/dmi/id/product_uuid") as fo:
             puuid = fo.readline().strip()
             if (puuid in fake_puuids):
-                raise
+                raise CommandException
             return puuid
     except:
         return '%s-%s' % (run_command([HOSTID])[0][0], str(uuid.uuid4()))


### PR DESCRIPTION
Increase maxPageSize from 5000 to 9000 predominantly to deal with larger installs, ie > 5000 users / groups. System wide change so should also accommodate all other datatable displays within the Web-UI.

Includes the following 2 unrelated minor dev / build related fixes:

- Remove gulp-eslint stage: currently blocks builds.
- Use specific CommandException to avoid conformance (ide) errors. This is to prevent PyCharm’s "No exception to reraise" error which hampers that IDE’s function re code analysis. The resulting code was tested to ensure it’s behaviour was as expected. Further comments re known fake / non unique motherboard uuids were added.

Fixes #1915 

@schakrava Ready for review

