### PR TITLE
regression - source build fails to fully initialise db. Fixes #1983

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,8 +20,8 @@ parts =
       stop-rockstor
       django
       scripts
-      postgres-setup
-      postgres-conf
+#      postgres-setup
+#      postgres-conf
       gunicorn
       nginx-conf
       shellinabox-conf
@@ -35,7 +35,6 @@ parts =
       js-libraries
       js-sync
       collectstatic
-      gulp-install
       supervisor
       supervisord-conf
       create-cert
@@ -43,6 +42,8 @@ parts =
       rockstor-pre-systemd-conf
       rockstor-systemd-conf
       bootstrap-systemd-conf
+# Note the following systemd links are checked / updated in turn by '.initrock'
+      setup-systemd-links
       def-kernel
       start-rockstor
 
@@ -73,13 +74,26 @@ recipe = plone.recipe.command
 command = systemctl stop rockstor
 update-command = ${stop-rockstor:command}
 
+[setup-systemd-links]
+recipe = plone.recipe.command
+command =
+    cp -f ${buildout:directory}/conf/rockstor-pre.service /etc/systemd/system/rockstor-pre.service &&
+    systemctl enable rockstor-pre.service &&
+    cp -f ${buildout:directory}/conf/rockstor.service /etc/systemd/system/rockstor.service &&
+    systemctl enable rockstor.service &&
+    cp -f ${buildout:directory}/conf/rockstor-bootstrap.service /etc/systemd/system/rockstor-bootstrap.service &&
+    systemctl enable rockstor-bootstrap.service &&
+    systemctl daemon-reload
+update-command = ${setup-systemd-links:command}
+
 [start-rockstor]
 recipe = plone.recipe.command
-command = cp -f ${buildout:directory}/conf/rockstor-pre.service /etc/systemd/system/rockstor-pre.service &&
-	  systemctl enable rockstor-pre.service &&
-	  systemctl daemon-reload &&
-	  systemctl restart rockstor-pre
-	  systemctl start rockstor
+# We stop rockstor-pre, just in case, to invoke a re-run via start of rockstor.
+command =
+    systemctl stop rockstor-pre &&
+# Following rockstor start will in turn start rockstor-pre if found stopped.
+# We then follow / test the usual systemd execution chain.
+    systemctl start rockstor
 update-command = ${start-rockstor:command}
 
 


### PR DESCRIPTION
Re-order db migration by early --fake-initial migration of contenttypes.

Refactor initial database initialisation to be only within initrock to centralised this mechanism, removes previous db migration redundancy within buildout and some associated legacy db operations and in turn avoids major duplication of db initialisation on initial clean (no db or no .initrock file) builds. Move to only invoking the initrock script (during source build) via systemd dependency execution. This gives
cleaner error reporting re failed dependency on rockstor-pre (which normally invokes initrock) and follows / tests normal execution flow.

Consequently avoided runtime error:
"Error creating new content types. Please make sure contenttypes is migrated before trying to migrate apps individually."
on recent first attempt migrations during clean (no db or no .initrock) builds.

Summary:

- Migrate --fake-initial contenttypes before individual apps.
- Remove buildout db prep to centralise within initrock.
- Use systemd execution chain to invoke initrock / rockstor-pre.
- Add systemd services setup step in buildout: required by prior item.
- Add debug logging for db delete within initrock.
- Add debug logging to existing db --fake migrations.
- Remove currently unused gulp-install from buildout, this entry breaks non legacy builds.

Fixes #1983 
See issue text and comment for development context.

@schakrava Ready for review.

Testing:
After deleting existing systemd links via:
```
rm -f /etc/systemd/system/rockstor-pre.service
rm -f /etc/systemd/system/rockstor.service
rm -f /etc/systemd/system/rockstor-bootstrap.service
systemctl daemon-reload
```
and ensuring we have no pre-existing .initrock file by building directly after a fresh transfer (prior rpm and rockstor dir uninstalled/deleted) we end up with a first time build success with the following showmigrations output:
```
/opt/rockstor-dev/bin/django showmigrations                        
admin
[ ] 0001_initial
auth
[X] 0001_initial
[X] 0002_alter_permission_name_max_length
[X] 0003_alter_user_email_max_length
[X] 0004_alter_user_username_opts
[X] 0005_alter_user_last_login_null
[X] 0006_require_contenttypes_0002
contenttypes
[X] 0001_initial
[X] 0002_remove_content_type_name
django_ztask
(no migrations)
oauth2_provider
[X] 0001_initial
[ ] 0002_08_updates
sessions
[ ] 0001_initial
sites
[ ] 0001_initial
smart_manager
[ ] 0001_initial
[ ] 0002_auto_20170216_1212
storageadmin
[X] 0001_initial
[X] 0002_auto_20161125_0051
[X] 0003_auto_20170114_1332
[X] 0004_auto_20170523_1140
[X] 0005_auto_20180913_0923
[X] 0006_dcontainerargs
```
which is consistent with prior first time build successes (pre tag 3.9.2-39) and a consistent index / id mapping within django_content_type (ie no id’s skipped) and the following django_migrations contents:

id | app | name | applied
-- | -- | -- | --
1 | contenttypes | 0001_initial | 2018-11-04 11:52:09.046277
2 | contenttypes | 0002_remove_content_type_name | 2018-11-04 11:52:09.080579
3 | auth | 0001_initial | 2018-11-04 11:52:11.620408
4 | oauth2_provider | 0001_initial | 2018-11-04 11:52:11.625451
5 | storageadmin | 0001_initial | 2018-11-04 11:52:11.629292
6 | auth | 0002_alter_permission_name_max_length | 2018-11-04 11:52:13.013702
7 | auth | 0003_alter_user_email_max_length | 2018-11-04 11:52:13.058906
8 | auth | 0004_alter_user_username_opts | 2018-11-04 11:52:13.071466
9 | auth | 0005_alter_user_last_login_null | 2018-11-04 11:52:13.086848
10 | auth | 0006_require_contenttypes_0002 | 2018-11-04 11:52:13.090587
11 | storageadmin | 0002_auto_20161125_0051 | 2018-11-04 11:52:14.680407
12 | storageadmin | 0003_auto_20170114_1332 | 2018-11-04 11:52:14.996502
13 | storageadmin | 0004_auto_20170523_1140 | 2018-11-04 11:52:15.122794
14 | storageadmin | 0005_auto_20180913_0923 | 2018-11-04 11:52:15.488624
15 | storageadmin | 0006_dcontainerargs | 2018-11-04 11:52:15.624022

Indicating our 2 most recent storageadmin migrations, the first non initial migrations in our post south setup to include 'migrations.CreateModel()', have been applied successfully, along with an early application of "contenttypes 0002_remove_content_type_name".

With subsequent (post migration / build) executions of the addition migration related command within this pr resulting in the following:
```
/opt/rockstor-dev/bin/django migrate --noinput --fake-initial --database=default contenttypes
Operations to perform:
  Apply all migrations: contenttypes
Running migrations:
  No migrations to apply.
```
Tested as this will be executed upon every rockstor-pre (initirock) invocation.

Caveats:
For the time being we have remaining remarked out / redundant / unused content within buildout.cfg; this is intended to aid in reverting these changes were there to be unforeseen side effects once distributed. A later pr can address this kipple.