### PR TITLE
Add support to Docker run command arguments during Rockon install. Fixes #1967

### DIFF
--- a/src/rockstor/storageadmin/migrations/0005_dcontainerargs.py
+++ b/src/rockstor/storageadmin/migrations/0005_dcontainerargs.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0004_auto_20170523_1140'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DContainerArgs',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=1024)),
+                ('val', models.CharField(max_length=1024, blank=True)),
+                ('container', models.ForeignKey(to='storageadmin.DContainer')),
+            ],
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -2,7 +2,7 @@
 Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
-RockStor is free software; you can redistribute it and/or modify
+RockStor is free software; you can redirstribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -45,7 +45,7 @@ from pool_balance import PoolBalance  # noqa E501
 from tls_certificate import TLSCertificate  # noqa E501
 from rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
                     ContainerOption, DCustomConfig, DContainerLink,  # noqa E501
-                    DContainerEnv)  # noqa E501
+                    DContainerEnv, DContainerArgs)  # noqa E501
 from smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
                    SMARTErrorLogSummary, SMARTTestLog, SMARTTestLogDetail,  # noqa E501
                    SMARTIdentity, SMARTInfo)  # noqa E501

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -2,7 +2,7 @@
 Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
-RockStor is free software; you can redirstribute it and/or modify
+RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.

--- a/src/rockstor/storageadmin/models/rockon.py
+++ b/src/rockstor/storageadmin/models/rockon.py
@@ -126,6 +126,15 @@ class ContainerOption(models.Model):
         app_label = 'storageadmin'
 
 
+class DContainerArgs(models.Model):
+    container = models.ForeignKey(DContainer)
+    name = models.CharField(max_length=1024)
+    val = models.CharField(max_length=1024, blank=True)
+
+    class Meta:
+        app_label = 'storageadmin'
+
+
 class DCustomConfig(models.Model):
     rockon = models.ForeignKey(RockOn)
     key = models.CharField(max_length=1024)

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -22,8 +22,8 @@ from rest_framework.response import Response
 from django.db import transaction
 from smart_manager.models import Service
 from storageadmin.models import (RockOn, DImage, DContainer, DPort, DVolume,
-                                 ContainerOption, DCustomConfig, DContainerArgs,
-                                 DContainerLink, DContainerEnv)
+                                 ContainerOption, DCustomConfig,
+                                 DContainerArgs, DContainerLink, DContainerEnv)
 from storageadmin.serializers import RockOnSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -22,7 +22,7 @@ from rest_framework.response import Response
 from django.db import transaction
 from smart_manager.models import Service
 from storageadmin.models import (RockOn, DImage, DContainer, DPort, DVolume,
-                                 ContainerOption, DCustomConfig,
+                                 ContainerOption, DCustomConfig, DContainerArgs,
                                  DContainerLink, DContainerEnv)
 from storageadmin.serializers import RockOnSerializer
 from storageadmin.util import handle_exception
@@ -317,6 +317,22 @@ class RockOnView(rfc.GenericView):
             for oo in ContainerOption.objects.filter(container=co):
                 if (oo.id not in id_l):
                     oo.delete()
+
+            cmd_args = containers[c].get('cmd_arguments', [])
+            id_l = []
+            for ca in cmd_args:
+                # there are no unique constraints on this model, so we need
+                # this bandaid.
+                if (DContainerArgs.objects.filter(
+                        container=co, name=ca[0], val=ca[1]).count() > 1):
+                    DContainerArgs.objects.filter(
+                        container=co, name=ca[0], val=ca[1]).delete()
+                cao, created = DContainerArgs.objects.get_or_create(
+                    container=co, name=ca[0], val=ca[1])
+                id_l.append(cao.id)
+            for cao in DContainerArgs.objects.filter(container=co):
+                if (cao.id not in id_l):
+                    cao.delete()
 
         l_d = r_d.get('container_links', {})
         for cname in l_d:

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -24,7 +24,7 @@ from django_ztask.decorators import task
 from cli.api_wrapper import APIWrapper
 from system.services import service_status
 from storageadmin.models import (RockOn, DContainer, DVolume, DPort,
-                                 DCustomConfig, DContainerLink,
+                                 DCustomConfig, DContainerLink, DContainerArgs,
                                  ContainerOption, DContainerEnv)
 from fs.btrfs import mount_share
 from rockon_utils import container_status
@@ -202,6 +202,13 @@ def envars(container):
         var_list.extend(['-e', '%s=%s' % (e.key, e.val)])
     return var_list
 
+def cargs(container):
+    cargs_list = []
+    for c in DContainerArgs.objects.filter(container=container):
+        cargs_list.append(c.name)
+        if (len(c.val.strip()) > 0):
+            cargs_list.append(c.val)
+    return cargs_list
 
 def generic_install(rockon):
     for c in DContainer.objects.filter(rockon=rockon).order_by('launch_order'):
@@ -221,6 +228,7 @@ def generic_install(rockon):
         cmd.extend(container_ops(c))
         cmd.extend(envars(c))
         cmd.append(c.dimage.name)
+        cmd.extend(cargs(c))
         run_command(cmd)
 
 

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -202,6 +202,7 @@ def envars(container):
         var_list.extend(['-e', '%s=%s' % (e.key, e.val)])
     return var_list
 
+
 def cargs(container):
     cargs_list = []
     for c in DContainerArgs.objects.filter(container=container):
@@ -209,6 +210,7 @@ def cargs(container):
         if (len(c.val.strip()) > 0):
             cargs_list.append(c.val)
     return cargs_list
+
 
 def generic_install(rockon):
     for c in DContainer.objects.filter(rockon=rockon).order_by('launch_order'):


### PR DESCRIPTION
Fixes #1967 
For some docker containers, it can be useful--if not necessary--to run add arguments to the `docker run` command. Modeled after the "options" object for Rockons' definitions, this commit adds support for such arguments to Rockons by:
1. Fetching arguments from a "cmd_arguments" object at the "container" level in the JSON file. Similar to the current 'options' object, this object must be in a 2-d array: "cmd_arguments": [ ["cowsay", "argument1"] ].
2. Store arguments in storageadmin under a new DContainerArgs table.
3. Extend the `docker run` call with these arguments after inserting the container's image name.

Tested with a [JSON for Docker's Whalesay image](https://gist.githubusercontent.com/FroggyFlox/a6dcf6b3eb7f6c4038ae26daffb919d2/raw/fe2d507b40961c5ebb942f8ee6ebb249c47a89f3/whalesay_test.json).

Passed Flake8's compliance tests.