### PR TITLE
Fix Rockon unknown state due to multi-line docker inspect

### DIFF
--- a/src/rockstor/storageadmin/views/rockon_utils.py
+++ b/src/rockstor/storageadmin/views/rockon_utils.py
@@ -28,7 +28,7 @@ def container_status(name):
     state = 'unknown_error'
     try:
         o, e, rc = run_command([DOCKER, 'inspect', '-f',
-                                '{{range $key, $value := .State}}{{$key}}:{{$value}},{{ end }}', name])  # noqa E501
+                                'Error:{{.State.Error}},ExitCode:{{.State.ExitCode}},Running:{{.State.Running}}', name])  # noqa E501
         state_d = {}
         for i in o[0].split(','):
             fields = i.split(':')


### PR DESCRIPTION
Fixes #1933. The proposal is to only gather the 3 fields we care about (Running, Error and ExitCode). Could be further improved by leaving the labels out and arbitrarily order the fields but would be less flexible.

Signed-off-by: Silvio Gissi <silvio@gissilabs.com>