### PR TITLE
support longer device names. Fixes #2026

### DIFF
--- a/src/rockstor/storageadmin/migrations/0009_auto_20200210_1948.py
+++ b/src/rockstor/storageadmin/migrations/0009_auto_20200210_1948.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0008_auto_20190115_1637'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='disk',
+            name='name',
+            field=models.CharField(unique=True, max_length=192),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -43,7 +43,7 @@ class Disk(models.Model):
     in turn are symlinks to sda, sdb etc.  eg ata-QEMU_HARDDISK_QM00005 ie
     mostly derived from model and serial number.
     """
-    name = models.CharField(max_length=128, unique=True)
+    name = models.CharField(max_length=192, unique=True)
     """btrfs devid 0 is place holder as real devids start from 1"""
     devid = models.PositiveSmallIntegerField(default=0)  # 0 to 32767
     """total size in KB. Zero if btrfs device detached/last stage of delete."""


### PR DESCRIPTION
Increase length our disk model name field from 128 to 192 chars. This accommodates for extra long by id devices names such as have been reported in for example the following SanDisk models:

- SanDisk Ultra Fit 64GB USB 3.0 (suspected: SDCZ43)
- SanDisk Ultra 32GB USB 3.0 (suspect: SDCZ48-O32G)

Includes Django database migration file.

Fixes #2026

Please see issue text for context and more information.

Ready for review.

Testing: 
The migration file was generated on a Leap15.1 source install:
```
leap15-1:/opt/rockstor-dev # /opt/rockstor-dev/bin/django makemigrations storageadmin
Migrations for 'storageadmin':
 0009_auto_20200210_1948.py:
   - Alter field name on disk
```
and subsequently applied to the running database (with all rockstor services stopped) without issue:
```
leap15-1:/opt/rockstor-dev # /opt/rockstor-dev/bin/django migrate storageadmin
Operations to perform:
 Apply all migrations: storageadmin
Running migrations:
 Rendering model states... DONE
 Applying storageadmin.0009_auto_20200210_1948... OK
The following content types are stale and need to be deleted:

   storageadmin | networkinterface
   storageadmin | poolstatistic
   storageadmin | sharestatistic

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

   Type 'yes' to continue, or 'no' to cancel: no
```
The resulting database was then inspected vi PyCharm tools and found to have been altered as expected:
before:
name varchar(128)
after
name varchar(192)
