### PR TITLE
Add Support for Docker run command arguments. Fixes #1967

### DIFF
--- a/src/rockstor/storageadmin/migrations/0006_dcontainerargs.py
+++ b/src/rockstor/storageadmin/migrations/0006_dcontainerargs.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0005_auto_20180913_0923'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DContainerArgs',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=1024)),
+                ('val', models.CharField(max_length=1024, blank=True)),
+                ('container', models.ForeignKey(to='storageadmin.DContainer')),
+            ],
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -45,7 +45,7 @@ from pool_balance import PoolBalance  # noqa E501
 from tls_certificate import TLSCertificate  # noqa E501
 from rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
                     ContainerOption, DCustomConfig, DContainerLink,  # noqa E501
-                    DContainerEnv, DContainerDevice)  # noqa E501
+                    DContainerEnv, DContainerDevice, DContainerArgs)  # noqa E501
 from smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
                    SMARTErrorLogSummary, SMARTTestLog, SMARTTestLogDetail,  # noqa E501
                    SMARTIdentity, SMARTInfo)  # noqa E501

--- a/src/rockstor/storageadmin/models/rockon.py
+++ b/src/rockstor/storageadmin/models/rockon.py
@@ -126,6 +126,15 @@ class ContainerOption(models.Model):
         app_label = 'storageadmin'
 
 
+class DContainerArgs(models.Model):
+    container = models.ForeignKey(DContainer)
+    name = models.CharField(max_length=1024)
+    val = models.CharField(max_length=1024, blank=True)
+
+    class Meta:
+        app_label = 'storageadmin'
+
+
 class DCustomConfig(models.Model):
     rockon = models.ForeignKey(RockOn)
     key = models.CharField(max_length=1024)

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -26,7 +26,7 @@ from system.services import service_status
 from storageadmin.models import (RockOn, DContainer, DVolume, DPort,
                                  DCustomConfig, DContainerLink,
                                  ContainerOption, DContainerEnv,
-                                 DContainerDevice)
+                                 DContainerDevice, DContainerArgs)
 from fs.btrfs import mount_share
 from rockon_utils import container_status
 import logging
@@ -206,6 +206,15 @@ def vol_owner_uid(container):
     return os.stat(share_mnt).st_uid
 
 
+def cargs(container):
+    cargs_list = []
+    for c in DContainerArgs.objects.filter(container=container):
+        cargs_list.append(c.name)
+        if (len(c.val.strip()) > 0):
+            cargs_list.append(c.val)
+    return cargs_list
+
+
 def envars(container):
     var_list = []
     for e in DContainerEnv.objects.filter(container=container):
@@ -233,6 +242,7 @@ def generic_install(rockon):
         cmd.extend(container_ops(c))
         cmd.extend(envars(c))
         cmd.append(c.dimage.name)
+        cmd.extend(cargs(c))
         run_command(cmd)
 
 


### PR DESCRIPTION
Fixes #1967 
This PR replaces the previous #1966 after upstream rebase.

For some docker containers, it can be useful--if not necessary--to run add arguments to the docker run command. Modeled after the "options" object for Rockons' definitions, this commit adds support for such arguments to Rockons by:

1. Fetching arguments from a "cmd_arguments" object at the "container" level in the JSON file. Similar to the current 'options' object, this object must be in a 2-d array: "cmd_arguments": [ ["cowsay", "argument1"] ].
1. Store arguments in storageadmin under a new DContainerArgs table.
3. Extend the docker run call with these arguments after inserting the container's image name.

Tested with a [JSON for Docker's Whalesay image](https://gist.githubusercontent.com/FroggyFlox/a6dcf6b3eb7f6c4038ae26daffb919d2/raw/fe2d507b40961c5ebb942f8ee6ebb249c47a89f3/whalesay_test.json).

Passed Flake8's compliance tests.