### PR TITLE
remove grubby dependency for kernel version reporting. Fixes #1955

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -517,7 +517,7 @@ def def_kernel():
 
 def kernel_info(supported_version):
     uname = os.uname()
-    if (uname[2] != supported_version):
+    if uname[2] != supported_version and os.path.isfile(GRUBBY):
         e_msg = ('You are running an unsupported kernel(%s). Some features '
                  'may not work properly.' % uname[2])
         carg = '--set-default=/boot/vmlinuz-{}'.format(supported_version)


### PR DESCRIPTION
Ensure that grubby exists prior to embarking on it's use. This circumvents an otherwise unintended failure to return the running kernel version for Web-UI display. For legacy systems (grubby pre-installed) this should not represent a functional change.

Fixes #1955 
Please see issue text for context.

@schakrava Ready for review.
