### PR TITLE
Fix size sorting on snapshots / shares pages.

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/shares.js
@@ -78,8 +78,8 @@ SharesView = RockstorLayoutView.extend({
         var customs = {
             columnDefs: [
                 { type: 'file-size', targets: 1 },
-                { type: 'file-size', targets: 3 },
-                { type: 'file-size', targets: 4 }
+                { type: 'file-size', targets: 2 },
+                { type: 'file-size', targets: 3 }
             ]
         };
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/snapshots.js
@@ -93,8 +93,8 @@ SnapshotsView = SnapshotsCommonView.extend({
 
         var customs = {
             columnDefs: [
-                { type: 'file-size', targets: 6 },
-                { type: 'file-size', targets: 7 }
+                { type: 'file-size', targets: 2 },
+                { type: 'file-size', targets: 3 }
             ]
         };
 


### PR DESCRIPTION
The snapshots sorting indexes were based off the snapshots table of an individual share.
`snapshots_table_template.jst`
This page doesn't actually use datatables. Corrected indexes to correct page `snapshots.jst`

The shares table indexes were off as table header has changed since (see `shares_table.jst`)

EDIT (added by @phillxnet ):
Fixes #1368
Fixes #1878