### PR TITLE
[openSUSE] improve JeOS compatibility re ROOT label. Fixes #2062

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -279,7 +279,7 @@ SFTP_MNT_ROOT = '/mnt3/'
 
 # System volume label when no btrfs volume label is set as per default openSUSE
 # install: ie 'btrfs fi show' gives 'Label: none'
-SYS_VOL_LABEL = 'system'
+SYS_VOL_LABEL = 'ROOT'
 
 TAP_DIR = '${django-settings-conf:taplib}'
 TAP_SERVER = ('127.0.0.1', ${django-settings-conf:tapport})

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -266,7 +266,7 @@ SFTP_MNT_ROOT = '/mnt3/'
 
 # System volume label when no btrfs volume label is set as per default openSUSE
 # install: ie 'btrfs fi show' gives 'Label: none'
-SYS_VOL_LABEL = 'system'
+SYS_VOL_LABEL = 'ROOT'
 
 TAP_DIR = '${django-settings-conf:taplib}'
 TAP_SERVER = ('127.0.0.1', ${django-settings-conf:tapport})

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -324,7 +324,8 @@ class DiskMixin(object):
                 # TODO: First call we reset none pool label member count times!
                 # Corner case but room for efficiency improvement.
                 # Consider building a list of pools relabeled to address issue.
-                if pool_name == 'none':
+                # N.B. 'system' for early source to rpm installs - openSUSE
+                if pool_name == 'none' or pool_name == 'system':
                     pool_name = set_pool_label(p_info.uuid, dev_name, d.root)
                 # Update our disk database entry with btrfs specific data.
                 dob.devid = p_info.devid


### PR DESCRIPTION
To enable the use of btrfs based openSUSE JeOS images we required a change from our default root pool label expectation (enforced default where non found) to be in line with the default found, and depended upon (fstab mount by label) in these JeOS images.

Summary of changes:
- Change 'no root pool label' auto label mechanism to use 'ROOT'; in line with btrfs based openSUSE JeOS images.
- Provide a mechanism to migrate existing source installs over to this new default: prior default was 'system'.

Fixes #2062 

Testing.
An existing openSUSE (Tumbleweed) source based install was recompiled in place and found to successfully self migrate from a 'system' root pool label to the new default of 'ROOT'. Note that source based installs are expected to be recompiled and there are, as yet, no rockstor rpms distributed for openSUSE. 