### PR TITLE
Fix restore of samba share export

### DIFF
--- a/src/rockstor/storageadmin/tests/test_disks.py
+++ b/src/rockstor/storageadmin/tests/test_disks.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -26,180 +26,180 @@ from storageadmin.tests.test_api import APITestMixin
 
 class DiskTests(APITestMixin, APITestCase):
     # fixtures = ['fix1.json']
-    fixtures = ['test_disks.json']
-    BASE_URL = '/api/disks'
+    fixtures = ["test_disks.json"]
+    BASE_URL = "/api/disks"
 
     @classmethod
     def setUpClass(cls):
         super(DiskTests, cls).setUpClass()
 
         # post mocks
-        cls.patch_wipe_disk = patch('storageadmin.views.disk.wipe_disk')
+        cls.patch_wipe_disk = patch("storageadmin.views.disk.wipe_disk")
         cls.mock_wipe_disk = cls.patch_wipe_disk.start()
-        cls.mock_wipe_disk.return_value = 'out', 'err', 0
+        cls.mock_wipe_disk.return_value = "out", "err", 0
 
-        cls.patch_scan_disks = patch('storageadmin.views.disk.scan_disks')
+        cls.patch_scan_disks = patch("storageadmin.views.disk.scan_disks")
         cls.mock_scan_disks = cls.patch_scan_disks.start()
 
-        cls.patch_blink_disk = patch('storageadmin.views.disk.blink_disk')
+        cls.patch_blink_disk = patch("storageadmin.views.disk.blink_disk")
         cls.mock_blink_disk = cls.patch_blink_disk.start()
 
-        cls.patch_mount_root = patch('storageadmin.views.disk.mount_root')
+        cls.patch_mount_root = patch("storageadmin.views.disk.mount_root")
         cls.mock_mount_root = cls.patch_mount_root.start()
 
-        cls.patch_pool_raid = patch('storageadmin.views.disk.pool_raid')
+        cls.patch_pool_raid = patch("storageadmin.views.disk.pool_raid")
         cls.mock_pool_raid = cls.patch_pool_raid.start()
-        cls.mock_pool_raid.return_value = {'data': 'single',
-                                           'metadata': 'single'}
+        cls.mock_pool_raid.return_value = {"data": "single", "metadata": "single"}
 
-        cls.patch_enable_quota = patch('storageadmin.views.disk.enable_quota')
+        cls.patch_enable_quota = patch("storageadmin.views.disk.enable_quota")
         cls.mock_enable_quota = cls.patch_enable_quota.start()
 
-        cls.patch_import_shares = patch(
-            'storageadmin.views.disk.import_shares')
+        cls.patch_import_shares = patch("storageadmin.views.disk.import_shares")
         cls.mock_import_shares = cls.patch_import_shares.start()
 
         # TODO: maybe patch as storageadmin.views.disk.smart.toggle_smart
-        cls.patch_toggle_smart = patch('system.smart.toggle_smart')
+        cls.patch_toggle_smart = patch("system.smart.toggle_smart")
         cls.mock_toggle_smart = cls.patch_toggle_smart.start()
-        cls.mock_toggle_smart.return_value = [''], [''], 0
+        cls.mock_toggle_smart.return_value = [""], [""], 0
 
         # primarily for test_btrfs_disk_import (to emulate a successful import)
-        cls.patch_get_pool_info = patch(
-            'storageadmin.views.disk.get_pool_info')
+        cls.patch_get_pool_info = patch("storageadmin.views.disk.get_pool_info")
         cls.mock_get_pool_info = cls.patch_get_pool_info.start()
-        cls.fake_pool_info = {'disks': ['mock-disk'], 'label': 'mock-label',
-                              'uuid': 'b3d201a8-b497-4365-a90d-a50c50b8e808'}
+        cls.fake_pool_info = {
+            "disks": ["mock-disk"],
+            "label": "mock-label",
+            "uuid": "b3d201a8-b497-4365-a90d-a50c50b8e808",
+        }
         cls.mock_get_pool_info.return_value = cls.fake_pool_info
 
-        cls.temp_disk = Disk(id=2, name='mock-disk', size=88025459,
-                             parted=False)
+        cls.temp_disk = Disk(id=2, name="mock-disk", size=88025459, parted=False)
 
     @classmethod
     def tearDownClass(cls):
         super(DiskTests, cls).tearDownClass()
 
     def test_disk_scan(self):
-        response = self.client.post(('{}/scan'.format(self.BASE_URL)),
-                                    data=None, format='json')
+        response = self.client.post(
+            ("{}/scan".format(self.BASE_URL)), data=None, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_invalid_disk_wipe(self):
         fake_dId = 99999
-        url = ('{}/{}/wipe'.format(self.BASE_URL, fake_dId))
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
-        e_msg = 'Disk id ({}) does not exist.'.format(fake_dId)
+        url = "{}/{}/wipe".format(self.BASE_URL, fake_dId)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        e_msg = "Disk id ({}) does not exist.".format(fake_dId)
         self.assertEqual(response.data[0], e_msg)
 
     def test_invalid_command(self):
-        url = ('{}/1/invalid'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
-        e_msg = ('Unsupported command (invalid). Valid commands are; wipe, '
-                 'btrfs-wipe, luks-format, btrfs-disk-import, blink-drive, '
-                 'enable-smart, disable-smart, smartcustom-drive, '
-                 'spindown-drive, pause, role-drive, '
-                 'luks-drive.')
+        url = "{}/1/invalid".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        e_msg = (
+            "Unsupported command (invalid). Valid commands are; wipe, "
+            "btrfs-wipe, luks-format, btrfs-disk-import, blink-drive, "
+            "enable-smart, disable-smart, smartcustom-drive, "
+            "spindown-drive, pause, role-drive, "
+            "luks-drive."
+        )
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_disk_wipe(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
         # btrfs-wipe is an aliase for wipe; ensure it exists.
-        url = ('{}/2/btrfs-wipe'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
+        url = "{}/2/btrfs-wipe".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        url = ('{}/2/wipe'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
+        url = "{}/2/wipe".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        e_msg = 'mock example exception surfaced from wipe_disk()'
+        e_msg = "mock example exception surfaced from wipe_disk()"
         self.mock_wipe_disk.side_effect = Exception(e_msg)
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertEqual(response.data[0], e_msg)
         self.mock_wipe_disk.side_effect = None
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_btrfs_disk_import(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
-        url = ('{}/2/btrfs-disk-import'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
+        url = "{}/2/btrfs-disk-import".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_btrfs_disk_import_fail(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
-        mock_e_msg = ("Error running a command. cmd = /sbin/btrfs fi show "
-                      "/dev/disk/by-id/{}. rc = 1. stdout = ['']. stderr = "
-                      "['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/"
-                      "{}', '']").format(self.temp_disk.name,
-                                         self.temp_disk.name)
+        mock_e_msg = (
+            "Error running a command. cmd = /sbin/btrfs fi show "
+            "/dev/disk/by-id/{}. rc = 1. stdout = ['']. stderr = "
+            "['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/"
+            "{}', '']"
+        ).format(self.temp_disk.name, self.temp_disk.name)
 
         self.mock_get_pool_info.side_effect = Exception(mock_e_msg)
 
-        url = ('{}/2/btrfs-disk-import'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
-        e_msg = "Failed to import any pool on device id ({}). " \
-                "Error: ({}).".format(self.temp_disk.id, mock_e_msg)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
+        url = "{}/2/btrfs-disk-import".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
+        e_msg = (
+            "Failed to import any pool on device db id ({}). "
+            "Error: ({}).".format(self.temp_disk.id, mock_e_msg)
+        )
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_blink_drive(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
-        url = ('{}/2/blink-drive'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
+        url = "{}/2/blink-drive".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_enable_smart(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
-        url = ('{}/2/enable-smart'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
-        e_msg = 'S.M.A.R.T support is not available on ' \
-                'disk ({}).'.format(self.temp_disk.name)
+        url = "{}/2/enable-smart".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        e_msg = "S.M.A.R.T support is not available on disk ({}).".format(
+            self.temp_disk.name
+        )
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_enable_smart_when_available(self, mock_disk):
 
         self.temp_disk.smart_available = True
         mock_disk.objects.get.return_value = self.temp_disk
 
-        url = ('{}/2/enable-smart'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK)
+        url = "{}/2/enable-smart".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @mock.patch('storageadmin.views.disk.Disk')
+    @mock.patch("storageadmin.views.disk.Disk")
     def test_disable_smart(self, mock_disk):
 
         mock_disk.objects.get.return_value = self.temp_disk
 
-        url = ('{}/2/disable-smart'.format(self.BASE_URL))
-        response = self.client.post(url, data=None, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR)
-        e_msg = 'S.M.A.R.T support is not available on ' \
-                'disk ({}).'.format(self.temp_disk.name)
+        url = "{}/2/disable-smart".format(self.BASE_URL)
+        response = self.client.post(url, data=None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        e_msg = "S.M.A.R.T support is not available on disk ({}).".format(
+            self.temp_disk.name
+        )
         self.assertEqual(response.data[0], e_msg)

--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -20,77 +20,310 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from mock import patch
 
-from storageadmin.models import Pool, Share, SambaCustomConfig, SambaShare
+from storageadmin.exceptions import RockStorAPIException
+from storageadmin.models import Pool, Share, SambaCustomConfig, SambaShare, User
 from storageadmin.tests.test_api import APITestMixin
 
+from storageadmin.views.samba import SambaListView, logger
 
-class SambaTests(APITestMixin, APITestCase):
+
+class SambaTests(APITestMixin, APITestCase, SambaListView):
     # fixture with:
     # share-smb - SMB exported with defaults: (comment "Samba-Export")
     # {'browsable': 'yes', 'guest_ok': 'no', 'read_only': 'no'}
     # share2 - no SMB export
     # fixtures = ['fix3.json']
-    fixtures = ['test_smb.json']
-    BASE_URL = '/api/samba'
+    fixtures = ["test_smb.json"]
+    BASE_URL = "/api/samba"
 
     @classmethod
     def setUpClass(cls):
         super(SambaTests, cls).setUpClass()
 
         # post mocks
-        cls.patch_mount_share = patch('storageadmin.views.samba.mount_share')
+        cls.patch_mount_share = patch("storageadmin.views.samba.mount_share")
         cls.mock_mount_share = cls.patch_mount_share.start()
 
         # mock Share model's mount_status utility
         # True = Share is mounted, False = Share unmounted
-        cls.patch_mount_status = patch('system.osi.mount_status')
+        cls.patch_mount_status = patch("system.osi.mount_status")
         cls.mock_mount_status = cls.patch_mount_status.start()
         cls.mock_mount_status.return_value = True
 
-        cls.patch_status = patch('storageadmin.views.samba.status')
+        cls.patch_status = patch("storageadmin.views.samba.status")
         cls.mock_status = cls.patch_status.start()
-        cls.mock_status.return_value = 'out', 'err', 0
+        cls.mock_status.return_value = "out", "err", 0
 
-        cls.patch_restart_samba = patch('storageadmin.views.samba.'
-                                        'restart_samba')
+        cls.patch_restart_samba = patch("storageadmin.views.samba.restart_samba")
         cls.mock_status = cls.patch_restart_samba.start()
 
-        cls.patch_refresh_smb_config = patch('storageadmin.views.samba.'
-                                             'refresh_smb_config')
+        cls.patch_refresh_smb_config = patch(
+            "storageadmin.views.samba.refresh_smb_config"
+        )
         cls.mock_refresh_smb_config = cls.patch_refresh_smb_config.start()
-        cls.mock_refresh_smb_config.return_value = 'smbconfig'
+        cls.mock_refresh_smb_config.return_value = "smbconfig"
 
         # all values as per fixture
-        cls.temp_pool = Pool(id=11, name='rock-pool', size=5242880)
-        cls.temp_share_smb = Share(id=23, name='share-smb', pool=cls.temp_pool)
+        cls.temp_pool = Pool(id=11, name="rock-pool", size=5242880)
+        cls.temp_share_smb = Share(id=23, name="share-smb", pool=cls.temp_pool)
         cls.temp_sambashare = SambaShare(id=1, share=cls.temp_share_smb)
         # cls.temp_smb_custom_config = \
         #     SambaCustomConfig(id=1, smb_share=cls.temp_sambashare)
 
-        cls.temp_share2 = Share(id=24, name='share2', pool=cls.temp_pool)
+        cls.temp_share2 = Share(id=24, name="share2", pool=cls.temp_pool)
 
     @classmethod
     def tearDownClass(cls):
         super(SambaTests, cls).tearDownClass()
 
-    def test_get(self):
+    def test_validate_input(self):
+        """
+        Test that _validate_input() returns a valid dict when:
+        1. all input data are filled and valid
+        2. no input data are specified (should return default options)
+        """
+        # 1. all input data are filled and valid
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        expected_result = {
+            "comment": "Samba-Export",
+            "read_only": "no",
+            "browsable": "yes",
+            "custom_config": [],
+            "guest_ok": "no",
+            "shadow_copy": False,
+        }
+        returned = self._validate_input(rdata=data)
+        self.assertEqual(
+            returned,
+            expected_result,
+            msg="Un-expected _validate_input() result:\n "
+            "returned = ({}).\n "
+            "expected = ({}).".format(returned, expected_result),
+        )
+
+        # 2. no input data are specified (should return default options)
+        data = {}
+        expected_result = {
+            "comment": "samba export",
+            "read_only": "no",
+            "browsable": "yes",
+            "custom_config": [],
+            "guest_ok": "no",
+            "shadow_copy": False,
+        }
+        returned = self._validate_input(rdata=data)
+        self.assertEqual(
+            returned,
+            expected_result,
+            msg="Un-expected _validate_input() result:\n "
+            "returned = ({}).\n "
+            "expected = ({}).".format(returned, expected_result),
+        )
+
+    def test_validate_input_error(self):
+        """
+        Test that _validate_input raises Exceptions when input data contain error(s).
+        The following cases are tested below:
+        1. invalid 'custom_config' information
+        2. invalid 'browsable' information
+        3. invalid 'guest_ok' information
+        4. invalid 'read_only' information
+        5. invalid 'shadow_copy' information
+        """
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "yes",
+            "custom_config": "not-a-list",
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self._validate_input(rdata=data)
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "maybe",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self._validate_input(rdata=data)
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": False,
+            "guest_ok": "maybe",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self._validate_input(rdata=data)
+        data = {
+            "read_only": "maybe",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self._validate_input(rdata=data)
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": ["test"],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["9", "10"],
+            "shadow_copy": True,
+            "guest_ok": "no",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self._validate_input(rdata=data)
+
+    @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
+    def test_create_samba_share(self, mock_validate_share):
+        """
+        Test that create_samba_share() returns a correct SambaShare object
+        when all conditions are valid.
+        """
+        mock_validate_share.return_value = self.temp_share_smb
+
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": [],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["23"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        expected_result = self.temp_sambashare
+        returned = self.create_samba_share(data)
+        self.assertEqual(
+            returned,
+            expected_result,
+            msg="Un-expected create_samba_share() result:\n "
+            "returned = ({} with id {}).\n "
+            "expected = ({} with id {}).".format(
+                returned, returned.id, expected_result, expected_result.id
+            ),
+        )
+
+    def test_create_samba_share_incorrect_share(self):
+        """
+        Test that create_samba_share() raises an exception
+        when a non-existing share is provided.
+        """
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": [],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["32"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        with self.assertRaises(RockStorAPIException):
+            self.create_samba_share(rdata=data)
+
+    @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
+    @mock.patch("storageadmin.views.samba.SambaShare.objects")
+    @mock.patch("storageadmin.views.samba.logger")
+    def test_create_samba_share_existing_export(
+        self, mock_validate_share, mock_sambashare, mock_logger
+    ):
+        """
+        Test that create_samba_share() logs the appropriate error
+        when the given share is already exported via Samba.
+        """
+        mock_validate_share.return_value = self.temp_share_smb
+        mock_sambashare.filter.return_value = mock_sambashare
+        mock_sambashare.exists.return_value = True
+
+        data = {
+            "read_only": "no",
+            "comment": "Samba-Export",
+            "admin_users": [],
+            "browsable": "yes",
+            "custom_config": [],
+            "snapshot_prefix": "",
+            "shares": ["23"],
+            "shadow_copy": False,
+            "guest_ok": "no",
+        }
+        # e_msg = ("Share ({}) is already exported via Samba.").format(
+        #     self.temp_share_smb.name
+        # )
+        self.create_samba_share(rdata=data)
+        mock_logger.error.assert_called()
+        # mock_logger.error.assert_called_with(e_msg)
+
+    @mock.patch("storageadmin.views.samba.SambaShare")
+    def test_get(self, mock_sambashare):
         """
         Test GET request
         1. Get base URL
-        2. Get request with id
+        2. Get request with valid id
+        """
+        self.get_base(self.BASE_URL)
+
+        # Create mock SambaShare
+        # smb_id = self.temp_sambashare.id
+        # Some conflict exists from a previous mock_sambashare, so set smb_id manually
+        smb_id = 1
+        # print("smb_id is {}".format(smb_id))
+        mock_sambashare.objects.get.return_value = self.temp_sambashare
+
+        # test get of detailed view for a valid smb_id
+        response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+        self.assertEqual(response.data["id"], smb_id)
+
+    def test_get_non_existent(self):
+        """
+        Test GET request
+        1. Get base URL
+        2. Get request with invalid id
         """
         # get base URL
         self.get_base(self.BASE_URL)
-
         # # get sambashare with id
         # response = self.client.get('{}/1'.format(self.BASE_URL))
         # self.assertEqual(response.status_code, status.HTTP_200_OK,
         #                  msg=response)
-
-        # get sambashare with non-existant id
-        response = self.client.get('{}/5'.format(self.BASE_URL))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND,
-                         msg=response)
+        # get sambashare with non-existent id
+        response = self.client.get("{}/5".format(self.BASE_URL))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, msg=response)
 
     def test_post_requests_1(self):
         """
@@ -99,65 +332,100 @@ class SambaTests(APITestMixin, APITestCase):
         """
 
         # create samba export with no share names
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes', }
+        data = {"browsable": "yes", "guest_ok": "yes", "read_only": "yes"}
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Must provide share names.'
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Must provide share names."
         self.assertEqual(response.data[0], e_msg)
 
-    def test_post_requests_2(self):
+    @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
+    @mock.patch("storageadmin.views.samba.User")
+    def test_post_requests_2(self, mock_user, mock_validate_share):
         """
          . Create a samba export for the share that has already been exported
         """
+        mock_validate_share.return_value = self.temp_share_smb
 
         # create samba with invalid browsable, guest_ok, read_only choices
-        data = {'shares': (24,), 'browsable': 'Y', 'guest_ok': 'yes',
-                'read_only': 'yes'}
+        data = {
+            "shares": ["23"],
+            "browsable": "Y",
+            "guest_ok": "yes",
+            "read_only": "yes",
+        }
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Invalid choice for browsable. Possible choices '
-                 'are yes or no.')
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Invalid choice for browsable. Possible choices are yes or no."
         self.assertEqual(response.data[0], e_msg)
 
-        data = {'shares': (24,), 'browsable': 'yes', 'guest_ok': 'Y',
-                'read_only': 'yes'}
+        data = {
+            "shares": ["23"],
+            "browsable": "yes",
+            "guest_ok": "Y",
+            "read_only": "yes",
+        }
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Invalid choice for guest_ok. Possible options are '
-                 'yes or no.')
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Invalid choice for guest_ok. Possible options are yes or no."
         self.assertEqual(response.data[0], e_msg)
 
-        data = {'shares': (24,), 'browsable': 'yes', 'guest_ok': 'yes',
-                'read_only': 'Y'}
+        data = {
+            "shares": ["23"],
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "Y",
+        }
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Invalid choice for read_only. Possible options '
-                 'are yes or no.')
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Invalid choice for read_only. Possible options are yes or no."
         self.assertEqual(response.data[0], e_msg)
 
         # create samba export
         # we use share id 24 (share2) as not yet smb exported.
-        data = {'shares': (24, ), 'browsable': 'yes', 'guest_ok': 'yes',
-                'read_only': 'yes', 'admin_users': ('admin', ),
-                'custom_config': ('CONFIG', 'XYZ')}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        smb_id = response.data['id']
+        data = {
+            "shares": ["24"],
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "admin_users": ("admin",),
+            "custom_config": ("CONFIG", "XYZ"),
+        }
+        mock_validate_share.return_value = self.temp_share2
+        mock_user.objects.get.side_effects = None
+        temp_user = User.objects.create(
+            username="admin", uid=1, gid=1, admin=False, user=self.user
+        )
+        mock_user.objects.get.return_value = temp_user
 
-        # test get of detailed view for the smb_id
-        response = self.client.get('{}/{}'.format(self.BASE_URL, smb_id))
-        self.assertEqual(response.status_code, status.HTTP_200_OK,
-                         msg=response.data)
-        self.assertEqual(response.data['id'], smb_id)
+        response = self.client.post(self.BASE_URL, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+
+        ## The test below may better belong to test_get() above, so move it there.
+        # smb_id = response.data["id"]
+        # print("response.data is {}".format(response.data))
+        #
+        # # test get of detailed view for the smb_id
+        # # First, save the SambaShare as created above (with id = 1)
+        # mock_sambashare.objects.get.return_value = self.temp_sambashare
+        # response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
+        # self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+        # self.assertEqual(response.data["id"], smb_id)
 
         # # TODO: Needs multiple share instances mocked
         # # create samba exports for multiple(3) shares at once
@@ -168,23 +436,42 @@ class SambaTests(APITestMixin, APITestCase):
         # self.assertEqual(response.status_code,
         #                  status.HTTP_200_OK, msg=response.data)
 
-        # create samba export with no admin users
-        data = {'shares': ('share5', ), 'browsable': 'yes', 'guest_ok': 'yes',
-                'read_only': 'yes', 'custom_config': ('CONFIG', 'XYZ')}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        ## post() does not raise exception in this condition anymore, but rather
+        ## logs an error as "Share (share.name) is already exported via Samba".
+        # # create samba export with the share that has already been exported above
+        # data = {
+        #     "shares": ["24"],
+        #     "browsable": "no",
+        #     "guest_ok": "yes",
+        #     "read_only": "yes",
+        # }
+        # response = self.client.post(self.BASE_URL, data=data)
+        # self.assertEqual(
+        #     response.status_code,
+        #     status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #     msg=response.data,
+        # )
+        # e_msg = "Share (share2) is already exported via Samba."
+        # self.assertEqual(response.data[0], e_msg)
 
-        # create samba export with the share that has already been exported
-        # above
-        data = {'shares': (24, ), 'browsable': 'no', 'guest_ok': 'yes',
-                'read_only': 'yes'}
+    @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
+    def test_post_requests_no_admin(self, mock_validate_share):
+        """
+        Test a valid post request creating a samba export
+        when no admin user is specified
+        """
+        mock_validate_share.return_value = self.temp_share_smb
+
+        # create samba export with no admin users
+        data = {
+            "shares": ["24"],
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "custom_config": ("CONFIG", "XYZ"),
+        }
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Share (share2) is already exported via Samba.'
-        self.assertEqual(response.data[0], e_msg)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
     def test_put_requests_1(self):
         """
@@ -193,18 +480,22 @@ class SambaTests(APITestMixin, APITestCase):
 
         # edit samba that does not exist
         smb_id = 99999
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes',
-                'admin_users': 'usr'}
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Samba export for the id ({}) does not exist.'.format(smb_id)
+        data = {
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "admin_users": "usr",
+        }
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Samba export for the id ({}) does not exist.".format(smb_id)
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.samba.SambaShare')
-
+    @mock.patch("storageadmin.views.samba.SambaShare")
     def test_put_requests_2(self, mock_sambashare):
         """
         1. Edit samba that does not exists
@@ -215,14 +506,19 @@ class SambaTests(APITestMixin, APITestCase):
 
         # edit samba with invalid custom config
         smb_id = 1
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes',
-                'custom_config': 'CONFIGXYZ'}
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Custom config must be a list of strings.'
+        data = {
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "custom_config": "CONFIGXYZ",
+        }
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Custom config must be a list of strings."
         self.assertEqual(response.data[0], e_msg)
 
         # test mount_share exception case
@@ -233,14 +529,15 @@ class SambaTests(APITestMixin, APITestCase):
         self.mock_mount_status.return_value = False
 
         smb_id = 1
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes', }
-        self.mock_mount_share.side_effect = KeyError('error')
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Failed to mount share (share-smb) due to a low level error.'
+        data = {"browsable": "yes", "guest_ok": "yes", "read_only": "yes"}
+        self.mock_mount_share.side_effect = KeyError("error")
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Failed to mount share (share-smb) due to a low level error."
         self.assertEqual(response.data[0], e_msg)
         # Return share mock mounted_state to mounted
         self.mock_mount_status.return_value = True
@@ -248,31 +545,38 @@ class SambaTests(APITestMixin, APITestCase):
         # happy path
         smb_id = 1
         self.mock_mount_share.side_effect = None
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes',
-                'admin_users': ('admin', ), 'custom_config': ('CONFIG', 'XYZ')}
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        data = {
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "admin_users": ("admin",),
+            "custom_config": ("CONFIG", "XYZ"),
+        }
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
         # edit samba export with admin user other than admin
         smb_id = 1
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes',
-                'admin_users': ('admin2', ), 'custom_config': ('CONFIG',
-                                                               'XYZ')}
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        data = {
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "admin_users": ("admin2",),
+            "custom_config": ("CONFIG", "XYZ"),
+        }
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
         # edit samba export passing no admin users
         smb_id = 1
-        data = {'browsable': 'yes', 'guest_ok': 'yes', 'read_only': 'yes',
-                'custom_config': ('CONFIG', 'XYZ')}
-        response = self.client.put('{}/{}'.format(self.BASE_URL, smb_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        data = {
+            "browsable": "yes",
+            "guest_ok": "yes",
+            "read_only": "yes",
+            "custom_config": ("CONFIG", "XYZ"),
+        }
+        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
     def test_delete_requests_1(self):
         """
@@ -280,24 +584,24 @@ class SambaTests(APITestMixin, APITestCase):
         """
         # Delete samba that does nor exists
         smb_id = 99999
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, smb_id))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Samba export for the id ({}) does not exist.'.format(smb_id)
+        response = self.client.delete("{}/{}".format(self.BASE_URL, smb_id))
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Samba export for the id ({}) does not exist.".format(smb_id)
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.samba.SambaShare')
+    @mock.patch("storageadmin.views.samba.SambaShare")
     def test_delete_requests_2(self, mock_sambashare):
         """
         . Delete samba
-
         """
 
         mock_sambashare.objects.get.return_value = self.temp_sambashare
 
         # happy path
         smb_id = 1
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, smb_id))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        response = self.client.delete("{}/{}".format(self.BASE_URL, smb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/views/config_backup.py
+++ b/src/rockstor/storageadmin/views/config_backup.py
@@ -82,9 +82,9 @@ def restore_samba_exports(ml):
         if (m['model'] == 'storageadmin.sambashare'):
             exports.append(m['fields'])
     for e in exports:
-        e['shares'] = [e['path'].split('/')[-1], ]
-        generic_post('%s/samba' % BASE_URL, e)
-    logger.debug('Finished restoring Samba exports.')
+        e['shares'] = []
+        e['shares'].append(e['share'])
+    generic_post('{}/samba'.format(BASE_URL), exports)
 
 
 def restore_afp_exports(ml):

--- a/src/rockstor/storageadmin/views/samba.py
+++ b/src/rockstor/storageadmin/views/samba.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -21,83 +21,82 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from django.db import transaction
 from django.conf import settings
-from storageadmin.models import (SambaShare, User, SambaCustomConfig)
+from storageadmin.models import SambaShare, User, SambaCustomConfig
 from storageadmin.serializers import SambaShareSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
 from share import ShareMixin
-from system.samba import (refresh_smb_config, status, restart_samba)
+from system.samba import refresh_smb_config, status, restart_samba
 from fs.btrfs import mount_share
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class SambaMixin(object):
     serializer_class = SambaShareSerializer
     DEF_OPTS = {
-        'comment': 'samba export',
-        'browsable': 'yes',
-        'guest_ok': 'no',
-        'read_only': 'no',
-        'custom_config': None,
-        'shadow_copy': False,
-        'snapshot_prefix': None,
+        "comment": "samba export",
+        "browsable": "yes",
+        "guest_ok": "no",
+        "read_only": "no",
+        "custom_config": None,
+        "shadow_copy": False,
+        "snapshot_prefix": None,
     }
-    BOOL_OPTS = ('yes', 'no',)
+    BOOL_OPTS = ("yes", "no")
 
     @staticmethod
     def _restart_samba():
         out = status()
-        if (out[2] == 0):
+        if out[2] == 0:
             restart_samba(hard=True)
 
     @classmethod
-    def _validate_input(cls, request, smbo=None):
+    def _validate_input(cls, rdata, smbo=None):
         options = {}
         def_opts = cls.DEF_OPTS
-        if (smbo is not None):
+        if smbo is not None:
             def_opts = cls.DEF_OPTS.copy()
-            def_opts['comment'] = smbo.comment
-            def_opts['browsable'] = smbo.browsable
-            def_opts['guest_ok'] = smbo.guest_ok
-            def_opts['read_only'] = smbo.read_only
-            def_opts['shadow_copy'] = smbo.shadow_copy
+            def_opts["comment"] = smbo.comment
+            def_opts["browsable"] = smbo.browsable
+            def_opts["guest_ok"] = smbo.guest_ok
+            def_opts["read_only"] = smbo.read_only
+            def_opts["shadow_copy"] = smbo.shadow_copy
 
-        options['comment'] = request.data.get('comment', def_opts['comment'])
-        options['browsable'] = request.data.get('browsable',
-                                                def_opts['browsable'])
+        options["comment"] = rdata.get("comment", def_opts["comment"])
+        options["browsable"] = rdata.get("browsable", def_opts["browsable"])
 
-        options['custom_config'] = request.data.get('custom_config', [])
-        if (type(options['custom_config']) != list):
-            e_msg = 'Custom config must be a list of strings.'
-            handle_exception(Exception(e_msg), request)
-        if (options['browsable'] not in cls.BOOL_OPTS):
-            e_msg = ('Invalid choice for browsable. Possible '
-                     'choices are yes or no.')
-            handle_exception(Exception(e_msg), request)
-        options['guest_ok'] = request.data.get('guest_ok',
-                                               def_opts['guest_ok'])
-        if (options['guest_ok'] not in cls.BOOL_OPTS):
-            e_msg = ('Invalid choice for guest_ok. Possible '
-                     'options are yes or no.')
-            handle_exception(Exception(e_msg), request)
-        options['read_only'] = request.data.get('read_only',
-                                                def_opts['read_only'])
-        if (options['read_only'] not in cls.BOOL_OPTS):
-            e_msg = ('Invalid choice for read_only. Possible '
-                     'options are yes or no.')
-            handle_exception(Exception(e_msg), request)
-        options['shadow_copy'] = request.data.get('shadow_copy',
-                                                  def_opts['shadow_copy'])
-        if (options['shadow_copy']):
-            options['snapshot_prefix'] = request.data.get(
-                'snapshot_prefix', def_opts['snapshot_prefix'])
-            if (options['snapshot_prefix'] is None or
-                    len(options['snapshot_prefix'].strip()) == 0):
-                e_msg = ('Invalid choice for snapshot_prefix. It must be a '
-                         'valid non-empty string.')
-                handle_exception(Exception(e_msg), request)
+        options["custom_config"] = rdata.get("custom_config", [])
+        if type(options["custom_config"]) != list:
+            e_msg = "Custom config must be a list of strings."
+            handle_exception(Exception(e_msg), rdata)
+        if options["browsable"] not in cls.BOOL_OPTS:
+            e_msg = "Invalid choice for browsable. Possible choices are yes or no."
+            handle_exception(Exception(e_msg), rdata)
+        options["guest_ok"] = rdata.get("guest_ok", def_opts["guest_ok"])
+        if options["guest_ok"] not in cls.BOOL_OPTS:
+            e_msg = "Invalid choice for guest_ok. Possible options are yes or no."
+            handle_exception(Exception(e_msg), rdata)
+        options["read_only"] = rdata.get("read_only", def_opts["read_only"])
+        if options["read_only"] not in cls.BOOL_OPTS:
+            e_msg = "Invalid choice for read_only. Possible options are yes or no."
+            handle_exception(Exception(e_msg), rdata)
+        options["shadow_copy"] = rdata.get("shadow_copy", def_opts["shadow_copy"])
+        if options["shadow_copy"]:
+            options["snapshot_prefix"] = rdata.get(
+                "snapshot_prefix", def_opts["snapshot_prefix"]
+            )
+            if (
+                options["snapshot_prefix"] is None
+                or len(options["snapshot_prefix"].strip()) == 0
+            ):
+                e_msg = (
+                    "Invalid choice for snapshot_prefix. It must be a "
+                    "valid non-empty string."
+                )
+                handle_exception(Exception(e_msg), rdata)
 
         return options
 
@@ -111,14 +110,17 @@ class SambaMixin(object):
                 # object.
                 try:
                     system_user = pwd.getpwnam(au)
-                    auo = User(username=au, uid=system_user.pw_uid,
-                               gid=system_user.pw_gid, admin=False)
+                    auo = User(
+                        username=au,
+                        uid=system_user.pw_uid,
+                        gid=system_user.pw_gid,
+                        admin=False,
+                    )
                     auo.save()
                 except KeyError:
                     # raise the outer exception as it's more meaningful to the
                     # user.
-                    raise Exception('Requested admin user(%s) does '
-                                    'not exist.' % au)
+                    raise Exception("Requested admin user(%s) does not exist." % au)
             finally:
                 auo.smb_shares.add(smb_share)
 
@@ -128,46 +130,55 @@ class SambaListView(SambaMixin, ShareMixin, rfc.GenericView):
 
     @transaction.atomic
     def post(self, request):
-        if ('shares' not in request.data):
-            e_msg = 'Must provide share names.'
-            handle_exception(Exception(e_msg), request)
-        shares = [self._validate_share(request, s) for s in
-                  request.data['shares']]
-        options = self._validate_input(request)
-        custom_config = options['custom_config']
-        del(options['custom_config'])
-        for share in shares:
-            if (SambaShare.objects.filter(share=share).exists()):
-                e_msg = ('Share ({}) is already exported via '
-                         'Samba.').format(share.name)
-                handle_exception(Exception(e_msg), request)
-        with self._handle_exception(request):
+        if isinstance(request.data, list):
+            for se in request.data:
+                smb_share = self.create_samba_share(se)
+        else:
+            smb_share = self.create_samba_share(request.data)
+        refresh_smb_config(list(SambaShare.objects.all()))
+        self._restart_samba()
+        return Response(SambaShareSerializer(smb_share).data)
+
+    def create_samba_share(self, rdata):
+        if "shares" not in rdata:
+            e_msg = "Must provide share names."
+            handle_exception(Exception(e_msg), rdata)
+        shares = [self._validate_share(rdata, s) for s in rdata["shares"]]
+        options = self._validate_input(rdata)
+        custom_config = options["custom_config"]
+        del options["custom_config"]
+        with self._handle_exception(rdata):
             for share in shares:
-                mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
-                options['share'] = share
-                options['path'] = mnt_pt
+                if SambaShare.objects.filter(share=share).exists():
+                    e_msg = ("Share ({}) is already exported via Samba.").format(
+                        share.name
+                    )
+                    logger.error(e_msg)
+                    smb_share = SambaShare.objects.get(share=share)
+                    # handle_exception(Exception(e_msg), rdata)
+                    continue
+                mnt_pt = "{}{}".format(settings.MNT_PT, share.name)
+                options["share"] = share
+                options["path"] = mnt_pt
                 smb_share = SambaShare(**options)
                 smb_share.save()
                 for cc in custom_config:
-                    cco = SambaCustomConfig(smb_share=smb_share,
-                                            custom_config=cc)
+                    cco = SambaCustomConfig(smb_share=smb_share, custom_config=cc)
                     cco.save()
                 if not share.is_mounted:
                     mount_share(share, mnt_pt)
 
-                admin_users = request.data.get('admin_users', [])
-                if (admin_users is None):
+                admin_users = rdata.get("admin_users", [])
+                if admin_users is None:
                     admin_users = []
                 self._set_admin_users(admin_users, smb_share)
-            refresh_smb_config(list(SambaShare.objects.all()))
-            self._restart_samba()
-            return Response(SambaShareSerializer(smb_share).data)
+        return smb_share
 
 
 class SambaDetailView(SambaMixin, rfc.GenericView):
     def get(self, *args, **kwargs):
         try:
-            data = SambaShare.objects.get(id=self.kwargs['smb_id'])
+            data = SambaShare.objects.get(id=self.kwargs["smb_id"])
             serialized_data = SambaShareSerializer(data)
             return Response(serialized_data.data)
         except SambaShare.DoesNotExist:
@@ -180,8 +191,7 @@ class SambaDetailView(SambaMixin, rfc.GenericView):
             SambaCustomConfig.objects.filter(smb_share=smbo).delete()
             smbo.delete()
         except:
-            e_msg = ('Samba export for the id ({}) '
-                     'does not exist.').format(smb_id)
+            e_msg = ("Samba export for the id ({}) does not exist.").format(smb_id)
             handle_exception(Exception(e_msg), request)
 
         with self._handle_exception(request):
@@ -195,24 +205,25 @@ class SambaDetailView(SambaMixin, rfc.GenericView):
             try:
                 smbo = SambaShare.objects.get(id=smb_id)
             except:
-                e_msg = ('Samba export for the id ({}) '
-                         'does not exist.').format(smb_id)
+                e_msg = ("Samba export for the id ({}) does not exist.").format(
+                    smb_id
+                )
                 handle_exception(Exception(e_msg), request)
 
-            options = self._validate_input(request, smbo=smbo)
-            custom_config = options['custom_config']
-            del(options['custom_config'])
+            options = self._validate_input(request.data, smbo=smbo)
+            custom_config = options["custom_config"]
+            del options["custom_config"]
             smbo.__dict__.update(**options)
-            admin_users = request.data.get('admin_users', [])
-            if (admin_users is None):
+            admin_users = request.data.get("admin_users", [])
+            if admin_users is None:
                 admin_users = []
             for uo in User.objects.filter(smb_shares=smbo):
-                if (uo.username not in admin_users):
+                if uo.username not in admin_users:
                     uo.smb_shares.remove(smbo)
             self._set_admin_users(admin_users, smbo)
             smbo.save()
             for cco in SambaCustomConfig.objects.filter(smb_share=smbo):
-                if (cco.custom_config not in custom_config):
+                if cco.custom_config not in custom_config:
                     cco.delete()
                 else:
                     custom_config.remove(cco.custom_config)
@@ -221,14 +232,16 @@ class SambaDetailView(SambaMixin, rfc.GenericView):
                 cco.save()
             for smb_o in SambaShare.objects.all():
                 if not smb_o.share.is_mounted:
-                    mnt_pt = ('%s%s' % (settings.MNT_PT, smb_o.share.name))
+                    mnt_pt = "%s%s" % (settings.MNT_PT, smb_o.share.name)
                     try:
                         mount_share(smb_o.share, mnt_pt)
                     except Exception as e:
                         logger.exception(e)
-                        if (smb_o.id == smbo.id):
-                            e_msg = ('Failed to mount share ({}) due to a low '
-                                     'level error.').format(smb_o.share.name)
+                        if smb_o.id == smbo.id:
+                            e_msg = (
+                                "Failed to mount share ({}) due to a low "
+                                "level error."
+                            ).format(smb_o.share.name)
                             handle_exception(Exception(e_msg), request)
 
             refresh_smb_config(list(SambaShare.objects.all()))

--- a/src/rockstor/system/config_backup.py
+++ b/src/rockstor/system/config_backup.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -21,37 +21,42 @@ import os
 from datetime import datetime
 from django.core.management import call_command
 from storageadmin.models import ConfigBackup
-from system.osi import (run_command, md5sum)
+from system.osi import run_command, md5sum
 
 logger = logging.getLogger(__name__)
 
 
 def backup_config():
-    models = {'storageadmin':
-              ['user', 'group', 'sambashare', 'sambacustomconfig',
-               'netatalkshare', 'nfsexport',
-               'nfsexportgroup', 'advancednfsexport', ],
-              'smart_manager':
-              ['service', ], }
+    models = {
+        "storageadmin": [
+            "user",
+            "group",
+            "sambashare",
+            "sambacustomconfig",
+            "netatalkshare",
+            "nfsexport",
+            "nfsexportgroup",
+            "advancednfsexport",
+        ],
+        "smart_manager": ["service"],
+    }
     model_list = []
     for a in models:
         for m in models[a]:
-            model_list.append('%s.%s' % (a, m))
-    logger.debug('model list = %s' % model_list)
+            model_list.append("{}.{}".format(a, m))
 
-    filename = ('backup-%s.json' % datetime.now().strftime('%Y-%m-%d-%H%M%S'))
+    filename = "backup-{}.json".format(datetime.now().strftime("%Y-%m-%d-%H%M%S"))
     cb_dir = ConfigBackup.cb_dir()
 
-    if (not os.path.isdir(cb_dir)):
+    if not os.path.isdir(cb_dir):
         os.mkdir(cb_dir)
     fp = os.path.join(cb_dir, filename)
-    with open(fp, 'w') as dfo:
-        call_command('dumpdata', *model_list, stdout=dfo)
-        dfo.write('\n')
-        call_command('dumpdata', database='smart_manager', *model_list,
-                     stdout=dfo)
-    run_command(['/usr/bin/gzip', fp])
-    gz_name = ('%s.gz' % filename)
+    with open(fp, "w") as dfo:
+        call_command("dumpdata", *model_list, stdout=dfo)
+        dfo.write("\n")
+        call_command("dumpdata", database="smart_manager", *model_list, stdout=dfo)
+    run_command(["/usr/bin/gzip", fp])
+    gz_name = "{}.gz".format(filename)
     fp = os.path.join(cb_dir, gz_name)
     size = os.stat(fp).st_size
     cbo = ConfigBackup(filename=gz_name, md5sum=md5sum(fp), size=size)


### PR DESCRIPTION
Fixes #2051
Fixes #2053
See #2052 for history of this PR.

As described in Issue #2051 restoring samba exports from a Config Backup currently fails silently as it remained based on the share name instead of the share id now used by Rockstor. Furthermore, in cases when the Config Backup contains 6 or more Samba exports, it can also fail due to systemctl blocking (by design) repeated restart of a given service within a small period of time.

### Aims
This PR aims at fixing both issues by:
1. Using the share ID rather than its name (fixes #2051)
2. Group all samba exports restore call together before restarting the Samba service rather than after every single one (fixes #2053).

### Logic
For point 1 described above, we still use the share ID already present in the Config Backup json file and sent it instead of the share name.
For point 2, the API call to create a Samba export (POST `/api/samba/<share_id>`) was refactored to separate the creation of samba export in the database from the system operations (writing of samba config & service restart). As a result, we can now loop through all shares included in the API call and fill in the database accordingly before using this updated information _at once_ to refresh the system's Samba config file and restart the service. In other words, the Samba service is now restarted only once regardless of the number of exports configured.

### Demonstration
1. On a Rockstor-3.9.2-48 system freshly installed and updated, 11 new shares were created on a single-disk pool (_test\_pool_) distinct from the system disk. All shares were thus exported via Samba.
![image](https://user-images.githubusercontent.com/30297881/61491865-27c97b80-a97e-11e9-9960-fa4bdf0778a7.png)



2. Save current config backup and download to local machine.
3. From the web-UI delete all but one Samba exports (in order to test for proper skipping of already-exported shares).
4. Restore config backup created in step 2 above.
5. All shares are now exported again.
![image](https://user-images.githubusercontent.com/30297881/61491891-36b02e00-a97e-11e9-886a-6a0b2dad9d4e.png)


The CentOS machine was then shutdown, and the disk containing the pool _test\_pool_ above was attached to a fresh LEAP15.1 VM.
6. After boot, the disk _test\_pool_ was imported, and the presence of all shares is verified, as well as the absence of any Samba export.
7. Go to "System > Config Backup" and upload config backup downloaded from step 2 above.
8. Restore this config backup.
9. All samba exports are now restored.
![image](https://user-images.githubusercontent.com/30297881/61491914-4465b380-a97e-11e9-9e36-b4f3bf95ae1a.png)


The Leap15.1 VM was then shutdown and steps 6-8 were repeated on a freshly built Rockstor on Tumbleweed20190708. All samba exports were properly restored.
![image](https://user-images.githubusercontent.com/30297881/61492023-82fb6e00-a97e-11e9-901d-bcfa6990bf11.png)


### Notes
Note that a typo was corrected in `test_disks.py`, fixing an assertion error due to the expected error message not representing the returned (and correct) error message. The corresponding test does not fail anymore.

### Testing
All previously passing unit tests are still passing. Nevertheless, due to the refactoring of `storagadmin.views.samba`, new unit tests are now included in `test_samba.py`. Note, however, that two tests still fail, but only due to issue with the test code itself rather than with the refactoring as the code behaves as intended.

#### CentOS

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok

----------------------------------------------------------------------
Ran 14 tests in 1.059s

FAILED (failures=1, errors=1)
```

#### Leap15.1 

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
```

#### Tumbleweed

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
```




### Full Testing Outputs
<details><summary>CentOS</summary>

```
[root@rockdev build]# ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (13.477s)
  Applying contenttypes.0001_initial... OK (0.056s)
  Applying auth.0001_initial... OK (0.288s)
  Applying admin.0001_initial... OK (0.100s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.119s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.053s)
  Applying auth.0003_alter_user_email_max_length... OK (0.047s)
  Applying auth.0004_alter_user_username_opts... OK (0.048s)
  Applying auth.0005_alter_user_last_login_null... OK (0.048s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.498s)
  Applying oauth2_provider.0002_08_updates... OK (0.319s)
  Applying sessions.0001_initial... OK (0.168s)
  Applying sites.0001_initial... OK (0.043s)
  Applying smart_manager.0001_initial... OK (0.634s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.039s)
  Applying storageadmin.0001_initial... OK (11.833s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.281s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.024s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.444s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.709s)
  Applying storageadmin.0006_dcontainerargs... OK (0.756s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.011s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.427s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (13.451s)
  Applying contenttypes.0001_initial... OK (0.041s)
  Applying auth.0001_initial... OK (0.069s)
  Applying admin.0001_initial... OK (0.059s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.164s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.050s)
  Applying auth.0003_alter_user_email_max_length... OK (0.060s)
  Applying auth.0004_alter_user_username_opts... OK (0.067s)
  Applying auth.0005_alter_user_last_login_null... OK (0.067s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.301s)
  Applying oauth2_provider.0002_08_updates... OK (0.268s)
  Applying sessions.0001_initial... OK (0.028s)
  Applying sites.0001_initial... OK (0.042s)
  Applying smart_manager.0001_initial... OK (2.278s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.039s)
  Applying storageadmin.0001_initial... OK (8.800s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.700s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.645s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.524s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.104s)
  Applying storageadmin.0006_dcontainerargs... OK (0.355s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.734s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.109s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Error running a command. cmd = /usr/sbin/usermod -s /bin/bash admin. rc = 6. stdout = [\'\']. stderr = ["usermod: user \'admin\' does not exist", \'\']' != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 102, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 168 tests in 18.884s

FAILED (failures=23, errors=7)
```

</details>

<details><summary>LEAP15.1</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.391s)
  Applying contenttypes.0001_initial... OK (0.049s)
  Applying auth.0001_initial... OK (0.229s)
  Applying admin.0001_initial... OK (0.072s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.096s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.045s)
  Applying auth.0003_alter_user_email_max_length... OK (0.039s)
  Applying auth.0004_alter_user_username_opts... OK (0.031s)
  Applying auth.0005_alter_user_last_login_null... OK (0.042s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.376s)
  Applying oauth2_provider.0002_08_updates... OK (0.241s)
  Applying sessions.0001_initial... OK (0.049s)
  Applying sites.0001_initial... OK (0.035s)
  Applying smart_manager.0001_initial... OK (0.593s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.027s)
  Applying storageadmin.0001_initial... OK (9.593s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.774s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.853s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.340s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.369s)
  Applying storageadmin.0006_dcontainerargs... OK (0.365s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.747s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.183s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (11.534s)
  Applying contenttypes.0001_initial... OK (0.037s)
  Applying auth.0001_initial... OK (0.076s)
  Applying admin.0001_initial... OK (0.061s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.119s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.047s)
  Applying auth.0003_alter_user_email_max_length... OK (0.048s)
  Applying auth.0004_alter_user_username_opts... OK (0.053s)
  Applying auth.0005_alter_user_last_login_null... OK (0.051s)
  Applying auth.0006_require_contenttypes_0002... OK (0.014s)
  Applying oauth2_provider.0001_initial... OK (0.195s)
  Applying oauth2_provider.0002_08_updates... OK (0.202s)
  Applying sessions.0001_initial... OK (0.022s)
  Applying sites.0001_initial... OK (0.025s)
  Applying smart_manager.0001_initial... OK (1.464s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.042s)
  Applying storageadmin.0001_initial... OK (8.486s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.581s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.652s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.531s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.958s)
  Applying storageadmin.0006_dcontainerargs... OK (0.307s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.667s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.932s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 102, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 168 tests in 21.194s

FAILED (failures=23, errors=7)
```

</details>

<details><summary>TumbleWeed</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
^C^COperations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (11.494s)
  Applying contenttypes.0001_initial... OK (0.051s)
  Applying auth.0001_initial... OK (0.277s)
  Applying admin.0001_initial... OK (0.110s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.115s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.061s)
  Applying auth.0003_alter_user_email_max_length... OK (0.053s)
  Applying auth.0004_alter_user_username_opts... OK (0.053s)
  Applying auth.0005_alter_user_last_login_null... OK (0.051s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.436s)
  Applying oauth2_provider.0002_08_updates... OK (0.309s)
  Applying sessions.0001_initial... OK (0.068s)
  Applying sites.0001_initial... OK (0.038s)
  Applying smart_manager.0001_initial... OK (0.601s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.042s)
  Applying storageadmin.0001_initial... OK (9.933s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.731s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.744s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.320s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.257s)
  Applying storageadmin.0006_dcontainerargs... OK (0.369s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.694s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.171s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (11.429s)
  Applying contenttypes.0001_initial... OK (0.025s)
  Applying auth.0001_initial... OK (0.069s)
  Applying admin.0001_initial... OK (0.044s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.119s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.043s)
  Applying auth.0003_alter_user_email_max_length... OK (0.035s)
  Applying auth.0004_alter_user_username_opts... OK (0.036s)
  Applying auth.0005_alter_user_last_login_null... OK (0.038s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.170s)
  Applying oauth2_provider.0002_08_updates... OK (0.155s)
  Applying sessions.0001_initial... OK (0.017s)
  Applying sites.0001_initial... OK (0.018s)
  Applying smart_manager.0001_initial... OK (1.420s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.040s)
  Applying storageadmin.0001_initial... OK (7.505s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.613s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.824s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.304s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.988s)
  Applying storageadmin.0006_dcontainerargs... OK (0.338s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.627s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.981s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libacl.so.1'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 102, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 168 tests in 22.211s

FAILED (failures=23, errors=7)
```


</details>