### PR TITLE
regression in dashboard disk activity widget. Fixes #1978

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -569,6 +569,9 @@ class DisksWidgetNamespace(RockstorIO):
             stats_file_path = '/proc/diskstats'
             cur_stats = {}
             interval = 1
+            # TODO: Consider refactoring the following to use Disk.temp_name or
+            # TODO: building byid_disk_map from the same. Ideally we would have
+            # TODO: performance testing in place prior to this move.
             # Build a list of our db's disk names, now in by-id type format.
             disks = [d.name for d in Disk.objects.all()]
             # /proc/diskstats has lines of the following form:

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1620,7 +1620,7 @@ def get_dev_byid_name(device_name, remove_path=False):
 
 
 def get_byid_name_map():
-    """Simple wrapper around 'ls -l /dev/disk/by-id' which returns a current
+    """Simple wrapper around 'ls -lr /dev/disk/by-id' which returns a current
     mapping of all attached by-id device names to their sdX counterparts. When
     multiple by-id names are found for the same sdX device then the longest is
     preferred, or when equal in length then the first listed is used. Intended
@@ -1636,7 +1636,7 @@ def get_byid_name_map():
     was encountered by run_command or no by-id type names were encountered.
     """
     byid_name_map = {}
-    out, err, rc = run_command([LS, '-l', '/dev/disk/by-id'],
+    out, err, rc = run_command([LS, '-lr', '/dev/disk/by-id'],
                                throw=True)
     if rc == 0:
         for each_line in out:


### PR DESCRIPTION
Recent improvements / bug fixes in the non dashboard by-id name selection has lead to a deviation in algorithms for by-id name resolution leading to a failure in the disk activity widget due to unknown by-id name selection within that widget. This only happens if all by-id names for a given device are of the same length.

Summary:

- Move dashboard 'temp name -> by-id' map generation to reverse lexicographical to normalise on by-id name selection across the system.
- Add TODO on potential dashboard code simplification in this area: has performance test pre-requisite.
- Add unit tests for both prior and current behaviour of get_byid_name_map() to ensure nature of change is understood.

Fixes #1978 
See issue text for further context.

@schakrava Ready for review

Testing:
The included additional unit tests indicate prior and proposed behaviour of the changed code with prior behaviour consistent with the observed/reported issue.
```
./bin/test --settings=test-settings -v 3 -p test_osi*
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok                                                                                                              
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok  
...
```

Caveat:
There is currently a failure to build issue in the master branch, db migration / creation related, that was worked around for the development of this issue. It may be pertinent to address this db initialisation / build issue prior to this pr's merge (I believe them to be unrelated). I will open another issue detailing my findings to date and further diagnose it's cause: looks to be related to recent db additions in master that break or surface prior hidden issues associated with clean db creation, as in a fresh build from source.
