### PR TITLE
Allow multiple versions for a docker image. Fixes #2017.

### DIFF
--- a/src/rockstor/scripts/rockon_delete.py
+++ b/src/rockstor/scripts/rockon_delete.py
@@ -19,9 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import sys
+
 from storageadmin.models import (RockOn, DContainer)
 from system.osi import run_command
-
 
 DOCKER = '/usr/bin/docker'
 
@@ -44,9 +44,11 @@ def delete_rockon():
         # We don't throw any exceptions because we want to ensure metadata is
         # deleted for sure. It would be nice to fully delete containers and
         # images, but that's not a hard requirement.
-        run_command([DOCKER, 'stop', c.name], throw=False)
-        run_command([DOCKER, 'rm', c.name], throw=False)
-        run_command([DOCKER, 'rmi', c.dimage.name], throw=False)
+        run_command([DOCKER, 'stop', c.name], throw=False, log=True)
+        run_command([DOCKER, 'rm', c.name], throw=False, log=True)
+        # Get image name with tag information
+        img_plus_tag = '{}:{}'.format(c.dimage.name, c.dimage.tag)
+        run_command([DOCKER, 'rmi', img_plus_tag], throw=False, log=True)
 
     ro.delete()
     print('Rock-On(%s) metadata in the db is deleted' % name)

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -195,9 +195,9 @@ class RockOnView(rfc.GenericView):
                     co.dimage.delete()
             if (co is None):
                 co = DContainer(name=c, rockon=ro)
-            defaults = {'tag': c_d.get('tag', 'latest'),
-                        'repo': 'na', }
+            defaults = {'repo': 'na', }
             io, created = DImage.objects.get_or_create(name=c_d['image'],
+                                                       tag=c_d.get('tag', 'latest'),
                                                        defaults=defaults)
             co.dimage = io
             co.launch_order = c_d['launch_order']


### PR DESCRIPTION
_**Note:**_ Although this pull-request (PR) is working as expected after testing of the underlying logic, I still need to test on openSUSE variants so I'm submitting this as _Draft_ for now. I will update once done.

Building on #2014, this pull request proposes to consider the docker container image tag **in combination** to the image name when parsing a rock-on JSON definition file. This would thus allow the use of different versions (tag) for the same docker container within a given rock-on, or across rock-ons.

# Aims & Logic
While both the image name _and_ the tag is taken into account when parsing the information from the rock-on JSON definition file, only the image name is used to select the `DImage` object that needs to be created/updated. As a result, any image tag information from a given image will overwrite the image tag of any pre-existing `DImage` object if it shares the same name (_i.e._ same docker project).
This PR fixes this simply by also accounting for the image **tag** when selecting the `DImage` object to be created/updated.

# Demonstration
On a Rockstor install freshly updated to upstream master, the following custom rock-on was uploaded to the local `rockons-metastore`:

```
{
	"Alpine With AddStorage Single": {
		"containers": {
			"alpine36": {
				"image": "alpine",
				"tag": "3.6",
				"launch_order": 1,
				"opts": [
					[
						"-it",
						""
					]
				],
				"ports": {},
				"volumes": {},
				"environment": {}
			},
  			"alpine_edge": {
				"image": "alpine",
				"tag": "edge",
				"launch_order": 2,
				"opts": [
					[
						"-it",
						""
					]
				],
				"ports": {},
				"volumes": {},
				"environment": {}
			},
			"alpine3": {
				"image": "alpine",
				"tag": "3",
				"launch_order": 3,
				"opts": [
					[
						"-it",
						""
					]
				],
				"ports": {},
				"volumes": {},
				"environment": {}
			},
			"alpinesingle": {
				"image": "alpine",
				"launch_order": 4,
				"opts": [
					[
						"-it",
						""
					]
				],
				"ports": {},
				"volumes": {},
				"environment": {}
			}
		},
		"description": "Alpine test tags Rock-on.",
		"ui": {
			"slug": ""
		},
		"volume_add_support": true,
		"website": "",
		"version": "1.0"
	}
}
```
As you can see above, this rock-on is simply designed to start 4 different containers of the same docker project (alpine) but each using a different image version. While only the last json entry was retained previously (as each new image entry was overwriting the previous one), the current PR allows all these containers to be started as intended:

```
[root@rockdev ~]# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
alpine              3                   961769676411        3 weeks ago         5.58MB
alpine              latest              961769676411        3 weeks ago         5.58MB
alpine              edge                70997d35b3ed        4 weeks ago         5.58MB
alpine              3.6                 43773d1dba76        6 months ago        4.02MB

[root@rockdev ~]# docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
1443f4ad2c71        alpine:latest       "/bin/sh"           39 minutes ago      Up 39 minutes                           alpinesingle
119400f1b6ba        alpine:3            "/bin/sh"           39 minutes ago      Up 39 minutes                           alpine3
469e70da98b1        alpine:edge         "/bin/sh"           39 minutes ago      Up 39 minutes                           alpine_edge
4ad024b3c1ae        alpine:3.6          "/bin/sh"           39 minutes ago      Up 39 minutes                           alpine36
```

Of note, the image tag information is also accounted for when using the `delete-rockon` script so that the correct image is removed from the system if the script is used.

@phillxnet, please note that I also added a few `log=True` flags to some `docker run` commands, in the same "spirit" than your recent PR (#2014). feel free to remove them if you think it's not necessary. I do find it useful when debugging.

# Testing
Soon...
