### PR TITLE
File sharing initialism inconsistencies. Fixes #2117

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/afp/afp.jst
@@ -17,7 +17,7 @@
     <div class="messages"></div>
     <!-- Content -->
     {{#if collectionNotEmpty}}
-      <table id="afp-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of afp exports">
+      <table id="afp-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of AFP exports">
         <thead>
           <tr>
             <th scope="col" abbr="Share name">Share</th>
@@ -39,11 +39,11 @@
         </tbody>
       </table>
       {{else}}
-      <table id="afp-exports-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" width="100%" summary="List of afp exports">
+      <table id="afp-exports-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" width="100%" summary="List of AFP exports">
         <tbody>
           <tr>
             <td colspan="5">
-              <h4>No afp exports have been created</h4>
+              <h4>No AFP exports have been created</h4>
             </td>
           </tr>
         </tbody>
@@ -51,9 +51,9 @@
     {{/if}}
 
     {{#if sharesNotEmpty}}
-      <a href="#add-afp-share" id="add-afp-share" class="btn btn-primary"><i class="glyphicon glyphicon-edit "></i> Add afp Export</a>
+      <a href="#add-afp-share" id="add-afp-share" class="btn btn-primary"><i class="glyphicon glyphicon-edit "></i> Add AFP Export</a>
     {{else}}
-      <a href="#add-afp-share" id="add-afp-share" class="btn btn-primary disabled" title="No shares available to export through afp"><i class="glyphicon glyphicon-edit "></i> Add afp Export</a>
+      <a href="#add-afp-share" id="add-afp-share" class="btn btn-primary disabled" title="No shares available to export through AFP"><i class="glyphicon glyphicon-edit "></i> Add AFP Export</a>
     {{/if}}
   </div>
 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/nfs/nfs_exports.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/nfs/nfs_exports.jst
@@ -39,7 +39,7 @@
     <div class="messages"></div>
     <!-- Content -->
     {{#if collectionNotEmpty}}
-      <table id="nfs-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of nfs exports">
+      <table id="nfs-exports-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of NFS exports">
         <thead>
           <tr>
             <th scope="col" abbr="Shares">Shares</th>
@@ -72,7 +72,7 @@
         <tbody>
           <tr>
             <td colspan="5">
-              <h4>No nfs exports have been created</h4>
+              <h4>No NFS exports have been created</h4>
             </td>
           </tr>
         </tbody>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/sftp/sftp.jst
@@ -15,7 +15,7 @@
     </div>
     <div class="messages"></div>
     {{#if collectionNotEmpty}}
-      <table id="sftp-shares-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of sftp shares">
+      <table id="sftp-shares-table" class="table table-bordered table-striped share-table data-table" width="100%" summary="List of SFTP shares">
         <thead>
           <tr>
             <th scope="col" abbr="Host String">Share</th>
@@ -35,11 +35,11 @@
         </tbody>
       </table>
       {{else}}
-      <table id="sftp-shares-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of sftp shares">
+      <table id="sftp-shares-table" class="table table-condensed table-bordered table-hover table-striped share-table tablesorter" summary="List of SFTP shares">
         <tbody>
           <tr>
             <td colspan="5">
-              <h4>No sftp shares have been created</h4>
+              <h4>No SFTP shares have been created</h4>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
- Changed 'afp' to 'AFP'
- Changed 'sftp' to 'SFTP'
- Changed 'nfs' to 'NFS'

Fixes #2117 