### PR TITLE
improve/add update channel/appman related text and doc links. Fixes #2106

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -1012,7 +1012,7 @@ $(document).ready(function() {
     };
 
     var distroInfo = function(data) {
-        $('#distro-info').text(data.distro);
+        $('#distro-info').text("Uses " + data.distro);
         $('#distro-info').attr('title', data.version);
     };
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -52,7 +52,7 @@
     </a>
     <ul class="dropdown-menu">
       <li><a id="documentation_nav" href="http://rockstor.com/docs" target="_blank">Documentation</a></li>
-      <li><a href="http://rockstor.com/forums" target="_blank">Community forums</a></li>
+      <li><a href="https://forum.rockstor.com/" target="_blank">Community forum</a></li>
       <li><a href="https://github.com/rockstor/rockstor-core/issues?state=open" target="_blank">Issue tracker</a></li>
       <li><a href="mailto:support@rockstor.com" target="_blank">Team e-mail</a></li>
     </ul>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/home/home_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/home/home_template.jst
@@ -31,36 +31,43 @@
   </div>
 </div>
 
-
+<!-- One off first login message -->
 <div class="modal fade" id="update-version-modal">
-  <div class="modal-dialog">
+  <div class="modal-dialog justify-content-center">
     <div class="modal-content">
-      <div class="modal-body">
-	<h3 id="update-version-modal-label">Thanks for installing Rockstor. We recommend updating to the latest version.</h3>
-	<br>
-	<h4>Would you like to update now?</h4>
-	<br>
+      <div class="modal-body" >
+        <h2 id="update-version-modal-label">Welcome to the Rockstor Web User Interface (Web-UI)</h2>
+        <h3> Activating a Rockstor package
+          <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank">Update Channel</a>
+          and updating is recommended. All pending system updates will be included.
+          <em> Please be patient, this can take some time.</em></h3>
+        <h4><em>Our Open Source development is dependant upon update channel subscriptions and donations.</em></h4>
+        <h4>Would you like to update now?</h4>
+        <br>
       </div>
       <div class="modal-footer">
-	<button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
-	<a id="updateYes" class="btn btn-primary" title="Update">Update Now</a>
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
+        <a id="updateYes" class="btn btn-primary" title="Update">Update Now</a>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div>
 
+<!-- Displayed upon visiting the Dashboard if no Update Channel is selected -->
 <div class="modal fade" id="update-channel-modal">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">
-	<h3 id="update-channel-modal-label">Stable updates are not activated.</h3>
-	<br>
-	<h4>We recommend activating Stable updates unless you wish to run cutting edge code and actively test Rockstor. By purchasing Stable subscription, you are providing the crucial support we need. So Thanks in advance!</h4>
-	<br>
+        <h2 id="update-channel-modal-label">Please select a Rockstor package <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank">Update Channel</a></h2>
+        <h3>- Stable updates: recommended for production use (paid).
+          <br>
+          - Testing updates: for development / actively testing latest code (free).</h3>
+        <h4><em>Our Open Source development is dependant upon update channel subscriptions and donations.</em></h4>
+        <br>
       </div>
       <div class="modal-footer">
-	<button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
-	<a id="activate" class="btn btn-primary" title="Update">I'll activate</a>
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
+        <a id="activate" class="btn btn-primary" title="Update">I'll activate</a>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -10,12 +10,15 @@ $(document).ready(function(){
     {{#is_sub_active defaultSub}}
     <div class="alert alert-danger">
       <p>
-	Testing updates are activated. These are cutting edge updates that should
-	be applied only after careful consideration. When an update is released,
-	read the changelog and proceed with caution.
+        <a href="http://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
+        are <strong>activated</strong>. These are cutting edge updates that should
+        be applied only after careful consideration. When an update is released,
+        read the changelog and proceed with caution.
       </p>
       <p>
-	Alternatively, Stable updates are generally recommended as shown below.
+        Alternatively,
+        <a href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
+        are generally recommended as shown below.
       </p>
     </div>
     {{/is_sub_active}}
@@ -23,11 +26,12 @@ $(document).ready(function(){
     {{#no_sub_active}}
     <div class="alert alert-success">
       <p>
-	You can receive software updates from one of the two update channels as
-	shown in the below table. Please activate a channel that is appropriate
-	for your needs. Stable updates are generally recommended, unless you want
-	to actively test Rockstor. If you have questions, email
-	support@rockstor.com
+        Rockstor package
+        <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank"> update channels. </a>
+        Please activate appropriately for your needs.
+        <br>- <strong>Stable updates</strong>: recommended for production use (paid).
+        <br>- <strong>Testing updates</strong>: for development / actively testing latest code (free).
+        <br>See our <a href="https://forum.rockstor.com/" target="_blank">friendly forum</a> for advise.
       </p>
     </div>
     {{/no_sub_active}}
@@ -38,15 +42,15 @@ $(document).ready(function(){
       <thead>
 	<tr class="active">
           <th>Feature</th>
-          <th>Stable Updates</th>
-          <th>Testing Updates</th>
+          <th><a href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a></th>
+          <th><a href="http://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a></th>
 	</tr>
       </thead>
       <tbody>
 	<tr>
           <td>Update Frequency</td>
-          <td>3-4 Weeks</td>
-          <td>2-3 days</td>
+          <td>1-2 Months</td>
+          <td>1-2 Weeks</td>
 	</tr>
 	<tr>
           <td>Priority of bug fixes</td>
@@ -150,8 +154,11 @@ $(document).ready(function(){
   <div id="updateInfo" class="alert alert-success">
     <p></p>
     <p>
-      Stable updates are activated. While it's not recommended, if you are
-      absolutely sure, Testing updates can be activated by clicking <a id="testing-modal"> here.</a>
+      <a href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
+      are <strong>activated</strong>. While it's not recommended, if you are
+      absolutely sure,
+      <a href="http://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
+      can be activated by clicking <a id="testing-modal"> here.</a>
     </p>
   </div>
   {{/is_sub_active}}
@@ -188,8 +195,8 @@ $(document).ready(function(){
 	  <li>Purchase the Activation code by clicking <a href="http://shop.rockstor.com/products/stable-release-channel-subscription#applianceid={{applianceId}}" target="_blank">here.</a>
 	  <li>The Activation code will be sent to you via e-mail.</li>
 	  <li>Come back to this screen and enter the Activation code.</li>
-	  <li>Enjoy Stable updates. Thanks for supporting Rockstor!</li>
 	</ol>
+        Thanks for helping to support Rockstor's development.
 	<form id="activate-stable-form" name="aform" class="form-horizontal">
 	  <div class="form-group">
 	    <label class="col-sm-4 control-label" for="activation-code">Activation Code <span class="required">*</span></label>
@@ -201,7 +208,11 @@ $(document).ready(function(){
 	      {{/if}}
 	    </div>
 	  </div>
-	  <p style="color:'#eb6841'">UUID for reference: {{applianceId}}</p>
+	  <p style="color:green">Current Appliance ID: {{applianceId}}</p>
+    <br>
+    Note our complementary self service <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.
+    <br>
+    The above 'Current Appliance ID' should match that within Appman for this computer.
 	  <div class="modal-footer">
   	    <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
   	    <a id="activateStable" class="btn btn-primary" title="Activate">Activate</a>
@@ -222,14 +233,14 @@ $(document).ready(function(){
       <div class="modal-body">
 	<p>
 	  Testing updates are high frequency updates that are released just
-	  after testing in development environment as opposed to Stable updates
+	  after development environment testing, as opposed to Stable updates
 	  that are released only after significant testing and qualification
-	  process. Because of this, Testing updates are cutting edge that are
+	  processes. Because of this, Testing updates are higher risk and are
 	  generally not recommended.
 	</p>
 	<p>
 	  Whenever an update is released, read the changelog and decide to
-	  update or not after careful consideration.
+	  update or not only after careful consideration.
 	</p>
       	<p>Are you sure?</p>
       </div>


### PR DESCRIPTION
Improve text & add doc links to update channel selection modal dialog reminder prompts: first login & Dashboard popups.

Includes:
- Improve update text clarity/brevity and add doc links accordingly.
- Update Frequency corrections for both channels.
- Normalise on ',.. dependant upon ...' text with donate modal dialog.
- Fix colour highlighting bug for Appliance ID text.
- Add Appman link and text on activation code entry dialog.
- Suggest forum rather than support email for general update channel selection assistance.
- Reduce apparent number of steps for Stable channel activation.
- Add "Uses" to distro base header text, i.e. "Uses openSUSE Linux:", "Uses Tumbleweed Linux:".

Additionally:
- Update menu forum link & text to avoid redirect & improve robustness:

Our prior forum link was rockstor.com/forums. This older dir reference is now redirected but consequently depends on two web servers. By going directly to the new sub-domain url we avoid this dual dependency and have this link work while our main site is down for maintenance; for example.

See also issue text for more context:
Fixes #2106
and
Fixes #1811 

Ready for review.

Testing:
All new links were verified as working and before/after dialog / affected page screen shots are to follow shortly.