### PR TITLE
pin python-engineio to 2.3.2 as recent 3.0.0 update breaks gevent. Fixes #1995

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'django-pipeline == 1.6.9',
         'django-ztask == 0.1.5',
         'djangorestframework == 3.1.1',
+        'python-engineio == 2.3.2',  # Revisit version post 3.0.0
         'gevent == 1.1.2',
         'gevent-websocket == 0.9.5',
         'mock == 1.0.1',


### PR DESCRIPTION
As of 25th November 2018 source builds failed to display live Web-UI header info such as time, Rockstor and kernel version etc. This was tracked down to an upstream python-engineio updated to 3.0.0. Although this update may not be the direct cause, pinning it's version to the latest prior released resolved the observed regressions.

Fixes #1995 

@schakrava Ready for review.

Notes:
An attempt was made to update our gevent  / gevent-websocket to their latest versions instead but this failed to fix the regression: with gevent-websockets at 0.10.1 and all gevent versions from latest 1.3.7 to 1.3.3 were tried without success. Also note that the 1.3 series of gevent (much improved) states a minimum supported python version higher than our legacy CentOS base, currently (2.7.5). NG Rockstor's OpenSUSE Leap 15.0 / Tumbleweed bases have 2.7.14 / 2.7.15 respectively.

Reference and quote re gevent: http://www.gevent.org/whatsnew_1_3.html

_"Caution Python 2.7.8 and below (Python 2.7 without a modern ssl module), is no longer tested or supported. The support code remains in this release and gevent can be installed on such implementations, but such usage is not supported. Support for Python 2.7.8 will be removed in the next major version of gevent."_

It is proposed that we re-visit this particular pinning when python-engineio is next updated.



