### PR TITLE
[openSUSE] Fix smartd config location in Rockstor-NG

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
@@ -1,6 +1,6 @@
 <script>
     /*
-    * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+    * Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
     * This file is part of RockStor.
     *
     * RockStor is free software; you can redistribute it and/or modify
@@ -28,7 +28,7 @@
                 <form class="form-horizontal" id="smartd-form" name="aform">
                     <div class="messages"></div>
                     <div class="form-group">
-                        <label class="col-sm-4 control-label" for="custom_config">configuration lines will be saved to the ROCKSTOR section in /etc/smartmontools/smartd.conf</label>
+                        <label class="col-sm-4 control-label" for="custom_config">configuration lines will be saved to the ROCKSTOR section in <em>smartd.conf</em></label>
                         <div class="col-sm-8">
                             {{#if config.custom_config}}
                             <textarea class="form-control" id="smartd_config" name="custom_config" rows="10">{{config.custom_config}}</textarea> {{else}}

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,25 +16,28 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import re
-from osi import run_command, get_base_device_byid, get_device_path
-from tempfile import mkstemp
-from shutil import move
 import logging
-from system.email_util import email_root
+import re
+from shutil import move
+from tempfile import mkstemp
+
+import distro
+
 from exceptions import CommandException
+from osi import run_command, get_base_device_byid, get_device_path
+from system.email_util import email_root
 
 logger = logging.getLogger(__name__)
 
-SMART = '/usr/sbin/smartctl'
-CAT = '/usr/bin/cat'
+SMART = "/usr/sbin/smartctl"
+CAT = "/usr/bin/cat"
 # enables reading file dumps of smartctl output instead of running smartctl
 # currently hardwired to read from eg:- /root/smartdumps/smart-H--info.out
 # default setting = False
 TESTMODE = False
 
 
-def info(device, custom_options='', test_mode=TESTMODE):
+def info(device, custom_options="", test_mode=TESTMODE):
     """
     Retrieve matching properties found in smartctl -H --info output.
     Used to populate the Identity / general info tab by views/disk_smart.py
@@ -44,41 +47,49 @@ def info(device, custom_options='', test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '-H', '--info'] + get_dev_options(device, custom_options),
-            throw=False)
+            [SMART, "-H", "--info"] + get_dev_options(device, custom_options),
+            throw=False,
+        )
     else:  # we are testing so use a smartctl -H --info file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-H--info.out'])
+        o, e, rc = run_command([CAT, "/root/smartdumps/smart-H--info.out"])
     # List of string matches to look for in smartctrl -H --info output.
     # Note the "|" char allows for defining alternative matches ie A or B
-    matches = ('Model Family:|Vendor:', 'Device Model:|Product:',
-               'Serial Number:|Serial number:',
-               'LU WWN Device Id:|Logical Unit id:',
-               'Firmware Version:|Revision', 'User Capacity:',
-               'Sector Sizes?:|Logical block size:', 'Rotation Rate:',
-               'Device is:', 'ATA Version is:',
-               'SATA Version is:', 'Local Time is:',
-               'SMART support is:.* Available',
-               'SMART support is:.* Enabled',
-               'SMART overall-health self-assessment|SMART Health Status:',)
+    matches = (
+        "Model Family:|Vendor:",
+        "Device Model:|Product:",
+        "Serial Number:|Serial number:",
+        "LU WWN Device Id:|Logical Unit id:",
+        "Firmware Version:|Revision",
+        "User Capacity:",
+        "Sector Sizes?:|Logical block size:",
+        "Rotation Rate:",
+        "Device is:",
+        "ATA Version is:",
+        "SATA Version is:",
+        "Local Time is:",
+        "SMART support is:.* Available",
+        "SMART support is:.* Enabled",
+        "SMART overall-health self-assessment|SMART Health Status:",
+    )
     # create a list of empty strings ready to store our smart results / values
-    res = ['', ] * len(matches)
-    version = ''
+    res = [""] * len(matches)
+    version = ""
     for line in o:
-        if (re.match('smartctl ', line) is not None):
-            version = ' '.join(line.split()[1:4])
+        if re.match("smartctl ", line) is not None:
+            version = " ".join(line.split()[1:4])
         for i in range(len(matches)):
-            if (re.match(matches[i], line) is not None):
+            if re.match(matches[i], line) is not None:
                 # find location of first colon
-                first_colon = re.search(':', line).start()
+                first_colon = re.search(":", line).start()
                 # Assume all characters after colon are the result / value and
                 # strip off begin and end spaces. Limit to 64 chars for db.
-                res[i] = line[first_colon + 1:].strip()[:64]
+                res[i] = line[first_colon + 1 :].strip()[:64]
     # smartctl version is expected at index 14 (15th item)
     res.insert(14, version)
     return res
 
 
-def extended_info(device, custom_options='', test_mode=TESTMODE):
+def extended_info(device, custom_options="", test_mode=TESTMODE):
     """Retrieves a list of SMART attributes found from parsing smartctl -a output
     Mostly ATA / SATA as SCSI uses a free form syntax for this.  Extracts all
     lines starting with ID# ATTRIBUTE_NAME and creates a dictionary of lists
@@ -92,31 +103,33 @@ def extended_info(device, custom_options='', test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '-a'] + get_dev_options(device, custom_options),
-            throw=False)
+            [SMART, "-a"] + get_dev_options(device, custom_options), throw=False
+        )
     else:  # we are testing so use a smartctl -a file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-a.out'])
+        o, e, rc = run_command([CAT, "/root/smartdumps/smart-a.out"])
     attributes = {}
     for i in range(len(o)):
-        if (re.match('Vendor Specific SMART Attributes with Thresholds:',
-                     o[i]) is not None):
-            if (len(o) > i + 1):
-                if (re.match('ID# ATTRIBUTE_NAME', o[i + 1]) is not None):
+        if (
+            re.match("Vendor Specific SMART Attributes with Thresholds:", o[i])
+            is not None
+        ):
+            if len(o) > i + 1:
+                if re.match("ID# ATTRIBUTE_NAME", o[i + 1]) is not None:
                     for j in range(i + 2, len(o)):
-                        if (o[j] == ''):
+                        if o[j] == "":
                             break
                         fields = o[j].strip().split()
-                        if (len(fields) > 10):
-                            fields[9] = ' '.join(fields[9:])
+                        if len(fields) > 10:
+                            fields[9] = " ".join(fields[9:])
                         # Some drives return "---" as a Threshold value, in
                         # this case substitute 999 as an integer equivalent.
-                        if fields[5] == '---':
-                            fields[5] = '999'
+                        if fields[5] == "---":
+                            fields[5] = "999"
                         attributes[fields[1]] = fields[0:10]
     return attributes
 
 
-def capabilities(device, custom_options='', test_mode=TESTMODE):
+def capabilities(device, custom_options="", test_mode=TESTMODE):
     """Retrieves a list of SMART capabilities found from parsing smartctl -c
     output ATA / SATA only.  Extracts all capabilities and build a dictionary
     of lists containing ID, Name, Flag, and description for each capability
@@ -128,31 +141,29 @@ def capabilities(device, custom_options='', test_mode=TESTMODE):
                       or test file
     """
     if not test_mode:
-        o, e, rc = run_command(
-            [SMART, '-c'] + get_dev_options(device, custom_options))
+        o, e, rc = run_command([SMART, "-c"] + get_dev_options(device, custom_options))
     else:  # we are testing so use a smartctl -c file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-c.out'])
+        o, e, rc = run_command([CAT, "/root/smartdumps/smart-c.out"])
     cap_d = {}
     for i in range(len(o)):
-        if (re.match('=== START OF READ SMART DATA SECTION ===',
-                     o[i]) is not None):
+        if re.match("=== START OF READ SMART DATA SECTION ===", o[i]) is not None:
             prev_line = None
             cur_cap = None
             for j in range(i + 2, len(o)):
-                if (re.match('.*:\s+\(.*\)', o[j]) is not None):
-                    cap = o[j][:o[j].index(':')]
-                    flag = o[j][(o[j].index('(') + 1):o[j].index(')')].strip()
-                    val = o[j][(o[j].index(')') + 1):].strip()
-                    if (val == 'seconds.' or val == 'minutes.'):
-                        val = '%s %s' % (flag, val)
-                        flag = ''
-                    if (prev_line is not None):
-                        cap = '%s %s' % (prev_line, cap)
+                if re.match(".*:\s+\(.*\)", o[j]) is not None:
+                    cap = o[j][: o[j].index(":")]
+                    flag = o[j][(o[j].index("(") + 1) : o[j].index(")")].strip()
+                    val = o[j][(o[j].index(")") + 1) :].strip()
+                    if val == "seconds." or val == "minutes.":
+                        val = "%s %s" % (flag, val)
+                        flag = ""
+                    if prev_line is not None:
+                        cap = "%s %s" % (prev_line, cap)
                         prev_line = None
                     cur_cap = cap
                     cap_d[cur_cap] = [flag, val]
-                elif (re.match('\s', o[j]) is not None):
-                    cap_d[cur_cap][1] += '\n'
+                elif re.match("\s", o[j]) is not None:
+                    cap_d[cur_cap][1] += "\n"
                     cap_d[cur_cap][1] += o[j].strip()
                 else:
                     prev_line = o[j].strip()
@@ -160,7 +171,7 @@ def capabilities(device, custom_options='', test_mode=TESTMODE):
     return cap_d
 
 
-def error_logs(device, custom_options='', test_mode=TESTMODE):
+def error_logs(device, custom_options="", test_mode=TESTMODE):
     """Retrieves a parsed list of SMART errors from the output of smartctl -l
     error May be empty if no errors, also returns a raw output of the error log
     itself
@@ -172,39 +183,40 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
     :return: log_l:   A list containing each line in turn of the error log.
     """
     local_base_dev = get_dev_options(device, custom_options)
-    smart_command = [SMART, '-l', 'error'] + local_base_dev
+    smart_command = [SMART, "-l", "error"] + local_base_dev
     if not test_mode:
         o, e, rc = run_command(smart_command, throw=False)
     else:
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart-l-error.out'])
+        o, e, rc = run_command([CAT, "/root/smartdumps/smart-l-error.out"])
     # As we mute exceptions when calling the above command we should at least
     # examine what we have as return code (rc); 64 has been seen when the error
     # log contains errors but otherwise executes successfully so we catch this.
     overide_rc = 64
-    e_msg = 'Drive %s has logged S.M.A.R.T errors. Please view ' \
-            'the Error logs tab for this device.' % local_base_dev
+    e_msg = (
+        "Drive %s has logged S.M.A.R.T errors. Please view "
+        "the Error logs tab for this device." % local_base_dev
+    )
     screen_return_codes(e_msg, overide_rc, o, e, rc, smart_command)
     ecode_map = {
-        'ABRT': 'Command ABoRTed',
-        'AMNF': 'Address Mark Not Found',
-        'CCTO': 'Command Completion Timed Out',
-        'EOM': 'End Of Media',
-        'ICRC': 'Interface Cyclic Redundancy Code (CRC) error',
-        'IDNF': 'IDentity Not Found',
-        'ILI': '(packet command-set specific)',
-        'MC': 'Media Changed',
-        'MCR': 'Media Change Request',
-        'NM': 'No Media',
-        'obs': 'obsolete',
-        'TK0NF': 'TracK 0 Not Found',
-        'UNC': 'UNCorrectable Error in Data',
-        'WP': 'Media is Write Protected',
+        "ABRT": "Command ABoRTed",
+        "AMNF": "Address Mark Not Found",
+        "CCTO": "Command Completion Timed Out",
+        "EOM": "End Of Media",
+        "ICRC": "Interface Cyclic Redundancy Code (CRC) error",
+        "IDNF": "IDentity Not Found",
+        "ILI": "(packet command-set specific)",
+        "MC": "Media Changed",
+        "MCR": "Media Change Request",
+        "NM": "No Media",
+        "obs": "obsolete",
+        "TK0NF": "TracK 0 Not Found",
+        "UNC": "UNCorrectable Error in Data",
+        "WP": "Media is Write Protected",
     }
     summary = {}
     log_l = []
     for i in range(len(o)):
-        if (re.match('=== START OF READ SMART DATA SECTION ===',
-                     o[i]) is not None):
+        if re.match("=== START OF READ SMART DATA SECTION ===", o[i]) is not None:
             err_num = None
             lifetime_hours = None
             state = None
@@ -212,31 +224,37 @@ def error_logs(device, custom_options='', test_mode=TESTMODE):
             details = None
             for j in range(i + 1, len(o)):
                 log_l.append(o[j])
-                if (re.match('Error ', o[j]) is not None):
+                if re.match("Error ", o[j]) is not None:
                     fields = o[j].split()
                     err_num = fields[1]
-                    if ('lifetime:' in fields):
-                        lifetime_hours = int(
-                            fields[fields.index('lifetime:') + 1])
-                if (re.match('When the command that caused the error occurred,'
-                             ' the device was',
-                             o[j].strip()) is not None):
-                    state = o[j].strip().split('the device was ')[1]
-                if (re.search('Error: ', o[j]) is not None):
-                    e_substr = o[j].split('Error: ')[1]
+                    if "lifetime:" in fields:
+                        lifetime_hours = int(fields[fields.index("lifetime:") + 1])
+                if (
+                    re.match(
+                        "When the command that caused the error occurred,"
+                        " the device was",
+                        o[j].strip(),
+                    )
+                    is not None
+                ):
+                    state = o[j].strip().split("the device was ")[1]
+                if re.search("Error: ", o[j]) is not None:
+                    e_substr = o[j].split("Error: ")[1]
                     e_fields = e_substr.split()
                     etype = e_fields[0]
-                    if (etype in ecode_map):
+                    if etype in ecode_map:
                         etype = ecode_map[etype]
-                    details = ' '.join(e_fields[1:]) if (
-                        len(e_fields) > 1) else 'No Sector Details Available'
-                    summary[err_num] = list(
-                        [lifetime_hours, state, etype, details])
+                    details = (
+                        " ".join(e_fields[1:])
+                        if (len(e_fields) > 1)
+                        else "No Sector Details Available"
+                    )
+                    summary[err_num] = list([lifetime_hours, state, etype, details])
                     err_num = lifetime_hours = state = etype = details = None
     return (summary, log_l)
 
 
-def test_logs(device, custom_options='', test_mode=TESTMODE):
+def test_logs(device, custom_options="", test_mode=TESTMODE):
     """Retrieves information from SMART Self-Test logs held by the drive.  Creates
     a dictionary of previous test info, indexed by test number and a list
     containing the remaining log info, each line is an item in the list.
@@ -245,43 +263,44 @@ def test_logs(device, custom_options='', test_mode=TESTMODE):
     :param test_mode: False causes cat from file rather than smartctl command
     :return: tuple of test_d as a dictionary of summarized test, plus a list
     """
-    smart_command = [SMART, '-l', 'selftest', '-l',
-                     'selective'] + get_dev_options(device, custom_options)
+    smart_command = [SMART, "-l", "selftest", "-l", "selective"] + get_dev_options(
+        device, custom_options
+    )
     if not test_mode:
         o, e, rc = run_command(smart_command, throw=False)
     else:
         o, e, rc = run_command(
-            [CAT, '/root/smartdumps/smart-l-selftest-l-selective.out'])
+            [CAT, "/root/smartdumps/smart-l-selftest-l-selective.out"]
+        )
     # A return code of 128 (non zero so run_command raises an exception) has
     # been seen when executing this command. Strange as it means
     # "Invalid argument to exit" anyway if we silence the throw of a generic
     # non 0 exception we can catch the 128, akin to 64 catch in error_logs().
     # N.B. no official list of rc = 128 in /usr/include/sysexits.h
     overide_rc = 128
-    e_msg = 'run_command(%s) returned an error of %s. This has undetermined ' \
-            'meaning. Please view the Self-Test Logs tab for this device.' \
-            % (smart_command, overide_rc)
+    e_msg = (
+        "run_command(%s) returned an error of %s. This has undetermined "
+        "meaning. Please view the Self-Test Logs tab for this device."
+        % (smart_command, overide_rc)
+    )
     screen_return_codes(e_msg, overide_rc, o, e, rc, smart_command)
     test_d = {}
     log_l = []
     for i in range(len(o)):
-        if (re.match('SMART Self-test log structure revision number',
-                     o[i]) is not None):
+        if re.match("SMART Self-test log structure revision number", o[i]) is not None:
             log_l.append(o[i])
-            if (len(o) > (i + 1)):
-                if (re.match('Num  Test_Description    Status',
-                             o[i + 1]) is not None):
+            if len(o) > (i + 1):
+                if re.match("Num  Test_Description    Status", o[i + 1]) is not None:
                     for j in range(i + 2, len(o)):
-                        if (re.match('# ', o[j]) is not None):
+                        if re.match("# ", o[j]) is not None:
                             # slit the line into fields using 2 or more spaces
-                            fields = re.split(r'\s\s+', o[j].strip()[2:])
+                            fields = re.split(r"\s\s+", o[j].strip()[2:])
                             # Some Seagate drives add an ongoing test progress
                             # report to the top of this log but there is then
                             # only one space delimiter and we loose a column.
                             if len(fields) == 5:  # it's normally 6 fields
                                 # we are missing a column (fast check)
-                                if re.match('Self-test routine in progress',
-                                            fields[2]):
+                                if re.match("Self-test routine in progress", fields[2]):
                                     # An ongoing self-test entry is to blame.
                                     status_fields = fields[2].split()
                                     # Move our last two line fields along one.
@@ -291,7 +310,7 @@ def test_logs(device, custom_options='', test_mode=TESTMODE):
                                     # freshly freed up column in line list.
                                     fields[3] = status_fields[-1]
                                     # Remove our % remaining in status field.
-                                    fields[2] = ' '.join(status_fields[:-1])
+                                    fields[2] = " ".join(status_fields[:-1])
                             # Remove the % char from this columns value
                             # and change % Remaining to % Completed.
                             fields[3] = 100 - int(fields[3][:-1])
@@ -301,13 +320,12 @@ def test_logs(device, custom_options='', test_mode=TESTMODE):
     return (test_d, log_l)
 
 
-def run_test(device, test, custom_options=''):
+def run_test(device, test, custom_options=""):
     # start a smart test(short, long or conveyance)
-    return run_command(
-        [SMART, '-t', test] + get_dev_options(device, custom_options))
+    return run_command([SMART, "-t", test] + get_dev_options(device, custom_options))
 
 
-def available(device, custom_options='', test_mode=TESTMODE):
+def available(device, custom_options="", test_mode=TESTMODE):
     """
     Returns boolean pair: true if SMART support is available on the device and
     true if SMART support is enabled.
@@ -317,45 +335,53 @@ def available(device, custom_options='', test_mode=TESTMODE):
     """
     if not test_mode:
         o, e, rc = run_command(
-            [SMART, '--info'] + get_dev_options(device, custom_options))
+            [SMART, "--info"] + get_dev_options(device, custom_options)
+        )
     else:  # we are testing so use a smartctl --info file dump instead
-        o, e, rc = run_command([CAT, '/root/smartdumps/smart--info.out'])
+        o, e, rc = run_command([CAT, "/root/smartdumps/smart--info.out"])
     a = False
     e = False
     for i in o:
         # N.B. .* in pattern match to allow for multiple spaces
-        if (re.match('SMART support is:.* Available', i) is not None):
+        if re.match("SMART support is:.* Available", i) is not None:
             a = True
-        if (re.match('SMART support is:.* Enabled', i) is not None):
+        if re.match("SMART support is:.* Enabled", i) is not None:
             e = True
     return a, e
 
 
-def toggle_smart(device, custom_options='', enable=False):
-    switch = 'on' if (enable) else 'off'
+def toggle_smart(device, custom_options="", enable=False):
+    switch = "on" if (enable) else "off"
     # enable SMART support of the device
     return run_command(
-        [SMART, '--smart=%s' % switch] + get_dev_options(device,
-                                                         custom_options))
+        [SMART, "--smart=%s" % switch] + get_dev_options(device, custom_options)
+    )
 
 
 def update_config(config):
-    SMARTD_CONFIG = '/etc/smartmontools/smartd.conf'
-    ROCKSTOR_HEADER = ('###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW '
-                       'THIS LINE###')
+    # The location of smartd.conf differs between openSUSE and CentOS.
+    # For sustainability and simplicity, set openSUSE's location as default
+    distro_id = distro.id()
+    if distro_id == "rockstor":
+        SMARTD_CONFIG = "/etc/smartmontools/smartd.conf"
+    else:
+        SMARTD_CONFIG = "/etc/smartd.conf"
+    ROCKSTOR_HEADER = (
+        "###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW " "THIS LINE###"
+    )
     fo, npath = mkstemp()
-    with open(SMARTD_CONFIG) as sfo, open(npath, 'w') as tfo:
+    with open(SMARTD_CONFIG) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
-            if (re.match('DEVICESCAN', line) is not None):
+            if re.match("DEVICESCAN", line) is not None:
                 # comment out this line, if not, smartd ignores everything else
-                tfo.write('#%s' % line)
-            elif (re.match(ROCKSTOR_HEADER, line) is None):
+                tfo.write("#%s" % line)
+            elif re.match(ROCKSTOR_HEADER, line) is None:
                 tfo.write(line)
             else:
                 break
-        tfo.write('%s\n' % ROCKSTOR_HEADER)
-        for l in config.split('\n'):
-            tfo.write('%s\n' % l)
+        tfo.write("%s\n" % ROCKSTOR_HEADER)
+        for l in config.split("\n"):
+            tfo.write("%s\n" % l)
 
     return move(npath, SMARTD_CONFIG)
 
@@ -380,16 +406,20 @@ def screen_return_codes(msg_on_hit, return_code_target, o, e, rc, command):
     # with the same.
     if rc == return_code_target:
         logger.error(msg_on_hit)
-        email_root('S.M.A.R.T error', msg_on_hit)
+        email_root("S.M.A.R.T error", msg_on_hit)
     # In all other non zero (error) instances we raise an exception as normal.
     elif rc != 0:
-        e_msg = ('non-zero code(%d) returned by command: %s output: '
-                 '%s error: %s' % (rc, command, o, e))
+        e_msg = "non-zero code(%d) returned by command: %s output: " "%s error: %s" % (
+            rc,
+            command,
+            o,
+            e,
+        )
         logger.error(e_msg)
-        raise CommandException(('%s' % command), o, e, rc)
+        raise CommandException(("%s" % command), o, e, rc)
 
 
-def get_dev_options(dev_byid, custom_options=''):
+def get_dev_options(dev_byid, custom_options=""):
     """Returns device specific options for all smartctl commands.  Note that in
     most cases this requires looking up the base device via get_base_device but
     in some instances this is not required as in the case of devices behind
@@ -404,31 +434,27 @@ def get_dev_options(dev_byid, custom_options=''):
     """
     # Initially our custom_options parameter may be None, ie db default prior
     # to any changes having been made. Deal with this by adding a guard.
-    if custom_options is None or custom_options == '':
+    if custom_options is None or custom_options == "":
         # Empty custom_options or they have never been set so just return
         # full path to base device as nothing else to do.
-        dev_options = [
-            get_device_path(get_base_device_byid(dev_byid, TESTMODE))]
+        dev_options = [get_device_path(get_base_device_byid(dev_byid, TESTMODE))]
     else:
         # Convert string of custom options into a list ready for run_command
         # TODO: think this ascii should be utf-8 as that's kernel standard
         # TODO: or just use str(custom_options).split()
-        dev_options = custom_options.encode('ascii').split()
+        dev_options = custom_options.encode("ascii").split()
         # Remove Rockstor native 'autodev' custom smart option raid dev target.
         # As we automatically add the full path by-id if a raid controller
         # target dev is not found, we can simply remove this option.
         # N.B. here we assume there is either 'autodev' or a specified target:
         # input validation was tested to reject both being entered.
-        if 'autodev' in dev_options:
-            dev_options.remove('autodev')
+        if "autodev" in dev_options:
+            dev_options.remove("autodev")
         # If our custom options don't contain a raid controller target then add
         # the full path to our base device as our last device specific option.
-        if (re.search('/dev/tw|/dev/cciss/c|/dev/sg|/dev/sd',
-                      custom_options) is None):
+        if re.search("/dev/tw|/dev/cciss/c|/dev/sg|/dev/sd", custom_options) is None:
             # add full path to our custom options as we see no raid target dev
-            dev_options += [
-                get_device_path(get_base_device_byid(dev_byid, TESTMODE))
-            ]
+            dev_options += [get_device_path(get_base_device_byid(dev_byid, TESTMODE))]
     # Note on raid controller target devices.  /dev/twe#, or /dev/twa#, or
     # /dev/twl# are 3ware controller targets devs respectively 3x-xxxx,
     # 3w-9xxx, and t2-sas (3ware/LSI 9750) drivers for respectively 6000, 7000,


### PR DESCRIPTION
Fixes #2070.
Thanks for @phillxnet for pointing out this simple fix.

This pull request proposes to use `python-distro` to simply point `SMARTD_CONFIG` variable to the correct path to smartd.conf, which differs between CentOS and openSUSE systems. As a result, this enables the customization of the SMART daemon from the webUI--as is currently possible in CentOS Rockstor.

@phillxnet, I believe this PR is **ready for review**.

# Aims & Logic

As established by @phillxnet in #1992, we can use `distro.id()` from the python2-distro package to get the distribution name, and use this to point the `SMARTD_CONFIG` variable to either the correct path:

| OS | `smartd.conf` location |
| ---: | --- |
| CentOS | /etc/smartmontools/smartd.conf |
| Leap 15.1 | /etc/smartd.conf |
| Tumbleweed | /etc/smartd.conf |

As we can see above, `smartd.conf`'s location is identical between Leap15.1 & Tumbleweed, and only differs in CentOS. For this reason, it is simpler to set the openSUSE's location as default, and only change it to the proper path in CentOS.

# Demonstration  
#### CentOS
1. Baseline is no custom config:
```
[root@rockdev ~]# tail -n2 /etc/smartmontools/smartd.conf 
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###


```

2. Set one custom parameter to the SMART daemon:
![image](https://user-images.githubusercontent.com/30297881/65993489-57f1c800-e45f-11e9-8791-429f74279006.png)

3. We now have:
```
[root@rockdev ~]# tail -n2 /etc/smartmontools/smartd.conf 
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###
DEVICESCAN -a
```

 #### Leap15.1
1. Baseline is no custom config:
```
rockdev:~ # tail -n 2 /etc/smartd.conf
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###

```

2. Set one custom parameter to the SMART daemon:
(same as above)

3. We now have:
```
rockdev:~ # tail -n 2 /etc/smartd.conf
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###
DEVICESCAN -a
```

 #### Tumbleweed
1. Baseline is no custom config:
```
rockdev:~ # tail -n 2 /etc/smartd.conf
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###

```

2. Set one custom parameter to the SMART daemon:
(same as above)

3. We now have:
```
rockdev:~ # tail -n 2 /etc/smartd.conf
###BEGIN: Rockstor smartd config. DO NOT EDIT BELOW THIS LINE###
DEVICESCAN -a
```


# Summary of commits
- Define SMARTD_CONFIG conditionally based on `distro.id()`
- Simplify UI text referring to smartd.conf to remove path (see screenshot above)
- Code formatting: Black compliance.

# Full testing outputs
<details><summary>CentOS</summary>

```
[root@rockdev build]# ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (13.906s)
  Applying contenttypes.0001_initial... OK (0.058s)
  Applying auth.0001_initial... OK (0.383s)
  Applying admin.0001_initial... OK (0.113s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.189s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.088s)
  Applying auth.0003_alter_user_email_max_length... OK (0.087s)
  Applying auth.0004_alter_user_username_opts... OK (0.086s)
  Applying auth.0005_alter_user_last_login_null... OK (0.073s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.837s)
  Applying oauth2_provider.0002_08_updates... OK (0.405s)
  Applying sessions.0001_initial... OK (0.071s)
  Applying sites.0001_initial... OK (0.122s)
  Applying smart_manager.0001_initial... OK (0.857s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.052s)
  Applying storageadmin.0001_initial... OK (14.593s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.376s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.011s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.522s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.667s)
  Applying storageadmin.0006_dcontainerargs... OK (0.613s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.354s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.774s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (16.047s)
  Applying contenttypes.0001_initial... OK (0.030s)
  Applying auth.0001_initial... OK (0.080s)
  Applying admin.0001_initial... OK (0.051s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.145s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.060s)
  Applying auth.0003_alter_user_email_max_length... OK (0.052s)
  Applying auth.0004_alter_user_username_opts... OK (0.052s)
  Applying auth.0005_alter_user_last_login_null... OK (0.051s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.244s)
  Applying oauth2_provider.0002_08_updates... OK (0.233s)
  Applying sessions.0001_initial... OK (0.022s)
  Applying sites.0001_initial... OK (0.035s)
  Applying smart_manager.0001_initial... OK (2.211s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.073s)
  Applying storageadmin.0001_initial... OK (11.800s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.964s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.856s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.470s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.474s)
  Applying storageadmin.0006_dcontainerargs... OK (0.447s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.867s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.363s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Error running a command. cmd = /usr/sbin/usermod -s /bin/bash admin. rc = 6. stdout = [\'\']. stderr = ["usermod: user \'admin\' does not exist", \'\']' != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 161 tests in 20.926s

FAILED (failures=25, errors=6)
```

</details>


<details><summary>Leap15.1</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.784s)
  Applying contenttypes.0001_initial... OK (0.071s)
  Applying auth.0001_initial... OK (0.249s)
  Applying admin.0001_initial... OK (0.075s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.099s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.040s)
  Applying auth.0003_alter_user_email_max_length... OK (0.046s)
  Applying auth.0004_alter_user_username_opts... OK (0.037s)
  Applying auth.0005_alter_user_last_login_null... OK (0.045s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.383s)
  Applying oauth2_provider.0002_08_updates... OK (0.234s)
  Applying sessions.0001_initial... OK (0.051s)
  Applying sites.0001_initial... OK (0.032s)
  Applying smart_manager.0001_initial... OK (0.546s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.028s)
  Applying storageadmin.0001_initial... OK (9.780s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.847s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.821s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.459s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.114s)
  Applying storageadmin.0006_dcontainerargs... OK (0.556s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.804s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.277s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (11.595s)
  Applying contenttypes.0001_initial... OK (0.028s)
  Applying auth.0001_initial... OK (0.049s)
  Applying admin.0001_initial... OK (0.037s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.114s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.046s)
  Applying auth.0003_alter_user_email_max_length... OK (0.043s)
  Applying auth.0004_alter_user_username_opts... OK (0.042s)
  Applying auth.0005_alter_user_last_login_null... OK (0.046s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.183s)
  Applying oauth2_provider.0002_08_updates... OK (0.171s)
  Applying sessions.0001_initial... OK (0.017s)
  Applying sites.0001_initial... OK (0.019s)
  Applying smart_manager.0001_initial... OK (1.277s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.190s)
  Applying storageadmin.0001_initial... OK (8.572s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.720s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.588s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.461s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.888s)
  Applying storageadmin.0006_dcontainerargs... OK (0.291s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.613s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.959s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 161 tests in 22.458s

FAILED (failures=25, errors=6)

```

</details>

<details><summary>Tumbleweed</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.085s)
  Applying contenttypes.0001_initial... OK (0.059s)
  Applying auth.0001_initial... OK (0.778s)
  Applying admin.0001_initial... OK (0.089s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.102s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.284s)
  Applying auth.0003_alter_user_email_max_length... OK (0.054s)
  Applying auth.0004_alter_user_username_opts... OK (0.055s)
  Applying auth.0005_alter_user_last_login_null... OK (0.053s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.870s)
  Applying oauth2_provider.0002_08_updates... OK (0.461s)
  Applying sessions.0001_initial... OK (0.071s)
  Applying sites.0001_initial... OK (0.038s)
  Applying smart_manager.0001_initial... OK (0.580s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.028s)
  Applying storageadmin.0001_initial... OK (11.241s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.647s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.739s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.362s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.033s)
  Applying storageadmin.0006_dcontainerargs... OK (0.563s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.727s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.272s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (10.608s)
  Applying contenttypes.0001_initial... OK (0.036s)
  Applying auth.0001_initial... OK (0.048s)
  Applying admin.0001_initial... OK (0.047s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.089s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.195s)
  Applying auth.0003_alter_user_email_max_length... OK (0.039s)
  Applying auth.0004_alter_user_username_opts... OK (0.041s)
  Applying auth.0005_alter_user_last_login_null... OK (0.039s)
  Applying auth.0006_require_contenttypes_0002... OK (0.017s)
  Applying oauth2_provider.0001_initial... OK (0.141s)
  Applying oauth2_provider.0002_08_updates... OK (0.146s)
  Applying sessions.0001_initial... OK (0.022s)
  Applying sites.0001_initial... OK (0.026s)
  Applying smart_manager.0001_initial... OK (2.387s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.235s)
  Applying storageadmin.0001_initial... OK (8.411s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.588s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.809s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.730s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.068s)
  Applying storageadmin.0006_dcontainerargs... OK (0.387s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.616s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.176s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
test_get (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_put (storageadmin.tests.test_network.NetworkTests) ... ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: test_get (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 141, in test_get
    status.HTTP_200_OK, msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_put (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 153, in test_put
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 137, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 159, in test_btrfs_disk_import_fail
    self.assertEqual(response.data[0], e_msg)
AssertionError: "Failed to import any pool on device db id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])." != "Failed to import any pool on device id (2). Error: (Error running a command. cmd = /sbin/btrfs fi show /dev/disk/by-id/mock-disk. rc = 1. stdout = ['']. stderr = ['ERROR: not a valid btrfs filesystem: /dev/disk/by-id/mock-disk', ''])."

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 124, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share id (24) does not exist.' != 'Invalid choice for browsable. Possible choices are yes or no.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 242, in test_put_requests_2
    msg=response.data)
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 1}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libacl.so.1'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 95, 'uid': 3, 'smb_shares': [], u'id': 1, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 161 tests in 21.701s

FAILED (failures=25, errors=6)
```

</details>