### PR TITLE
fixed issue 2060 with support link

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/popuperr.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/popuperr.jst
@@ -29,11 +29,7 @@
         </a>
         to copy the above traceback to your clipboard.
     </li>
-    {{#if stable}}
-        <li>Create a support ticket with information from above two steps <a href="https://support.rockstor.com/open.php" target="_blank">here</a>.</li>
-    {{else}}
-        <li>Create a support topic with information from above two steps <a href="https://forum.rockstor.com/new-topic?title={{detail}}&category=support" target="_blank">here</a>.</li>
-        {{/if}}
+      <li>Create a support topic with information from above two steps <a href="https://forum.rockstor.com/new-topic?title={{detail}}&category=support" target="_blank">here</a>.</li>
   </ol>
 </div> <!-- err-help -->
 {{/unless}}


### PR DESCRIPTION
This fixes the support.rockstor.com link in ./src/rockstor/storageadmin/static/storageadmin/js/templates/common/popuperr.jst
It simply removed the if statement for stable and leaves the forum link for opening an issue.
https://github.com/rockstor/rockstor-core/issues/2060