### PR TITLE
Fix ENV display in RockonInstall_summary-table. Fixes #2029

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/summary_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/summary_table.jst
@@ -19,6 +19,7 @@
     <td>{{@key}}</td>
     <td>{{this}}</td>
   </tr>
+  {{/each}}
   {{#each cc_map}}
   <tr>
     <td>Custom</td>
@@ -39,6 +40,5 @@
     <td>{{@key}}</td>
     <td>{{this}}</td>
   </tr>
-  {{/each}}
   {{/each}}
 </table>


### PR DESCRIPTION
The {{#each port_map}} tag was improperly closed, causing the rest of the template to be dysfunctional.
An example consequence is described in #2029 where the ENV variable values are not displayed to the user. See the image below taken from this issue thanks to @martinwlee:

![image](https://user-images.githubusercontent.com/48964809/55290266-1fe2cd00-53c9-11e9-81ec-936cc9ac22a0.jpg)


This commit simply relocates the closing {{/each}} tag to its proper location.
Following the example above, the ENV values are properly displayed at the rockon install summary:
![image](https://user-images.githubusercontent.com/30297881/55292393-5532ef00-53b8-11e9-8bb2-de9e619ac603.png)

Fixes #2029. 
