### PR TITLE
regression in unit tests - environment outdated since 3.9.2-45. Fixes #1993

### DIFF
--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 # Django settings for Rockstor project.
 import os
+import subprocess, distro
 
 DEBUG = ${django-settings-conf:debug}
 TEMPLATE_DEBUG = DEBUG
@@ -385,3 +386,22 @@ UPDATE_CHANNELS = {
 		'url': 'rockstor.com/rockrepo-testing',
 		},
 }
+
+# Setup OS specific command paths via 'which cmd' calls
+# N.B. this method will not work with an alias, ie in CentOS
+# which ls
+# alias ls='ls --color=auto'
+#         /usr/bin/ls
+# The following have been tested in CentOS, openSUSE Leap15, and Tumbleweed
+UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
+SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
+CHKCONFIG_BIN = subprocess.check_output(["which", "chkconfig"]).rstrip()
+
+# Establish our OS base id, name, and version:
+# Use id for code path decisions. Others are for Web-UI display purposes.
+# Examples given are for CentOS Rockstor variant, Leap 15, and Tumblweed.
+OS_DISTRO_ID = distro.id()  # rockstor, opensuse-leap, opensuse-tumbleweed
+OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed
+# Note that the following will capture the build os version.
+# For live updates (running system) we call distro.version() directly in code.
+OS_DISTRO_VERSION = distro.version()  # 3, 15.0 ,20181107


### PR DESCRIPTION
Adds previously omitted python imports and associated settings to template file test-settings.conf.in. These same changes were previously only applied to the non testing environment template file settings.conf.in.

Fixes test_btrfs* runs.

Fixes #1993 

@schakrava Ready for Review.
Apologies as I recently broke (via omission) the test environment (in pr #1990 ) and this is the fix.

Proof of fix (using test_btrfs subset of unit tests):
before pr:
```
./bin/test --settings=test-settings -v 3 -p test_btrfs*
...
AttributeError: 'Settings' object has no attribute 'SHUTDOWN'
```
after pr:
```
./bin/test --settings=test-settings -v 3 -p test_btrfs*
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok

----------------------------------------------------------------------
Ran 37 tests in 0.044s

OK
```

