### PR TITLE
Source package default smb.service in "Built on openSUSE" variants. Fixes #2127

### DIFF
--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,25 +16,28 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import logging
+import re
 import shutil
-from rest_framework.response import Response
-from storageadmin.util import handle_exception
-from system.services import systemctl, service_status
-from system.samba import (update_global_config, restart_samba,
-                          get_global_config)
-from django.db import transaction
+from tempfile import mkstemp
+
 from django.conf import settings
+from django.db import transaction
+from rest_framework.response import Response
+
 from base_service import BaseServiceDetailView
 from smart_manager.models import Service
-from system.osi import md5sum
 from smart_manager.serializers import ServiceStatusSerializer
+from storageadmin.util import handle_exception
+from system.osi import md5sum
+from system.samba import update_global_config, restart_samba, get_global_config
+from system.services import systemctl, service_status
 
-import logging
 logger = logging.getLogger(__name__)
 
 
 class SambaServiceView(BaseServiceDetailView):
-    service_name = 'smb'
+    service_name = "smb"
 
     @transaction.atomic
     def get(self, request, *args, **kwargs):
@@ -52,68 +55,115 @@ class SambaServiceView(BaseServiceDetailView):
         """
         service = Service.objects.get(name=self.service_name)
 
-        if (command == 'config'):
+        if command == "config":
             try:
-                config = request.data.get('config', {})
+                config = request.data.get("config", {})
                 global_config = {}
-                if 'global_config' in config:
-                    gc_lines = config['global_config'].split('\n')
+                if "global_config" in config:
+                    gc_lines = config["global_config"].split("\n")
                     for l in gc_lines:
-                        gc_param = l.strip().split(' = ')
-                        if (len(gc_param) == 2):
-                            if '=' in gc_param[0]:
+                        gc_param = l.strip().split(" = ")
+                        if len(gc_param) == 2:
+                            if "=" in gc_param[0]:
                                 raise Exception(
-                                    'Syntax error, one param has wrong '
-                                    'spaces around equal signs, '
-                                    'please check syntax of '
-                                    '\'%s\'' % ''.join(gc_param))
-                            global_config[gc_param[0].strip().lower()] = gc_param[1].strip()  # noqa
+                                    "Syntax error, one param has wrong "
+                                    "spaces around equal signs, "
+                                    "please check syntax of "
+                                    "'%s'" % "".join(gc_param)
+                                )
+                            global_config[gc_param[0].strip().lower()] = gc_param[
+                                1
+                            ].strip()  # noqa
                     # #E501 Default set current workgroup to one got via samba
                     # config page
-                    global_config['workgroup'] = config['workgroup']
+                    global_config["workgroup"] = config["workgroup"]
                 else:
                     global_config = config
                 # Check Active Directory config and status if AD configured and
                 # ON set workgroup to AD retrieved workgroup else AD not
                 # running and leave workgroup to one choosen by user
-                adso = Service.objects.get(name='active-directory')
+                adso = Service.objects.get(name="active-directory")
                 adconfig = None
                 adso_status = 1
-                if (adso.config is not None):
+                if adso.config is not None:
                     adconfig = self._get_config(adso)
                     adso_out, adso_err, adso_status = service_status(
-                        'active-directory', adconfig)
+                        "active-directory", adconfig
+                    )
                     if adso_status == 0:
-                        global_config['workgroup'] = adconfig['workgroup']
+                        global_config["workgroup"] = adconfig["workgroup"]
                     else:
                         adconfig = None
 
                 self._save_config(service, global_config)
                 update_global_config(global_config, adconfig)
-                restart_samba(hard=True)
+                _, _, smb_rc = service_status(self.service_name)
+                # Restart samba only if already ON
+                # rc == 0 if service is ON, rc != 0 otherwise
+                if smb_rc == 0:
+                    restart_samba(hard=True)
             except Exception as e:
-                e_msg = ('Samba could not be configured. Try again. '
-                         'Exception: %s' % e.__str__())
+                e_msg = (
+                    "Samba could not be configured. Try again. "
+                    "Exception: %s" % e.__str__()
+                )
                 handle_exception(Exception(e_msg), request)
         else:
             try:
-                if (command == 'stop'):
-                    systemctl('smb', 'disable')
-                    systemctl('nmb', 'disable')
+                if command == "stop":
+                    systemctl("smb", "disable")
+                    systemctl("nmb", "disable")
                 else:
-                    systemd_name = '%s.service' % self.service_name
-                    ss_dest = ('/etc/systemd/system/%s' % systemd_name)
-                    ss_src = ('%s/%s' % (settings.CONFROOT, systemd_name))
-                    sum1 = md5sum(ss_dest)
-                    sum2 = md5sum(ss_src)
-                    if (sum1 != sum2):
-                        shutil.copy(ss_src, ss_dest)
-                    systemctl('smb', 'enable')
-                    systemctl('nmb', 'enable')
-                systemctl('nmb', command)
-                systemctl('smb', command)
+                    systemd_name = "{}.service".format(self.service_name)
+                    distro_id = settings.OS_DISTRO_ID
+                    self._write_smb_service(systemd_name, distro_id)
+                    systemctl("smb", "enable")
+                    systemctl("nmb", "enable")
+                systemctl("nmb", command)
+                systemctl("smb", command)
             except Exception as e:
-                e_msg = ('Failed to %s samba due to a system error: %s'
-                         % (command, e.__str__()))
+                e_msg = "Failed to {} samba due to a system error: {}".format(
+                    command, e.__str__()
+                )
                 handle_exception(Exception(e_msg), request)
         return Response()
+
+    def _write_smb_service(self, systemd_name, distro_id):
+        """
+        Customize smb.service file in a distro-dependent manner.
+        In rockstor-based systems, source from settings.CONFROOT.
+        In opensuse-based systems, source from package default.
+        Check for differences before final copy.
+        :param systemd_name:
+        :param distro_id:
+        :return:
+        """
+        ss_dest = "/etc/systemd/system/{}".format(systemd_name)
+
+        # BEGIN CentOS section
+        if distro_id == "rockstor":
+            ss_src = "{}/{}".format(settings.CONFROOT, systemd_name)
+            sum1 = md5sum(ss_dest)
+            sum2 = md5sum(ss_src)
+            if sum1 != sum2:
+                shutil.copy(ss_src, ss_dest)
+        # END CentOS section
+
+        else:
+            ss_src = "/usr/lib/systemd/system/smb.service"
+            # Customize package's default
+            fo, npath = mkstemp()
+            with open(ss_src) as ino, open(npath, "w") as tfo:
+                for l in ino.readlines():
+                    if re.match("After=", l) is not None:
+                        tfo.write(
+                            "{} {}\n".format(l.strip(), "rockstor-bootstrap.service")
+                        )
+                    else:
+                        tfo.write(l)
+
+            # Check for diff and then move file from temp to final location
+            sum1 = md5sum(ss_dest)
+            sum2 = md5sum(npath)
+            if sum1 != sum2:
+                shutil.move(npath, ss_dest)

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,80 +16,84 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
-from services import service_status
+import os
+import re
 import shutil
 from tempfile import mkstemp
-import re
-import os
-from storageadmin.models import SambaCustomConfig
+
 from django.conf import settings
 
+from osi import run_command
+from services import service_status
+from storageadmin.models import SambaCustomConfig
 
-TESTPARM = '/usr/bin/testparm'
-SMB_CONFIG = '/etc/samba/smb.conf'
-SYSTEMCTL = '/usr/bin/systemctl'
-CHMOD = '/usr/bin/chmod'
-RS_SHARES_HEADER = '####BEGIN: Rockstor SAMBA CONFIG####'
-RS_SHARES_FOOTER = '####END: Rockstor SAMBA CONFIG####'
-RS_AD_HEADER = '####BEGIN: Rockstor ACTIVE DIRECTORY CONFIG####'
-RS_AD_FOOTER = '####END: Rockstor ACTIVE DIRECTORY CONFIG####'
-RS_CUSTOM_HEADER = '####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####'
-RS_CUSTOM_FOOTER = '####END: Rockstor SAMBA GLOBAL CUSTOM####'
+TESTPARM = "/usr/bin/testparm"
+SMB_CONFIG = "/etc/samba/smb.conf"
+SYSTEMCTL = "/usr/bin/systemctl"
+CHMOD = "/usr/bin/chmod"
+RS_SHARES_HEADER = "####BEGIN: Rockstor SAMBA CONFIG####"
+RS_SHARES_FOOTER = "####END: Rockstor SAMBA CONFIG####"
+RS_AD_HEADER = "####BEGIN: Rockstor ACTIVE DIRECTORY CONFIG####"
+RS_AD_FOOTER = "####END: Rockstor ACTIVE DIRECTORY CONFIG####"
+RS_CUSTOM_HEADER = "####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####"
+RS_CUSTOM_FOOTER = "####END: Rockstor SAMBA GLOBAL CUSTOM####"
 
 
-def test_parm(config='/etc/samba/smb.conf'):
-    cmd = [TESTPARM, '-s', config]
+def test_parm(config="/etc/samba/smb.conf"):
+    cmd = [TESTPARM, "-s", config]
     o, e, rc = run_command(cmd, throw=False)
-    if (rc != 0):
-        raise Exception('Syntax error while checking the temporary '
-                        'samba config file')
+    if rc != 0:
+        raise Exception(
+            "Syntax error while checking the temporary samba config file"
+        )
     return True
 
 
 def rockstor_smb_config(fo, exports):
-    mnt_helper = os.path.join(settings.ROOT_DIR, 'bin/mnt-share')
-    fo.write('%s\n' % RS_SHARES_HEADER)
+    mnt_helper = os.path.join(settings.ROOT_DIR, "bin/mnt-share")
+    fo.write("%s\n" % RS_SHARES_HEADER)
     for e in exports:
-        admin_users = ''
+        admin_users = ""
         for au in e.admin_users.all():
-            admin_users = '%s%s ' % (admin_users, au.username)
-        fo.write('[%s]\n' % e.share.name)
+            admin_users = "%s%s " % (admin_users, au.username)
+        fo.write("[%s]\n" % e.share.name)
         fo.write('    root preexec = "%s %s"\n' % (mnt_helper, e.share.name))
-        fo.write('    root preexec close = yes\n')
-        fo.write('    comment = %s\n' % e.comment.encode('utf-8'))
-        fo.write('    path = %s\n' % e.path)
-        fo.write('    browseable = %s\n' % e.browsable)
-        fo.write('    read only = %s\n' % e.read_only)
-        fo.write('    guest ok = %s\n' % e.guest_ok)
-        if (len(admin_users) > 0):
-            fo.write('    admin users = %s\n' % admin_users)
-        if (e.shadow_copy):
-            fo.write('    shadow:format = .' + e.snapshot_prefix + '_%Y%m%d%H%M\n')  # noqa E501
-            fo.write('    shadow:basedir = %s\n' % e.path)
-            fo.write('    shadow:snapdir = ./\n')
-            fo.write('    shadow:sort = desc\n')
-            fo.write('    shadow:localtime = yes\n')
-            fo.write('    vfs objects = shadow_copy2\n')
-            fo.write('    veto files = /.%s*/\n' % e.snapshot_prefix)
+        fo.write("    root preexec close = yes\n")
+        fo.write("    comment = %s\n" % e.comment.encode("utf-8"))
+        fo.write("    path = %s\n" % e.path)
+        fo.write("    browseable = %s\n" % e.browsable)
+        fo.write("    read only = %s\n" % e.read_only)
+        fo.write("    guest ok = %s\n" % e.guest_ok)
+        if len(admin_users) > 0:
+            fo.write("    admin users = %s\n" % admin_users)
+        if e.shadow_copy:
+            fo.write(
+                "    shadow:format = ." + e.snapshot_prefix + "_%Y%m%d%H%M\n"
+            )  # noqa E501
+            fo.write("    shadow:basedir = %s\n" % e.path)
+            fo.write("    shadow:snapdir = ./\n")
+            fo.write("    shadow:sort = desc\n")
+            fo.write("    shadow:localtime = yes\n")
+            fo.write("    vfs objects = shadow_copy2\n")
+            fo.write("    veto files = /.%s*/\n" % e.snapshot_prefix)
         for cco in SambaCustomConfig.objects.filter(smb_share=e):
-            if (cco.custom_config.strip()):
-                fo.write('    %s\n' % cco.custom_config)
-    fo.write('%s\n' % RS_SHARES_FOOTER)
+            if cco.custom_config.strip():
+                fo.write("    %s\n" % cco.custom_config)
+    fo.write("%s\n" % RS_SHARES_FOOTER)
 
 
 def refresh_smb_config(exports):
     fh, npath = mkstemp()
-    with open(SMB_CONFIG) as sfo, open(npath, 'w') as tfo:
+    with open(SMB_CONFIG) as sfo, open(npath, "w") as tfo:
         rockstor_section = False
         for line in sfo.readlines():
-            if (re.match(RS_SHARES_HEADER, line) is not None):
+            if re.match(RS_SHARES_HEADER, line) is not None:
                 rockstor_section = True
                 rockstor_smb_config(tfo, exports)
                 break
             else:
                 tfo.write(line)
-        if (rockstor_section is False):
+        if rockstor_section is False:
             rockstor_smb_config(tfo, exports)
     test_parm(npath)
     shutil.move(npath, SMB_CONFIG)
@@ -98,82 +102,85 @@ def refresh_smb_config(exports):
 # write out new [global] section and re-write the existing rockstor section.
 def update_global_config(smb_config=None, ad_config=None):
     fh, npath = mkstemp()
-    if (smb_config is None):
+    if smb_config is None:
         smb_config = {}
 
-    with open(SMB_CONFIG) as sfo, open(npath, 'w') as tfo:
+    with open(SMB_CONFIG) as sfo, open(npath, "w") as tfo:
         # Start building samba [global] section with base config
-        tfo.write('[global]\n')
+        tfo.write("[global]\n")
 
         # Write some defaults samba params
         # only if not passed via samba custom config
         smb_default_options = {
-            'log file': '/var/log/samba/log.%m',
-            'log level': 3,
-            'load printers': 'no',
-            'cups options': 'raw',
-            'printcap name': '/dev/null',
-            'map to guest': 'Bad User'
+            "log file": "/var/log/samba/log.%m",
+            "log level": 3,
+            "load printers": "no",
+            "cups options": "raw",
+            "printcap name": "/dev/null",
+            "map to guest": "Bad User",
         }
         for key, value in smb_default_options.iteritems():
             if key not in smb_config:
-                tfo.write('    %s = %s\n' % (key, value))
+                tfo.write("    %s = %s\n" % (key, value))
 
         # Fill samba [global] section with our custom samba params
         # before updating smb_config dict with AD data to avoid
         # adding non samba params like AD username and password
-        if (smb_config is not None):
-            tfo.write('\n%s\n' % RS_CUSTOM_HEADER)
+        if smb_config is not None:
+            tfo.write("\n%s\n" % RS_CUSTOM_HEADER)
             for k in smb_config:
-                if (ad_config is not None and k == 'workgroup'):
-                    tfo.write('    %s = %s\n' % (k, ad_config[k]))
+                if ad_config is not None and k == "workgroup":
+                    tfo.write("    %s = %s\n" % (k, ad_config[k]))
                     continue
-                tfo.write('    %s = %s\n' % (k, smb_config[k]))
-            tfo.write('%s\n\n' % RS_CUSTOM_FOOTER)
+                tfo.write("    %s = %s\n" % (k, smb_config[k]))
+            tfo.write("%s\n\n" % RS_CUSTOM_FOOTER)
 
         # Next add AD config to smb_config and build AD section
-        if (ad_config is not None):
+        if ad_config is not None:
             smb_config.update(ad_config)
 
-        domain = smb_config.pop('domain', None)
-        if (domain is not None):
-            idmap_high = int(smb_config['idmap_range'].split()[2])
-            default_range = '%s - %s' % (idmap_high + 1, idmap_high + 1000000)
-            workgroup = ad_config['workgroup']
-            tfo.write('%s\n' % RS_AD_HEADER)
-            tfo.write('    security = ads\n')
-            tfo.write('    realm = %s\n' % domain)
-            tfo.write('    template shell = /bin/sh\n')
-            tfo.write('    kerberos method = secrets and keytab\n')
-            tfo.write('    winbind use default domain = false\n')
-            tfo.write('    winbind offline logon = true\n')
-            tfo.write('    winbind enum users = yes\n')
-            tfo.write('    winbind enum groups = yes\n')
-            tfo.write('    idmap config * : backend = tdb\n')
-            tfo.write('    idmap config * : range = %s\n' % default_range)
+        domain = smb_config.pop("domain", None)
+        if domain is not None:
+            idmap_high = int(smb_config["idmap_range"].split()[2])
+            default_range = "%s - %s" % (idmap_high + 1, idmap_high + 1000000)
+            workgroup = ad_config["workgroup"]
+            tfo.write("%s\n" % RS_AD_HEADER)
+            tfo.write("    security = ads\n")
+            tfo.write("    realm = %s\n" % domain)
+            tfo.write("    template shell = /bin/sh\n")
+            tfo.write("    kerberos method = secrets and keytab\n")
+            tfo.write("    winbind use default domain = false\n")
+            tfo.write("    winbind offline logon = true\n")
+            tfo.write("    winbind enum users = yes\n")
+            tfo.write("    winbind enum groups = yes\n")
+            tfo.write("    idmap config * : backend = tdb\n")
+            tfo.write("    idmap config * : range = %s\n" % default_range)
             # enable rfc2307 schema and collect UIDS from AD DC we assume if
             # rfc2307 then winbind nss info too - collects AD DC home and shell
             # for each user
-            if (smb_config.pop('rfc2307', None)):
-                tfo.write('    idmap config %s : backend = ad\n' % workgroup)
-                tfo.write('    idmap config %s : range = %s\n' %
-                          (workgroup, smb_config['idmap_range']))
-                tfo.write('    idmap config %s : schema_mode = rfc2307\n'
-                          % workgroup)
-                tfo.write('    winbind nss info = rfc2307\n')
+            if smb_config.pop("rfc2307", None):
+                tfo.write("    idmap config %s : backend = ad\n" % workgroup)
+                tfo.write(
+                    "    idmap config %s : range = %s\n"
+                    % (workgroup, smb_config["idmap_range"])
+                )
+                tfo.write("    idmap config %s : schema_mode = rfc2307\n" % workgroup)
+                tfo.write("    winbind nss info = rfc2307\n")
             else:
-                tfo.write('    idmap config %s : backend = rid\n' % workgroup)
-                tfo.write('    idmap config %s : range = %s\n' %
-                          (workgroup, smb_config['idmap_range']))
-            tfo.write('%s\n\n' % RS_AD_FOOTER)
+                tfo.write("    idmap config %s : backend = rid\n" % workgroup)
+                tfo.write(
+                    "    idmap config %s : range = %s\n"
+                    % (workgroup, smb_config["idmap_range"])
+                )
+            tfo.write("%s\n\n" % RS_AD_FOOTER)
 
         # After default [global], custom [global] and AD writes
         # finally add smb shares
         rockstor_section = False
         for line in sfo.readlines():
-            if (re.match(RS_SHARES_HEADER, line) is not None):
+            if re.match(RS_SHARES_HEADER, line) is not None:
                 rockstor_section = True
-            if (rockstor_section is True):
+            if rockstor_section is True:
                 tfo.write(line)
     test_parm(npath)
     shutil.move(npath, SMB_CONFIG)
@@ -188,35 +195,36 @@ def get_global_config():
         global_custom_section = False
         for l in sfo.readlines():
             # Check one, entering smb.conf [global] section
-            if (re.match('\[global]', l) is not None):
+            if re.match("\[global]", l) is not None:
                 global_section = True
                 continue
             # Check two, entering Rockstor custome params section under
             # [global]
-            if (re.match(RS_CUSTOM_HEADER, l) is not None):
+            if re.match(RS_CUSTOM_HEADER, l) is not None:
                 global_custom_section = True
                 continue
-            if ((global_custom_section and
-                 re.match(RS_CUSTOM_FOOTER, l) is not None)):
+            if global_custom_section and re.match(RS_CUSTOM_FOOTER, l) is not None:
                 global_custom_section = False
                 continue
             # we ignore lines outside [global], empty lines, or
             # commends(starting with # or ;)
-            if ((not global_section or
-                 not global_custom_section or
-                 len(l.strip()) == 0 or
-                 re.match('#', l) is not None or
-                 re.match(';', l) is not None)):
+            if (
+                not global_section
+                or not global_custom_section
+                or len(l.strip()) == 0
+                or re.match("#", l) is not None
+                or re.match(";", l) is not None
+            ):
                 continue
-            if (global_section and re.match('\[', l) is not None):
+            if global_section and re.match("\[", l) is not None:
                 global_section = False
                 continue
-            fields = l.strip().split(' = ')
+            fields = l.strip().split(" = ")
             if len(fields) < 2:
                 continue
             # reset config to a usable dictionary since we're about to add
             # something to it
-            if(config is None):
+            if config is None:
                 config = {}
             config[fields[0].strip()] = fields[1].strip()
     # return our config variable, which is either None, or a dictionary with
@@ -228,19 +236,19 @@ def restart_samba(hard=False):
     """
     call whenever config is updated
     """
-    mode = 'reload'
-    if (hard):
-        mode = 'restart'
-    run_command([SYSTEMCTL, mode, 'smb'])
-    return run_command([SYSTEMCTL, mode, 'nmb'])
+    mode = "reload"
+    if hard:
+        mode = "restart"
+    run_command([SYSTEMCTL, mode, "smb"], log=True)
+    return run_command([SYSTEMCTL, mode, "nmb"], log=True)
 
 
 def update_samba_discovery():
-    avahi_smb_config = '/etc/avahi/services/smb.service'
-    if (os.path.isfile(avahi_smb_config)):
+    avahi_smb_config = "/etc/avahi/services/smb.service"
+    if os.path.isfile(avahi_smb_config):
         os.remove(avahi_smb_config)
-    return run_command([SYSTEMCTL, 'restart', 'avahi-daemon', ])
+    return run_command([SYSTEMCTL, "restart", "avahi-daemon"])
 
 
 def status():
-    return service_status('smb')
+    return service_status("smb")


### PR DESCRIPTION
Fixes #2127.  
@phillxnet: ready for review.
_Warning_: I originally wanted not to squash the Black formatting to keep them separate in order to better highlight the changes in this PR, but I somehow messed it up and ended squashing everybody together. I apologize for the resulting "heaviness" of the changes.

This pull request (PR) proposes to source the `smb.service` file from the upstream samba default template instead of using our own template that is currently troublesome in Rockstor built on openSUSE (see #2127 for details). Notably, this will be done **only in Rockstor built on openSUSE** and not legacy Rockstor to ensure we maintain current compatibility with current release.

This PR also fixes the unwanted restart of Samba service before it is configured, thereby assuring the customizations required by Rockstor are present in the running `smb.service` file (see #2127 for details).

### Aims & Logic
In Rockstor built on openSUSE **only**, this PR proposes to use the samba package default service file located at `/usr/lib/systemd/system/smb.service` as a template. When starting the Samba service from the webUI, this file is read and customized by adding the `rockstor-bootstrap.service` at the end of the `After=` line. The rest is written as is into a temp file. This temp file is then compared with the currently existing one (if any) at `etc/systemd/system/smb.service` using md5sum, and moved to its destination if different (same logic as before this PR).

To fix the unwanted restart of the Samba service upon change of its configuration, we now check whether the Samba service is currently running. If not running, we save the new config but do not restart Samba, thereby assuring we only start Samba when explicitly commanded by the user when clicking the Samba service toggle button. If the Samba service is currently running, however, we do restart it to make sure the new config is taken.


### Demonstration
First tested in Leap 15.1.
1. The Samba service is currently not configured:
```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                              config                              
----+--------------------+------------------+------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
  2 | smb                | Samba            | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
(17 rows)
```
2. Click little wrench icon and click cancel in the modal: Samba does NOT start (in current master: it starts without customizing `samba.service`)
```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                              config                              
----+--------------------+------------------+------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
  2 | smb                | Samba            | 
(17 rows)

rockdev:/opt/build # systemctl status smb
â—� smb.service - Samba SMB Daemon
   Loaded: loaded (/usr/lib/systemd/system/smb.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
```

3. Click the little wrench icon again and this time set the WORKGROUP to MYROCKYGROUP. Click submit and Samba does not start. The database is configured, however.
```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                              config                              
----+--------------------+------------------+------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
  2 | smb                | Samba            | {"workgroup": "MYROCKGROUP"}
(17 rows)

rockdev:/opt/build # systemctl status smb
â—� smb.service - Samba SMB Daemon
   Loaded: loaded (/usr/lib/systemd/system/smb.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
```

4. Click the little wrench icon and add a global option customization. Click Save and the Samba service is still not started. 
![image](https://user-images.githubusercontent.com/30297881/74867382-94e12d00-5322-11ea-93ad-94a7e3bca038.png)

```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                               config                               
----+--------------------+------------------+--------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
  2 | smb                | Samba            | {"socket options": "SO_SNDBUF=131072", "workgroup": "MYROCKGROUP"}
(17 rows)

rockdev:/opt/build # systemctl status smb
â—� smb.service - Samba SMB Daemon
   Loaded: loaded (/usr/lib/systemd/system/smb.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
```


5. Start Samba service. The new `smb.service` file is created in `/etc/systemd/system/smb.service` with the `rockstor-bootstrap.service` added at the end of the `After=` line.
```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                               config                               
----+--------------------+------------------+--------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
  2 | smb                | Samba            | {"socket options": "SO_SNDBUF=131072", "workgroup": "MYROCKGROUP"}
(17 rows)
```
```shell script
rockdev:/opt/build # systemctl status smb
â—� smb.service - Samba SMB Daemon
   Loaded: loaded (/etc/systemd/system/smb.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2020-02-19 13:02:51 EST; 17s ago
  Process: 5618 ExecStartPre=/usr/share/samba/update-apparmor-samba-profile (code=exited, status=0/SUCCESS)
 Main PID: 5619 (smbd)
   Status: "smbd: ready to serve connections..."
    Tasks: 4 (limit: 4915)
   CGroup: /system.slice/smb.service
           â”œâ”€5619 /usr/sbin/smbd --foreground --no-process-group
           â”œâ”€5623 /usr/sbin/smbd --foreground --no-process-group
           â”œâ”€5624 /usr/sbin/smbd --foreground --no-process-group
           â””â”€5626 /usr/sbin/smbd --foreground --no-process-group

Feb 19 13:02:49 rockdev systemd[1]: Starting Samba SMB Daemon...
Feb 19 13:02:51 rockdev smbd[5619]: [2020/02/19 13:02:51.656155,  0] ../lib/util/become_daemon.c:138(daemon_ready)
Feb 19 13:02:51 rockdev systemd[1]: Started Samba SMB Daemon.
Feb 19 13:02:51 rockdev smbd[5619]:   daemon_ready: STATUS=daemon 'smbd' finished starting up and ready to serve connections
```
```shell script
rockdev:/opt/build # cat /etc/systemd/system/smb.service
[Unit]
Description=Samba SMB Daemon
After=network.target nmb.service winbind.service rockstor-bootstrap.service

[Service]
Type=notify
NotifyAccess=all
Environment=KRB5CCNAME=/run/samba/krb5cc_samba
LimitNOFILE=16384
EnvironmentFile=-/etc/sysconfig/samba
ExecStartPre=/usr/share/samba/update-apparmor-samba-profile
ExecStart=/usr/sbin/smbd --foreground --no-process-group $SMBDOPTIONS
ExecReload=/usr/bin/kill -HUP $MAINPID

[Install]
WantedBy=multi-user.target
```
 
 6. While Samba is still ON, click the little wrench icon and remove the global option customization. Click save and notice how Samba service is restarted in the logs.
```shell script
rockdev:/opt/build # psql -U rocky -d smartdb -c "SELECT * from smart_manager_service"
Password for user rocky: 
 id |        name        |   display_name   |                              config                              
----+--------------------+------------------+------------------------------------------------------------------
  9 | rockstor           | Rockstor         | 
 10 | smartd             | S.M.A.R.T        | 
 11 | active-directory   | Active Directory | 
  5 | ntpd               | NTP              | 
 12 | nut                | NUT-UPS          | 
 13 | snmpd              | SNMP             | 
  8 | sftp               | SFTP             | 
 14 | docker             | Rock-on          | 
  1 | replication        | Replication      | 
 15 | shellinaboxd       | Shell In A Box   | {"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}
  3 | nfs                | NFS              | 
  7 | ldap               | LDAP             | 
  6 | nis                | NIS              | 
 16 | netatalk           | AFP              | 
 17 | ztask-daemon       | ZTaskd           | 
 18 | rockstor-bootstrap | Bootstrap        | 
  2 | smb                | Samba            | {"workgroup": "MYROCKGROUP"}
(17 rows)
```
```shell script
rockdev:/opt/build # cat /etc/systemd/system/smb.service
[Unit]
Description=Samba SMB Daemon
After=network.target nmb.service winbind.service rockstor-bootstrap.service

[Service]
Type=notify
NotifyAccess=all
Environment=KRB5CCNAME=/run/samba/krb5cc_samba
LimitNOFILE=16384
EnvironmentFile=-/etc/sysconfig/samba
ExecStartPre=/usr/share/samba/update-apparmor-samba-profile
ExecStart=/usr/sbin/smbd --foreground --no-process-group $SMBDOPTIONS
ExecReload=/usr/bin/kill -HUP $MAINPID

[Install]
WantedBy=multi-user.target
```
```shell script
rockdev:/opt/build # systemctl status smb
â—� smb.service - Samba SMB Daemon
   Loaded: loaded (/etc/systemd/system/smb.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2020-02-19 13:05:29 EST; 1min 0s ago
  Process: 6346 ExecStartPre=/usr/share/samba/update-apparmor-samba-profile (code=exited, status=0/SUCCESS)
 Main PID: 6347 (smbd)
   Status: "smbd: ready to serve connections..."
    Tasks: 4 (limit: 4915)
   Memory: 8.1M
      CPU: 93ms
   CGroup: /system.slice/smb.service
           â”œâ”€6347 /usr/sbin/smbd --foreground --no-process-group
           â”œâ”€6349 /usr/sbin/smbd --foreground --no-process-group
           â”œâ”€6350 /usr/sbin/smbd --foreground --no-process-group
           â””â”€6351 /usr/sbin/smbd --foreground --no-process-group

Feb 19 13:05:29 rockdev systemd[1]: Starting Samba SMB Daemon...
Feb 19 13:05:29 rockdev smbd[6347]: [2020/02/19 13:05:29.585475,  0] ../lib/util/become_daemon.c:138(daemon_ready)
Feb 19 13:05:29 rockdev systemd[1]: Started Samba SMB Daemon.
Feb 19 13:05:29 rockdev smbd[6347]:   daemon_ready: STATUS=daemon 'smbd' finished starting up and ready to serve connections
```
```shell script
rockdev:/opt/build # cat /etc/samba/smb.conf 
[global]
    log level = 3
    map to guest = Bad User
    cups options = raw
    log file = /var/log/samba/log.%m
    printcap name = /dev/null
    load printers = no

####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####
    workgroup = MYROCKGROUP
####END: Rockstor SAMBA GLOBAL CUSTOM####
```
```shell script
linux-c4sl:~ # tail -f /opt/build/var/log/rockstor.log 
(...)
[19/Feb/2020 13:05:29] DEBUG [system.osi:103] Running command: /usr/bin/systemctl restart smb
[19/Feb/2020 13:05:29] DEBUG [system.osi:103] Running command: /usr/bin/systemctl restart nmb
```


The procedure above was replicated in Tumbleweed.

In CentOS, the same steps are repeated but the same custom base `smb.service` file as before is used:
```shell script
[root@Rockstor build]# cat /etc/systemd/system/smb.service
[Unit]
Description=Samba SMB Daemon
After=syslog.target network.target nmb.service rockstor-bootstrap.service

[Service]
Environment=KRB5CCNAME=/run/samba/krb5cc_samba
Type=notify
NotifyAccess=all
PIDFile=/run/smbd.pid
LimitNOFILE=16384
EnvironmentFile=-/etc/sysconfig/samba
ExecStart=/usr/sbin/smbd $SMBDOPTIONS
ExecReload=/usr/bin/kill -HUP $MAINPID

[Install]
WantedBy=multi-user.target
```

### Special notes  
The new `_write_smb_service()` function was written with the future deprecation of the CentOS bit in mind. As a result, comment lines were included to indicate the beginning and end of the CentOS-specific lines. To deprecate, one would (almost) simply need to delete the lines between these two comments. This is why some part of the code in this function can seem redundant for now.

As mentioned in the summary of commits below, I originally tried to use `systemd-analyze verify temp_smb.service` to validate the customized service file before moving it into place. This was not working as consistently as I'd hope, however, as `systemd-analyze verify [FILE]` seems to load other service files as well _sometimes_ which resulted in possible false positive when trying to look for errors.


### Summary of commits
First draft for distro-specific customization of smb.service.
- First attempt at systemd-analyze verify service file. Comment for now as not ready.
- Source distro_id from Django settings.
- When saving Samba config, do not restart service if it was not previously configured.
- When saving Samba config, only restart service if it is currently ON.
- Add skeleton for test_smb.py and add more logger.debug to get example data.
- Revert "Add skeleton for test_smb.py and add more logger.debug to get example data." This reverts commit 047300f3
- Remove approach using a 'configured' variable.
- Revert attempt at using systemd-analyze to validate service file.
- Cleanup logger statements as well as commented code.
- Update copyrights dates.
- Black formatting

### Testing
No new unit tests were written. They would need to be added in the future, however.

**_CentOS_**:  

```shell script
Ran 189 tests in 22.541s

FAILED (failures=23, errors=6)
```

**_Leap 15.1_**:  

```shell script
Ran 189 tests in 25.030s

FAILED (failures=23, errors=6)
```

**_Tumbleweed_**:  

```shell script
Ran 189 tests in 27.617s

FAILED (failures=23, errors=6)
```


### Full Testing Outputs
<details><summary>CentOS</summary>

```
[root@Rockstor build]# ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (17.389s)
  Applying contenttypes.0001_initial... OK (0.065s)
  Applying auth.0001_initial... OK (0.487s)
  Applying admin.0001_initial... OK (0.106s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.151s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.058s)
  Applying auth.0003_alter_user_email_max_length... OK (0.059s)
  Applying auth.0004_alter_user_username_opts... OK (0.056s)
  Applying auth.0005_alter_user_last_login_null... OK (0.059s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.846s)
  Applying oauth2_provider.0002_08_updates... OK (1.440s)
  Applying sessions.0001_initial... OK (0.077s)
  Applying sites.0001_initial... OK (0.037s)
  Applying smart_manager.0001_initial... OK (0.835s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.044s)
  Applying storageadmin.0001_initial... OK (18.070s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.500s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.372s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.647s)
  Applying storageadmin.0005_auto_20180913_0923... OK (2.098s)
  Applying storageadmin.0006_dcontainerargs... OK (0.525s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.185s)
  Applying storageadmin.0008_auto_20190115_1637... OK (2.182s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.507s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (17.256s)
  Applying contenttypes.0001_initial... OK (0.053s)
  Applying auth.0001_initial... OK (0.097s)
  Applying admin.0001_initial... OK (0.076s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.410s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.078s)
  Applying auth.0003_alter_user_email_max_length... OK (0.076s)
  Applying auth.0004_alter_user_username_opts... OK (0.050s)
  Applying auth.0005_alter_user_last_login_null... OK (0.126s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.219s)
  Applying oauth2_provider.0002_08_updates... OK (0.212s)
  Applying sessions.0001_initial... OK (0.111s)
  Applying sites.0001_initial... OK (0.020s)
  Applying smart_manager.0001_initial... OK (2.168s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.045s)
  Applying storageadmin.0001_initial... OK (11.377s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.264s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.070s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.487s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.545s)
  Applying storageadmin.0006_dcontainerargs... OK (0.508s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.978s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.726s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.566s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Error running a command. cmd = /usr/sbin/usermod -s /bin/bash admin. rc = 6. stdout = [\'\']. stderr = ["usermod: user \'admin\' does not exist", \'\']' != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 22.541s

FAILED (failures=23, errors=6)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...

```

</details>

<details><summary>Leap15.1</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.834s)
  Applying contenttypes.0001_initial... OK (0.144s)
  Applying auth.0001_initial... OK (0.340s)
  Applying admin.0001_initial... OK (0.099s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.131s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.052s)
  Applying auth.0003_alter_user_email_max_length... OK (0.050s)
  Applying auth.0004_alter_user_username_opts... OK (0.044s)
  Applying auth.0005_alter_user_last_login_null... OK (0.060s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.523s)
  Applying oauth2_provider.0002_08_updates... OK (0.393s)
  Applying sessions.0001_initial... OK (0.086s)
  Applying sites.0001_initial... OK (0.110s)
  Applying smart_manager.0001_initial... OK (0.730s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.039s)
  Applying storageadmin.0001_initial... OK (13.088s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.943s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.876s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.419s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.558s)
  Applying storageadmin.0006_dcontainerargs... OK (0.456s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.895s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.385s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.429s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.701s)
  Applying contenttypes.0001_initial... OK (0.032s)
  Applying auth.0001_initial... OK (0.072s)
  Applying admin.0001_initial... OK (0.221s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.114s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.041s)
  Applying auth.0003_alter_user_email_max_length... OK (0.051s)
  Applying auth.0004_alter_user_username_opts... OK (0.043s)
  Applying auth.0005_alter_user_last_login_null... OK (0.042s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.300s)
  Applying oauth2_provider.0002_08_updates... OK (0.185s)
  Applying sessions.0001_initial... OK (0.018s)
  Applying sites.0001_initial... OK (0.024s)
  Applying smart_manager.0001_initial... OK (1.542s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.060s)
  Applying storageadmin.0001_initial... OK (10.182s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.849s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.784s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.408s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.215s)
  Applying storageadmin.0006_dcontainerargs... OK (0.408s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.842s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.490s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.428s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 25.030s

FAILED (failures=23, errors=6)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...

```


</details>


<details><summary>Tumbleweed</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.103s)
  Applying contenttypes.0001_initial... OK (0.057s)
  Applying auth.0001_initial... OK (0.288s)
  Applying admin.0001_initial... OK (0.124s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.121s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.050s)
  Applying auth.0003_alter_user_email_max_length... OK (0.049s)
  Applying auth.0004_alter_user_username_opts... OK (0.039s)
  Applying auth.0005_alter_user_last_login_null... OK (0.058s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.420s)
  Applying oauth2_provider.0002_08_updates... OK (0.316s)
  Applying sessions.0001_initial... OK (0.061s)
  Applying sites.0001_initial... OK (0.040s)
  Applying smart_manager.0001_initial... OK (0.710s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.036s)
  Applying storageadmin.0001_initial... OK (12.228s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.884s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.894s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.414s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.516s)
  Applying storageadmin.0006_dcontainerargs... OK (0.454s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.889s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.389s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.457s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.776s)
  Applying contenttypes.0001_initial... OK (0.031s)
  Applying auth.0001_initial... OK (0.067s)
  Applying admin.0001_initial... OK (0.061s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.122s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.047s)
  Applying auth.0003_alter_user_email_max_length... OK (0.046s)
  Applying auth.0004_alter_user_username_opts... OK (0.050s)
  Applying auth.0005_alter_user_last_login_null... OK (0.250s)
  Applying auth.0006_require_contenttypes_0002... OK (0.014s)
  Applying oauth2_provider.0001_initial... OK (0.198s)
  Applying oauth2_provider.0002_08_updates... OK (0.190s)
  Applying sessions.0001_initial... OK (0.025s)
  Applying sites.0001_initial... OK (0.024s)
  Applying smart_manager.0001_initial... OK (1.416s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.040s)
  Applying storageadmin.0001_initial... OK (9.946s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.019s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.848s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.407s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.176s)
  Applying storageadmin.0006_dcontainerargs... OK (0.407s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.835s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.496s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.427s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 308, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 183, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 538, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libacl.so.1'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 27.617s

FAILED (failures=23, errors=6)
```


</details>


