### PR TITLE
[openSUSE] don't rely on PGDATA env var. Fixes #2041

### DIFF
--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -357,7 +357,7 @@ def main():
             if os.path.isfile('/usr/bin/initdb'):
                 logger.debug('running generic initdb on {}'.format(pg_data))
                 run_command(
-                    ['su', '-', 'postgres', '-c', '/usr/bin/initdb', pg_data])
+                    ['su', '-', 'postgres', '-c', '/usr/bin/initdb -D {}'.format(pg_data)])
         logging.info('Done.')
         run_command([SYSCTL, 'restart', 'postgresql'])
         run_command([SYSCTL, 'status', 'postgresql'])


### PR DESCRIPTION
Explicitly define Postgresql db 'data' directory, in openSUSE code path, via initdb's -D option. Use existing in code pg_data var which is set to the normal default of '/var/lib/pgsql/data' anyway. Prior use of pg_data in this code path was ineffectual.

Fixes #2041 

Ready for review.

Please see issue text for context, including forum origin references.

