### PR TITLE
Show warn on dashboard if errors occurs on IO or fs. Fixes #1532

### DIFF
--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import json
 from django.db import models
+from fs.btrfs import get_dev_io_error_stats
 from storageadmin.models import Pool
 from system.osi import get_disk_power_status, read_hdparm_setting, \
     get_disk_APM_level, get_dev_temp_name
@@ -26,6 +27,7 @@ from system.osi import get_disk_power_status, read_hdparm_setting, \
 class AttachedManager(models.Manager):
     """Manager subclass to return only attached disks"""
     use_for_related_fields = True
+
     def attached(self):
         # Return default queryset after excluding name="detached-*" items.
         # Alternative lookup type __regex=r'^detached-'
@@ -98,6 +100,14 @@ class Disk(models.Model):
     def apm_level(self, *args, **kwargs):
         try:
             return get_disk_APM_level(str(self.name))
+        except:
+            return None
+
+    @property
+    def io_error_stats(self, *args, **kwargs):
+        # json charfield format
+        try:
+            return get_dev_io_error_stats(str(self.name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -40,6 +40,7 @@ class DiskInfoSerializer(serializers.ModelSerializer):
     apm_level = serializers.CharField()
     temp_name = serializers.CharField()
     target_name = serializers.CharField()
+    io_error_stats = serializers.CharField()
 
     class Meta:
         model = Disk
@@ -53,6 +54,7 @@ class PoolInfoSerializer(serializers.ModelSerializer):
     is_mounted = serializers.BooleanField()
     quotas_enabled = serializers.BooleanField()
     has_missing_dev = serializers.BooleanField()
+    dev_stats_ok = serializers.BooleanField()
 
     class Meta:
         model = Pool

--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -797,13 +797,13 @@ label.error { font-size: 12px; color: #b94a48; }
 
 #breadcrumbs h3 { color: #005580; padding: 0; margin: 0;}
 
-#appliance-name, #local-time, #direct-shell, #shutdown-status, #pool-degraded-status {
+#appliance-name, #local-time, #direct-shell, #shutdown-status, #pool-degraded-status, #pool-dev-stats {
     color: #FFFFFF;
     font-family: Roboto-Light;
     font-size: 12px;
 }
 
-#local-time, #direct-shell, #shutdown-status, #pool-degraded-status {
+#local-time, #direct-shell, #shutdown-status, #pool-degraded-status, #pool-dev-stats {
     padding-left: 20px;
     display: inline-block;
 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -1064,6 +1064,23 @@ $(document).ready(function() {
         }
     };
 
+    var displayPoolDevStats = function (data) {
+        var html = '';
+        if (data.status === 'errors') {
+            html += '<i class="fa fa-warning fa-inverse" style="color: red;"> Pool Device Errors Alert </i>';
+            $('#pool-dev-stats').fadeOut(1500, function(){
+                $('#pool-dev-stats').attr('title', data.message);
+                $('#pool-dev-stats').html(html).fadeIn(1500);
+            });
+        } else {
+            $('#pool-dev-stats').fadeOut(1500, function() {
+                $('#pool-dev-stats').attr('title', '');
+                $('#pool-dev-stats').empty();
+            });
+        }
+    };
+
+
     var displayLoadAvg = function(data) {
         var n = parseInt(data);
         var mins = Math.floor(n / 60) % 60;
@@ -1179,6 +1196,7 @@ $(document).ready(function() {
     RockStorSocket.addListener(displayUpdate, this, 'sysinfo:software_update');
     RockStorSocket.addListener(displayShutdownStatus, this, 'sysinfo:shutdown_status');
     RockStorSocket.addListener(displayPoolDegradedStatus, this, 'sysinfo:pool_degraded_status');
+    RockStorSocket.addListener(displayPoolDevStats, this, 'sysinfo:pool_dev_stats');
 
     //insert pagination partial helper functions here
     Handlebars.registerHelper('pagination', function() {

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -113,8 +113,11 @@
                     {{/each}}
                 {{/if}}
                 {{#if this.has_missing_dev}}
-                    <strong><span style="color:red">SOME MISSING</span></strong>
+                    <strong><span style="color:red">(SOME MISSING) </span></strong>
                 {{/if}}
+                {{#unless this.dev_stats_ok}}
+                    <strong><span style="color:red">(DEV ERRORS DETECTED)</span></strong>
+                {{/unless}}
             </td>
             <td>{{#if (isRoot this.role)}}
                     N/A

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
@@ -2,7 +2,13 @@
     {{#if pool.has_missing_dev}}
     &nbsp;(<strong><span style="color:red">Some Missing</span></strong>)
     {{/if}}
+    {{#unless pool.dev_stats_ok}}
+    (<strong><span style="color:red">Device errors detected</span></strong>)
+    {{/unless}}
 </h3>
+
+<i>Cumulative pool errors per device - 'btrfs dev stats -z /mnt2/{{pool.name}}'
+    to reset.</i>
 
 <table id="pool-disk-table"
        class="table table-condensed table-bordered table-hover">
@@ -10,6 +16,12 @@
     <tr>
         <th scope="col" abbr="Name">Name</th>
         <th scope="col" abbr="Capacity">Capacity</th>
+        <th scope="col" abbr="write_io_errs">Write I/O errors</th>
+        <th scope="col" abbr="read_io_errs">Read I/O errors</th>
+        <th scope="col" abbr="flush_io_errs">Flush I/O errors</th>
+        <th scope="col" abbr="corruption_errs">Corruption errors</th>
+        <th scope="col" abbr="generation_errs">Generation errors</th>
+
     </tr>
     </thead>
     <tbody>
@@ -25,6 +37,7 @@
             {{/if}}
         </td>
         <td>{{humanReadableSize this.size}}</td>
+        {{ioErrorStatsTableData this.io_error_stats}}
     </tr>
     {{/each}}
     {{else}}
@@ -46,6 +59,7 @@
             {{/if}}
         </td>
         <td>{{humanReadableSize this.size}}</td>
+        {{ioErrorStatsTableData this.io_error_stats}}
     </tr>
     {{/each}}
     {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -128,6 +128,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         this.$('#ph-resize-pool-info').html(
             this.resize_pool_info_template({
                 pool: this.pool.toJSON()
+
             })
         );
         this.$('ul.nav.nav-tabs').tabs('div.css-panes > div');
@@ -411,6 +412,36 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
             }
             // In all other cases return false.
             return false;
+        });
+
+        Handlebars.registerHelper('ioErrorStatsTableData', function (stats) {
+            // var _this = this;
+            var statsAsJson = asJSON(stats);
+            if (statsAsJson === false) {
+                var failMsg = '<td colspan="5">Device stats unsupported - try ' +
+                    '\'btrfs dev stats /mnt2/' + this.pool_name + '\'.</td>';
+                return new Handlebars.SafeString(failMsg);
+            }
+            var html = '';
+            var ioStatsHeaders = [
+                'write_io_errs',
+                'read_io_errs',
+                'flush_io_errs',
+                'corruption_errs',
+                'generation_errs'
+            ];
+            // We have a json of a disk's io_error_stats.
+            // Create consecutive <td> (table data) entries for each in order.
+            ioStatsHeaders.forEach(function(statsElement){
+                var value = statsAsJson[statsElement]
+                if (value === '0') {
+                    html += '<td>' + value + '</td>';
+                } else {
+                    html += '<td><strong><span style="color:darkred">' + value;
+                    html += '</span></strong></td>';
+                }
+            });
+            return new Handlebars.SafeString(html);
         });
 
         Handlebars.registerHelper('getPoolCreationDate', function(date) {

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -168,6 +168,7 @@
       <a id="direct-shell" href="#shell"><i class="fa fa-desktop fa-inverse"></i>&nbsp;System Shell</a>
       <div id="shutdown-status"></div>
       <div id="pool-degraded-status"></div>
+      <div id="pool-dev-stats"></div>
       <div id="uptime"></div>
       <div id="appliance-loadavg"></div>
       <div id="yum-msg"><a id="yumupdates"></a></div>


### PR DESCRIPTION
Adds "Pool Device Errors Alert" related pool and disk properties and surfaces them within the Web-UI. Sources 'btrfs dev stats' with pool/vol mount point and member device nodes as targets respectively.

Modelled on the prior merged:
"surface pool missing disk info in UI" #1897 (7adaea3)

Summary
1. add dev_stats_ok() boolean property to pool model.
2. add Web-UI header alert "Pool Device Errors Alert" with tooltip text indicating the trigger pools, sourced from 1.
3. add "(DEV ERRORS DETECTED)" alert within 'Disks' column of the appropriate pool overview table column, sourced from 1.
4. add "(Device errors detected)" in 'Disks' subtitle of the appropriate pool details page, sourced from 1.
5. add io_error_stats() json string property to disk model.
6. add cumulative pool errors per device to the pool details view disks table, sourced from 5.
7. add unit tests for the 2 new model property generators.

Fixes # 1532
Please see issue discussion text for context and images of the resulting Web-UI additions.

@schakrava Ready for review.

Testing:
All changed Python files pass Flake 8.
In addition to the indicated unit tests:
```
./bin/test --settings=test-settings -v 3 -p test_btrfs*
...
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
...
```
Corruption errors were introduced to a nearly full and recently balanced raid1 btrfs vol via variants of the following command:
```
dd bs=512 count=10000 seek=1000 if=/dev/urandom of=/dev/disk/by-id/virtio-serial-777
```
I.e. 5.1 MBs (10000*512 consecutive bytes) of random raw disk manipulation.

A scrub was then performed and all errors were corrected (>1000 csum). But as this pool had non zero cumulative errors the Web-UI header appeared as expected. A consequent visit or refresh of the affected pool’s detail page indicated the expected number of corruption errors. Executing the suggested (within Web-UI) reset command then resulted in the Web-UI header alert no longer being displayed (30 seconds max delay). And a refresh of the associated pool’s details page then showed zero errors in all columns. And to check the presentation order the template in get_dev_io_error_stats() was hardwired to return consecutive numbers which then displayed as expected in the cumulative errors table columns.

As this Alert system shares UI space with the existing ‘Pool Degraded Alert’ a check was made that when both are active, both alerts are effectively displayed: images available in issue comments.

Importing a pool with existing errors was also tested to successfully trigger the Web-UI header alert, no page refresh required.

Caveates:
- No Web-UI element to reset stats, i.e. reports only. A command to do so is presented in text.
- Fails to report per disk error details associated with a detached devices (we would need to track devid: ie for >1 detached devices). Again we present via text an appropriate command for guidance.
These short falls in usability can be addressed in one or more separate issue/pull request sets.