### PR TITLE
Source docker.service configuration from package in openSUSE

### DIFF
--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -76,8 +76,11 @@ class DockerServiceView(BaseServiceDetailView):
             distro_id = distro.id()  # for Leap 15 <--> Tumbleweed moves.
             if distro_id not in KNOWN_DISTRO_IDS:
                 distro_id = 'generic'
-            # TODO: Consider sourcing /usr/lib/systemd/system/docker.service
-            inf = '{}/docker-{}.service'.format(settings.CONFROOT, distro_id)
+            # If openSUSE, source conf file from docker package itself
+            if re.match('opensuse', distro_id) is not None:
+                inf = '/usr/lib/systemd/system/docker.service'
+            else:
+                inf = '{}/docker-{}.service'.format(settings.CONFROOT, distro_id)
             outf = '/etc/systemd/system/docker.service'
             with open(inf) as ino, open(outf, 'w') as outo:
                 for l in ino.readlines():


### PR DESCRIPTION
Fixes #2044 

In Leap 15.1 rc, the docker package was updated, breaking our use of `docker-opensuse-leap.service` due to unmet dependencies. 
As proposed in a previous rework from @phillxnet (#1989, see below), we can move to sourcing the docker-ce package's configuration file directly and apply our custom settings onto it. This will help keep our custom settings in sync with any changes in the upstream docker-ce package.
https://github.com/rockstor/rockstor-core/blob/1102e2805a9290704ed6f3fd8963dbab37674c5e/src/rockstor/smart_manager/views/docker_service.py#L79

Note that these changes are proposed to be done only for OpenSUSE-based Rockstor builds in order to keep full compatibility with our existing centOS builds.

### Summary of changes
This PR simply sources the package's `docker.service` file from `/usr/lib/systemd/system/docker.service` if `distro_id` is either `opensuse-lead` or `opensuse-tumbleweed`.

### Turning the Rock-on service ON
#### CentOS
```
May 21 10:50:01 rockdev systemd[1]: Reloading.
May 21 10:50:01 rockdev systemd[1]: Starting Docker Socket for the API.
May 21 10:50:01 rockdev systemd[1]: Listening on Docker Socket for the API.
May 21 10:50:01 rockdev systemd[1]: Started Docker Application Container Engine.
```

#### Leap 15.1 rc
```
May 21 10:16:57 rockdev systemd[1]: Reloading.
May 21 10:16:57 rockdev systemd[1]: Starting Docker Application Container Engine...
May 21 10:16:58 rockdev kernel: bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
May 21 10:16:58 rockdev kernel: Bridge firewalling registered
May 21 10:16:58 rockdev kernel: nf_conntrack version 0.5.0 (16384 buckets, 65536 max)
May 21 10:16:58 rockdev kernel: ip_tables: (C) 2000-2006 Netfilter Core Team
May 21 10:16:58 rockdev kernel: Initializing XFRM netlink socket
May 21 10:16:58 rockdev kernel: Netfilter messages via NETLINK v0.30.
May 21 10:16:58 rockdev kernel: ctnetlink v0.93: registering with nfnetlink.
May 21 10:16:58 rockdev systemd-udevd[29250]: link_config: autonegotiation is unset or enabled, the speed and duplex are not writable.
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.5767] manager: (docker0): new Bridge device (/org/freedesktop/NetworkManager/Devices/3)
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6129] device (docker0): state change: unmanaged -> unavailable (reason 'connection-assumed', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6148] keyfile: add connection in-memory (76d248d1-0646-4b2d-af60-d64db1b236c4,"docker0")
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6153] device (docker0): state change: unavailable -> disconnected (reason 'connection-assumed', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6161] device (docker0): Activation: starting connection 'docker0' (76d248d1-0646-4b2d-af60-d64db1b236c4)
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6165] device (docker0): state change: disconnected -> prepare (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6169] device (docker0): state change: prepare -> config (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6173] device (docker0): state change: config -> ip-config (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6174] device (docker0): state change: ip-config -> ip-check (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6178] device (docker0): state change: ip-check -> secondaries (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6180] device (docker0): state change: secondaries -> activated (reason 'none', sys-iface-state: 'external')
May 21 10:16:58 rockdev NetworkManager[803]: <info>  [1558448218.6189] device (docker0): Activation: successful, device activated.
May 21 10:16:58 rockdev dbus-daemon[709]: [system] Activating via systemd: service name='org.freedesktop.nm_dispatcher' unit='dbus-org.freedesktop.nm-dispatcher.service' requested by ':1.2' (uid=0 pid=803 comm="/usr/sbin/NetworkManager --no-daemon ")
May 21 10:16:58 rockdev kernel: IPv6: ADDRCONF(NETDEV_UP): docker0: link is not ready
May 21 10:16:58 rockdev systemd[1]: Starting Network Manager Script Dispatcher Service...
May 21 10:16:58 rockdev dbus-daemon[709]: [system] Successfully activated service 'org.freedesktop.nm_dispatcher'
May 21 10:16:58 rockdev systemd[1]: Started Network Manager Script Dispatcher Service.
May 21 10:16:58 rockdev nm-dispatcher[29277]: req:1 'up' [docker0]: new request (3 scripts)
May 21 10:16:58 rockdev nm-dispatcher[29277]: req:1 'up' [docker0]: start running ordered scripts...
May 21 10:16:58 rockdev systemd[1]: Started Docker Application Container Engine.
```

#### Tumbleweed 20190517

```
May 21 10:30:58 rockdev systemd[1]: Starting Docker Application Container Engine...
May 21 10:30:59 rockdev kernel: bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
May 21 10:30:59 rockdev kernel: Bridge firewalling registered
May 21 10:30:59 rockdev kernel: bpfilter: Loaded bpfilter_umh pid 3236
May 21 10:30:59 rockdev kernel: Initializing XFRM netlink socket
May 21 10:30:59 rockdev systemd-udevd[3228]: Using default interface naming scheme 'v240'.
May 21 10:30:59 rockdev NetworkManager[888]: <info>  [1558449059.1882] manager: (docker0): new Bridge device (/org/freedesktop/NetworkManager/Devices/3)
May 21 10:30:59 rockdev systemd-udevd[3228]: link_config: autonegotiation is unset or enabled, the speed and duplex are not writable.
May 21 10:30:59 rockdev systemd-udevd[3228]: Could not generate persistent MAC address for docker0: No such file or directory
May 21 10:30:59 rockdev systemd[1]: Started Docker Application Container Engine.
```

### Final docker.service contents
#### CentOS  
```
[root@rockdev ~]# cat /etc/systemd/system/docker.service 
[Unit]
Description=Docker Application Container Engine
Documentation=http://docs.docker.com
After=network.target docker.socket rockstor-bootstrap.service
Requires=docker.socket

[Service]
ExecStart=/opt/build/bin/docker-wrapper /mnt2/rockons_root
MountFlags=slave
LimitNOFILE=1048576
LimitNPROC=1048576
LimitCORE=infinity

[Install]
WantedBy=multi-user.target
[root@rockdev ~]# 
```

#### Leap 15.1 rc

```
linux-1pi9:~ # cat /etc/systemd/system/docker.service 
[Unit]
Description=Docker Application Container Engine
Documentation=http://docs.docker.com
After=network.target lvm2-monitor.service SuSEfirewall2.service rockstor-bootstrap.service

[Service]
EnvironmentFile=/etc/sysconfig/docker

# While Docker has support for socket activation (-H fd://), this is not
# enabled by default because enabling socket activation means that on boot your
# containers won't start until someone tries to administer the Docker daemon.
Type=notify
NotifyAccess=all
ExecStart=/opt/build/bin/docker-wrapper --add-runtime oci=/usr/sbin/docker-runc $DOCKER_NETWORK_OPTIONS $DOCKER_OPTS /mnt2/rockons_root
ExecReload=/bin/kill -s HUP $MAINPID

# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=1048576
LimitNPROC=infinity
LimitCORE=infinity

# Uncomment TasksMax if your systemd version supports it.
# Only systemd 226 and above support this property.
TasksMax=infinity

# Set delegate yes so that systemd does not reset the cgroups of docker containers
# Only systemd 218 and above support this property.
Delegate=yes

# Kill only the docker process, not all processes in the cgroup.
KillMode=process

# Restart the docker process if it exits prematurely.
Restart=on-failure
StartLimitBurst=3
StartLimitInterval=60s

[Install]
WantedBy=multi-user.target
```

#### Tumbleweed 20190517

```
rockdev:~ # cat /etc/systemd/system/docker.service 
[Unit]
Description=Docker Application Container Engine
Documentation=http://docs.docker.com
After=network.target lvm2-monitor.service SuSEfirewall2.service rockstor-bootstrap.service

[Service]
EnvironmentFile=/etc/sysconfig/docker

# While Docker has support for socket activation (-H fd://), this is not
# enabled by default because enabling socket activation means that on boot your
# containers won't start until someone tries to administer the Docker daemon.
Type=notify
NotifyAccess=all
ExecStart=/opt/build/bin/docker-wrapper --add-runtime oci=/usr/sbin/docker-runc $DOCKER_NETWORK_OPTIONS $DOCKER_OPTS /mnt2/rockons_root
ExecReload=/bin/kill -s HUP $MAINPID

# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=1048576
LimitNPROC=infinity
LimitCORE=infinity

# Uncomment TasksMax if your systemd version supports it.
# Only systemd 226 and above support this property.
TasksMax=infinity

# Set delegate yes so that systemd does not reset the cgroups of docker containers
# Only systemd 218 and above support this property.
Delegate=yes

# Kill only the docker process, not all processes in the cgroup.
KillMode=process

# Restart the docker process if it exits prematurely.
Restart=on-failure
StartLimitBurst=3
StartLimitInterval=60s

[Install]
WantedBy=multi-user.target
```

### Shortcomings and potential improvements
Should we test for the existence of the source file (`/usr/lib/systemd/system/docker.service`) and raise an exception if not found? It is my understanding that the docker-ce package will be "shipped" with the Rockstor build so it should always be present, but should we still account for this possibility?

