### PR TITLE
Skip empty label fields

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -1241,7 +1241,9 @@ RockonAddLabel = RockstorWizardPage.extend({
             return $.Deferred().reject();
         }
         var field_data = $('input[name^=labels]').map(function(idx, elem) {
-            return $(elem).val();
+            if ($(elem).val() != "") {
+                return $(elem).val();
+            }
         }).get();
         var new_labels = {};
         field_data.forEach(function(prop) {


### PR DESCRIPTION
Add simple if statement to ignore fields with empty values for labels.

Fixes #2018.