### PR TITLE
Add support for scheduled tasks to the config backup/restore feature

### DIFF
--- a/src/rockstor/smart_manager/fixtures/scheduled_tasks.json
+++ b/src/rockstor/smart_manager/fixtures/scheduled_tasks.json
@@ -1,0 +1,168 @@
+[
+  {
+    "fields": {
+      "username": "admin",
+      "first_name": "",
+      "last_name": "",
+      "is_active": true,
+      "is_superuser": false,
+      "is_staff": false,
+      "last_login": "2014-11-05T14:19:15.421Z",
+      "groups": [],
+      "user_permissions": [],
+      "password": "pbkdf2_sha256$12000$bIlTp3bZu4if$HhIMeQVPN/0NJz0NtrVj7ib8h+xHZkUT/md5DaPlq6A=",
+      "email": "",
+      "date_joined": "2014-11-05T14:19:13.535Z"
+    },
+    "model": "auth.user",
+    "pk": 1
+  },
+  {
+    "fields": {
+      "pqgroup_rusage": 16,
+      "group": "root",
+      "name": "home",
+      "perms": "755",
+      "pqgroup": "2015/1",
+      "eusage": 16,
+      "uuid": null,
+      "pqgroup_eusage": 16,
+      "compression_algo": null,
+      "owner": "root",
+      "replica": false,
+      "qgroup": "0/257",
+      "toc": "2019-07-30T17:27:39.474Z",
+      "subvol_name": "home",
+      "rusage": 16,
+      "pool": 1,
+      "size": 7035904
+    },
+    "model": "storageadmin.share",
+    "pk": 1
+  },
+  {
+    "fields": {
+      "pqgroup_rusage": 16,
+      "group": "root",
+      "name": "test_share01",
+      "perms": "755",
+      "pqgroup": "2015/34",
+      "eusage": 16,
+      "uuid": null,
+      "pqgroup_eusage": 16,
+      "compression_algo": null,
+      "owner": "root",
+      "replica": false,
+      "qgroup": "0/257",
+      "toc": "2019-07-30T17:27:39.715Z",
+      "subvol_name": "test_share01",
+      "rusage": 16,
+      "pool": 3,
+      "size": 5242880
+    },
+    "model": "storageadmin.share",
+    "pk": 4
+  },
+  {
+    "fields": {
+      "raid": "single",
+      "compression": "no",
+      "uuid": "cc05c31d-6a89-47cd-bbba-c8f4419d9a9b",
+      "name": "rockstor_rockstor",
+      "mnt_options": null,
+      "role": "root",
+      "toc": "2019-07-30T17:27:39.257Z",
+      "size": 7035904
+    },
+    "model": "storageadmin.pool",
+    "pk": 1
+  },
+  {
+    "fields": {
+      "raid": "single",
+      "compression": "no",
+      "uuid": "56395eae-ab39-4649-85d4-072847eb56a2",
+      "name": "main_pool",
+      "mnt_options": null,
+      "role": null,
+      "toc": "2019-07-30T17:27:39.276Z",
+      "size": 5242880
+    },
+    "model": "storageadmin.pool",
+    "pk": 2
+  },
+  {
+    "fields": {
+      "raid": "single",
+      "compression": "no",
+      "uuid": "ceba82ad-f7a5-404e-87cf-1c74aabb48ed",
+      "name": "test_pool",
+      "mnt_options": null,
+      "role": null,
+      "toc": "2019-07-30T17:27:39.298Z",
+      "size": 5242880
+    },
+    "model": "storageadmin.pool",
+    "pk": 3
+  },
+  {
+    "fields": {
+      "task_type": "scrub",
+      "name": "scurb-testpool01",
+      "enabled": false,
+      "crontabwindow": "*-*-*-*-*-*",
+      "crontab": "42 3 * * 5",
+      "json_meta": "{\"pool_name\": \"test_pool\", \"pool\": \"3\"}"
+    },
+    "model": "smart_manager.taskdefinition",
+    "pk": 10
+  },
+  {
+    "fields": {
+      "task_type": "snapshot",
+      "name": "snap-test",
+      "enabled": false,
+      "crontabwindow": "*-*-*-*-*-*",
+      "crontab": "42 3 * * *",
+      "json_meta": "{\"writable\": true, \"visible\": true, \"prefix\": \"snaptest\", \"share\": \"4\", \"max_count\": \"4\"}"
+    },
+    "model": "smart_manager.taskdefinition",
+    "pk": 15
+  },
+  {
+    "fields": {
+      "task_type": "reboot",
+      "name": "sys_reboot",
+      "enabled": false,
+      "crontabwindow": "*-*-*-*-*-*",
+      "crontab": "42 3 1 * *",
+      "json_meta": "{}"
+    },
+    "model": "smart_manager.taskdefinition",
+    "pk": 16
+  },
+  {
+    "fields": {
+      "task_type": "shutdown",
+      "name": "sys_shutdown",
+      "enabled": false,
+      "crontabwindow": "*-*-*-*-*-*",
+      "crontab": "42 3 1 1 *",
+      "json_meta": "{\"wakeup\": false, \"rtc_hour\": 0, \"rtc_minute\": 0}"
+    },
+    "model": "smart_manager.taskdefinition",
+    "pk": 17
+  },
+  {
+    "fields": {
+      "task_type": "suspend",
+      "name": "sys_suspend",
+      "enabled": false,
+      "crontabwindow": "*-*-*-*-*-*",
+      "crontab": "0 * * * *",
+      "json_meta": "{\"wakeup\": true, \"rtc_hour\": 0, \"rtc_minute\": 0}"
+    },
+    "model": "smart_manager.taskdefinition",
+    "pk": 18
+  }
+]

--- a/src/rockstor/smart_manager/tests/test_task_scheduler.py
+++ b/src/rockstor/smart_manager/tests/test_task_scheduler.py
@@ -1,0 +1,246 @@
+"""
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class TaskSchedulerTests(APITestCase):
+    multi_db = True
+    fixtures = ["scheduled_tasks.json"]
+    BASE_URL = "/api/sm/tasks"
+
+    def session_login(self):
+        self.client.login(username="admin", password="admin")
+
+    def test_get(self):
+        """
+        Test GET request
+        """
+        # get scheduled task with valid id
+        self.session_login()
+        response = self.client.get("{}/10".format(self.BASE_URL))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response)
+
+        # get scheduled task with invalid id
+        self.session_login()
+        response = self.client.get("{}/100".format(self.BASE_URL))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response)
+
+    def test_post_valid(self):
+        """
+        Test valid POST request
+        """
+        datalist = [
+            {
+                "task_type": "scrub",
+                "name": "scrubtest",
+                "enabled": False,
+                "crontab": "42 3 * * 5",
+                "meta": {"pool": "3"},
+                "crontabwindow": "*-*-*-*-*-*",
+            },
+            {
+                "task_type": "snapshot",
+                "name": "snapshot_test",
+                "enabled": False,
+                "crontab": "42 3 * * 5",
+                "meta": {
+                    "writable": True,
+                    "visible": True,
+                    "prefix": "snaptest",
+                    "share": "4",
+                    "max_count": "4",
+                },
+                "crontabwindow": "*-*-*-*-*-*",
+            },
+            {
+                "task_type": "reboot",
+                "name": "sys_reboot_test",
+                "enabled": False,
+                "crontab": "42 3 * * 5",
+                "meta": {},
+                "crontabwindow": "*-*-*-*-*-*",
+            },
+            {
+                "task_type": "shutdown",
+                "name": "sys_shutdown_test",
+                "enabled": False,
+                "crontab": "42 3 * * 5",
+                "meta": {"wakeup": False, "rtc_hour": "0", "rtc_minute": "0"},
+                "crontabwindow": "*-*-*-*-*-*",
+            },
+            {
+                "task_type": "suspend",
+                "name": "sys_suspend_test",
+                "enabled": False,
+                "crontab": "42 3 * * 5",
+                "meta": {"wakeup": True, "rtc_hour": "0", "rtc_minute": "0"},
+                "crontabwindow": "*-*-*-*-*-*",
+            },
+        ]
+        self.session_login()
+        for data in datalist:
+            response = self.client.post("{}/".format(self.BASE_URL), data=data)
+            self.assertEqual(
+                response.status_code, status.HTTP_200_OK, msg=response.content
+            )
+
+    def test_post_name_exists(self):
+        """
+        Test invalid POST request when a task with the same name already exists.
+        It should return an exception.
+        """
+        data = {
+            "task_type": "scrub",
+            "name": "scurb-testpool01",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {"pool": "3"},
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+
+        self.session_login()
+        response = self.client.post("{}/".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.content,
+        )
+
+    def test_post_invalid_type(self):
+        """
+        Test invalid POST request when a task type is incorrect.
+        It should return an exception.
+        """
+        data = {
+            "task_type": "unsupported_type",
+            "name": "test_scrub",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {"pool": "3"},
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+
+        self.session_login()
+        response = self.client.post("{}/".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.content,
+        )
+
+    def test_put_valid(self):
+        """
+        Test PUT request with valid tdid
+        """
+        data = {
+            "task_type": "snapshot",
+            "name": "snapshot_test",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {
+                "writable": True,
+                "visible": True,
+                "prefix": "snaptest",
+                "share": "4",
+                "max_count": "4",
+            },
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+        tdid = 15
+        self.session_login()
+        response = self.client.put("{}/{}".format(self.BASE_URL, tdid), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
+
+    def test_put_invalid(self):
+        """
+        Test PUT request with invalid tdid
+        """
+        data = {
+            "task_type": "snapshot",
+            "name": "snapshot_test",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {
+                "writable": True,
+                "visible": True,
+                "prefix": "snaptest",
+                "share": "4",
+                "max_count": "4",
+            },
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+        tdid = 150
+        self.session_login()
+        response = self.client.put("{}/{}".format(self.BASE_URL, tdid), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.content,
+        )
+
+    def test_delete_valid(self):
+        """
+        Test delete request with valid tdid
+        """
+        data = {
+            "task_type": "snapshot",
+            "name": "snapshot_test",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {
+                "writable": True,
+                "visible": True,
+                "prefix": "snaptest",
+                "share": "4",
+                "max_count": "4",
+            },
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+        tdid = 15
+        self.session_login()
+        response = self.client.delete("{}/{}".format(self.BASE_URL, tdid), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
+
+    def test_delete_invalid(self):
+        """
+        Test delete request with invalid tdid
+        """
+        data = {
+            "task_type": "snapshot",
+            "name": "snapshot_test",
+            "enabled": False,
+            "crontab": "42 3 * * 5",
+            "meta": {
+                "writable": True,
+                "visible": True,
+                "prefix": "snaptest",
+                "share": "4",
+                "max_count": "4",
+            },
+            "crontabwindow": "*-*-*-*-*-*",
+        }
+        tdid = 150
+        self.session_login()
+        response = self.client.delete("{}/{}".format(self.BASE_URL, tdid), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.content,
+        )

--- a/src/rockstor/smart_manager/views/task_scheduler.py
+++ b/src/rockstor/smart_manager/views/task_scheduler.py
@@ -16,17 +16,19 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from smart_manager.models import TaskDefinition
-from storageadmin.models import (Pool, Share, EmailClient)
-from smart_manager.serializers import TaskDefinitionSerializer
-from django.db import transaction
-from django.conf import settings
 import json
-from rest_framework.response import Response
-from storageadmin.util import handle_exception
-import rest_framework_custom as rfc
-
 import logging
+
+from django.conf import settings
+from django.db import transaction
+from rest_framework.response import Response
+
+import rest_framework_custom as rfc
+from smart_manager.models import TaskDefinition
+from smart_manager.serializers import TaskDefinitionSerializer
+from storageadmin.models import (Pool, Share, EmailClient)
+from storageadmin.util import handle_exception
+
 logger = logging.getLogger(__name__)
 
 
@@ -136,19 +138,18 @@ class TaskSchedulerListView(TaskSchedulerMixin, rfc.GenericView):
         with self._handle_exception(request):
             name = request.data['name']
             if (TaskDefinition.objects.filter(name=name).exists()):
-                msg = ('Another task exists with the same name(%s). Choose '
-                       'a different name' % name)
+                msg = ('Another task exists with the same name({}). Choose '
+                       'a different name'.format(name))
                 handle_exception(Exception(msg), request)
 
             task_type = request.data['task_type']
             if (task_type not in self.valid_tasks):
-                e_msg = ('Unknown task type: %s cannot be scheduled' % name)
+                e_msg = ('Unknown task type: {} cannot be scheduled'.format(name))
                 handle_exception(Exception(e_msg), request)
 
             crontab, crontabwindow, meta = self._validate_input(request)
             json_meta = json.dumps(meta)
             enabled = self._validate_enabled(request)
-
             td = TaskDefinition(name=name, task_type=task_type,
                                 crontab=crontab, crontabwindow=crontabwindow,
                                 json_meta=json_meta, enabled=enabled)

--- a/src/rockstor/storageadmin/views/config_backup.py
+++ b/src/rockstor/storageadmin/views/config_backup.py
@@ -183,7 +183,6 @@ def restore_scheduled_tasks(ml):
                 "meta": jmeta,
             }
             tasks.append(taskdef)
-    logger.debug("tasks = ({}).".format(tasks))
     for t in tasks:
         generic_post("{}/sm/tasks/".format(BASE_URL), t)
     logger.debug("Finished restoring scheduled tasks.")

--- a/src/rockstor/storageadmin/views/config_backup.py
+++ b/src/rockstor/storageadmin/views/config_backup.py
@@ -16,71 +16,76 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
-from rest_framework.response import Response
-from django.db import transaction
-from django.conf import settings
-from storageadmin.models import ConfigBackup
-from storageadmin.serializers import ConfigBackupSerializer
-from storageadmin.util import handle_exception
-import rest_framework_custom as rfc
-from system.osi import md5sum
-from system.config_backup import backup_config
-from rest_framework.parsers import FileUploadParser, MultiPartParser
-from django_ztask.decorators import task
-from cli.rest_util import api_call
 import gzip
 import json
 import logging
+import os
+
+from django.conf import settings
+from django.db import transaction
+from django_ztask.decorators import task
+from rest_framework.parsers import FileUploadParser, MultiPartParser
+from rest_framework.response import Response
+
+import rest_framework_custom as rfc
+from cli.rest_util import api_call
+from storageadmin.models import ConfigBackup
+from storageadmin.serializers import ConfigBackupSerializer
+from storageadmin.util import handle_exception
+from system.config_backup import backup_config
+from system.osi import md5sum
+
 logger = logging.getLogger(__name__)
-BASE_URL = 'https://localhost/api'
+BASE_URL = "https://localhost/api"
 
 
 def generic_post(url, payload):
-    headers = {'content-type': 'application/json', }
+    headers = {"content-type": "application/json"}
     try:
-        api_call(url, data=payload, calltype='post', headers=headers,
-                 save_error=False)
-        logger.debug('Successfully created resource: {}. '
-                     'Payload: {}'.format(url, payload))
+        api_call(url, data=payload, calltype="post", headers=headers, save_error=False)
+        logger.debug(
+            "Successfully created resource: {}. Payload: {}".format(url, payload)
+        )
     except Exception as e:
-        logger.error('Exception occurred while creating resource: {}. '
-                     'Payload: {}. Exception: {}. '
-                     'Moving on.'.format(url, payload, e.__str__()))
+        logger.error(
+            "Exception occurred while creating resource: {}. "
+            "Payload: {}. Exception: {}. "
+            "Moving on.".format(url, payload, e.__str__())
+        )
 
 
 def restore_users_groups(ml):
-    logger.debug('Started restoring users and groups.')
+    logger.debug("Started restoring users and groups.")
     users = []
     groups = []
     # Dictionary to map group pk to group name. Used to re-establishes user
     # to group name relationship.
     groupname_from_pk = {}
     for m in ml:
-        if (m['model'] == 'storageadmin.user'):
-            users.append(m['fields'])
-        if (m['model'] == 'storageadmin.group'):
-            groupname_from_pk[m['pk']] = m['fields']['groupname']
-            groups.append(m['fields'])
+        if m["model"] == "storageadmin.user":
+            users.append(m["fields"])
+        if m["model"] == "storageadmin.group":
+            groupname_from_pk[m["pk"]] = m["fields"]["groupname"]
+            groups.append(m["fields"])
 
     # order is important, first create all the groups and then users.
     for g in groups:
-        generic_post('%s/groups' % BASE_URL, g)
+        generic_post("%s/groups" % BASE_URL, g)
     for u in users:
         # Replace user record 'group' field pk value with resolved group name.
-        u['group'] = groupname_from_pk[u['group']]
+        u["group"] = groupname_from_pk[u["group"]]
         # users are created with default(rockstor) password
-        u['password'] = 'rockstor'
-        generic_post('%s/users' % BASE_URL, u)
-    logger.debug('Finished restoring users and groups.')
+        u["password"] = "rockstor"
+        generic_post("%s/users" % BASE_URL, u)
+    logger.debug("Finished restoring users and groups.")
 
 
 def restore_samba_exports(ml):
-    logger.debug('Started restoring Samba exports.')
+    logger.debug("Started restoring Samba exports.")
     exports = []
     for m in ml:
-        if (m['model'] == 'storageadmin.sambashare'):
-            exports.append(m['fields'])
+        if m["model"] == "storageadmin.sambashare":
+            exports.append(m["fields"])
     for e in exports:
         e['shares'] = []
         e['shares'].append(e['share'])
@@ -88,64 +93,106 @@ def restore_samba_exports(ml):
 
 
 def restore_afp_exports(ml):
-    logger.debug('Started restoring AFP exports.')
+    logger.debug("Started restoring AFP exports.")
     exports = []
     for m in ml:
-        if (m['model'] == 'storageadmin.netatalkshare'):
-            exports.append(m['fields'])
-    if (len(exports) > 0):
-        logger.debug('Starting Netatalk service')
-        generic_post('%s/sm/services/netatalk/start' % BASE_URL, {})
+        if m["model"] == "storageadmin.netatalkshare":
+            exports.append(m["fields"])
+    if len(exports) > 0:
+        logger.debug("Starting Netatalk service")
+        generic_post("%s/sm/services/netatalk/start" % BASE_URL, {})
     for e in exports:
-        e['shares'] = [e['path'].split('/')[-1], ]
-        generic_post('%s/netatalk' % BASE_URL, e)
-    logger.debug('Finished restoring AFP exports.')
+        e["shares"] = [e["path"].split("/")[-1]]
+        generic_post("%s/netatalk" % BASE_URL, e)
+    logger.debug("Finished restoring AFP exports.")
 
 
 def restore_nfs_exports(ml):
-    logger.debug('Started restoring NFS exports.')
+    logger.debug("Started restoring NFS exports.")
     exports = []
     export_groups = {}
-    adv_exports = {'entries': [], }
+    adv_exports = {"entries": []}
     for m in ml:
-        if (m['model'] == 'storageadmin.nfsexport'):
-            exports.append(m['fields'])
-        elif (m['model'] == 'storageadmin.nfsexportgroup'):
-            m['fields']['pk'] = m['pk']
-            export_groups[m['pk']] = m['fields']
-        elif (m['model'] == 'storageadmin.advancednfsexport'):
-            adv_exports['entries'].append(m['fields']['export_str'])
+        if m["model"] == "storageadmin.nfsexport":
+            exports.append(m["fields"])
+        elif m["model"] == "storageadmin.nfsexportgroup":
+            m["fields"]["pk"] = m["pk"]
+            export_groups[m["pk"]] = m["fields"]
+        elif m["model"] == "storageadmin.advancednfsexport":
+            adv_exports["entries"].append(m["fields"]["export_str"])
     for e in exports:
-        if (len(e['mount'].split('/')) != 3):
-            logger.debug('skipping nfs export with mount: %s' % e['mount'])
+        if len(e["mount"].split("/")) != 3:
+            logger.debug("skipping nfs export with mount: %s" % e["mount"])
             continue
-        e['shares'] = [e['mount'].split('/')[2], ]
-        payload = dict(export_groups[e['export_group']], **e)
-        generic_post('%s/nfs-exports' % BASE_URL, payload)
-    generic_post('%s/adv-nfs-exports' % BASE_URL, adv_exports)
-    logger.debug('Finished restoring NFS exports.')
+        e["shares"] = [e["mount"].split("/")[2]]
+        payload = dict(export_groups[e["export_group"]], **e)
+        generic_post("%s/nfs-exports" % BASE_URL, payload)
+    generic_post("%s/adv-nfs-exports" % BASE_URL, adv_exports)
+    logger.debug("Finished restoring NFS exports.")
 
 
 def restore_services(ml):
-    logger.debug('Started restoring services.')
+    logger.debug("Started restoring services.")
     services = {}
     for m in ml:
-        if (m['model'] == 'smart_manager.service'):
-            name = m['fields']['name']
-            config = m['fields']['config']
-            if (config is not None):
+        if m["model"] == "smart_manager.service":
+            name = m["fields"]["name"]
+            config = m["fields"]["config"]
+            if config is not None:
                 config = json.loads(config)
-                services[name] = {'config': config, }
-    logger.debug('services = ({}).'.format(services))
+                services[name] = {"config": config}
+    logger.debug("services = ({}).".format(services))
     for s in services:
-        generic_post('%s/sm/services/%s/config' % (BASE_URL, s), services[s])
-    logger.debug('Finished restoring services.')
+        generic_post("%s/sm/services/%s/config" % (BASE_URL, s), services[s])
+    logger.debug("Finished restoring services.")
+
+
+def restore_scheduled_tasks(ml):
+    """
+    Parses the config backup to re-create a valid POST request to be sent to the
+    sm/tasks API in order to re-create the scheduled task(s) in question.
+    If multiple tasks are to be re-created, the config for each one is stored
+    inside a list that is then looped through to send an api request for each task.
+    Need the following info for each request:
+        - name
+        - task_type
+        - crontab
+        - crontabwindow
+        - meta
+        - enabled
+    :param ml: list of smart_manager models of interest as parsed by restore_config()
+    """
+    logger.debug("Started restoring scheduled tasks.")
+    tasks = []
+    for m in ml:
+        if m["model"] == "smart_manager.taskdefinition":
+            name = m["fields"]["name"]
+            task_type = m["fields"]["task_type"]
+            crontab = m["fields"]["crontab"]
+            crontabwindow = m["fields"]["crontabwindow"]
+            enabled = m["fields"]["enabled"]
+            json_meta = m["fields"]["json_meta"]
+            if json_meta is not None:
+                jmeta = json.loads(json_meta)
+            taskdef = {
+                "name": name,
+                "task_type": task_type,
+                "crontab": crontab,
+                "crontabwindow": crontabwindow,
+                "enabled": enabled,
+                "meta": jmeta,
+            }
+            tasks.append(taskdef)
+    logger.debug("tasks = ({}).".format(tasks))
+    for t in tasks:
+        generic_post("{}/sm/tasks/".format(BASE_URL), t)
+    logger.debug("Finished restoring scheduled tasks.")
 
 
 @task()
 def restore_config(cbid):
     cbo = ConfigBackup.objects.get(id=cbid)
-    fp = os.path.join(settings.MEDIA_ROOT, 'config-backups', cbo.filename)
+    fp = os.path.join(settings.MEDIA_ROOT, "config-backups", cbo.filename)
     gfo = gzip.open(fp)
     lines = gfo.readlines()
     sa_ml = json.loads(lines[0])
@@ -159,7 +206,7 @@ def restore_config(cbid):
     # restore_dashboard(ml)
     # restore_appliances(ml)
     # restore_network(sa_ml)
-    # restore_scheduled_tasks(ml)
+    restore_scheduled_tasks(sm_ml)
     # restore_rockons(ml)
 
 
@@ -168,36 +215,35 @@ class ConfigBackupMixin(object):
 
 
 class ConfigBackupListView(ConfigBackupMixin, rfc.GenericView):
-
     def get_queryset(self, *args, **kwargs):
         for cbo in ConfigBackup.objects.all():
             fp = os.path.join(ConfigBackup.cb_dir(), cbo.filename)
-            if (not os.path.isfile(fp)):
+            if not os.path.isfile(fp):
                 cbo.delete()
             fp_md5sum = md5sum(fp)
-            if (fp_md5sum != cbo.md5sum):
-                logger.error('md5sum mismatch for {}. cbo: {} file: {}. '
-                             'Deleting dbo.'.format(cbo.filename, cbo.md5sum,
-                                                    fp_md5sum))
+            if fp_md5sum != cbo.md5sum:
+                logger.error(
+                    "md5sum mismatch for {}. cbo: {} file: {}. "
+                    "Deleting dbo.".format(cbo.filename, cbo.md5sum, fp_md5sum)
+                )
                 cbo.delete()
-        return ConfigBackup.objects.filter().order_by('-id')
+        return ConfigBackup.objects.filter().order_by("-id")
 
     @transaction.atomic
     def post(self, request):
-        logger.debug('backing up config...')
+        logger.debug("backing up config...")
         with self._handle_exception(request):
             cbo = backup_config()
             return Response(ConfigBackupSerializer(cbo).data)
 
 
 class ConfigBackupDetailView(ConfigBackupMixin, rfc.GenericView):
-
     @transaction.atomic
     def delete(self, request, backup_id):
         with self._handle_exception(request):
             cbo = self._validate_input(backup_id, request)
             fp = os.path.join(ConfigBackup.cb_dir(), cbo.filename)
-            if (os.path.isfile(fp)):
+            if os.path.isfile(fp):
                 os.remove(fp)
             cbo.delete()
             return Response()
@@ -205,8 +251,8 @@ class ConfigBackupDetailView(ConfigBackupMixin, rfc.GenericView):
     @transaction.atomic
     def post(self, request, backup_id):
         with self._handle_exception(request):
-            command = request.data.get('command', 'restore')
-            if (command == 'restore'):
+            command = request.data.get("command", "restore")
+            if command == "restore":
                 cbo = self._validate_input(backup_id, request)
                 # models that need to be restored.
                 # 1. User, Group, Accesskeys?
@@ -216,9 +262,9 @@ class ConfigBackupDetailView(ConfigBackupMixin, rfc.GenericView):
                 # 5. Appliances?
                 # 6. Scheduled Tasks
                 # 7. SFTP, AFP
-                logger.debug('restore starting...')
+                logger.debug("restore starting...")
                 restore_config.async(cbo.id)
-                logger.debug('restore submitted...')
+                logger.debug("restore submitted...")
         return Response()
 
     @staticmethod
@@ -226,8 +272,9 @@ class ConfigBackupDetailView(ConfigBackupMixin, rfc.GenericView):
         try:
             return ConfigBackup.objects.get(id=backup_id)
         except ConfigBackup.DoesNotExist:
-            e_msg = ('Config backup for the id ({}) '
-                     'does not exist.').format(backup_id)
+            e_msg = ("Config backup for the id ({}) does not exist.").format(
+                backup_id
+            )
             handle_exception(Exception(e_msg), request)
 
 
@@ -237,27 +284,28 @@ class ConfigBackupUpload(ConfigBackupMixin, rfc.GenericView):
     def get_queryset(self, *args, **kwargs):
         for cbo in ConfigBackup.objects.all():
             fp = os.path.join(ConfigBackup.cb_dir(), cbo.filename)
-            if (not os.path.isfile(fp)):
+            if not os.path.isfile(fp):
                 cbo.delete()
             fp_md5sum = md5sum(fp)
-            if (fp_md5sum != cbo.md5sum):
-                logger.error('md5sum mismatch for {}. cbo: {} file: {}. '
-                             'Deleting dbo'.format(cbo.filename, cbo.md5sum,
-                                                   fp_md5sum))
+            if fp_md5sum != cbo.md5sum:
+                logger.error(
+                    "md5sum mismatch for {}. cbo: {} file: {}. "
+                    "Deleting dbo".format(cbo.filename, cbo.md5sum, fp_md5sum)
+                )
                 cbo.delete()
-        return ConfigBackup.objects.filter().order_by('-id')
+        return ConfigBackup.objects.filter().order_by("-id")
 
     def post(self, request, format=None):
         with self._handle_exception(request):
-            filename = request.data['file-name']
-            file_obj = request.data['file']
-            if (ConfigBackup.objects.filter(filename=filename).exists()):
-                msg = ('Config backup ({}) already exists. Uploading a '
-                       'duplicate is not allowed.').format(filename)
+            filename = request.data["file-name"]
+            file_obj = request.data["file"]
+            if ConfigBackup.objects.filter(filename=filename).exists():
+                msg = (
+                    "Config backup ({}) already exists. Uploading a "
+                    "duplicate is not allowed."
+                ).format(filename)
                 handle_exception(Exception(msg), request)
-            cbo = ConfigBackup.objects.create(
-                filename=filename, config_backup=file_obj
-            )
+            cbo = ConfigBackup.objects.create(filename=filename, config_backup=file_obj)
             cb_dir = ConfigBackup.cb_dir()
             if not os.path.isdir(cb_dir):
                 os.mkdir(cb_dir)

--- a/src/rockstor/system/config_backup.py
+++ b/src/rockstor/system/config_backup.py
@@ -29,12 +29,6 @@ logger = logging.getLogger(__name__)
 
 
 def backup_config():
-    models = {'storageadmin':
-              ['user', 'group', 'sambashare', 'sambacustomconfig',
-               'netatalkshare', 'nfsexport',
-               'nfsexportgroup', 'advancednfsexport', ],
-              'smart_manager':
-              ['service', 'taskdefinition', ], }
     models = {
         "storageadmin": [
             "user",

--- a/src/rockstor/system/config_backup.py
+++ b/src/rockstor/system/config_backup.py
@@ -19,7 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import logging
 import os
 from datetime import datetime
+
 from django.core.management import call_command
+
 from storageadmin.models import ConfigBackup
 from system.osi import run_command, md5sum
 
@@ -27,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 
 def backup_config():
+    models = {'storageadmin':
+              ['user', 'group', 'sambashare', 'sambacustomconfig',
+               'netatalkshare', 'nfsexport',
+               'nfsexportgroup', 'advancednfsexport', ],
+              'smart_manager':
+              ['service', 'taskdefinition', ], }
     models = {
         "storageadmin": [
             "user",
@@ -38,7 +46,10 @@ def backup_config():
             "nfsexportgroup",
             "advancednfsexport",
         ],
-        "smart_manager": ["service"],
+        "smart_manager": [
+            "service",
+            "taskdefinition"
+        ],
     }
     model_list = []
     for a in models:


### PR DESCRIPTION
Fixes #2058.
For PR history, see #2057.

This pull request proposes to add support for **Scheduled tasks** to the config backup and restore feature. This includes all five types of tasks: `scrub`, `snapshot`, `reboot`, `shutdown`, `suspend`.
Moreover, as the task_scheduler views were not covered by unit tests, new related API tests were written.

### Aims & Logic
This PR first adds the relevant smart_manager model `TaskDefinition` to the list of models included in the backup. Then it adds a new method (`restore_scheduled_tasks()`) that parses this information to create a valid POST request to `api/sm/tasks` in order to proceed with the re-creation of the scheduled task.

### Demonstration
1. On a Rockstor-3.9.2-48 system freshly installed and updated, several new scheduled tasks were created on a single-disk pool (_test\_pool_) distinct from the system disk.
![image](https://user-images.githubusercontent.com/30297881/62298361-e1295600-b440-11e9-8854-bed7bd1e65f9.png)

2. Save current config backup and download to local machine.
3. From the web-UI delete all but one scheduled tasks (in order to test for proper skipping of already-existing tasks).
![image](https://user-images.githubusercontent.com/30297881/62298432-01591500-b441-11e9-83d5-27e53c3b507c.png)

4. Restore config backup created in step 2 above.
5. All scheduled tasks are now restored.
![image](https://user-images.githubusercontent.com/30297881/62298499-1a61c600-b441-11e9-9def-dc670d9ab405.png)


The CentOS machine was then shutdown, and the disk containing the pool _test\_pool_ above was attached to a fresh LEAP15.1 VM.
6. After boot, the disk _test\_pool_ was imported, and the presence of all shares is verified, as well as the absence of any scheduled task.
7. Go to "System > Config Backup" and upload config backup downloaded from step 2 above.
8. Restore this config backup.
9. All scheduled tasks are now restored.

The Leap15.1 VM was then shutdown and steps 6-8 were repeated on a freshly built Rockstor on Tumbleweed20190708. All scheduled tasks were properly restored.

### Summary of commits
- Include smart_manager.taskdefinition model in backup
- Create new method to restore this newly-included model.
- Add first tests for smart_manager.views.task_scheduler.get_queryset
- Add tests for valid POST request and placeholders for test of invalid POST requests
- Add test for invalid POST request due to already existing name.
- Add test for invalid POST request due to unsupported task type.
- Add tests for valid and invalid PUT and DELETE requests.

### Testing
New unit tests are now included in `test_task_scheduler.py`.


#### CentOS

```
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok

----------------------------------------------------------------------
Ran 8 tests in 2.030s

OK
```

#### Leap15.1 

```
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok

----------------------------------------------------------------------
Ran 8 tests in 2.422s

OK
```

#### Tumbleweed

```
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok

----------------------------------------------------------------------
Ran 8 tests in 1.925s

OK
```

### Caveats & shortcomings
@phillxnet, note that this PR will probably need to be rebased if/once #2055 is merged. I, of course, will do so if/when needed.


### Full Testing Outputs
<details><summary>CentOS</summary>

```
[root@rockdev build]# ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.151s)
  Applying contenttypes.0001_initial... OK (0.062s)
  Applying auth.0001_initial... OK (0.316s)
  Applying admin.0001_initial... OK (0.102s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.142s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.058s)
  Applying auth.0003_alter_user_email_max_length... OK (0.057s)
  Applying auth.0004_alter_user_username_opts... OK (0.053s)
  Applying auth.0005_alter_user_last_login_null... OK (0.062s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.511s)
  Applying oauth2_provider.0002_08_updates... OK (0.352s)
  Applying sessions.0001_initial... OK (0.068s)
  Applying sites.0001_initial... OK (0.051s)
  Applying smart_manager.0001_initial... OK (0.671s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.034s)
  Applying storageadmin.0001_initial... OK (11.522s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.753s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.769s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.338s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.132s)
  Applying storageadmin.0006_dcontainerargs... OK (0.402s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.912s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.204s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.510s)
  Applying contenttypes.0001_initial... OK (0.035s)
  Applying auth.0001_initial... OK (0.048s)
  Applying admin.0001_initial... OK (0.033s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.101s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.035s)
  Applying auth.0003_alter_user_email_max_length... OK (0.035s)
  Applying auth.0004_alter_user_username_opts... OK (0.036s)
  Applying auth.0005_alter_user_last_login_null... OK (0.047s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.213s)
  Applying oauth2_provider.0002_08_updates... OK (0.194s)
  Applying sessions.0001_initial... OK (0.019s)
  Applying sites.0001_initial... OK (0.019s)
  Applying smart_manager.0001_initial... OK (1.409s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.043s)
  Applying storageadmin.0001_initial... OK (9.518s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.725s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.786s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.369s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.378s)
  Applying storageadmin.0006_dcontainerargs... OK (0.412s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.666s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.034s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Error running a command. cmd = /usr/sbin/usermod -s /bin/bash admin. rc = 6. stdout = [\'\']. stderr = ["usermod: user \'admin\' does not exist", \'\']' != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 169 tests in 19.907s

FAILED (failures=25, errors=6)
```

</details>

<details><summary>Leap15.1</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.375s)
  Applying contenttypes.0001_initial... OK (0.044s)
  Applying auth.0001_initial... OK (0.193s)
  Applying admin.0001_initial... OK (0.071s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.090s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.046s)
  Applying auth.0003_alter_user_email_max_length... OK (0.036s)
  Applying auth.0004_alter_user_username_opts... OK (0.031s)
  Applying auth.0005_alter_user_last_login_null... OK (0.039s)
  Applying auth.0006_require_contenttypes_0002... OK (0.007s)
  Applying oauth2_provider.0001_initial... OK (0.361s)
  Applying oauth2_provider.0002_08_updates... OK (0.284s)
  Applying sessions.0001_initial... OK (0.055s)
  Applying sites.0001_initial... OK (0.034s)
  Applying smart_manager.0001_initial... OK (0.703s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.032s)
  Applying storageadmin.0001_initial... OK (9.638s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.899s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.769s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.392s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.229s)
  Applying storageadmin.0006_dcontainerargs... OK (0.561s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.734s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.157s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (10.577s)
  Applying contenttypes.0001_initial... OK (0.033s)
  Applying auth.0001_initial... OK (0.067s)
  Applying admin.0001_initial... OK (0.054s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.123s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.042s)
  Applying auth.0003_alter_user_email_max_length... OK (0.051s)
  Applying auth.0004_alter_user_username_opts... OK (0.046s)
  Applying auth.0005_alter_user_last_login_null... OK (0.049s)
  Applying auth.0006_require_contenttypes_0002... OK (0.014s)
  Applying oauth2_provider.0001_initial... OK (0.172s)
  Applying oauth2_provider.0002_08_updates... OK (0.176s)
  Applying sessions.0001_initial... OK (0.021s)
  Applying sites.0001_initial... OK (0.020s)
  Applying smart_manager.0001_initial... OK (1.207s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.044s)
  Applying storageadmin.0001_initial... OK (8.751s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.709s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.649s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.295s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.097s)
  Applying storageadmin.0006_dcontainerargs... OK (0.296s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.591s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.894s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 169 tests in 22.695s

FAILED (failures=25, errors=6)
```


</details>


<details><summary>Tumbleweed</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (11.552s)
  Applying contenttypes.0001_initial... OK (0.069s)
  Applying auth.0001_initial... OK (0.306s)
  Applying admin.0001_initial... OK (0.095s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.096s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.048s)
  Applying auth.0003_alter_user_email_max_length... OK (0.047s)
  Applying auth.0004_alter_user_username_opts... OK (0.032s)
  Applying auth.0005_alter_user_last_login_null... OK (0.047s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.426s)
  Applying oauth2_provider.0002_08_updates... OK (0.300s)
  Applying sessions.0001_initial... OK (0.074s)
  Applying sites.0001_initial... OK (0.042s)
  Applying smart_manager.0001_initial... OK (0.543s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.028s)
  Applying storageadmin.0001_initial... OK (10.593s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.732s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.788s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.415s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.211s)
  Applying storageadmin.0006_dcontainerargs... OK (0.591s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.763s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.222s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.681s)
  Applying contenttypes.0001_initial... OK (0.028s)
  Applying auth.0001_initial... OK (0.053s)
  Applying admin.0001_initial... OK (0.037s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.099s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.036s)
  Applying auth.0003_alter_user_email_max_length... OK (0.036s)
  Applying auth.0004_alter_user_username_opts... OK (0.037s)
  Applying auth.0005_alter_user_last_login_null... OK (0.040s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.158s)
  Applying oauth2_provider.0002_08_updates... OK (0.164s)
  Applying sessions.0001_initial... OK (0.017s)
  Applying sites.0001_initial... OK (0.022s)
  Applying smart_manager.0001_initial... OK (1.555s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.035s)
  Applying storageadmin.0001_initial... OK (7.303s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.538s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.572s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.514s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.861s)
  Applying storageadmin.0006_dcontainerargs... OK (0.291s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.586s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.899s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libacl.so.1'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 169 tests in 22.771s

FAILED (failures=25, errors=6)
```


</details>