### PR TITLE
add system pool auto label and enhance associated db mechanisms. Fixes #1947

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -276,6 +276,10 @@ MNT_PT = '/mnt2/'
 NFS_EXPORT_ROOT = '/export/'
 SFTP_MNT_ROOT = '/mnt3/'
 
+# System volume label when no btrfs volume label is set as per default openSUSE
+# install: ie 'btrfs fi show' gives 'Label: none'
+SYS_VOL_LABEL = 'system'
+
 TAP_DIR = '${django-settings-conf:taplib}'
 TAP_SERVER = ('127.0.0.1', ${django-settings-conf:tapport})
 MAX_TAP_WORKERS = 10

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -263,6 +263,10 @@ MNT_PT = '/mnt2/'
 NFS_EXPORT_ROOT = '/export/'
 SFTP_MNT_ROOT = '/mnt3/'
 
+# System volume label when no btrfs volume label is set as per default openSUSE
+# install: ie 'btrfs fi show' gives 'Label: none'
+SYS_VOL_LABEL = 'system'
+
 TAP_DIR = '${django-settings-conf:taplib}'
 TAP_SERVER = ('127.0.0.1', ${django-settings-conf:tapport})
 MAX_TAP_WORKERS = 10


### PR DESCRIPTION
Normalise use of 'btrfs fi show' for label info and when no label is found, initiate an auto label; given the existence of a by-id (device serial). If no serial and no label on the system drive / pool then skip system pool / vol db counterpart creation. Also adds better logging and earlier fail points concerning no by-id (no serial) by avoiding subsequent mount attempts of associated vols and subvols.

Summary:

- Make ‘btrfs fi show’ via get_pool_info() canonical for volume label retrieval, retaining a fail over to disk label for robustness.
- Extend existing auto volume (pool) labeling, within get_pool_info(), to account specifically for the system pool: see previous issue #1342, pr #1683, for non system disk.
- Improve system volume database management code to be more robust to no system volume label scenarios; including in concert with no by-id name being available (ie no serial on system disk).
- Add debug logging re system pool database counterpart creation or otherwise (ie no by-id in combination with no serial).
- Dynamically retrieve and assign / update system volume (pool) raid; where a by-id name is available.
- Move previous multiple hardcoded ‘system’ label references to settings.conf.in / test-settings.conf.in, see caveats section of pr #1935.
- Avoid all pool mounts when the referenced disk has no by-id name, and error log accordingly: avoiding later complex fail messages where downstream code requires by-id naming.
- Avoid share import / status update when the associated pool is not mounted, error log accordingly.
- Avoid mount attempts of prior known shares whose associated pool is not mounted, error log accordingly.

Fixes #1947
Please see issue text for further context.

@schakrava Ready for review (really this time - hopefully).

Note that the default ‘system’ label was chosen to differentiate between legacy ‘rockstor_rockstor’ labelled pools and non legacy system pools. It is not advised that we maintain the rockstor_rockstor system label when we relabel as then there is no outward indication that this system has been relabelled and all testing has concentrated on a separation between legacy (existing label of ‘rockstor_rockstor’) and proposed new system bases which by default have no existing system vol / pool label and very different vol / subvol layouts.

Testing:
Legacy, and non legacy systems were tested, in the latter case with and without snapper root config. All configs were confirmed to work as expected with either no system drive label only or in combination with no system drive serial, where with the latter it was also confirmed that post serial addition and reboot, the system pool was successfully labelled and surfaced. All configs were also tested for their ability to re-label the system drive were it to have it’s existing label removed via:
btrfs fi label / ''

Unit test results (no additional test added):
./bin/test --settings=test-settings -v 3 -p test_btrfs*
All ok
and
./bin/test  --settings=test-settings -v 3 -p test_osi*
All ok

Caveats:
In this pr we introduce additional double conversions of device names, ie from temp (canonical) type of sda to by-id and then back again. This is inelegant and slow (though not significantly) and could be addressed in future refactoring but is left for the time being to help reduce the scope of these code changes.