### PR TITLE
Implement Add Labels feature for already-installed Rock-Ons. Fixes #1998

### DIFF
--- a/src/rockstor/storageadmin/migrations/0007_auto_20181210_0740.py
+++ b/src/rockstor/storageadmin/migrations/0007_auto_20181210_0740.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0006_dcontainerargs'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DContainerLabel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(max_length=1024, null=True)),
+                ('val', models.CharField(max_length=1024, null=True)),
+                ('container', models.ForeignKey(to='storageadmin.DContainer')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='dcontainerlabel',
+            unique_together=set([('container', 'val')]),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -45,7 +45,8 @@ from pool_balance import PoolBalance  # noqa E501
 from tls_certificate import TLSCertificate  # noqa E501
 from rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
                     ContainerOption, DCustomConfig, DContainerLink,  # noqa E501
-                    DContainerEnv, DContainerDevice, DContainerArgs)  # noqa E501
+                    DContainerEnv, DContainerDevice, DContainerArgs,
+                    DContainerLabel)  # noqa E501
 from smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
                    SMARTErrorLogSummary, SMARTTestLog, SMARTTestLogDetail,  # noqa E501
                    SMARTIdentity, SMARTInfo)  # noqa E501

--- a/src/rockstor/storageadmin/models/rockon.py
+++ b/src/rockstor/storageadmin/models/rockon.py
@@ -165,3 +165,13 @@ class DContainerDevice(models.Model):
     class Meta:
         unique_together = ('container', 'dev')
         app_label = 'storageadmin'
+
+
+class DContainerLabel(models.Model):
+    container = models.ForeignKey(DContainer)
+    key = models.CharField(max_length=1024, null=True)
+    val = models.CharField(max_length=1024, null=True)
+
+    class Meta:
+        unique_together = ('container', 'val')
+        app_label = 'storageadmin'

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -24,8 +24,8 @@ from storageadmin.models import (Disk, Pool, Share, Snapshot, NFSExport,
                                  NFSExportGroup, SFTP, AdvancedNFSExport,
                                  OauthApp, NetatalkShare, Group, PoolBalance,
                                  SambaCustomConfig, TLSCertificate,
-                                 RockOn, DVolume, DPort, DCustomConfig,
-                                 DContainerEnv, DContainerDevice,
+                                 RockOn, DContainer, DVolume, DPort, DCustomConfig,
+                                 DContainerEnv, DContainerDevice, DContainerLabel,
                                  SMARTAttribute, SMARTCapability, SMARTInfo,
                                  SMARTErrorLog, SMARTErrorLogSummary,
                                  SMARTTestLog, SMARTTestLogDetail,
@@ -241,6 +241,11 @@ class RockOnSerializer(serializers.ModelSerializer):
         model = RockOn
 
 
+class RockOnContainerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DContainer
+
+
 class RockOnVolumeSerializer(serializers.ModelSerializer):
     share_name = serializers.CharField()
 
@@ -266,6 +271,11 @@ class RockOnEnvironmentSerializer(serializers.ModelSerializer):
 class RockOnDeviceSerializer(serializers.ModelSerializer):
     class Meta:
         model = DContainerDevice
+
+
+class RockOnLabelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DContainerLabel
 
 
 class SMARTCapabilitySerializer(serializers.ModelSerializer):

--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -1248,6 +1248,16 @@ form { margin: 0px; }
     margin-bottom: 12px;
 }
 
+.input-btn {
+    display: inline !important;
+    width: 70% !important;
+}
+
+#field1 {
+    display: inline !important;
+    width: 83% !important;
+}
+
 input[type="checkbox"].inline {
   margin-top: 0px;
 }

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -173,14 +173,23 @@ var ImageCollection = RockStorPaginatedCollection.extend({
 });
 
 var Container = Backbone.Model.extend({
-    url: function() {
-        return '/api/rockons/';
-    }
+    urlRoot: '/api/rockons/docker/containers/' + this.rid
 });
 
 var ContainerCollection = RockStorPaginatedCollection.extend({
-    model: Image,
-    baseUrl: '/api/rockons/docker/containers'
+    model: Container,
+    initialize: function(models, options) {
+        this.constructor.__super__.initialize.apply(this, arguments);
+        if (options) {
+            this.rid = options.rid;
+        }
+    },
+    baseUrl: function() {
+        if (this.rid) {
+            return '/api/rockons/docker/containers/' + this.rid;
+        }
+        return '/api/rockons/docker/containers';
+    }
 });
 
 var Snapshot = Backbone.Model.extend({
@@ -738,6 +747,26 @@ var RockOnDeviceCollection = RockStorPaginatedCollection.extend({
             return '/api/rockons/devices/' + this.rid;
         }
         return '/api/rockons/devices';
+    }
+});
+
+var RockOnLabel = Backbone.Model.extend({
+    urlRoot: '/api/rockon/labels/' + this.rid
+});
+
+var RockOnLabelCollection = RockStorPaginatedCollection.extend({
+    model: RockOnLabel,
+    initialize: function(models, options) {
+        this.constructor.__super__.initialize.apply(this, arguments);
+        if (options) {
+            this.rid = options.rid;
+        }
+    },
+    baseUrl: function() {
+        if (this.rid) {
+            return '/api/rockons/labels/' + this.rid;
+        }
+        return '/api/rockons/labels';
     }
 });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels.jst
@@ -1,0 +1,1 @@
+<div id="ph-add-labels-form"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels_form.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels_form.jst
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="col-md-10">
+    <label class="control-label"></label>
+    <div class="form-box">
+      <form id="container-select-form" name="aform" class="form-horizontal">
+	<div class="messages"></div>
+	{{#unless containers}}
+	<h3>There are no containers to label.</h3>
+	{{else}}
+	<div class="form-group">
+	  <label class="col-sm-3 control-label" for="containers">Container: <span class="required">*</span></label>
+
+	  <div class="controls col-sm-5">
+	    <select class="form-control" id="container" name="container" placeholder="Select a container. ">
+	      <option></option>
+	      {{#each containers}}
+	      <option value="{{this.name}}">{{this.name}}</option>
+	      {{/each}}
+	    </select>
+	  </div>
+	  <i class="fa fa-info-circle fa-lg" title="Select the container to which to a label should be added."></i>
+	</div>
+ 	<div id="label-box1" class="form-group">
+	  <label class="col-sm-3 control-label" for="labels">Label:  <span class="required">*</span></label>
+	  <div class="controls col-sm-5">
+          <input class="form-control input-btn" name="labels[]" id="field1" placeholder="Enter a label" type="text" /><button id="b1" class="btn" type="button">+</button>
+	  </div>
+	  <i class="fa fa-info-circle fa-lg" title="Enter the desired label in the following form: mycustomlabel"></i>
+	</div>
+	<div class="label-box-new"></div>
+    {{/unless}}
+	  </form>
+  	</div>
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels_form.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/add_labels_form.jst
@@ -18,7 +18,7 @@
 	      {{/each}}
 	    </select>
 	  </div>
-	  <i class="fa fa-info-circle fa-lg" title="Select the container to which to a label should be added."></i>
+	  <i class="fa fa-info-circle fa-lg" title="Select the container to which a label should be added."></i>
 	</div>
  	<div id="label-box1" class="form-group">
 	  <label class="col-sm-3 control-label" for="labels">Label:  <span class="required">*</span></label>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
@@ -43,5 +43,12 @@
         <td>{{this.key}}</td>
     </tr>
 {{/each}}
-
+{{#each labels}}
+    <tr>
+        <td>Label</td>
+        <td>{{this.key}}</td>
+        <td>{{this.val}}</td>
+    </tr>
+{{/each}}
+{{display_newLabels}}
 </table>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/wizard_summary.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/wizard_summary.jst
@@ -1,0 +1,35 @@
+<script>
+/*
+ * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * This file is part of RockStor.
+ *
+ * RockStor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * RockStor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+</script>
+
+<div class="row">
+  <div class="col-md-12">
+    <div id="ph-wizard-header">
+      <h3>{{title}}</h3>
+    </div>
+    <div id="ph-wizard-contents">
+    </div>
+    <div id="ph-wizard-buttons" class="col-md-12">
+      <button id="next-page" class="btn btn-primary wizard-btn">Next</button>
+      <button id="add-label" class="btn btn-primary wizard-btn">Label</button>
+      <button id="prev-page" class="btn wizard-btn">Back</button>
+    </div>
+  </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -1034,10 +1034,10 @@ RockonSettingsWizardView = WizardView.extend({
             } else {
                 if (this.rockon.get('status') == 'started') {
                     var _this = this;
-                    this.$('#next-page').click(function() {
+                    this.$('.wizard-btn').click(function() {
                         //disabling the button so that the backbone event is not triggered after the alert click.
-                        _this.$('#next-page').prop('disabled', true);
-                        alert('Rock-on must be turned off to add storage.');
+                        _this.$('.wizard-btn').prop('disabled', true);
+                        alert('Rock-on must be turned off to change its settings.');
                     });
                 }
             }

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -882,8 +882,15 @@ RockonInfoView = WizardView.extend({
 });
 
 RockonSettingsWizardView = WizardView.extend({
+    events: {
+        'click #next-page': 'nextPage',
+        'click #prev-page': 'prevPage',
+        'click #add-label': 'addLabels'
+    },
+
     initialize: function() {
         WizardView.prototype.initialize.apply(this, arguments);
+        this.template = window.JST.rockons_wizard_summary;
         this.pages = [RockonSettingsSummary, ];
         this.rockon = this.model.get('rockon');
         this.volumes = new RockOnVolumeCollection(null, {
@@ -901,8 +908,18 @@ RockonSettingsWizardView = WizardView.extend({
         this.environment = new RockOnEnvironmentCollection(null, {
             rid: this.rockon.id
         });
+        this.labels = new RockOnLabelCollection(null, {
+            rid: this.rockon.id
+        });
+        this.containers = new ContainerCollection(null, {
+            rid: this.rockon.id
+        });
+
         this.shares = {};
         this.model.set('shares', this.shares);
+        this.new_labels = {};
+        this.model.set('new_labels', this.new_labels);
+        this.evAgg.bind('addLabels', this.addLabels, this);
     },
 
     fetchVolumes: function() {
@@ -925,6 +942,16 @@ RockonSettingsWizardView = WizardView.extend({
         });
     },
 
+    fetchDevices: function() {
+        var _this = this;
+        this.devices.fetch({
+            success: function() {
+                _this.model.set('devices', _this.devices);
+                _this.fetchCustomConfig();
+            }
+        });
+    },
+
     fetchCustomConfig: function() {
         var _this = this;
         this.custom_config.fetch({
@@ -935,24 +962,42 @@ RockonSettingsWizardView = WizardView.extend({
         });
     },
 
-    fetchDevices: function() {
-        var _this = this;
-        this.ports.fetch({
-            success: function() {
-                _this.model.set('devices', _this.devices);
-                _this.fetchCustomConfig();
-            }
-        });
-    },
-    
     fetchEnvironment: function() {
         var _this = this;
         this.environment.fetch({
             success: function() {
                 _this.model.set('environment', _this.environment);
+                _this.fetchContainers();
+            }
+        });
+    },
+
+    fetchContainers: function() {
+        var _this = this;
+        this.containers.fetch({
+            success: function() {
+                _this.model.set('containers', _this.containers);
+                _this.fetchLabels();
+            }
+        });
+    },
+
+    fetchLabels: function() {
+        var _this = this;
+        this.labels.fetch({
+            success: function() {
+                _this.model.set('labels', _this.labels);
                 _this.addPages();
             }
         });
+    },
+
+    addLabels: function() {
+        this.pages[1] = RockonAddLabel;
+        this.pages[2] = RockonSettingsSummary;
+        this.pages[3] = RockonSettingsComplete;
+        WizardView.prototype.render.apply(this, arguments);
+        return this;
     },
 
     render: function() {
@@ -981,6 +1026,8 @@ RockonSettingsWizardView = WizardView.extend({
     modifyButtonText: function() {
         if (this.currentPageNum == 0) {
             this.$('#prev-page').hide();
+            this.$('#add-label').html('Add Label');
+            this.$('#add-label').css({'display': 'inline'});
             this.$('#next-page').html('Add Storage');
             if (!this.rockon.get('volume_add_support')) {
                 this.$('#next-page').hide();
@@ -999,9 +1046,11 @@ RockonSettingsWizardView = WizardView.extend({
             this.$('#next-page').html('Next');
         } else if (this.currentPageNum == (this.pages.length - 1)) {
             this.$('#prev-page').show();
+            this.$('#add-label').hide();
             this.$('#next-page').html('Submit');
         } else {
             this.$('#prev-page').show();
+            this.$('#add-label').hide();
             this.$('#next-page').html('Next');
             this.$('#ph-wizard-buttons').show();
         }
@@ -1080,8 +1129,128 @@ RockonAddShare = RockstorWizardPage.extend({
         this.model.set('shares', this.share_map);
         return $.Deferred().resolve();
     }
+});
 
+RockonAddLabel = RockstorWizardPage.extend({
+    initialize: function() {
+        this.template = window.JST.rockons_add_labels;
+        this.sub_template = window.JST.rockons_add_labels_form;
+        this.rockon = this.model.get('rockon');
+        this.containers = new ContainerCollection(null, {
+            rid: this.rockon.id
+        });
+        this.containers.setPageSize(100);
+        this.count = 1;
+        this.maxlabels = 10; // Define maximum numbers of labels
+        RockstorWizardPage.prototype.initialize.apply(this, arguments);
+        this.containers.on('reset', this.renderContainers, this);
+    },
 
+    events: {
+        'click #b1': 'addField',
+        'click .remove-me': 'removeField'
+    },
+
+    addField: function(event) {
+        event.preventDefault();
+        var count = this.count;
+        if (count < this.maxlabels) {
+            count++;
+            this.count = count;
+            var nbox = '<div id="label-box' + count +'" class="form-group">' +
+                '<label class="col-sm-3 control-label" for="labels">Label:  <span class="required">*</span></label>' +
+                '<div class="controls col-sm-5">' +
+                '<input class="form-control input-btn" name="labels[]" id="field' + count +'" placeholder="Enter another label" type="text" />' +
+                '<button id="remove_' + count + '" class="btn btn-danger remove-me">-</button>' +
+                '<button id="b1" class="btn" type="button">+</button>' +
+                '</div>' +
+                '<i class="fa fa-info-circle fa-lg" title="Enter the desired label in the following form: mycustomlabel"></i>' +
+                '</div>';
+            var newbox = $(nbox);
+            $('.label-box-new').append(newbox);
+        } else {
+            alert('Maximum number of labels reached.');
+        }
+    },
+
+    removeField: function(event) {
+        event.preventDefault();
+        var count = this.count;
+        $(event.currentTarget).parent('div').parent('div').remove();
+        count--;
+        this.count = count;
+        return this;
+    },
+
+    render: function() {
+        RockstorWizardPage.prototype.render.apply(this, arguments);
+        this.containers.fetch();
+        return this;
+    },
+
+    fetchContainers: function() {
+        var _this = this;
+        this.containers.fetch({
+            success: function() {
+                _this.model.set('containers', _this.containers);
+            }
+        });
+        return this;
+    },
+
+    renderContainers: function() {
+        this.containers_map = this.model.get('containers');
+        this.used_containers = [];
+        var _this = this;
+        for (var c in this.containers_map) {
+            this.used_containers.push(c);
+        }
+        this.filtered_containers = this.containers.filter(function(container) {
+            if (_this.used_containers.indexOf(container.get('name')) == -1) {
+                return container;
+            }
+        }, this);
+        this.$('#ph-add-labels-form').html(this.sub_template({
+            containers: this.filtered_containers.map(function(c) {
+                return c.toJSON();
+            })
+        }));
+        this.container_form = this.$('#container-select-form');
+        this.validator = this.container_form.validate({
+            rules: {
+                'container': 'required',
+                'labels[]': 'required'
+            },
+            messages: {
+                'container': 'Please select a container',
+                'labels[]': 'Please enter a label'
+            }
+        });
+        // Ensure previous page is correct
+        if (this.rockon.get('volume_add_support')) {
+            this.parent.pages[1] = RockonAddShare;
+        } else {
+        this.parent.pages[1] = RockonAddLabel;
+        }
+        return this;
+    },
+
+    save: function() {
+        if (!this.container_form.valid()) {
+            this.validator.showErrors();
+            return $.Deferred().reject();
+        }
+        var field_data = $('input[name^=labels]').map(function(idx, elem) {
+            return $(elem).val();
+        }).get();
+        var new_labels = {};
+        field_data.forEach(function(prop) {
+            new_labels[prop] = this.$('#container').val();
+        });
+        this.new_labels = new_labels;
+        this.model.set('new_labels', this.new_labels);
+        return $.Deferred().resolve();
+    }
 });
 
 RockonInfoSummary = RockstorWizardPage.extend({
@@ -1099,7 +1268,6 @@ RockonInfoSummary = RockstorWizardPage.extend({
         }));
         return this;
     }
-
 });
 
 RockonSettingsSummary = RockstorWizardPage.extend({
@@ -1121,19 +1289,46 @@ RockonSettingsSummary = RockstorWizardPage.extend({
             cc: this.model.get('custom_config').toJSON(),
             device: this.model.get('devices').toJSON(),
             env: this.model.get('environment').toJSON(),
+            labels: this.model.get('labels').toJSON(),
+            new_labels: this.model.get('new_labels'),
             rockon: this.model.get('rockon')
         }));
+        // Ensure previous page is correct
+        if (!$.isEmptyObject(this.model.get('new_labels'))) {
+            this.parent.pages[1] = RockonAddLabel;
+        } else {
+            if (this.rockon.get('volume_add_support')) {
+                this.parent.pages[1] = RockonAddShare;
+            } else {
+                this.parent.pages[1] = RockonAddLabel;
+            }
+        }
         return this;
     },
-    //@todo: remove this helper after finding out where new volumes is being used.
+
     initHandlebarHelpers: function() {
         Handlebars.registerHelper('display_newVolumes', function() {
+            // Display newly-defined shares and their corresponding mapping
+            // for confimation before submit in settings_summary_table.jst
             var html = '';
             for (share in this.new_volumes) {
                 html += '<tr>';
                 html += '<td>Share</td>';
                 html += '<td>' + this.new_volumes[share] + '</td>';
                 html += '<td>' + share + '</td>';
+                html += '</tr>';
+            }
+            return new Handlebars.SafeString(html);
+        });
+        Handlebars.registerHelper('display_newLabels', function() {
+            // Display newly-defined labels and their corresponding container
+            // for confimation before submit in settings_summary_table.jst
+            var html = '';
+            for (new_label in this.new_labels) {
+                html += '<tr>';
+                html += '<td>Label</td>';
+                html += '<td>' + this.new_labels[new_label] + '</td>';
+                html += '<td>' + new_label + '</td>';
                 html += '</tr>';
             }
             return new Handlebars.SafeString(html);
@@ -1146,6 +1341,7 @@ RockonSettingsComplete = RockstorWizardPage.extend({
         this.template = window.JST.rockons_update_complete;
         this.rockon = this.model.get('rockon');
         this.shares = this.model.get('shares');
+        this.new_labels = this.model.get('new_labels');
         RockstorWizardPage.prototype.initialize.apply(this, arguments);
     },
 
@@ -1166,7 +1362,8 @@ RockonSettingsComplete = RockstorWizardPage.extend({
             dataType: 'json',
             contentType: 'application/json',
             data: JSON.stringify({
-                'shares': this.shares
+                'shares': this.shares,
+                'labels': this.new_labels
             }),
             success: function() {}
         });

--- a/src/rockstor/storageadmin/urls/rockons.py
+++ b/src/rockstor/storageadmin/urls/rockons.py
@@ -17,18 +17,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.conf.urls import patterns, url
-from storageadmin.views import (RockOnView, RockOnIdView, RockOnVolumeView,
+from storageadmin.views import (RockOnView, RockOnIdView,
+                                RockOnVolumeView,
                                 RockOnPortView, RockOnCustomConfigView,
-                                RockOnEnvironmentView, RockOnDeviceView)
+                                RockOnEnvironmentView, RockOnDeviceView,
+                                RockOnContainerView, RockOnLabelView)
 
 urlpatterns = patterns(
     '',
     url(r'^$', RockOnView.as_view(), ),
     url(r'^/volumes/(?P<rid>\d+)$', RockOnVolumeView.as_view(), ),
+    url(r'^/docker/containers/(?P<rid>\d+)$', RockOnContainerView.as_view(), ),
     url(r'^/ports/(?P<rid>\d+)$', RockOnPortView.as_view(), ),
     url(r'^/customconfig/(?P<rid>\d+)$', RockOnCustomConfigView.as_view(), ),
     url(r'^/environment/(?P<rid>\d+)$', RockOnEnvironmentView.as_view(), ),
     url(r'^/devices/(?P<rid>\d+)$', RockOnDeviceView.as_view(), ),
+    url(r'^/labels/(?P<rid>\d+)$', RockOnLabelView.as_view(), ),
     url(r'^/(?P<command>update)$', RockOnView.as_view(), ),
     url(r'^/(?P<rid>\d+)$', RockOnIdView.as_view(), ),
     url(r'^/(?P<rid>\d+)/(?P<command>install|uninstall|update|start|stop|state_update|status_update)$',  # noqa E501

--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -45,11 +45,13 @@ from pool_balance import PoolBalanceView  # noqa F401
 from tls_certificate import TLSCertificateView  # noqa F401
 from rockon import RockOnView  # noqa F401
 from rockon_id import RockOnIdView  # noqa F401
+from rockon_container import RockOnContainerView  # noqa F401
 from rockon_volume import RockOnVolumeView  # noqa F401
 from rockon_port import RockOnPortView  # noqa F401
 from rockon_custom_config import RockOnCustomConfigView  # noqa F401
 from rockon_environment import RockOnEnvironmentView  # noqa F401
 from rockon_device import RockOnDeviceView  # noqa F401
+from rockon_labels import RockOnLabelView  # noqa F401
 from disk_smart import DiskSMARTDetailView  # noqa F401
 from config_backup import (ConfigBackupListView, ConfigBackupDetailView,  # noqa F401
                            ConfigBackupUpload)  # noqa F401

--- a/src/rockstor/storageadmin/views/rockon_container.py
+++ b/src/rockstor/storageadmin/views/rockon_container.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from storageadmin.models import (RockOn, DContainer)
+from storageadmin.serializers import RockOnContainerSerializer
+import rest_framework_custom as rfc
+from storageadmin.util import handle_exception
+
+
+class RockOnContainerView(rfc.GenericView):
+    serializer_class = RockOnContainerSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        try:
+            rockon = RockOn.objects.get(id=self.kwargs['rid'])
+        except:
+            e_msg = 'Rock-on ({}) does not exist.'.format(self.kwargs['rid'])
+            handle_exception(Exception(e_msg), self.request)
+
+        containers = DContainer.objects.filter(rockon=rockon)
+        return containers.order_by('id')

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -26,7 +26,8 @@ from system.services import service_status
 from storageadmin.models import (RockOn, DContainer, DVolume, DPort,
                                  DCustomConfig, DContainerLink,
                                  ContainerOption, DContainerEnv,
-                                 DContainerDevice, DContainerArgs)
+                                 DContainerDevice, DContainerArgs,
+                                 DContainerLabel)
 from fs.btrfs import mount_share
 from rockon_utils import container_status
 import logging
@@ -222,6 +223,14 @@ def envars(container):
     return var_list
 
 
+def labels_ops(container):
+    labels_list = []
+    for l in DContainerLabel.objects.filter(container=container):
+        if len(l.val.strip()) > 0:
+            labels_list.extend(['--label', '%s' % (l.val)])
+    return labels_list
+
+
 def generic_install(rockon):
     for c in DContainer.objects.filter(rockon=rockon).order_by('launch_order'):
         rm_container(c.name)
@@ -241,6 +250,7 @@ def generic_install(rockon):
         cmd.extend(port_ops(c))
         cmd.extend(container_ops(c))
         cmd.extend(envars(c))
+        cmd.extend(labels_ops(c))
         cmd.append(c.dimage.name)
         cmd.extend(cargs(c))
         run_command(cmd)

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -183,6 +183,7 @@ class RockOnIdView(rfc.GenericView):
                 rockon.save()
                 for co in DContainer.objects.filter(rockon=rockon):
                     DVolume.objects.filter(container=co, uservol=True).delete()
+                    DContainerLabel.objects.filter(container=co).delete()
             elif (command == 'update'):
                 self._pending_check(request)
                 if (rockon.state != 'installed'):

--- a/src/rockstor/storageadmin/views/rockon_labels.py
+++ b/src/rockstor/storageadmin/views/rockon_labels.py
@@ -1,0 +1,37 @@
+"""
+Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from storageadmin.models import (RockOn, DContainer, DContainerLabel)
+from storageadmin.serializers import RockOnLabelSerializer
+import rest_framework_custom as rfc
+from storageadmin.util import handle_exception
+
+
+class RockOnLabelView(rfc.GenericView):
+    serializer_class = RockOnLabelSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        try:
+            rockon = RockOn.objects.get(id=self.kwargs['rid'])
+        except:
+            e_msg = 'Rock-on ({}) does not exist.'.format(self.kwargs['rid'])
+            handle_exception(Exception(e_msg), self.request)
+
+        containers = DContainer.objects.filter(rockon=rockon)
+        return DContainerLabel.objects.filter(
+            container__in=containers).order_by('id')


### PR DESCRIPTION
Implement new feature to allow users to specify Docker container labels to already-installed Rock-Ons. Fixes #1998 

### Concept and implementation  
This new feature is modeled after the current "Add storage" option to allow the users to facilitate the creation of multi-containers Rock-ons and most importantly multi-Rock-Ons environments, for which container labels can be crucial for identification of containers by other containers in the same environment. The Docker-aware Traefik reverse-proxy, for instance, makes [heavy use of labels](https://docs.traefik.io/user-guide/docker-and-lets-encrypt/#labels) to set its options and recognize which containers to place behind its proxy.

In Rockstor, and as mentioned in the corresponding issue (#1998), these containers labels can be defined either at the definition stage (`json` file) or from the webUI by the user, making use of the already setup container_update feature for the "Add Storage" option. As the latter is the only one allowing the user to define its own custom labels easily, it is greatly preferred.
As a result, this PR implement a new "Add Label" button found under the `RockOn Settings` window, next to the existing "Add Storage" button. Its function is showcased below:  

![issue1998_rockonaddlabel](https://user-images.githubusercontent.com/30297881/49762714-8c11b780-fc98-11e8-9eb2-041308fe3408.gif)

  
As each label needs to be applied at the **container level** rather than the Rock-On level, the first step requires the user to select the container to which the label(s) are to be applied through a drop-down menu showing all containers included in the Rockon:  

![image](https://user-images.githubusercontent.com/30297881/49762830-ee6ab800-fc98-11e8-80a2-c0579d7e7a3c.png)


Then, a dynamic series of `input text` fields allow the user to define one or more labels. The current limit is set at 10, mainly for cosmetic reasons as the window tends to overflow on shorter screen spaces.

Then, the list of container --> label mapping is summarizing for the user to confirm. Upon submission, the `update` procedure is started, in which Rockstor uninstalls the Rock-On before re-installing it with the new label(s) applied using the `--label xxx` flag to the `docker run` command, repeated as many times as there are labels defined. Note that although Docker established some character restrictions in labels, these are not enforced (yet?) so I chose not to enforce them either. **Let me know if you'd like this validation added.** See the relevant [Docker documentation](https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations):  

> Label keys should begin and end with a lower-case letter and should only contain lower-case alphanumeric characters, the period character (.), and the hyphen character (-). Consecutive periods or hyphens are not allowed.
> The period character (.) separates namespace “fields”. Label keys without namespaces are reserved for CLI use, allowing users of the CLI to interactively label Docker objects using shorter typing-friendly strings.
> These guidelines are not currently enforced and additional guidelines may apply to specific use cases.  

This PR was rebased on Rockstor 3.9.2-45 and tested under a clean new build.


### Known limitations
@schakrava , some points could be further improved, but let me know if any is considered blocking for now:  

1. The `input type=text` fields are not perfectly aligned horizontally, as well as their dynamic buttons.  
2. Related to the arbitrary limit of labels set to 10, no scrollbar appears when needed... I couldn't find a clean and robust way (robust between browsers) to implement it as of yet.  
3. Similarly, their horizontal alignment was forced in [CSS](https://github.com/FroggyFlox/rockstor-core/blob/9d03d2bd472ae46891002bdf91fc1986fc5f27d4/src/rockstor/storageadmin/static/storageadmin/css/style.css#L1251-L1259) as repasted below:     

```
.input-btn {
    display: inline !important;
    width: 70% !important;
}


#field1 {
    display: inline !important;
    width: 83% !important;
}
```

### Main changes 

1. New storageadmin model to store newly-defined labels: _DcontainerLabel_ A migration file is included in the PR. It was generated and tested as follows:  
```
[root@rockdev ~]# /opt/build/bin/django makemigrations storageadmin
Migrations for 'storageadmin':
  0007_auto_20181210_0740.py:
    - Create model DContainerLabel
    - Alter unique_together for dcontainerlabel (1 constraint(s))

[root@rockdev ~]# /opt/build/bin/django migrate storageadmin
Operations to perform:
  Apply all migrations: storageadmin
Running migrations:
  Rendering model states... DONE
  Applying storageadmin.0007_auto_20181210_0740... OK
The following content types are stale and need to be deleted:

    storageadmin | networkinterface
    storageadmin | poolstatistic
    storageadmin | sharestatistic

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

    Type 'yes' to continue, or 'no' to cancel: no

[root@rockdev ~]# /opt/build/bin/django showmigrations
admin
 [ ] 0001_initial
auth
 [X] 0001_initial
 [X] 0002_alter_permission_name_max_length
 [X] 0003_alter_user_email_max_length
 [X] 0004_alter_user_username_opts
 [X] 0005_alter_user_last_login_null
 [X] 0006_require_contenttypes_0002
contenttypes
 [X] 0001_initial
 [X] 0002_remove_content_type_name
django_ztask
 (no migrations)
oauth2_provider
 [X] 0001_initial
 [ ] 0002_08_updates
sessions
 [ ] 0001_initial
sites
 [ ] 0001_initial
smart_manager
 [ ] 0001_initial
 [ ] 0002_auto_20170216_1212
storageadmin
 [X] 0001_initial
 [X] 0002_auto_20161125_0051
 [X] 0003_auto_20170114_1332
 [X] 0004_auto_20170523_1140
 [X] 0005_auto_20180913_0923
 [X] 0006_dcontainerargs
 [X] 0007_auto_20181210_0740
```

2. Additions and changes to [storageadmin JS models](https://github.com/FroggyFlox/rockstor-core/blob/9d03d2bd472ae46891002bdf91fc1986fc5f27d4/src/rockstor/storageadmin/static/storageadmin/js/models/models.js#L175-L193): Fix URL for `Container` and `ContainerCollection`, needed to pull up the containers included in the Rock-On of interest. After looking throughout the repo for the use of the `Container` model but failing to see any, I decided to modify it to fit my needs. In particular, the `model` definition for the `ContainerCollection` was switched from `Image` to `Container`, and the corresponding urls for API calls were corrected. 
`url(r'^/docker/containers/(?P<rid>\d+)$', RockOnContainerView.as_view(), ),` and 
`    url(r'^/labels/(?P<rid>\d+)$', RockOnLabelView.as_view(), ),`.  

3. Additions and changes to [storageadmin JS models](https://github.com/FroggyFlox/rockstor-core/blob/9d03d2bd472ae46891002bdf91fc1986fc5f27d4/src/rockstor/storageadmin/static/storageadmin/js/models/models.js#L753-L771): `RockOnLabel` and `RockOnLabelCollection`, with their corresponding additions in urls for API calls.  

4. Changed template for `RockonSettingSummaryWizard` to a new one dedicated one with the addition of the new "Add Label" button next to the existing "Add Storage" one.  

5. Similarly, add new templates for `add-labels` and `add-labels-form`.  

6. Fix previously incorrect fetch of Rock-On _Devices_ to be displayed in the RckOnSettingsSummary table. I improperly implemented that in #1962; I apologize for missing this in this previous PR.  

7. Flake8 and ESLint formatting on newly-added code was verified.

