### PR TITLE
pin django-braces to restore django version compatibility. Fixes #2102

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         'requests == 1.1.0',
         'six == 1.10.0',
         'distro',
+        'django-braces == 1.13.0',  # 1.14.0 (30 Dec 2019) needs Django 1.11.0+
     ]
 
 )


### PR DESCRIPTION
On 30th Dec 2019 django-braces version 1.14.0 was release. This has a new minimum Django requirement of 1.11.0. To restore project django version compatibility we pin django-braces to the previously released version.

Fixes #2102 

Please see referenced issue for details of the observed build failure.

## Testing
Prior builds post 30th Dec 2019 fail as details in referenced issue.
Post pr patch the same build arrangements succeed.