### PR TITLE
[openSUSE] replace legacy yum with dnf-yum. Fixes #2092

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -296,7 +296,7 @@ def rockstor_pkg_update_check(subscription=None):
         # "Listing changelogs since 2019-11-29" - legacy yum and dnf-yum
         # "Listing all changelogs" - legacy yum and dnf-yum with no --count=#
         # "Listing # latest changelogs" - dnf-yum with a --count=# options
-        if re.search("Listing", l) is not None:
+        if re.match("Listing", l) is not None:
             available = True
         if not available:
             continue

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -251,6 +251,7 @@ def repo_status(subscription):
 
 
 def rockstor_pkg_update_check(subscription=None):
+    distro_id = distro.id()
     if subscription is not None:
         switch_repo(subscription)
     pkg = "rockstor"
@@ -262,8 +263,17 @@ def rockstor_pkg_update_check(subscription=None):
     available = False
     new_version = None
     updates = []
+    if distro_id == "rockstor":
+        changelog_cmd = [YUM, "changelog", date, pkg]
+    else:  # We are assuming openSUSE with dnf-yum specific options
+        if date != "all":
+            changelog_cmd = [YUM, "changelog", "--since", date, pkg]
+        else:
+            # Here we list the default number of changelog entries:
+            # defaults to last 8 releases but states "Listing all changelogs"
+            changelog_cmd = [YUM, "changelog", pkg]
     try:
-        o, e, rc = run_command([YUM, "changelog", date, pkg])
+        o, e, rc = run_command(changelog_cmd)
     except CommandException as e:
         # Catch as yet unconfigured repos ie Leap 15.1: error log accordingly.
         # Avoids breaking current version display and update channel selection.

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -108,7 +108,8 @@ def rpm_build_info(pkg):
     try:
         o, e, rc = run_command([YUM, "info", "installed", "-v", pkg])
     except CommandException as e:
-        # Catch "No matching Packages to list" so we can return None, None.
+        # Catch "No matching Packages to list" so we can return:
+        # "Unknown Version", None
         emsg = "Error: No matching Packages to list"
         # By checking both the first error element and the second to last we
         # catch one yum waiting for another to release yum lock.
@@ -275,7 +276,7 @@ def rockstor_pkg_update_check(subscription=None):
     try:
         o, e, rc = run_command(changelog_cmd)
     except CommandException as e:
-        # Catch as yet unconfigured repos ie Leap 15.1: error log accordingly.
+        # Catch as yet unconfigured repos ie openSUSE Stable error log accordingly.
         # Avoids breaking current version display and update channel selection.
         emsg = "Error\\: Cannot retrieve repository metadata \\(repomd.xml\\)"
         if re.match(emsg, e.err[-2]) is not None:

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -282,7 +282,7 @@ def rockstor_pkg_update_check(subscription=None):
             logger.error(
                 "Rockstor repo for distro.id ({}) version ({}) may "
                 "not exist: pending or deprecated.\nReceived: ({}).".format(
-                    distro.id(), distro.version(), e.err
+                    distro_id, distro.version(), e.err
                 )
             )
             new_version = version  # Explicitly set (flag) for code clarity.

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -339,6 +339,12 @@ class SystemPackageTests(unittest.TestCase):
             )
 
     def test_rpm_build_info(self):
+        """
+        rpm_build_info strips out and concatenates Version and Release info for the
+        rockstor package. This is returned along with a standardised date format for
+        the Buildtime which is also parse out. N.B. the build time has 1 day added
+        to it for historical reasons.
+        """
         # legacy rockstor/CentOS YUM:
         dist_id = ["rockstor"]
         out = [


### PR DESCRIPTION
Yum has now long been superseded by dnf and given a recent suspected deprecation of legacy yum (which is python 2 based), and a missing yum package within Tumbleweed, if we move now to dnf-yum in both Leap15.x and Tumbleweed bases we further reduce our legacy dependencies.

This patch addresses a minor date formatting difference to enable the proposed dependency change from yum/yum-changelog to dnf-yum/dnf-plugins-core.

Fixes #2092 

~~Ready for review.~~

Prior to this pr our existing master branch recently failed to meet it's legacy dependency on Tumbleweed. Building with the indicated newer dependencies resulting in a failure to identify the build time of our installed RPM and thus a failure to identify relevant changelog elements. This in turn broke our Web-UI update capability.

Caveat:
The proposed dependency changed enabled here, that of moving to dnf-yum/dnf-plugins-core, brings with it a subsequent dependency on python3-distro. This is not thought to be a problem but is indicated as of future relevance, ie see issue:
move to python 3 #1877
especially given our current dependency on python2-distro.
