### PR TITLE
[Config Backup/Restore] Restore Service status

### DIFF
--- a/src/rockstor/system/config_backup.py
+++ b/src/rockstor/system/config_backup.py
@@ -42,6 +42,7 @@ def backup_config():
         ],
         "smart_manager": [
             "service",
+            "servicestatus",
             "taskdefinition"
         ],
     }


### PR DESCRIPTION
Fixes #2087.

As described in #2087, although we already restore the configurations of our services, their **status** is NOT restored.

This PR thus proposes to save the status of services in the config backup, and use this information to turn ON the services during the restore procedure. As a result, not only would the configuration of each service be restored, but their ON/OFF status would be the same as at the time of the backup creation.

## Aims & Logic
As the ON/OFF status of each service is already stored in smart_manager under the `servicestatus` model, one can simply dump all entries from this model during the config backup creation. At the end of the current procedure to restore the config of services, we can thus now also use the information from this newly-included model to fetch the ON/OFF status of each service. Then, we can simply send a `POST` call to the sm/services API to start the given service. pending:
- the service was ON in the config backup
- the service is currently OFF on the system

## Demonstration
1. On a CentOS Rockstor install, the following services are configured and turned ON:
- Rock-on
- Samba
![image](https://user-images.githubusercontent.com/30297881/69017525-a7d81000-0975-11ea-8709-731e82dc4ff4.png)

2. A config backup is created and downloaded in a separate machine.
3. Both the _Rock-on_ and _Samba_ services are turned OFF:
![image](https://user-images.githubusercontent.com/30297881/69017570-eec60580-0975-11ea-8fa4-f614616d9b2c.png)

4. The config backup created in step 2 above is then restored, and we can confirm that both the _Rock-on_ and _Samba_ services are back ON:
![image](https://user-images.githubusercontent.com/30297881/69017821-503aa400-0977-11ea-819f-4f7abac48898.png)

5. On a freshly dev-built Leap15.1, the same config backup can be uploaded and restored, resulting in both services being turned back ON:
![image](https://user-images.githubusercontent.com/30297881/69018244-677a9100-0979-11ea-8546-fe66154c9995.png)

The latter step was also successfully tested in Tumbleweed.

@phillxnet, I believe this is ready for review, but let me know if you'd like additional testing. As I could only test the successful trigger of a few services, I'm not sure if you'd like to have further and more thorough testing done.

## Summary of commits
- Validate service status in config backup from name
- Check the current status of the service and turn ON if:
-- the service was ON in the backup
-- the service is currently OFF on the new install