### PR TITLE
[openSUSE] adapt to shellinabox package differences. Fixes #2006

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -24,7 +24,6 @@ parts =
 #      postgres-conf
       gunicorn
       nginx-conf
-      shellinabox-conf
       stop-shellinabox
       django-settings-conf
       test-settings-conf
@@ -59,11 +58,6 @@ command =
 recipe = collective.recipe.template
 input = ${buildout:directory}/conf/nginx.conf.in
 output = ${buildout:directory}/etc/nginx/nginx.conf
-
-[shellinabox-conf]
-recipe = collective.recipe.template
-input = ${buildout:directory}/conf/shellinaboxd.in
-output = /etc/sysconfig/shellinaboxd
 
 [stop-shellinabox]
 recipe = plone.recipe.command

--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -385,12 +385,20 @@ NUT_LISTEN_ON_IP = '0.0.0.0'
 NUT_SYSTEM_SHUTDOWNCMD = '/sbin/shutdown -h +0'
 
 # Shell In A Box base settings
-SHELLINABOX = {
-	'user': 'root',
-	'group': 'root',
-	'port': '4200',
-	'certs': '/var/lib/shellinabox'
-}
+if distro.id() == 'rockstor':
+    SHELLINABOX = {
+        'user': 'shellinabox',
+        'group': 'shellinabox',
+        'port': '4200',
+        'certs': '/var/lib/shellinabox'
+    }
+else:
+    SHELLINABOX = {
+        'user': 'shellinabox',
+        'group': 'shellinabox',
+        'port': '4200',
+        'certs': '/etc/shellinabox/certs'
+    }
 
 UPDATE_CHANNELS = {
 		'stable': {

--- a/conf/shellinaboxd.in
+++ b/conf/shellinaboxd.in
@@ -1,7 +1,0 @@
-# Shell In A Box configured by Rockstor
-
-USER=root
-GROUP=root
-CERTDIR=/var/lib/shellinabox
-PORT=4200
-OPTS="--no-beep --localhost-only --disable-ssl -s /:LOGIN --css white-on-black.css

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import shutil
-from system.osi import (run_command, md5sum)
+from system.osi import run_command, md5sum
 from system import services
 import logging
 import sys
@@ -30,30 +30,30 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-SYSCTL = '/usr/bin/systemctl'
+SYSCTL = "/usr/bin/systemctl"
 BASE_DIR = settings.ROOT_DIR
-BASE_BIN = '%sbin' % BASE_DIR
-DJANGO = '%s/django' % BASE_BIN
-STAMP = '%s/.initrock' % BASE_DIR
-FLASH_OPTIMIZE = '%s/flash-optimize' % BASE_BIN
-PREP_DB = '%s/prep_db' % BASE_BIN
-SUPERCTL = '%s/supervisorctl' % BASE_BIN
-OPENSSL = '/usr/bin/openssl'
-GRUBBY = '/usr/sbin/grubby'
-RPM = '/usr/bin/rpm'
-YUM = '/usr/bin/yum'
-IP = '/usr/sbin/ip'
+BASE_BIN = "%sbin" % BASE_DIR
+DJANGO = "%s/django" % BASE_BIN
+STAMP = "%s/.initrock" % BASE_DIR
+FLASH_OPTIMIZE = "%s/flash-optimize" % BASE_BIN
+PREP_DB = "%s/prep_db" % BASE_BIN
+SUPERCTL = "%s/supervisorctl" % BASE_BIN
+OPENSSL = "/usr/bin/openssl"
+GRUBBY = "/usr/sbin/grubby"
+RPM = "/usr/bin/rpm"
+YUM = "/usr/bin/yum"
+IP = "/usr/sbin/ip"
 
 
 def delete_old_kernels(logging, num_retain=5):
     # Don't keep more than num_retain kernels
-    o, e, rc = run_command([RPM, '-q', 'kernel-ml'])
+    o, e, rc = run_command([RPM, "-q", "kernel-ml"])
     ml_kernels = o[:-1]  # last entry is an empty string.
     ml_kernels = sorted(ml_kernels)
     # centos kernels, may or may not be installed.
     centos_kernels = []
-    o, e, rc = run_command([RPM, '-q', 'kernel'], throw=False)
-    if (rc == 0):
+    o, e, rc = run_command([RPM, "-q", "kernel"], throw=False)
+    if rc == 0:
         centos_kernels = o[:-1]
 
     # Don't delete current running kernel
@@ -62,30 +62,29 @@ def delete_old_kernels(logging, num_retain=5):
     default_kernel = settings.SUPPORTED_KERNEL_VERSION
     deleted = 0
     for k in centos_kernels:
-        kv = k.split('kernel-')[1]
-        if (kv != running_kernel and kv != default_kernel):
-            run_command([YUM, 'remove', '-y', k])
+        kv = k.split("kernel-")[1]
+        if kv != running_kernel and kv != default_kernel:
+            run_command([YUM, "remove", "-y", k])
             deleted += 1
-            logging.info('Deleted old Kernel: %s' % k)
-    for i in range(len(centos_kernels) + len(ml_kernels) - deleted -
-                   num_retain):
-        kv = ml_kernels[i].split('kernel-ml-')[1]
-        if (kv != running_kernel and kv != default_kernel):
-            run_command([YUM, 'remove', '-y', ml_kernels[i]])
-            logging.info('Deleted old Kernel: %s' % ml_kernels[i])
+            logging.info("Deleted old Kernel: %s" % k)
+    for i in range(len(centos_kernels) + len(ml_kernels) - deleted - num_retain):
+        kv = ml_kernels[i].split("kernel-ml-")[1]
+        if kv != running_kernel and kv != default_kernel:
+            run_command([YUM, "remove", "-y", ml_kernels[i]])
+            logging.info("Deleted old Kernel: %s" % ml_kernels[i])
 
 
 def inet_addrs(interface=None):
-    cmd = [IP, 'addr', 'show']
+    cmd = [IP, "addr", "show"]
     if interface is not None:
         cmd.append(interface)
     o, _, _ = run_command(cmd)
     ipaddr_list = []
     for l in o:
-        if (re.match('inet ', l.strip()) is not None):
+        if re.match("inet ", l.strip()) is not None:
             inet_fields = l.split()
             if len(inet_fields) > 1:
-                ip_fields = inet_fields[1].split('/')
+                ip_fields = inet_fields[1].split("/")
                 if len(ip_fields) == 2:
                     ipaddr_list.append(ip_fields[0])
     return ipaddr_list
@@ -98,19 +97,20 @@ def current_rockstor_mgmt_ip(logger):
 
     ipaddr = None
     port = 443
-    so = Service.objects.get(name='rockstor')
+    so = Service.objects.get(name="rockstor")
 
     if so.config is not None:
         config = json.loads(so.config)
-        port = config['listener_port']
+        port = config["listener_port"]
         try:
-            ipaddr_list = inet_addrs(config['network_interface'])
+            ipaddr_list = inet_addrs(config["network_interface"])
             if len(ipaddr_list) > 0:
                 ipaddr = ipaddr_list[0]
         except Exception as e:
             # interface vanished.
-            logger.exception('Exception while gathering current management '
-                             'ip: {e}'.format(e=e))
+            logger.exception(
+                "Exception while gathering current management " "ip: {e}".format(e=e)
+            )
 
     return ipaddr, port
 
@@ -121,26 +121,32 @@ def init_update_issue(logger):
     if ipaddr is None:
         ipaddr_list = inet_addrs()
 
-    with open('/etc/issue', 'w') as ifo:
-        if (ipaddr is None and len(ipaddr_list) == 0):
-            ifo.write('The system does not yet have an ip address.\n')
-            ifo.write('Rockstor cannot be configured using the web interface '
-                      'without this.\n\n')
-            ifo.write('Press Enter to receive updated network status\n')
-            ifo.write('If this message persists please login as root and '
-                      'configure your network using nmtui, then reboot.\n')
+    with open("/etc/issue", "w") as ifo:
+        if ipaddr is None and len(ipaddr_list) == 0:
+            ifo.write("The system does not yet have an ip address.\n")
+            ifo.write(
+                "Rockstor cannot be configured using the web interface "
+                "without this.\n\n"
+            )
+            ifo.write("Press Enter to receive updated network status\n")
+            ifo.write(
+                "If this message persists please login as root and "
+                "configure your network using nmtui, then reboot.\n"
+            )
         else:
-            ifo.write('\nRockstor is successfully installed.\n\n')
+            ifo.write("\nRockstor is successfully installed.\n\n")
             if ipaddr is not None:
-                port_str = ''
+                port_str = ""
                 if port != 443:
-                    port_str = ':{0}'.format(port)
-                ifo.write('web-ui is accessible with this link: '
-                          'https://{0}{1}\n\n'.format(ipaddr, port_str))
+                    port_str = ":{0}".format(port)
+                ifo.write(
+                    "web-ui is accessible with this link: "
+                    "https://{0}{1}\n\n".format(ipaddr, port_str)
+                )
             else:
-                ifo.write('web-ui is accessible with the following links:\n')
+                ifo.write("web-ui is accessible with the following links:\n")
                 for i in ipaddr_list:
-                    ifo.write('https://{0}\n'.format(i))
+                    ifo.write("https://{0}\n".format(i))
     return ipaddr
 
 
@@ -149,52 +155,56 @@ def update_nginx(logger):
         ip, port = current_rockstor_mgmt_ip(logger)
         services.update_nginx(ip, port)
     except Exception as e:
-        logger.exception('Exception while updating nginx: {e}'.format(e=e))
+        logger.exception("Exception while updating nginx: {e}".format(e=e))
 
 
 def set_def_kernel(logger, version=settings.SUPPORTED_KERNEL_VERSION):
-    supported_kernel_path = ('/boot/vmlinuz-%s' % version)
-    if (not os.path.isfile(supported_kernel_path)):
-        return logger.error('Supported kernel(%s) does not exist' %
-                            supported_kernel_path)
+    supported_kernel_path = "/boot/vmlinuz-%s" % version
+    if not os.path.isfile(supported_kernel_path):
+        return logger.error(
+            "Supported kernel(%s) does not exist" % supported_kernel_path
+        )
     try:
-        o, e, rc = run_command([GRUBBY, '--default-kernel'])
-        if (o[0] == supported_kernel_path):
-            return logging.info('Supported kernel(%s) is already the default' %
-                                supported_kernel_path)
+        o, e, rc = run_command([GRUBBY, "--default-kernel"])
+        if o[0] == supported_kernel_path:
+            return logging.info(
+                "Supported kernel(%s) is already the default" % supported_kernel_path
+            )
     except Exception as e:
-        return logger.error('Exception while listing the default kernel: %s'
-                            % e.__str__())
+        return logger.error(
+            "Exception while listing the default kernel: %s" % e.__str__()
+        )
 
     try:
-        run_command([GRUBBY, '--set-default=%s' % supported_kernel_path])
-        return logger.info('Default kernel set to %s' % supported_kernel_path)
+        run_command([GRUBBY, "--set-default=%s" % supported_kernel_path])
+        return logger.info("Default kernel set to %s" % supported_kernel_path)
     except Exception as e:
-        return logger.error('Exception while setting kernel(%s) as '
-                            'default: %s' % (version, e.__str__()))
+        return logger.error(
+            "Exception while setting kernel(%s) as "
+            "default: %s" % (version, e.__str__())
+        )
 
 
 def update_tz(logging):
     # update timezone variable in settings.py
-    zonestr = os.path.realpath('/etc/localtime').split('zoneinfo/')[1]
-    logging.info('system timezone = %s' % zonestr)
-    sfile = '%s/src/rockstor/settings.py' % BASE_DIR
+    zonestr = os.path.realpath("/etc/localtime").split("zoneinfo/")[1]
+    logging.info("system timezone = %s" % zonestr)
+    sfile = "%s/src/rockstor/settings.py" % BASE_DIR
     fo, npath = mkstemp()
     updated = False
-    with open(sfile) as sfo, open(npath, 'w') as tfo:
+    with open(sfile) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
-            if (re.match('TIME_ZONE = ', line) is not None):
-                curzone = line.strip().split('= ')[1].strip("'")
-                if (curzone == zonestr):
+            if re.match("TIME_ZONE = ", line) is not None:
+                curzone = line.strip().split("= ")[1].strip("'")
+                if curzone == zonestr:
                     break
                 else:
                     tfo.write("TIME_ZONE = '%s'\n" % zonestr)
                     updated = True
-                    logging.info('Changed timezone from %s to %s' %
-                                 (curzone, zonestr))
+                    logging.info("Changed timezone from %s to %s" % (curzone, zonestr))
             else:
                 tfo.write(line)
-    if (updated):
+    if updated:
         shutil.move(npath, sfile)
     else:
         os.remove(npath)
@@ -203,35 +213,38 @@ def update_tz(logging):
 
 def bootstrap_sshd_config(logging):
     # Set AllowUsers if needed
-    with open('/etc/ssh/sshd_config', 'a+') as sfo:
+    with open("/etc/ssh/sshd_config", "a+") as sfo:
         found = False
         for line in sfo.readlines():
-            if (re.match(settings.SSHD_HEADER, line) is not None or
-                    re.match('AllowUsers ', line) is not None):
+            if (
+                re.match(settings.SSHD_HEADER, line) is not None
+                or re.match("AllowUsers ", line) is not None
+            ):
                 # if header is found,
                 found = True
-                logging.info('sshd_config already has the updates.'
-                             ' Leaving it unchanged.')
+                logging.info(
+                    "sshd_config already has the updates." " Leaving it unchanged."
+                )
                 break
-        if (not found):
-            sfo.write('%s\n' % settings.SSHD_HEADER)
-            sfo.write('AllowUsers root\n')
-            logging.info('updated sshd_config')
-            run_command([SYSCTL, 'restart', 'sshd'])
+        if not found:
+            sfo.write("%s\n" % settings.SSHD_HEADER)
+            sfo.write("AllowUsers root\n")
+            logging.info("updated sshd_config")
+            run_command([SYSCTL, "restart", "sshd"])
 
 
 def require_postgres(logging):
-    rs_dest = '/etc/systemd/system/rockstor-pre.service'
-    rs_src = '%s/conf/rockstor-pre.service' % BASE_DIR
-    logging.info('updating rockstor-pre service..')
-    with open(rs_dest, 'w') as dfo, open(rs_src) as sfo:
+    rs_dest = "/etc/systemd/system/rockstor-pre.service"
+    rs_src = "%s/conf/rockstor-pre.service" % BASE_DIR
+    logging.info("updating rockstor-pre service..")
+    with open(rs_dest, "w") as dfo, open(rs_src) as sfo:
         for l in sfo.readlines():
             dfo.write(l)
-            if (re.match('After=postgresql.service', l) is not None):
-                dfo.write('Requires=postgresql.service\n')
-                logging.info('rockstor-pre now requires postgresql')
-    run_command([SYSCTL, 'daemon-reload'])
-    return logging.info('systemd daemon reloaded')
+            if re.match("After=postgresql.service", l) is not None:
+                dfo.write("Requires=postgresql.service\n")
+                logging.info("rockstor-pre now requires postgresql")
+    run_command([SYSCTL, "daemon-reload"])
+    return logging.info("systemd daemon reloaded")
 
 
 def establish_shellinaboxd_service(logging):
@@ -257,206 +270,271 @@ def establish_shellinaboxd_service(logging):
         run_command([SYSCTL, "daemon-reload"])
         return logging.info("- established shellinaboxd.service file")
 
+
 def enable_rockstor_service(logging):
-    rs_dest = '/etc/systemd/system/rockstor.service'
-    rs_src = '%s/conf/rockstor.service' % BASE_DIR
+    rs_dest = "/etc/systemd/system/rockstor.service"
+    rs_src = "%s/conf/rockstor.service" % BASE_DIR
     sum1 = md5sum(rs_dest)
     sum2 = md5sum(rs_src)
-    if (sum1 != sum2):
-        logging.info('updating rockstor systemd service')
+    if sum1 != sum2:
+        logging.info("updating rockstor systemd service")
         shutil.copy(rs_src, rs_dest)
-        run_command([SYSCTL, 'enable', 'rockstor'])
-        logging.info('Done.')
-    logging.info('rockstor service looks correct. Not updating.')
+        run_command([SYSCTL, "enable", "rockstor"])
+        logging.info("Done.")
+    logging.info("rockstor service looks correct. Not updating.")
 
 
 def enable_bootstrap_service(logging):
-    name = 'rockstor-bootstrap.service'
-    bs_dest = '/etc/systemd/system/%s' % name
-    bs_src = ('%s/conf/%s' % (BASE_DIR, name))
+    name = "rockstor-bootstrap.service"
+    bs_dest = "/etc/systemd/system/%s" % name
+    bs_src = "%s/conf/%s" % (BASE_DIR, name)
     sum1 = "na"
-    if (os.path.isfile(bs_dest)):
+    if os.path.isfile(bs_dest):
         sum1 = md5sum(bs_dest)
     sum2 = md5sum(bs_src)
-    if (sum1 != sum2):
-        logging.info('updating rockstor-bootstrap systemd service')
+    if sum1 != sum2:
+        logging.info("updating rockstor-bootstrap systemd service")
         shutil.copy(bs_src, bs_dest)
-        run_command([SYSCTL, 'enable', name])
-        run_command([SYSCTL, 'daemon-reload'])
-        return logging.info('Done.')
-    return logging.info('%s looks correct. Not updating.' % name)
+        run_command([SYSCTL, "enable", name])
+        run_command([SYSCTL, "daemon-reload"])
+        return logging.info("Done.")
+    return logging.info("%s looks correct. Not updating." % name)
 
 
 def update_smb_service(logging):
-    name = 'smb.service'
-    ss_dest = '/etc/systemd/system/%s' % name
-    if (not os.path.isfile(ss_dest)):
-        return logging.info('%s is not enabled. Not updating.')
-    ss_src = '%s/conf/%s' % (BASE_DIR, name)
+    name = "smb.service"
+    ss_dest = "/etc/systemd/system/%s" % name
+    if not os.path.isfile(ss_dest):
+        return logging.info("%s is not enabled. Not updating.")
+    ss_src = "%s/conf/%s" % (BASE_DIR, name)
     sum1 = md5sum(ss_dest)
     sum2 = md5sum(ss_src)
-    if (sum1 != sum2):
-        logging.info('Updating %s' % name)
+    if sum1 != sum2:
+        logging.info("Updating %s" % name)
         shutil.copy(ss_src, ss_dest)
-        run_command([SYSCTL, 'daemon-reload'])
-        return logging.info('Done.')
-    return logging.info('%s looks correct. Not updating.' % name)
+        run_command([SYSCTL, "daemon-reload"])
+        return logging.info("Done.")
+    return logging.info("%s looks correct. Not updating." % name)
 
 
 def main():
     loglevel = logging.INFO
-    if (len(sys.argv) > 1 and sys.argv[1] == '-x'):
+    if len(sys.argv) > 1 and sys.argv[1] == "-x":
         loglevel = logging.DEBUG
-    logging.basicConfig(format='%(asctime)s: %(message)s', level=loglevel)
+    logging.basicConfig(format="%(asctime)s: %(message)s", level=loglevel)
     set_def_kernel(logging)
     try:
         delete_old_kernels(logging)
     except Exception as e:
-        logging.debug('Exception while deleting old kernels. Soft error. '
-                      'Moving on.')
+        logging.debug("Exception while deleting old kernels. Soft error. " "Moving on.")
         logging.exception(e)
 
-    cert_loc = '%s/certs/' % BASE_DIR
-    if (os.path.isdir(cert_loc)):
-        if (not os.path.isfile('%s/rockstor.cert' % cert_loc) or
-                not os.path.isfile('%s/rockstor.key' % cert_loc)):
+    cert_loc = "%s/certs/" % BASE_DIR
+    if os.path.isdir(cert_loc):
+        if not os.path.isfile("%s/rockstor.cert" % cert_loc) or not os.path.isfile(
+            "%s/rockstor.key" % cert_loc
+        ):
             shutil.rmtree(cert_loc)
 
-    if (not os.path.isdir(cert_loc)):
+    if not os.path.isdir(cert_loc):
         os.mkdir(cert_loc)
-        dn = ("/C=US/ST=Rockstor user's state/L=Rockstor user's "
-              "city/O=Rockstor user/OU=Rockstor dept/CN=rockstor.user")
-        logging.info('Creating openssl cert...')
-        run_command([OPENSSL, 'req', '-nodes', '-newkey', 'rsa:2048',
-                     '-keyout', '%s/first.key' % cert_loc, '-out',
-                     '%s/rockstor.csr' % cert_loc, '-subj', dn])
-        logging.debug('openssl cert created')
-        logging.info('Creating rockstor key...')
-        run_command([OPENSSL, 'rsa', '-in', '%s/first.key' % cert_loc, '-out',
-                     '%s/rockstor.key' % cert_loc])
-        logging.debug('rockstor key created')
-        logging.info('Singing cert with rockstor key...')
-        run_command([OPENSSL, 'x509', '-in', '%s/rockstor.csr' % cert_loc,
-                     '-out', '%s/rockstor.cert' % cert_loc, '-req', '-signkey',
-                     '%s/rockstor.key' % cert_loc, '-days', '3650'])
-        logging.debug('cert signed.')
-        logging.info('restarting nginx...')
-        run_command([SUPERCTL, 'restart', 'nginx'])
+        dn = (
+            "/C=US/ST=Rockstor user's state/L=Rockstor user's "
+            "city/O=Rockstor user/OU=Rockstor dept/CN=rockstor.user"
+        )
+        logging.info("Creating openssl cert...")
+        run_command(
+            [
+                OPENSSL,
+                "req",
+                "-nodes",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                "%s/first.key" % cert_loc,
+                "-out",
+                "%s/rockstor.csr" % cert_loc,
+                "-subj",
+                dn,
+            ]
+        )
+        logging.debug("openssl cert created")
+        logging.info("Creating rockstor key...")
+        run_command(
+            [
+                OPENSSL,
+                "rsa",
+                "-in",
+                "%s/first.key" % cert_loc,
+                "-out",
+                "%s/rockstor.key" % cert_loc,
+            ]
+        )
+        logging.debug("rockstor key created")
+        logging.info("Singing cert with rockstor key...")
+        run_command(
+            [
+                OPENSSL,
+                "x509",
+                "-in",
+                "%s/rockstor.csr" % cert_loc,
+                "-out",
+                "%s/rockstor.cert" % cert_loc,
+                "-req",
+                "-signkey",
+                "%s/rockstor.key" % cert_loc,
+                "-days",
+                "3650",
+            ]
+        )
+        logging.debug("cert signed.")
+        logging.info("restarting nginx...")
+        run_command([SUPERCTL, "restart", "nginx"])
 
-    logging.info('Checking for flash and Running flash optimizations if '
-                 'appropriate.')
-    run_command([FLASH_OPTIMIZE, '-x'], throw=False)
+    logging.info(
+        "Checking for flash and Running flash optimizations if " "appropriate."
+    )
+    run_command([FLASH_OPTIMIZE, "-x"], throw=False)
     try:
-        logging.info('Updating the timezone from the system')
+        logging.info("Updating the timezone from the system")
         update_tz(logging)
     except Exception as e:
-        logging.error('Exception while updating timezone: %s' % e.__str__())
+        logging.error("Exception while updating timezone: %s" % e.__str__())
         logging.exception(e)
 
     try:
-        logging.info('Updating sshd_config')
+        logging.info("Updating sshd_config")
         bootstrap_sshd_config(logging)
     except Exception as e:
-        logging.error('Exception while updating sshd_config: %s' % e.__str__())
+        logging.error("Exception while updating sshd_config: %s" % e.__str__())
 
-    if (not os.path.isfile(STAMP)):
-        logging.info('Please be patient. This script could take a few minutes')
-        shutil.copyfile('%s/conf/django-hack' % BASE_DIR,
-                        '%s/django' % BASE_BIN)
-        run_command([SYSCTL, 'enable', 'postgresql'])
-        logging.debug('Progresql enabled')
-        pg_data = '/var/lib/pgsql/data'
-        if (os.path.isdir(pg_data)):
-            logger.debug('Deleting /var/lib/pgsql/data')
-            shutil.rmtree('/var/lib/pgsql/data')
-        logging.info('initializing Postgresql...')
+    if not os.path.isfile(STAMP):
+        logging.info("Please be patient. This script could take a few minutes")
+        shutil.copyfile("%s/conf/django-hack" % BASE_DIR, "%s/django" % BASE_BIN)
+        run_command([SYSCTL, "enable", "postgresql"])
+        logging.debug("Progresql enabled")
+        pg_data = "/var/lib/pgsql/data"
+        if os.path.isdir(pg_data):
+            logger.debug("Deleting /var/lib/pgsql/data")
+            shutil.rmtree("/var/lib/pgsql/data")
+        logging.info("initializing Postgresql...")
         # Conditionally run this only if found (CentOS/RedHat script)
-        if os.path.isfile('/usr/bin/postgresql-setup'):
-            logger.debug('running postgresql-setup initdb')
+        if os.path.isfile("/usr/bin/postgresql-setup"):
+            logger.debug("running postgresql-setup initdb")
             # Legacy (CentOS) db init command
-            run_command(['/usr/bin/postgresql-setup', 'initdb'])
+            run_command(["/usr/bin/postgresql-setup", "initdb"])
         else:
             ## In eg openSUSE run the generic initdb from postgresql##-server
-            if os.path.isfile('/usr/bin/initdb'):
-                logger.debug('running generic initdb on {}'.format(pg_data))
+            if os.path.isfile("/usr/bin/initdb"):
+                logger.debug("running generic initdb on {}".format(pg_data))
                 run_command(
-                    ['su', '-', 'postgres', '-c', '/usr/bin/initdb -D {}'.format(pg_data)])
-        logging.info('Done.')
-        run_command([SYSCTL, 'restart', 'postgresql'])
-        run_command([SYSCTL, 'status', 'postgresql'])
-        logging.debug('Postgresql restarted')
-        logging.info('Creating app databases...')
-        run_command(['su', '-', 'postgres', '-c', '/usr/bin/createdb smartdb'])
-        logging.debug('smartdb created')
-        run_command(['su', '-', 'postgres', '-c',
-                     '/usr/bin/createdb storageadmin'])
-        logging.debug('storageadmin created')
-        logging.info('Done')
-        logging.info('Initializing app databases...')
-        run_command(['su', '-', 'postgres', '-c', "psql -c \"CREATE ROLE rocky WITH SUPERUSER LOGIN PASSWORD 'rocky'\""])  # noqa E501
-        logging.debug('rocky ROLE created')
-        run_command(['su', '-', 'postgres', '-c', "psql storageadmin -f %s/conf/storageadmin.sql.in" % BASE_DIR])  # noqa E501
-        logging.debug('storageadmin app database loaded')
-        run_command(['su', '-', 'postgres', '-c',
-                     "psql smartdb -f %s/conf/smartdb.sql.in" % BASE_DIR])
-        logging.debug('smartdb app database loaded')
-        logging.info('Done')
-        run_command(['cp', '-f', '%s/conf/postgresql.conf' % BASE_DIR,
-                     '/var/lib/pgsql/data/'])
-        logging.debug('postgresql.conf copied')
-        run_command(['cp', '-f', '%s/conf/pg_hba.conf' % BASE_DIR,
-                     '/var/lib/pgsql/data/'])
-        logging.debug('pg_hba.conf copied')
-        run_command([SYSCTL, 'restart', 'postgresql'])
-        logging.info('Postgresql restarted')
-        run_command(['touch', STAMP])
+                    [
+                        "su",
+                        "-",
+                        "postgres",
+                        "-c",
+                        "/usr/bin/initdb -D {}".format(pg_data),
+                    ]
+                )
+        logging.info("Done.")
+        run_command([SYSCTL, "restart", "postgresql"])
+        run_command([SYSCTL, "status", "postgresql"])
+        logging.debug("Postgresql restarted")
+        logging.info("Creating app databases...")
+        run_command(["su", "-", "postgres", "-c", "/usr/bin/createdb smartdb"])
+        logging.debug("smartdb created")
+        run_command(["su", "-", "postgres", "-c", "/usr/bin/createdb storageadmin"])
+        logging.debug("storageadmin created")
+        logging.info("Done")
+        logging.info("Initializing app databases...")
+        run_command(
+            [
+                "su",
+                "-",
+                "postgres",
+                "-c",
+                "psql -c \"CREATE ROLE rocky WITH SUPERUSER LOGIN PASSWORD 'rocky'\"",
+            ]
+        )  # noqa E501
+        logging.debug("rocky ROLE created")
+        run_command(
+            [
+                "su",
+                "-",
+                "postgres",
+                "-c",
+                "psql storageadmin -f %s/conf/storageadmin.sql.in" % BASE_DIR,
+            ]
+        )  # noqa E501
+        logging.debug("storageadmin app database loaded")
+        run_command(
+            [
+                "su",
+                "-",
+                "postgres",
+                "-c",
+                "psql smartdb -f %s/conf/smartdb.sql.in" % BASE_DIR,
+            ]
+        )
+        logging.debug("smartdb app database loaded")
+        logging.info("Done")
+        run_command(
+            ["cp", "-f", "%s/conf/postgresql.conf" % BASE_DIR, "/var/lib/pgsql/data/"]
+        )
+        logging.debug("postgresql.conf copied")
+        run_command(
+            ["cp", "-f", "%s/conf/pg_hba.conf" % BASE_DIR, "/var/lib/pgsql/data/"]
+        )
+        logging.debug("pg_hba.conf copied")
+        run_command([SYSCTL, "restart", "postgresql"])
+        logging.info("Postgresql restarted")
+        run_command(["touch", STAMP])
         require_postgres(logging)
-        logging.info('Done')
+        logging.info("Done")
 
-    logging.info('Running app database migrations...')
-    migration_cmd = [DJANGO, 'migrate', '--noinput', ]
-    fake_migration_cmd = migration_cmd + ['--fake']
-    fake_initial_migration_cmd = migration_cmd + ['--fake-initial']
-    smartdb_opts = ['--database=smart_manager', 'smart_manager']
+    logging.info("Running app database migrations...")
+    migration_cmd = [DJANGO, "migrate", "--noinput"]
+    fake_migration_cmd = migration_cmd + ["--fake"]
+    fake_initial_migration_cmd = migration_cmd + ["--fake-initial"]
+    smartdb_opts = ["--database=smart_manager", "smart_manager"]
 
     # Migrate Content types before individual apps
-    logger.debug('migrate (--fake-initial) contenttypes')
-    run_command(
-        fake_initial_migration_cmd + ['--database=default', 'contenttypes'])
+    logger.debug("migrate (--fake-initial) contenttypes")
+    run_command(fake_initial_migration_cmd + ["--database=default", "contenttypes"])
 
-    for app in ('storageadmin', 'smart_manager'):
-        db = 'default'
-        if app == 'smart_manager':
+    for app in ("storageadmin", "smart_manager"):
+        db = "default"
+        if app == "smart_manager":
             db = app
-        o, e, rc = run_command([DJANGO, 'migrate', '--list',
-                                '--database=%s' % db, app])
+        o, e, rc = run_command([DJANGO, "migrate", "--list", "--database=%s" % db, app])
         initial_faked = False
         for l in o:
-            if l.strip() == '[X] 0001_initial':
+            if l.strip() == "[X] 0001_initial":
                 initial_faked = True
                 break
         if not initial_faked:
-            db_arg = '--database=%s' % db
-            logger.debug('migrate (--fake) db=({}) app=({}) 0001_initial'
-                         .format(db, app))
-            run_command(fake_migration_cmd + [db_arg, app, '0001_initial'])
+            db_arg = "--database=%s" % db
+            logger.debug(
+                "migrate (--fake) db=({}) app=({}) 0001_initial".format(db, app)
+            )
+            run_command(fake_migration_cmd + [db_arg, app, "0001_initial"])
 
-    run_command(migration_cmd + ['auth'])
-    run_command(migration_cmd + ['storageadmin'])
+    run_command(migration_cmd + ["auth"])
+    run_command(migration_cmd + ["storageadmin"])
     run_command(migration_cmd + smartdb_opts)
-    run_command(migration_cmd + ['django_ztask'])
-    logging.info('Done')
-    logging.info('Running prepdb...')
-    run_command([PREP_DB, ])
-    logging.info('Done')
+    run_command(migration_cmd + ["django_ztask"])
+    logging.info("Done")
+    logging.info("Running prepdb...")
+    run_command([PREP_DB])
+    logging.info("Done")
 
-    logging.info('stopping firewalld...')
-    run_command([SYSCTL, 'stop', 'firewalld'])
-    run_command([SYSCTL, 'disable', 'firewalld'])
-    logging.info('firewalld stopped and disabled')
+    logging.info("stopping firewalld...")
+    run_command([SYSCTL, "stop", "firewalld"])
+    run_command([SYSCTL, "disable", "firewalld"])
+    logging.info("firewalld stopped and disabled")
     update_nginx(logging)
 
-    shutil.copyfile('/etc/issue', '/etc/issue.rockstor')
+    shutil.copyfile("/etc/issue", "/etc/issue.rockstor")
     init_update_issue(logging)
 
     establish_shellinaboxd_service(logging)
@@ -464,5 +542,5 @@ def main():
     enable_bootstrap_service(logging)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/rockstor/scripts/prep_db.py
+++ b/src/rockstor/scripts/prep_db.py
@@ -22,34 +22,38 @@ from storageadmin.models import Setup
 
 def register_services():
     services = {
-        'AFP': 'netatalk',
-        'NFS': 'nfs',
-        'Samba': 'smb',
-        'NIS': 'nis',
-        'NTP': 'ntpd',
-        'Active Directory': 'active-directory',
-        'LDAP': 'ldap',
-        'SFTP': 'sftp',
-        'Replication': 'replication',
-        'SNMP': 'snmpd',
-        'Rock-on': 'docker',
-        'S.M.A.R.T': 'smartd',
-        'NUT-UPS': 'nut',
-        'ZTaskd': 'ztask-daemon',
-        'Bootstrap': 'rockstor-bootstrap',
-        'Shell In A Box': 'shellinaboxd',
-        'Rockstor': 'rockstor'
-        }
+        "AFP": "netatalk",
+        "NFS": "nfs",
+        "Samba": "smb",
+        "NIS": "nis",
+        "NTP": "ntpd",
+        "Active Directory": "active-directory",
+        "LDAP": "ldap",
+        "SFTP": "sftp",
+        "Replication": "replication",
+        "SNMP": "snmpd",
+        "Rock-on": "docker",
+        "S.M.A.R.T": "smartd",
+        "NUT-UPS": "nut",
+        "ZTaskd": "ztask-daemon",
+        "Bootstrap": "rockstor-bootstrap",
+        "Shell In A Box": "shellinaboxd",
+        "Rockstor": "rockstor",
+    }
 
+    # N.B. all other services have null as their default config with service.
+    # Consider bringing shellinaboxd in line with this now default behaviour.
     services_configs = {
-        'shellinaboxd': ('{"detach": false, "css": "white-on-black", '
-                         '"shelltype": "LOGIN"}')
-        }
+        "shellinaboxd": (
+            '{"detach": false, "css": "white-on-black", ' '"shelltype": "LOGIN"}'
+        )
+    }
 
     for k, v in services.items():
         try:
             so = Service.objects.get(name=v)
             so.display_name = k
+            # Apply any configuration defaults found in services_configs.
             if v in services_configs:
                 so.config = services_configs[v]
         except Service.DoesNotExist:
@@ -57,7 +61,7 @@ def register_services():
         finally:
             so.save()
     for so in Service.objects.filter():
-        if (so.display_name not in services):
+        if so.display_name not in services:
             so.delete()
 
 

--- a/src/rockstor/smart_manager/views/shellinaboxd_service.py
+++ b/src/rockstor/smart_manager/views/shellinaboxd_service.py
@@ -15,37 +15,44 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-
 from rest_framework.response import Response
 from system.services import systemctl
 from base_service import BaseServiceDetailView
 from smart_manager.models import Service
-from system.shell import (update_shell_config, restart_shell)
-
+from system.shell import update_shell_config, restart_shell
+import json
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class ShellInABoxServiceView(BaseServiceDetailView):
-    name = 'shellinaboxd'
+    service_name = "shellinaboxd"
 
     def post(self, request, command):
-        service = Service.objects.get(name=self.name)
+        service = Service.objects.get(name=self.service_name)
 
-        if (command == 'config'):
-            config = request.data.get('config')
+        if command == "config":
+            config = request.data.get("config")
             self._save_config(service, config)
-            shelltype = config.get('shelltype')
-            css = config.get('css')
+            shelltype = config.get("shelltype")
+            css = config.get("css")
             update_shell_config(shelltype, css)
-            restart_shell()
+            restart_shell(self.service_name)
 
-        elif (command == 'start'):
-            systemctl(self.name, 'enable')
-            systemctl(self.name, 'start')
+        elif command == "start":
+            # Assert config from db to re-establish our config file.
+            # Avoids using package default config on first enable.
+            # TODO: config assert every time is a little heavy / overkill.
+            config = json.loads(service.config)
+            shelltype = config.get("shelltype")
+            css = config.get("css")
+            update_shell_config(shelltype, css)
+            systemctl(self.service_name, "enable")
+            systemctl(self.service_name, "start")
 
-        elif (command == 'stop'):
-            systemctl(self.name, 'stop')
-            systemctl(self.name, 'disable')
+        elif command == "stop":
+            systemctl(self.service_name, "stop")
+            systemctl(self.service_name, "disable")
 
         return Response()

--- a/src/rockstor/system/shell.py
+++ b/src/rockstor/system/shell.py
@@ -17,47 +17,50 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from osi import run_command
-from services import service_status
 import shutil
 from tempfile import mkstemp
 from django.conf import settings
 
-SHELL_CONFIG = '/etc/sysconfig/shellinaboxd'
-SYSTEMCTL = '/usr/bin/systemctl'
+# Config file for /repositories/shells/.../shells.repo shellinabox package.
+# This package references the following config file in it's service file.
+SHELL_CONFIG = "/etc/sysconfig/shellinabox"
+PREFIX = "SHELLINABOXD_"
+# The to-be-legacy CentOS shellinabox package config
+if settings.OS_DISTRO_ID == "rockstor":
+    SHELL_CONFIG = "/etc/sysconfig/shellinaboxd"
+    PREFIX = ""
+SYSTEMCTL = "/usr/bin/systemctl"
 
 
-def update_shell_config(shelltype='LOGIN', css='white-on-black'):
+def update_shell_config(shelltype="LOGIN", css="white-on-black"):
     fh, npath = mkstemp()
-    with open(npath, 'w') as tfo:
+    with open(npath, "w") as tfo:
         # Write shellinaboxd default config
-        tfo.write('# Shell In A Box configured by Rockstor\n\n')
-        tfo.write('USER=%s\n' % settings.SHELLINABOX.get('user'))
-        tfo.write('GROUP=%s\n' % settings.SHELLINABOX.get('group'))
-        tfo.write('CERTDIR=%s\n' % settings.SHELLINABOX.get('certs'))
-        tfo.write('PORT=%s\n' % settings.SHELLINABOX.get('port'))
+        tfo.write("# Shell In A Box configured by Rockstor\n\n")
+        tfo.write("{}USER={}\n".format(PREFIX, settings.SHELLINABOX.get("user")))
+        tfo.write("{}GROUP={}\n".format(PREFIX, settings.SHELLINABOX.get("group")))
+        tfo.write("{}CERTDIR={}\n".format(PREFIX, settings.SHELLINABOX.get("certs")))
+        tfo.write("{}PORT={}\n".format(PREFIX, settings.SHELLINABOX.get("port")))
         # Add config customization for css and shelltype
         # IMPORTANT
         # --localhost-only to block shell direct access and because behind
         # nginx --disable-ssl because already on rockstor ssl --no-beep to
         # avoid sounds and possible crashes under FF - see man pages
-        tfo.write('OPTS="--no-beep --localhost-only --disable-ssl ')
+        tfo.write('{}OPTS="--no-beep --localhost-only --disable-ssl '.format(PREFIX))
         # Switch between LOGIN connection and SSH connection LOGIN connection
         # only uid > 1000 allowed, su required to become root\n SSH connection
         # root login allowed too
-        tfo.write('-s /:%s ' % shelltype)
+        tfo.write("-s /:{} ".format(shelltype))
         # If white on black add --css option Default black on white --css
         # option not required / shellinaboxd fails
-        if (css == 'white-on-black'):
-            tfo.write('--css %s.css' % css)
-
+        if css == "white-on-black":
+            tfo.write("--css {}.css".format(css))
+        # And we finally close quote and carriage return the compound OPTS line:
+        tfo.write('"\n')
     shutil.move(npath, SHELL_CONFIG)
 
 
-def restart_shell():
+def restart_shell(sysd_name):
     # simply restart shellinaboxd service No return code checks because rc!=0
     # documented also for nicely running state
-    return run_command([SYSTEMCTL, 'restart', 'shellinaboxd'])
-
-
-def status():
-    return service_status('shellinaboxd')
+    return run_command([SYSTEMCTL, "restart", sysd_name])


### PR DESCRIPTION
A recently available OBS shells.repo hosted shellinabox package had breaking differences from our prior epel CentOS pacakge. The following code changes were made to support both packages concurrently ~~(see testing section for pending changes to the OBS package)~~:

Fixes #2006 

- Move to re-configure service on every service enable and black format the associated file: shellinaboxd_service.py, with minor refactoring.
- Remove build time 'initial' config file instantiation, along with the prior listed change this establishes a single point, within code, where our desired configuration is written. This also ensures we overwrite package default config prior to initial service start.
- Establish distro specific configuration options: the proposed openSUSE shells repo package has a different certificates location.
- Go with both package defaults re user/group for running the shellinabox deamon.
- Account for differing default configuration file names.
- Account for differing systemd service file names by normalising on our existing 'shellinaboxd' and establishing this if not found during the initrock.py script run by rockstor-pre.service.
- Improve comments in prep_db.py pertaining to shellinaboxd + black format.
- Remove unused status() and associated import from shell.py.
- Pass systemd service name to shell.py to reduce hardcoded instances.
- Move shell.py to string.format + black formatting.
- Fix existing bug where shellinabox config file options had no closing quote and carriage return.

@FroggyFlox Ready for review.
Apologies as I didn't manage to split out all of the black formatting, but the largest file was blacked in it's own commit. Not all files were blacked but bit by bit.

## Testing:
In our openSUSE targets I used a slightly modified version of the indicated OBS shell.repo shellinabox package ~~that carries two proposed, and submitted for inclusion upstream, systemd service file fixes by this pr's author:
https://build.opensuse.org/package/show/home:rockstor:branches:shells/shellinabox~~
EDIT: The proposed / submitted upstream changes have now been accepted upstream. As part of this edit I have update the indicated repos to reference the upstream one that now incorporates the referenced systemd servcie file fixes.

This package was chosen via research by @FroggyFlox and myself as it had recently been adopted and moved into the official OBS shells.repo repository. It also contains fixes for shortfalls of a few other existing shellinabox packages available in other individual OBS repos, ie no system, firewalld, and openssl v1.1 compatibility. All of which we require.

### Leap15.1:
```
zypper addrepo --refresh -p105 http://download.opensuse.org/repositories/shells/openSUSE_Leap_15.1/ shells
```
### Tumbleweed:
```
zypper addrepo --refresh -p105 http://download.opensuse.org/repositories/shells/openSUSE_Tumbleweed/ shells
```
with subsequent:
```
zypper refresh
(trust temporarily or always)
```
A lower priority than default (99) is suggested to allow for default priority override (edit) and to avoid other shell entries within this repo from superseding default packages.  ~~if this package enters the standard repositories; although a vendor change would likely also be required.~~

Functionally tested to work as expected on a 'rockstor' CentOS base and the openSUSE Leap15.1, & Tubleweed distributions, all via a from scratch source build of rockstor-core.

## Caveates:
1. Under certain timings the initial invocation of the shell when started from the Web-UI header link and it's own page System - System Shell results in "502 Bad Gateway"
To reproduce:
When the service is off and is enabled via:
- System - System Shell
- or Web-UI header “System Shell”
Work around = Web Browser Page refresh (does not work with popup window option).

2. Popup window mode flaky.
When “Open shell in a popup windows” config option is selected (non default):
- Works but is a little flaky as needs a master window refresh to re-enable popup window invocation once one is closed.

These 2 caveats were observed in Leap15.1, and have been seen in our to-be legacy CentOS base but have yet to be seen in the Tumbleweed instance; but are believed to be generic to the base packages' function or our general implementation and were considered out side the realm of this pull request.
