### PR TITLE
Implement a delete missing disk in pool UI #1700

### DIFF
--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -107,14 +107,14 @@ class Disk(models.Model):
     def io_error_stats(self, *args, **kwargs):
         # json charfield format
         try:
-            return get_dev_io_error_stats(str(self.name))
+            return get_dev_io_error_stats(str(self.target_name))
         except:
             return None
 
     @property
     def temp_name(self, *args, **kwargs):
         try:
-            return get_dev_temp_name(str(self.name))
+            return get_dev_temp_name(str(self.target_name))
         except:
             return None
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/disks_table.jst
@@ -22,7 +22,7 @@
       {{/if}}
     </td>
     <td>{{humanReadableSize this.size}}</td>
-    <td><input type="checkbox" name="diskname" id="{{this.name}}" value="{{this.name}}" class="diskname"></td>
+    <td><input type="checkbox" name="diskid" id="{{this.id}}" value='{"id": {{this.id}}, "name": "{{this.name}}"}' class="diskid"></td>
   {{/each}}
   </tbody>
 </table>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/disk/disks_table.jst
@@ -21,8 +21,13 @@
     <tr>
       <td><a href="#disks/{{this.id}}"><i class="glyphicon glyphicon-hdd"></i>&nbsp;{{this.name}}</a>
         {{#if this.offline}}
-            <a href="#" class="delete" data-disk-id="{{this.id}}" title="Disk is unusable because it is detached.
-            Click to delete it from the system if it is not to be reattached." rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>
+            {{#if this.pool_name}}
+                <i class="glyphicon glyphicon-map-marker" title="Drive is a detached member of a Rockstor managed Pool." rel="tooltip"></i>
+                <a href="#pools/{{this.pool}}"><i class="glyphicon glyphicon-exclamation-sign" title="Use linked Pool page Resize / ReRaid 'Remove disks' option if no reattachment is planned." rel="tooltip"></i></a>
+            {{else}}
+                <a href="#" class="delete" data-disk-id="{{this.id}}" title="Disk is unusable because it is detached.
+                Click to delete it from the system if it is not to be reattached." rel="tooltip"><i class="glyphicon glyphicon-trash"></i></a>
+            {{/if}}
         {{else if (isRootDevice this.role)}}
               <i class="glyphicon glyphicon-registration-mark" title="Rockstor System Drive." rel="tooltip"></i>
         {{else if (isLuksContainer this.role)}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/choice.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/choice.jst
@@ -5,8 +5,9 @@
 <br>
 <h4>Select an operation to perform on {{display_poolName}}</h4>
 <ol>
-  <li><h4><a href="#" id="change-raid">Modify RAID level</a></h4></li>
-  <li><h4><a href="#" id="add-disks">Add disks</a></h4></li>
+  <li><h4><a href="#" id="change-raid">Modify RAID level only</a></h4></li>
+  <li><h4><a href="#" id="add-disks">Add disks (optional RAID change)</a></h4></li>
   <li><h4><a href="#" id="remove-disks">Remove disks</a></h4></li>
+  <li><h4>Replace existing disk (planned option)</h4></li>
 </ol> 
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/remove_disks_complete.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/remove_disks_complete.jst
@@ -6,6 +6,6 @@
 </div>
 <br>
 <div class="alert alert-success">
-  <h4>Resize is initiated. A balance process is kicked off to redistribute data. It could take a while. You can check the status in the Balances tab. Its finish marks the success of resize.</h4>
+  <h4>Resize initiated - disk addition or raid change entails a subsequent Rockstor visible balance which may take several hours. Check status in the Balances tab. Disk delete progress is currently unmonitored.</h4>
 </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize_pool_info.jst
@@ -7,6 +7,32 @@
     {{/unless}}
 </h3>
 
+{{#if pool.has_missing_dev}}
+    <h4><u>Maintenance required</u></h4>
+    {{#unless (isDegradedRw pool.mount_status)}}
+    Missing disk removal requires <strong>degraded,rw</strong> mount options.
+    {{/unless}}
+    {{#if pool.is_mounted}}
+        {{#if (isWritable pool.mount_status)}}
+            {{#if (isDegradedRw pool.mount_status)}}
+                <a href="#" class="js-delete-missing" data-pool-id="{{pool.id}}" title="If detached members listed use - Resize/ReRaid 'Remove disks' - instead." rel="tooltip">
+                <i class="glyphicon glyphicon-erase"></i> Delete a missing disk if pool has no detached members.</a><br>
+                <strong>Header "Pool Degraded Alert" persists during delete process (can take several hours).</strong><br>
+            {{else}}
+                Consider <strong>degraded,ro</strong> to refresh backups first.<br>
+            {{/if}}
+        {{else}}
+            Pool is read only (<strong>ro</strong>).<br> Refresh backups before using <strong>degraded,rw</strong>.
+        {{/if}}
+        Active 'degraded' option is sticky: once unset a reboot is required to deactivate it.<br>
+    {{else}}
+        Pool is currently (<strong>unmounted</strong>).<br>
+        Consider <strong>degraded,ro</strong> to refresh backups first.<br>
+    {{/if}}
+    Reload page to refresh active mount options.
+    <br><br>
+{{/if}}
+
 <i>Cumulative pool errors per device - 'btrfs dev stats -z /mnt2/{{pool.name}}'
     to reset.</i>
 
@@ -15,6 +41,7 @@
     <thead>
     <tr>
         <th scope="col" abbr="Name">Name</th>
+        <th scope="col" abbr="Temp Name">Temp Name</th>
         <th scope="col" abbr="Capacity">Capacity</th>
         <th scope="col" abbr="write_io_errs">Write I/O errors</th>
         <th scope="col" abbr="read_io_errs">Read I/O errors</th>
@@ -35,6 +62,9 @@
                title="Open LUKS Volume, click to review." rel="tooltip">
                 <i class="glyphicon glyphicon-eye-open"></i></a>
             {{/if}}
+        </td>
+        <td>
+            {{this.temp_name}}
         </td>
         <td>{{humanReadableSize this.size}}</td>
         {{ioErrorStatsTableData this.io_error_stats}}
@@ -58,6 +88,9 @@
                 <i class="glyphicon glyphicon-eye-open"></i></a>
             {{/if}}
         </td>
+        <td>
+            {{this.temp_name}}
+        </td>
         <td>{{humanReadableSize this.size}}</td>
         {{ioErrorStatsTableData this.io_error_stats}}
     </tr>
@@ -67,4 +100,5 @@
 </table>
 
 <a id="js-resize-pool" class="btn btn-primary" href="#">
-    <i class="glyphicon glyphicon-edit "></i> Resize Pool</a></br>
+    <i class="glyphicon glyphicon-edit "></i> Resize/ReRaid Pool</a></br>
+

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
@@ -29,7 +29,7 @@ PoolAddDisks = RockstorWizardPage.extend({
 
     events: {
         'click #checkAll': 'selectAllCheckboxes',
-        'click [class="diskname"]': 'clickCheckbox'
+        'click [class="diskid"]': 'clickCheckbox'
     },
 
     initialize: function () {
@@ -95,12 +95,12 @@ PoolAddDisks = RockstorWizardPage.extend({
             return $.Deferred().reject();
         }
         var _this = this;
-        var checked = this.$('.diskname:checked').length;
-        var diskNames = [];
-        this.$('.diskname:checked').each(function (i) {
-            diskNames.push($(this).val());
+        var checked = this.$('.diskid:checked').length;
+        var diskIds = [];
+        this.$('.diskid:checked').each(function (i) {
+            diskIds.push($(this).val());
         });
-        this.model.set('diskNames', diskNames);
+        this.model.set('diskIds', diskIds);
         if (this.model.get('raidChange')) {
             this.model.set('raidLevel', this.$('#raid-level').val());
         }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/remove_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/remove_disks.js
@@ -27,7 +27,7 @@
 PoolRemoveDisks = RockstorWizardPage.extend({
     events: {
         'click #checkAll': 'selectAllCheckboxes',
-        'click [class="diskname"]': 'clickCheckbox'
+        'click [class="diskid"]': 'clickCheckbox'
     },
 
     initialize: function() {
@@ -74,12 +74,12 @@ PoolRemoveDisks = RockstorWizardPage.extend({
 
     save: function() {
         var _this = this;
-        var checked = this.$('.diskname:checked').length;
-        var diskNames = [];
-        this.$('.diskname:checked').each(function(i) {
-            diskNames.push($(this).val());
+        var checked = this.$('.diskid:checked').length;
+        var diskIds = [];
+        this.$('.diskid:checked').each(function(i) {
+            diskIds.push($(this).val());
         });
-        this.model.set('diskNames', diskNames);
+        this.model.set('diskIds', diskIds);
         return $.Deferred().resolve();
     },
 

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -302,6 +302,10 @@ class DiskMixin(object):
             # First find pool association if any:
             if is_byid and d.fstype == 'btrfs':
                 # use the canonical reference from get_pool_info()
+                # TODO: The following breaks with btrfs in partition, needs:
+                # TODO: if d.parted then extract the dev from d.partitions that
+                # TODO: has value 'btrfs' and get it's byid_disk_name.
+                # TODO: Added in pr #1949 commit a608d18 released (3.9.2-32)
                 p_info = get_pool_info(byid_disk_name, d.root)
                 # The above call also enacts a pool auto labeling mechanism.
                 pool_name = p_info['label']


### PR DESCRIPTION
Extend the existing pool details page and it's Resize/ReRaid wizard to facilitate the removal of detached / missing disks. Includes a number of bug fixes re Pool edits, mostly concerned with disk add / remove when a pool has one or more detached members. Advise and link on Disks page against detached members of managed pools. Note that detached disks with no managed pool association are unaffected by these changes. I.e. they can be, as before, removed (from db) via a bin icon.

Summary:
- Ensure pool is mounted prior to add / remove / raid change actions and present a user error if this prerequisite is not met.
- Add 'btrfs device delete missing' function to managed pool detached member via the existing 'Remove disks' option within Pool details page 'Resize/ReRaid Pool'.
- Web-UI Disk's page - add map icon to identify "... detached member of a Rockstor managed Pool." tooltip quote.
- Web-UI Disk's page - add exclamation mark "Use the associated Pool page Resize/ReRaid 'Remove disks' option if it is not to be reattached." tooltip quote.
- Web-UI Pool details page - add contextually aware text / link giving advice and optional 'dev delete missing' work around for when no detached disks are known: i.e importing a degraded pool on a fresh
install for disaster recovery.
- Change remaining / resulting disk count validation to account for detached disks.
- Remove redundant balance after disk delete (pool member removal) operation.
- Change disk model temp_name property to return canonical variant of target_name, ie make it redirect role aware.
- Add pool details page Disk table "Temp Name" column (first and currently only use of temp_name disk model property).
- Fix bug where io_error_stats failed for btrfs-in-partition (ie redirect role).
- Add "Replace existing disk (planned option)"" placeholder Web-UI text.
- Minor rewording of user facing messages re pool edits.
- Minor variable name refactoring / renaming.
- Manage disk selection within Resize/ReRaid wizard and consequent validation via disk id not disk name, fixes buggy behaviour re detached disk management.
- Add TODO: re running resize_pool() as async task, relevant mostly to disk delete as a time out is generated on all but trivially small pools.
- Add TODO: pool_info() - move 'disks' to dictionary with (devid, size, used) tuple value.
- Add TODO: _update_disk_state() - how to fix a recent btrfs in partition regression (my fault).

Fixes #1700 
See issue comments for context and images of added Web-UI elements.
And as the last remaining sub-issue linked in the following super set issues:
Fixes #737
(6 other dependant and now closed issues).
Fixes #1199 
(5 other dependant and now closed issues).

@schakrava Ready for Review

Testing:
All affected pool edit options were tested to behave as expected (given known caveats below) on both KVM systems and real hardware.

Caveats:
- When removing a drive live "btrfs fi show" and consequently Rockstor indicate detached / missing pool members. But prior to a reboot any attempt to 'btrfs device delete missing' results in a '... no missing devices..' type error which we do surface. Post reboot delete missing works as intended.
- As "btrfs device delete (missing or otherwise)" initiates an internal balance that can take several hours we experience a time out that break the Web-UI feedback and associated db updates for this operation. However this is a related but independent issue which is detailed in existing issue:
"pool resize disk removal unknown internal error and no UI counterpart" #1722
The work around for the time being is to execute the same disk removal operation again where the second attempt (if post internal balance completion) executes as expected due to the initial disk removal having now succeeded and so is skipped, avoiding the cause of the timeout that breaks the otherwise functional (on trivially small pools) btrfs device delete (missing or otherwise) pool operation.