### PR TITLE
changelog fails on version lines. Fixes #2054

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
@@ -239,28 +239,40 @@ VersionView = RockstorLayoutView.extend({
         var contributors = [];
 
         for (var i = 0; i < logArray.length; i++) {
-            var hashIndex = logArray[i].indexOf('#');
-            var atRateIndex = logArray[i].indexOf('@');
-            issues[i] = logArray[i].substring(hashIndex + 1, atRateIndex - 1);
-            var namesNum = logArray[i].indexOf('@') + 1;
-            changeDescription[i] = logArray[i].substring(0, hashIndex - 1);
-            nextString[i] = logArray[i].substring(namesNum, logArray[i].length);
-            contributors[i] = nextString[i].split(' @');
+            if (logArray[i] == '' || logArray[i].substring(0, 1) == '*') {
+                // Preserve empty lines and package version entries 'as is'
+                // and Bold for section emphasis.
+                changeDescription[i] = logArray[i]
+            } else {
+                var hashIndex = logArray[i].indexOf('#');
+                var atRateIndex = logArray[i].indexOf('@');
+                issues[i] = logArray[i].substring(hashIndex + 1, atRateIndex - 1);
+                var namesNum = logArray[i].indexOf('@') + 1;
+                changeDescription[i] = logArray[i].substring(0, hashIndex - 1);
+                nextString[i] = logArray[i].substring(namesNum, logArray[i].length);
+                contributors[i] = nextString[i].split(' @');
+            }
         }
         for (var k = 0; k < changeDescription.length; k++) {
             var cl = changeDescription[k];
-            cl += '<a href="https://github.com/rockstor/rockstor-core/issues/';
-            cl += issues[k];
-            cl += '" target="_blank"> #';
-            cl += issues[k];
-            cl += '</a>';
-
-            for (var j = 0; j < contributors[k].length; j++) {
-                cl += '<a href="https://github.com/';
-                cl += contributors[k][j];
-                cl += '" target="_blank"> @';
-                cl += contributors[k][j];
+            // Don't process package version lines for issue and contributor
+            if (cl == '' || cl.substring(0, 1) == '*') {
+                cl = '<strong>' + cl + '</strong>'
+            } else {
+                cl += '<a href="https://github.com/rockstor/rockstor-core/issues/';
+                cl += issues[k];
+                cl += '" target="_blank"> #';
+                cl += issues[k];
                 cl += '</a>';
+                if (typeof contributors[k] !== 'undefined') {
+                    for (var j = 0; j < contributors[k].length; j++) {
+                        cl += '<a href="https://github.com/';
+                        cl += contributors[k][j];
+                        cl += '" target="_blank"> @';
+                        cl += contributors[k][j];
+                        cl += '</a>';
+                    }
+                }
             }
             changeLogArray.push(new Handlebars.SafeString(cl));
         }

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -225,6 +225,7 @@ def update_check(subscription=None):
             if (len(l.strip()) == 0):
                 log = False
         if (re.match('\* ', l) is not None):
+            updates.append(l)
             log = True
     if (new_version is None):
         new_version = version


### PR DESCRIPTION
Previously rockstor update rpm package changelog version lines were not passed to the Web-UI parsing code, and empty lines were rendered as inadvertent meaningless GitHub links. This pr is intended to resolve these issues by:

- Improving Web-UI changelog parsing to account for both empty and release version line entries, the latter begin with "*".
- Removing version lines filter mechanism in low level changelog parser.

Fixes #2054 

Testing:
Please see issue text and embedded images for functional tests performed using rpm packages containing relevant changelog entries (those dated accordingly). 

Caveats:
Post this pull request we still have an outstanding issue (as yet not submitted to GitHub) where we fail to construct working GitHub links when more than a single issue is referenced, i.e as per the following example line:
```
-Fix size sorting on snapshots / shares pages. Fixes #1368 #1878 @Psykar
```
