### PR TITLE
improve subvol mount code robustness. Fixes #1923

### DIFF
--- a/src/rockstor/storageadmin/tests/test_share_commands.py
+++ b/src/rockstor/storageadmin/tests/test_share_commands.py
@@ -33,16 +33,10 @@ class ShareCommandTests(APITestMixin, APITestCase):
     def setUpClass(cls):
         super(ShareCommandTests, cls).setUpClass()
 
-        # post mocks
-        cls.patch_update_quota = patch('storageadmin.views.share_command.'
-                                       'update_quota')
-        cls.mock_update_quota = cls.patch_update_quota.start()
-        cls.mock_update_quota.return_value = 'foo'
-
-        cls.patch_rollback_snap = patch('storageadmin.views.share_command.'
-                                        'rollback_snap')
-        cls.mock_rollback_snap = cls.patch_rollback_snap.start()
-        cls.mock_rollback_snap.return_value = True
+        cls.patch_create_repclone = patch('storageadmin.views.share_command.'
+                                          'create_repclone')
+        cls.mock_create_repclone = cls.patch_create_repclone.start()
+        cls.mock_create_repclone.return_value = Response('{"message": "ok!"}')
 
         cls.patch_create_clone = patch('storageadmin.views.share_command.'
                                        'create_clone')

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -122,7 +122,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
             for snap in Snapshot.objects.all():
                 if (snap.uvisible):
                     try:
-                        mount_snap(snap.share, snap.real_name)
+                        mount_snap(snap.share, snap.real_name, snap.qgroup)
                     except Exception as e:
                         e_msg = ('Failed to make the snapshot ({}) visible. '
                                  'Exception: ({}).').format(snap.real_name,

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -60,12 +60,12 @@ def sftp_snap_toggle(share, mount=True):
                                     share.owner, share.name,
                                     snap.name))
         if (mount and not is_mounted(mnt_pt)):
-            mount_snap(share, snap.name, mnt_pt)
+            mount_snap(share, snap.name, snap.qgroup, mnt_pt)
         elif (is_mounted(mnt_pt) and not mount):
             umount_root(mnt_pt)
 
 
-def toggle_sftp_visibility(share, snap_name, on=True):
+def toggle_sftp_visibility(share, snap_name, snap_qgroup, on=True):
     if (not SFTP.objects.filter(share=share).exists()):
         return
 
@@ -73,7 +73,7 @@ def toggle_sftp_visibility(share, snap_name, on=True):
                                 share.name, snap_name))
     if (on):
         if (not is_mounted(mnt_pt)):
-            mount_snap(share, snap_name, mnt_pt)
+            mount_snap(share, snap_name, snap_qgroup, mnt_pt)
     else:
         umount_root(mnt_pt)
 


### PR DESCRIPTION
Mount subvols via subvolid derived from share/snap model qgroup fields.

A significant element of this commit/pr is the deprecation / removal of rollback_snap() in favour of re-using the newer create-repclone(). This helps to remove the number of areas within code that a subvol mount is enacted, whilst simultaneously addressing a quota update issue associated with rollback_snap()'s caller in share_command.py

- Includes re-use of create-repclone() code for share rollback, replacing the prior, and older, rollback_snap().
- Above helps to reduce the number of disparate locations a mount is enacted by the removal of the older rollback_snap.
- Removes older rollback_snap()'s caller's incorrect use of update_quota().
- Reduces number of low level calls in higher level management code.
- Adds replication abort prior to share delete if no on-disk snap found: taken from the prior rollback_snap() code.
- Move informative snap-to-share message from debug to info.
- Passes qgroup (and hence subvol id) from upper level management code to lower level mount code to avoid redundant subvolid system queries.
- Updates test_share_commands.py unit test mocks accordingly.

Fixes #1923 
and also:
Fixes #1880 
by way of problem code removal.

@schakrava Ready for review.

Testing:
The unit test modifications were tested via:
```
./bin/test -v 2 -p test_share_commands*
```

test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok

Manual share/snap creation with the various available options was as expected along with the promotion of a snap to share via the clone mechanism. All expected mount states / behaviours were as expected and unchanged from pre pr behaviour.

A greater than 5 cycle replication was also tested in both directions using fresh builds of master with this pr applied to test both send and receive ends.

N.B. we have an existing bug re share rollback where prior snapshots are lost to the UI. This has yet to be issued but is unaffected / identically reproduced by this pr's changes to the rollback code. I have a reproducer sequence and will issue accordingly soon.