### PR TITLE
add non legacy distro aware repo configuration. Fixes #1991

### DIFF
--- a/base-buildout.cfg
+++ b/base-buildout.cfg
@@ -61,7 +61,7 @@ command =
 	postgresql-server postgresql-devel kernel-ml btrfs-progs rsync \
 	nfs-utils avahi netatalk smartmontools net-tools sos hdparm \
 	postfix cyrus-sasl-plain yum-cron nano usbutils pciutils shellinabox \
-	epel-release cryptsetup docker-ce python-distro
+	epel-release cryptsetup docker-ce python-distro yum-changelog
 
 [rpm-deps-nut]
 recipe = plone.recipe.command

--- a/src/rockstor/storageadmin/views/update_subscription.py
+++ b/src/rockstor/storageadmin/views/update_subscription.py
@@ -36,7 +36,7 @@ class UpdateSubscriptionListView(rfc.GenericView):
         return UpdateSubscription.objects.all()
 
     def _toggle_repos(self, on='stable', off='testing', password=None):
-        # toggle between testing and stabel repos
+        # toggle between testing and stable repos
         ncd = settings.UPDATE_CHANNELS[on]
         fcd = settings.UPDATE_CHANNELS[off]
         try:


### PR DESCRIPTION
Adds distro awareness to the existing repository configuration to encompass our next generation openSUSE Leap and Tumbleweed distribution bases. The repository structure assumed is as proposed/detailed in the associated issue text.

Summary:

- Add disto aware repo configuration for openSUSE Leap and Tumbleweed (next gen Rockstor).
- Fix Rockstor NG source to rpm install transition.
- Fix compliance with unconfigured repo. Allows for updates in only one channel i.e. preserving the user option to change the update subscription channel when defaulting to, or having selected, a deprecated or yet to be configured update channel.
- Fix unintended repository file permissions: auto resolves (post patch) by visiting “Software Update” page.
- Fix Rockstor NG version display for source installs.
- Fix missing yum-changelog package dependency: package name tested with yum on legacy and NG distros.
- For dev/source installs (no rockstor rpm installed) list entire changelog of available rpm. Prior use of ‘None’ for date parameter was silently interpreted as ‘all’ in older (legacy) yum-changelog but caused command exceptions in newer openSUSE versions of the same. Manual concurs with new use.
- Trivial code comment addition and typo.
- Changed rockstor repos from 1m to 1h for metadata_expire (to reduce server load).

Fixes #1991 

@schakrava Ready for review. See issue text for repo structure assumed within pr.
Git history caveat: I neglected to mention the metadata_expire change in the git commit message. Let me know if you would like for me to re-present this pr due to this omission.

Testing:

A source build, categorised as ‘unknown version’, offers an ‘update’ when any ‘rockstor’ rpm version is available: tested using existing CentOS based repos. Caveat for subsequent ‘upgrade’ is that the source build is assumed NOT to be in /opt/rockstor.

Legacy Rockstor (CentOS based) and Rockstor NG (openSUSE Leap & Tumbleweed based):
Successfully offered and configured both update channels from clean source builds as per repo dir structure proposed/detailed in issue text (unchanged for existing legacy repos).

