### PR TITLE
failure to build on Tumbleweed for master tag 3.9.2-52. Fixes #2113

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'pytz == 2014.3',
         'pyzmq == 15.0.0',
         'requests == 1.1.0',
-        'six == 1.10.0',
+        'six == 1.14.0',  # 1.14.0 (15 Jan 2020) Python 2/3 compat lib
         'distro',
         'django-braces == 1.13.0',  # 1.14.0 (30 Dec 2019) needs Django 1.11.0+
     ]


### PR DESCRIPTION
Simply updates, but leaves pinned, our six library dependency. Note that from the six changelog:
https://github.com/benjaminp/six/blob/master/CHANGES this latest version of the library removes Pytnon2.6 and 3.2 compatibility. However we are assuming a minimum python 2.7 anyway.

Fixes #2113
