### PR TITLE
revise donate menu item within Web-UI. Fixes #2104

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -988,7 +988,7 @@ $(document).ready(function() {
         }
     });
 
-    // donate button handler
+    // donate menu item handler
     $('#donate_nav').click(function(event) {
         if (event) {
             event.preventDefault();
@@ -996,23 +996,8 @@ $(document).ready(function() {
         $('#donate-modal').modal('show');
     });
 
-    $('#donate-modal #contrib-custom').click(function(e) {
-        $('#donate-modal #custom-amount').css('display', 'inline');
-    });
-    $('#donate-modal .contrib-other').click(function(e) {
-        $('#donate-modal #custom-amount').css('display', 'none');
-    });
-
-    $('#donate-modal #donateYes').click(function(event) {
-        contrib = $('#donate-modal input[type="radio"][name="contrib"]:checked').val();
-        if (contrib == 'custom') {
-            contrib = $('#custom-amount').val();
-        }
-        if (_.isNull(contrib) || _.isEmpty(contrib) || isNaN(contrib)) {
-            contrib = 0; // set contrib to 0, let user input the number on paypal
-        }
-        $('#contrib-form input[name="amount"]').val(contrib);
-        $('#contrib-form').submit();
+    // donate modal paypal donate button handler
+    $('#donate-modal #paypal_donate_button').click(function(event) {
         $('#donate-modal').modal('hide');
     });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -57,7 +57,7 @@
       <li><a href="mailto:support@rockstor.com" target="_blank">Team e-mail</a></li>
     </ul>
   </li>
-  <li><a id="donate_nav" href="#"><i class="fa fa-heart fa-lg" style="color:#BA0707" ></i> Donate</a></li>
+  <li><a id="donate_nav" href="#"></i> Donate</a></li>
   <li><a href="http://shop.rockstor.com" target="_blank"><i class="fa fa-shopping-cart fa-lg" style="color:#E76545"></i> Shop</a></li>
 
 </ul>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -124,7 +124,7 @@ $(document).ready(function(){
   {{#is_sub_active defaultSub}}
   <div class="alert alert-success" id="contrib-alert">
     <h4>We are happy to make this update available to you. Please support us by
-      <a id="donateYes" href="#version"> Donating</a> or making a <a href="http://shop.rockstor.com" target="_blank"> Purchase</a></h4>
+      <a id="showDonateModal" href="#">Donating</a> or making a <a href="http://shop.rockstor.com" target="_blank"> Purchase</a></h4>
   </div>
   {{/is_sub_active}}
   <a id="update" class="btn btn-primary" title="start update">Start Update</a>
@@ -173,16 +173,6 @@ $(document).ready(function(){
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
-
-<form id="contrib-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank"i style="display:none">
-  <input type="hidden" name="cmd" value="_xclick" />
-  <input type="hidden" name="business" value="WUDA5UNJXDCZ8" />
-  <input type="hidden" name="currency_code" value="USD" />
-  <input type="hidden" name="item_name" value="Support Rockstor development" />
-  <input type="hidden" name="amount" value="10" />
-  <input type="hidden" name="cn" value="Note to Rockstor developers" />
-  <input type="hidden" name="no_shipping" value="1" />
-</form>
 
 <div id="activate-stable" class="modal fade">
   <div class="modal-dialog">

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
@@ -27,7 +27,7 @@
 VersionView = RockstorLayoutView.extend({
     events: {
         'click #update': 'update',
-        'click #donateYes': 'donateYes',
+        'click #showDonateModal': 'showDonateModal',
         'click #autoUpdateSwitch': 'autoUpdateSwitch',
         'click #enableAuto': 'enableAutoUpdate',
         'click #disableAuto': 'disableAutoUpdate',
@@ -120,10 +120,8 @@ VersionView = RockstorLayoutView.extend({
         });
     },
 
-    donateYes: function() {
-        var contrib = 0;
-        this.$('input[name="amount"]').val(contrib);
-        this.$('#contrib-form').submit();
+    showDonateModal: function() {
+        $('#donate-modal').modal('show');
     },
 
     update: function() {

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -265,7 +265,7 @@
             dependant upon update channel subscriptions and donations.</h5>
           <form id="inner-contrib-form"
                 action="https://www.paypal.com/cgi-bin/webscr" method="post"
-                target="_blank">
+                target="_blank" style="text-align: center;">
             <input type="hidden" name="cmd" value="_s-xclick"/>
             <input type="hidden" name="hosted_button_id"
                    value="P72VDTYULUZTC"/>

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -278,6 +278,7 @@
             <!--      <img alt="" border="0" src="https://www.paypal.com/en_GB/i/scr/pixel.gif"-->
             <!--           width="1" height="1"/>-->
           </form>
+              <em>Upon clicking the above button, you will be redirected to our donation handler PayPal.</em>
         </div><!-- /.model-body -->
       </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -251,43 +251,36 @@
   </div>
 
   <div class="modal fade" id="donate-modal">
-      <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h3 id="donate-modal-label">Thank you! for supporting Rockstor development</h3>
-      </div>
-      <div class="modal-body">
-        <div class="radio">
-          <label>
-        <input type="radio" name="contrib" id="contrib10" value="10" checked>$10
-          </label>
-        <div class="radio">
-          <label>
-        <input type="radio" name="contrib" class="contrib-other" id="contrib20" value="20">$20
-          </label>
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"
+                  aria-label="Close"><span aria-hidden="true">&times;</span>
+          </button>
+          <h2 id="donate-modal-label">Please consider donating to help support
+            Rockstor's development</h2>
         </div>
-        <div class="radio">
-          <label>
-        <input type="radio" name="contrib" class="contrib-other" id="contrib30" value="30">$30
-          </label>
-        </div>
-        <div class="radio">
-          <label>
-        <input type="radio" name="contrib" class="contrib-other" id="contrib50" value="50">$50 (Free Rockstor USB drive)
-          </label>
-        </div>
-        <div class="radio">
-          <label>
-        <input type="radio" name="contrib" id="contrib-custom" value="custom">Other
-          </label>
-        </div>
-        &nbsp;<input class="span2" id="custom-amount" name="custom-amount" placeholder="Enter amount" style="display: none">
-        <br><br>
-        <a id="donateYes" class="btn btn-primary" title="Donate">Donate</a>
-      </div>
-    </div><!-- /.modal-content -->
-      </div><!-- /.modal-dialog -->
+        <div class="modal-body">
+          <h5 id="donate-modal-subtitle">Our Open Source development is
+            dependant upon update channel subscriptions and donations.</h5>
+          <form id="inner-contrib-form"
+                action="https://www.paypal.com/cgi-bin/webscr" method="post"
+                target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick"/>
+            <input type="hidden" name="hosted_button_id"
+                   value="P72VDTYULUZTC"/>
+            <input type="image"
+                   src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_SM.gif"
+                   border="0" name="paypal_donate_button"
+                   id="paypal_donate_button"
+                   title="PayPal - The safer, easier way to pay online!"
+                   alt="Donate with PayPal button"/>
+            <!--      <img alt="" border="0" src="https://www.paypal.com/en_GB/i/scr/pixel.gif"-->
+            <!--           width="1" height="1"/>-->
+          </form>
+        </div><!-- /.model-body -->
+      </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
   </div><!-- /.modal -->
 
 
@@ -295,15 +288,6 @@
       {% csrf_token %}
   </form>
 
-  <form id="contrib-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank"i style="display:none">
-      <input type="hidden" name="cmd" value="_xclick" />
-      <input type="hidden" name="business" value="WUDA5UNJXDCZ8" />
-      <input type="hidden" name="currency_code" value="USD" />
-      <input type="hidden" name="item_name" value="Support Rockstor development" />
-      <input type="hidden" name="amount" value="10" />
-      <input type="hidden" name="cn" value="Note to Rockstor developers" />
-      <input type="hidden" name="no_shipping" value="1" />
-  </form>
 
     <script src="/static/js/lib/bootstrap.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
Update/revise donate Web-UI mechanism to shift example donation amounts mechanism to our consequent handler, PayPal, and adopt PayPal's default donate button to clarify the handler used.

Includes:
- Simplified donate modal window contents and supporting JS mechanism as we now depend on our handler (PayPal) to provide the proposed amounts / options.
- As part of above, remove the USB key 'bonus' option as this is no longer available.
- Update payee to new maintainer.
- Remove red heart icon in main menu as 'eyesoure' and aesthetically inconsistent.
- Have our Testing Channel subscription page donate link invoke the same main menu invoked donate dialog: more consistent and enables a single point of communication with regard to the purpose of these donations.

Fixes #2104 

Ready for review.

Testing:
Functional testing of the resulting modal appearance and removal, on cross/donate click, and the associated PayPal link were tested as working. The post Testing Channel subscription state of the Software Update page donate link was also tested to invoke the donate dialog modal as intended.

Screen captures of the before and after menu/dialog elements affected are to follow.