### PR TITLE
missing validation - megaraid custom smart option raid dev target. Fixes #1942

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/smartcustom_disks.jst
@@ -2,13 +2,15 @@
 <p>Please see the <a href="https://www.smartmontools.org/" target="_blank">Smartmontools</a> manual page for 
     <a href="https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in" target="_blank"> smartctl</a>
     for possible custom options.</p>
-<li><p>For smartmontools supported USB attached devices, ie USB to SATA adapters, please see: <a
+<li>For smartmontools supported USB attached devices, ie USB to SATA adapters, please see: <a
     href="https://www.smartmontools.org/wiki/Supported_USB-Devices" target="_blank">USB Device Support</a>.
-    </p>
 </li>
-<li><p>For smartmontools supported RAID controllers please see: <a
+<br>
+<li>For smartmontools supported RAID controllers please see: <a
     href="https://www.smartmontools.org/wiki/Supported_RAID-Controllers" target="_blank">Checking disks behind RAID controllers</a>.
-</p></li>
+  <br><i>Note: 'autodev' option for hpt, megaraid, and aacraid to replace /dev/sdX parameter, JBOD assumed.</i>
+</li>
+<br>
 <p class="text-warning">This is an advanced option that is only required in specific circumstances.
  Please follow the above links to understand any options you choose to enter.</p>
 <p class="bg-info"><strong>Note: </strong>Supported smart options are <strong>-d</strong> to specify special devices and <strong>-T</strong> to set

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/smartcustom_disks.js
@@ -81,7 +81,9 @@ SmartcustomDiskView = RockstorLayoutView.extend({
             // Areca sata /dev/sg[2-9] but for hpahcisr and hpsa drivers /dev/sg[0-9]* (lsscsi -g to help)
             // so we still have an issue there.
             // HP Smart array with cciss driver uses /dev/cciss/c[0-9]d0
-            var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/];
+            // HighPoint RocketRaid SATA RAID controller (hpt), LSI MegaRAID SAS RAID controller Dell PERC 5/i,6/i controller (megaraid)
+            // and Adaptec SAS RAID controller (​aacraid) all expect /dev/sd[a-z] type raid device targets.
+            var raidTargetRegExp = [/\/dev\/tw[e|a|l][0-9][0-5]{0,1}$/, /\/dev\/sg[0-9]$/, /\/dev\/cciss\/c[0-9]d0$/, /\/dev\/sd[a-z]$/, /autodev$/];
             // Initial cascade of syntactic checks.
             if (smartcustom_options.length == 0) {
                 // allow zero length (empty) entry to remove existing options

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -414,9 +414,17 @@ def get_dev_options(dev_byid, custom_options=''):
         # TODO: think this ascii should be utf-8 as that's kernel standard
         # TODO: or just use str(custom_options).split()
         dev_options = custom_options.encode('ascii').split()
+        # Remove Rockstor native 'autodev' custom smart option raid dev target.
+        # As we automatically add the full path by-id if a raid controller
+        # target dev is not found, we can simply remove this option.
+        # N.B. here we assume there is either 'autodev' or a specified target:
+        # input validation was tested to reject both being entered.
+        if 'autodev' in dev_options:
+            dev_options.remove('autodev')
         # If our custom options don't contain a raid controller target then add
         # the full path to our base device as our last device specific option.
-        if (re.search('/dev/tw|/dev/cciss/c|/dev/sg', custom_options) is None):
+        if (re.search('/dev/tw|/dev/cciss/c|/dev/sg|/dev/sd',
+                      custom_options) is None):
             # add full path to our custom options as we see no raid target dev
             dev_options += [
                 get_device_path(get_base_device_byid(dev_byid, TESTMODE))


### PR DESCRIPTION
Adds previously missing '/dev/sd[a-z]' raid target device regex. This type of device is a valid target for megaraid, aacraid, and hpt drivers.

Summary:
- Add /dev/sd[a-z] regex (as above).
- Add code comments for the above.
- Add convenience raid target device regex of 'autodev': explicitly substitutes current disk by-id name (full path). Considered more robust than the above 'hard wired' device name option.
- Enhance custom S.M.A.R.T options pre-processor, get_dev_options(), to handle the above 2 additional raid target device options.
- Document the 'autodev' option on the "Add drive specific custom S.M.A.R.T options" page.
- Improve / correct html formatting on the "Add drive specific custom S.M.A.R.T options" page.

Fixes #1942 

@schakrava Ready for review.

Tested by observing the resulting smartctl command line post pr:

    -d megaraid,0 /dev/sda

results in expected:

    /usr/sbin/smartctl -c -d megaraid,0 /dev/sda

and:

    -d megaraid,0 autodev

results in expected:

    /usr/sbin/smartctl -c -d megaraid,0 /dev/disk/by-id/ata-QEMU_HARDDISK_bcache-bdev-1

Caveats.

The 'autodev' option is actually redundant given our existing input validation for custom smart options allows for no target raid device; and results in the same behaviour. However it was though more proper to add this options as future improvements in input validation may remove this 'loop hole' and the 'autodev' option's function is explicit.

Testing note:
The tests performed were strictly syntactic as no megaraid, hpt, or aacraid hardware was available at the time of development. However our existing S.M.A.R.T custom options have so far behaved as expected when directed to by-id names, but this is not a guarantee that the same is true for the given raid drivers target device parameter.
