### PR TITLE
Enable Time Machine support via Samba. Fixes #1910.

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -428,7 +428,6 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
 SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
 CHKCONFIG_BIN = subprocess.check_output(["which", "chkconfig"]).rstrip()
-AVAHID_BIN = subprocess.check_output(["which", "avahi-daemon"]).rstrip()
 
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.

--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -428,6 +428,7 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
 SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
 CHKCONFIG_BIN = subprocess.check_output(["which", "chkconfig"]).rstrip()
+AVAHID_BIN = subprocess.check_output(["which", "avahi-daemon"]).rstrip()
 
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.

--- a/src/rockstor/storageadmin/migrations/0010_sambashare_time_machine.py
+++ b/src/rockstor/storageadmin/migrations/0010_sambashare_time_machine.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0009_auto_20200210_1948'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sambashare',
+            name='time_machine',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/samba_share.py
+++ b/src/rockstor/storageadmin/models/samba_share.py
@@ -39,6 +39,7 @@ class SambaShare(models.Model):
     guest_ok = models.CharField(max_length=3, choices=BOOLEAN_CHOICES,
                                 default=NO)
     shadow_copy = models.BooleanField(default=False)
+    time_machine = models.BooleanField(default=False)
     snapshot_prefix = models.CharField(max_length=128, null=True)
 
     def admin_users(self):

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/add_samba_export.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/samba/add_samba_export.jst
@@ -70,15 +70,24 @@
                title="Comment string to associate with the new share">
           </div>
         </div>
-
+        <div class="form-group">
+             <div class="col-sm-4"></div>
+        <div class="col-sm-4">
+          <input type="checkbox" class="mutually-exclusive" name="time_machine"
+                 {{#if smbShareTimeMachine}}
+                 checked="true"
+                 {{/if}}
+          id="time_machine">    Is this export for Time Machine? &nbsp;&nbsp;<a id="time-machine-info" href="#" class="moreinfo"><i class="fa fa-info-circle"></i></a>
+        </div>
+          </div> <!-- closing form group -->
       <div class="form-group">
              <div class="col-sm-4"></div>
         <div class="col-sm-4">
-          <input type="checkbox" name="shadow_copy"
+          <input type="checkbox" class="mutually-exclusive" name="shadow_copy"
                  {{#if smbSnapshotPrefixRule}}
                  checked="true"
                  {{/if}}
-          id="shadow_copy">Enable Shadow Copy? &nbsp;&nbsp;<a id="shadow-copy-info" href="#" class="moreinfo"><i class="fa fa-info-circle"></i></a>
+          id="shadow_copy">    Enable Shadow Copy? &nbsp;&nbsp;<a id="shadow-copy-info" href="#" class="moreinfo"><i class="fa fa-info-circle"></i></a>
         </div>
           </div> <!-- closing form group -->
           <div class="form-group"
@@ -140,6 +149,27 @@
     Snapshots. Read our <a href="http://rockstor.com/docs"
                            target="_blank">documentation</a> for more information.
   </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="time-machine-info-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h4 id="myModalLabel">Time Machine</h4>
+      </div>
+      <div class="modal-body">
+        <div class="messages"></div>
+        <p>
+          This feature is needed if the Share is to be used for Time Machine backup from Mac
+            OS X clients. By enabling this feature, you can browse older versions of files
+            from Mac OS X. You can read technical details on
+            <a href="https://en.wikipedia.org/wiki/Time_Machine_(macOS)" target="_blank">Wikipedia</a>
+             or <a href="https://support.apple.com/en-us/HT201250" target="_blank">Apple's documentation</a>.
+        </p>
       </div>
     </div>
   </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
@@ -28,7 +28,9 @@ AddSambaExportView = RockstorLayoutView.extend({
     events: {
         'click #cancel': 'cancel',
         'click #shadow-copy-info': 'shadowCopyInfo',
-        'click #shadow_copy': 'toggleSnapPrefix'
+        'click #time-machine-info': 'TimeMachineInfo',
+        'click #shadow_copy': 'toggleSnapPrefix',
+        'click .mutually-exclusive': 'disableBoxes'
     },
 
     initialize: function() {
@@ -95,12 +97,14 @@ AddSambaExportView = RockstorLayoutView.extend({
         var configList = '',
             smbShareName,
             smbShadowCopy,
+            smbTimeMachine,
             smbComment,
             smbSnapPrefix = '';
         if (this.sShares != null) {
             var config = this.sShares.get('custom_config');
             smbShareName = this.sShares.get('share');
             smbShadowCopy = this.sShares.get('shadow_copy');
+            smbTimeMachine = this.sShares.get('time_machine');
             smbComment = this.sShares.get('comment');
             smbSnapPrefix = this.sShares.get('snapshot_prefix');
 
@@ -120,6 +124,7 @@ AddSambaExportView = RockstorLayoutView.extend({
             smbShare: this.sShares,
             smbShareName: smbShareName,
             smbShareShadowCopy: smbShadowCopy,
+            smbShareTimeMachine: smbTimeMachine,
             smbShareComment: smbComment,
             smbShareSnapPrefix: smbSnapPrefix,
             smbSnapshotPrefixRule: smbSnapshotPrefixBool,
@@ -208,12 +213,32 @@ AddSambaExportView = RockstorLayoutView.extend({
         $('#shadow-copy-info-modal').modal('show');
     },
 
+    TimeMachineInfo: function(event) {
+        event.preventDefault();
+        $('#time-machine-info-modal').modal({
+            keyboard: false,
+            show: false,
+            backdrop: 'static'
+        });
+        $('#time-machine-info-modal').modal('show');
+    },
+
     toggleSnapPrefix: function() {
         var cbox = this.$('#shadow_copy');
         if (cbox.prop('checked')) {
             this.$('#snapprefix-ph').css('visibility', 'visible');
         } else {
             this.$('#snapprefix-ph').css('visibility', 'hidden');
+        }
+    },
+
+    disableBoxes: function() {
+        if (this.$('#shadow_copy').attr('checked')) {
+            this.$('#time_machine').attr('disabled', true);
+        } else if (this.$('#time_machine').attr('checked')) {
+            this.$('#shadow_copy').attr('disabled', true);
+        } else {
+            this.$('.mutually-exclusive').attr('disabled', false);
         }
     },
 

--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -16,15 +16,14 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 import mock
+from mock import patch
 from rest_framework import status
 from rest_framework.test import APITestCase
-from mock import patch
 
 from storageadmin.exceptions import RockStorAPIException
-from storageadmin.models import Pool, Share, SambaCustomConfig, SambaShare, User
+from storageadmin.models import Pool, Share, SambaShare, User
 from storageadmin.tests.test_api import APITestMixin
-
-from storageadmin.views.samba import SambaListView, logger
+from storageadmin.views.samba import SambaListView
 
 
 class SambaTests(APITestMixin, APITestCase, SambaListView):
@@ -92,12 +91,14 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
             "snapshot_prefix": "",
             "shares": ["9", "10"],
             "shadow_copy": False,
+            "time_machine": True,
             "guest_ok": "no",
         }
         expected_result = {
             "comment": "Samba-Export",
             "read_only": "no",
             "browsable": "yes",
+            "time_machine": True,
             "custom_config": [],
             "guest_ok": "no",
             "shadow_copy": False,
@@ -117,6 +118,7 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
             "comment": "samba export",
             "read_only": "no",
             "browsable": "yes",
+            "time_machine": False,
             "custom_config": [],
             "guest_ok": "no",
             "shadow_copy": False,

--- a/src/rockstor/storageadmin/views/samba.py
+++ b/src/rockstor/storageadmin/views/samba.py
@@ -106,7 +106,6 @@ class SambaMixin(object):
                 )
                 handle_exception(Exception(e_msg), rdata)
         options["time_machine"] = rdata.get("time_machine", def_opts["time_machine"])
-        logger.debug("time_machine is = {}".format(options["time_machine"]))
         if not isinstance(options["time_machine"], bool):
             e_msg = (
                 "Invalid choice for time_machine. Possible options are True or False."

--- a/src/rockstor/storageadmin/views/samba.py
+++ b/src/rockstor/storageadmin/views/samba.py
@@ -30,7 +30,12 @@ from share import ShareMixin
 from storageadmin.models import SambaShare, User, SambaCustomConfig
 from storageadmin.serializers import SambaShareSerializer
 from storageadmin.util import handle_exception
-from system.samba import refresh_smb_config, status, restart_samba, refresh_smb_discovery
+from system.samba import (
+    refresh_smb_config,
+    status,
+    restart_samba,
+    refresh_smb_discovery,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +108,9 @@ class SambaMixin(object):
         options["time_machine"] = rdata.get("time_machine", def_opts["time_machine"])
         logger.debug("time_machine is = {}".format(options["time_machine"]))
         if not isinstance(options["time_machine"], bool):
-            e_msg = "Invalid choice for time_machine. Possible options are True or False."
+            e_msg = (
+                "Invalid choice for time_machine. Possible options are True or False."
+            )
             handle_exception(Exception(e_msg), rdata)
 
         return options
@@ -128,7 +135,7 @@ class SambaMixin(object):
                 except KeyError:
                     # raise the outer exception as it's more meaningful to the
                     # user.
-                    raise Exception("Requested admin user(%s) does not exist." % au)
+                    raise Exception("Requested admin user({}) does not exist.".format(au))
             finally:
                 auo.smb_shares.add(smb_share)
 
@@ -215,9 +222,7 @@ class SambaDetailView(SambaMixin, rfc.GenericView):
             try:
                 smbo = SambaShare.objects.get(id=smb_id)
             except:
-                e_msg = ("Samba export for the id ({}) does not exist.").format(
-                    smb_id
-                )
+                e_msg = ("Samba export for the id ({}) does not exist.").format(smb_id)
                 handle_exception(Exception(e_msg), request)
 
             options = self._validate_input(request.data, smbo=smbo)

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -28,7 +28,6 @@ from services import service_status, define_avahi_service
 from storageadmin.models import SambaCustomConfig
 
 TESTPARM = "/usr/bin/testparm"
-AVAHID = settings.AVAHID_BIN
 SMB_CONFIG = "/etc/samba/smb.conf"
 TM_CONFIG = "/etc/avahi/services/timemachine.service"
 SYSTEMCTL = "/usr/bin/systemctl"
@@ -279,7 +278,7 @@ def refresh_smb_discovery(exports):
         define_avahi_service("timemachine", share_names=tm_exports)
 
     # Reload avahi config / or restart it
-    run_command([AVAHID, "--reload", ], log=True)
+    run_command([SYSTEMCTL, "restart", "avahi-daemon"], log=True)
 
 
 def update_samba_discovery():

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -27,71 +27,70 @@ from osi import run_command
 from services import service_status, define_avahi_service
 from storageadmin.models import SambaCustomConfig
 
-TESTPARM = '/usr/bin/testparm'
+TESTPARM = "/usr/bin/testparm"
 AVAHID = settings.AVAHID_BIN
-SMB_CONFIG = '/etc/samba/smb.conf'
-TM_CONFIG = '/etc/avahi/services/timemachine.service'
-SYSTEMCTL = '/usr/bin/systemctl'
-CHMOD = '/usr/bin/chmod'
-RS_SHARES_HEADER = '####BEGIN: Rockstor SAMBA CONFIG####'
-RS_SHARES_FOOTER = '####END: Rockstor SAMBA CONFIG####'
-RS_AD_HEADER = '####BEGIN: Rockstor ACTIVE DIRECTORY CONFIG####'
-RS_AD_FOOTER = '####END: Rockstor ACTIVE DIRECTORY CONFIG####'
-RS_CUSTOM_HEADER = '####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####'
-RS_CUSTOM_FOOTER = '####END: Rockstor SAMBA GLOBAL CUSTOM####'
+SMB_CONFIG = "/etc/samba/smb.conf"
+TM_CONFIG = "/etc/avahi/services/timemachine.service"
+SYSTEMCTL = "/usr/bin/systemctl"
+CHMOD = "/usr/bin/chmod"
+RS_SHARES_HEADER = "####BEGIN: Rockstor SAMBA CONFIG####"
+RS_SHARES_FOOTER = "####END: Rockstor SAMBA CONFIG####"
+RS_AD_HEADER = "####BEGIN: Rockstor ACTIVE DIRECTORY CONFIG####"
+RS_AD_FOOTER = "####END: Rockstor ACTIVE DIRECTORY CONFIG####"
+RS_CUSTOM_HEADER = "####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####"
+RS_CUSTOM_FOOTER = "####END: Rockstor SAMBA GLOBAL CUSTOM####"
+
 
 def test_parm(config="/etc/samba/smb.conf"):
     cmd = [TESTPARM, "-s", config]
     o, e, rc = run_command(cmd, throw=False)
     if rc != 0:
-        raise Exception(
-            "Syntax error while checking the temporary samba config file"
-        )
+        raise Exception("Syntax error while checking the temporary samba config file")
     return True
 
 
 def rockstor_smb_config(fo, exports):
     mnt_helper = os.path.join(settings.ROOT_DIR, "bin/mnt-share")
-    fo.write("%s\n" % RS_SHARES_HEADER)
+    fo.write("{}\n".format(RS_SHARES_HEADER))
     for e in exports:
         admin_users = ""
         for au in e.admin_users.all():
-            admin_users = "%s%s " % (admin_users, au.username)
-        fo.write("[%s]\n" % e.share.name)
-        fo.write('    root preexec = "%s %s"\n' % (mnt_helper, e.share.name))
+            admin_users = "{}{} ".format(admin_users, au.username)
+        fo.write("[{}]\n".format(e.share.name))
+        fo.write('    root preexec = "{} {}"\n'.format(mnt_helper, e.share.name))
         fo.write("    root preexec close = yes\n")
-        fo.write("    comment = %s\n" % e.comment.encode("utf-8"))
-        fo.write("    path = %s\n" % e.path)
-        fo.write("    browseable = %s\n" % e.browsable)
-        fo.write("    read only = %s\n" % e.read_only)
-        fo.write("    guest ok = %s\n" % e.guest_ok)
+        fo.write("    comment = {}\n".format(e.comment.encode("utf-8")))
+        fo.write("    path = {}\n".format(e.path))
+        fo.write("    browseable = {}\n".format(e.browsable))
+        fo.write("    read only = {}\n".format(e.read_only))
+        fo.write("    guest ok = {}\n".format(e.guest_ok))
         if len(admin_users) > 0:
-            fo.write("    admin users = %s\n" % admin_users)
+            fo.write("    admin users = {}\n".format(admin_users))
         if e.shadow_copy:
             fo.write(
                 "    shadow:format = ." + e.snapshot_prefix + "_%Y%m%d%H%M\n"
             )  # noqa E501
-            fo.write("    shadow:basedir = %s\n" % e.path)
+            fo.write("    shadow:basedir = {}\n".format(e.path))
             fo.write("    shadow:snapdir = ./\n")
             fo.write("    shadow:sort = desc\n")
             fo.write("    shadow:localtime = yes\n")
             fo.write("    vfs objects = shadow_copy2\n")
-            fo.write("    veto files = /.%s*/\n" % e.snapshot_prefix)
-        elif (e.time_machine):
-            fo.write('    vfs objects = catia fruit streams_xattr\n')
-            fo.write('    fruit:timemachine = yes\n')
-            fo.write('    fruit:metadata = stream\n')
-            fo.write('    fruit:veto_appledouble = no\n')
-            fo.write('    fruit:posix_rename = no\n')
-            fo.write('    fruit:wipe_intentionally_left_blank_rfork = yes\n')
-            fo.write('    fruit:delete_empty_adfiles = yes\n')
-            fo.write('    fruit:encoding = private\n')
-            fo.write('    fruit:locking = none\n')
-            fo.write('    fruit:resource = file\n')
+            fo.write("    veto files = /.{}*/\n".format(e.snapshot_prefix))
+        elif e.time_machine:
+            fo.write("    vfs objects = catia fruit streams_xattr\n")
+            fo.write("    fruit:timemachine = yes\n")
+            fo.write("    fruit:metadata = stream\n")
+            fo.write("    fruit:veto_appledouble = no\n")
+            fo.write("    fruit:posix_rename = no\n")
+            fo.write("    fruit:wipe_intentionally_left_blank_rfork = yes\n")
+            fo.write("    fruit:delete_empty_adfiles = yes\n")
+            fo.write("    fruit:encoding = private\n")
+            fo.write("    fruit:locking = none\n")
+            fo.write("    fruit:resource = file\n")
         for cco in SambaCustomConfig.objects.filter(smb_share=e):
             if cco.custom_config.strip():
-                fo.write("    %s\n" % cco.custom_config)
-    fo.write("%s\n" % RS_SHARES_FOOTER)
+                fo.write("    {}\n".format(cco.custom_config))
+    fo.write("{}\n".format(RS_SHARES_FOOTER))
 
 
 def refresh_smb_config(exports):
@@ -133,19 +132,19 @@ def update_global_config(smb_config=None, ad_config=None):
         }
         for key, value in smb_default_options.iteritems():
             if key not in smb_config:
-                tfo.write("    %s = %s\n" % (key, value))
+                tfo.write("    {} = {}\n".format(key, value))
 
         # Fill samba [global] section with our custom samba params
         # before updating smb_config dict with AD data to avoid
         # adding non samba params like AD username and password
         if smb_config is not None:
-            tfo.write("\n%s\n" % RS_CUSTOM_HEADER)
+            tfo.write("\n{}\n".format(RS_CUSTOM_HEADER))
             for k in smb_config:
                 if ad_config is not None and k == "workgroup":
-                    tfo.write("    %s = %s\n" % (k, ad_config[k]))
+                    tfo.write("    {} = {}\n".format(k, ad_config[k]))
                     continue
-                tfo.write("    %s = %s\n" % (k, smb_config[k]))
-            tfo.write("%s\n\n" % RS_CUSTOM_FOOTER)
+                tfo.write("    {} = {}\n".format(k, smb_config[k]))
+            tfo.write("{}\n\n".format(RS_CUSTOM_FOOTER))
 
         # Next add AD config to smb_config and build AD section
         if ad_config is not None:
@@ -154,11 +153,11 @@ def update_global_config(smb_config=None, ad_config=None):
         domain = smb_config.pop("domain", None)
         if domain is not None:
             idmap_high = int(smb_config["idmap_range"].split()[2])
-            default_range = "%s - %s" % (idmap_high + 1, idmap_high + 1000000)
+            default_range = "{} - {}".format(idmap_high + 1, idmap_high + 1000000)
             workgroup = ad_config["workgroup"]
-            tfo.write("%s\n" % RS_AD_HEADER)
+            tfo.write("{}\n".format(RS_AD_HEADER))
             tfo.write("    security = ads\n")
-            tfo.write("    realm = %s\n" % domain)
+            tfo.write("    realm = {}\n".format(domain))
             tfo.write("    template shell = /bin/sh\n")
             tfo.write("    kerberos method = secrets and keytab\n")
             tfo.write("    winbind use default domain = false\n")
@@ -166,25 +165,29 @@ def update_global_config(smb_config=None, ad_config=None):
             tfo.write("    winbind enum users = yes\n")
             tfo.write("    winbind enum groups = yes\n")
             tfo.write("    idmap config * : backend = tdb\n")
-            tfo.write("    idmap config * : range = %s\n" % default_range)
+            tfo.write("    idmap config * : range = {}\n".format(default_range))
             # enable rfc2307 schema and collect UIDS from AD DC we assume if
             # rfc2307 then winbind nss info too - collects AD DC home and shell
             # for each user
             if smb_config.pop("rfc2307", None):
-                tfo.write("    idmap config %s : backend = ad\n" % workgroup)
+                tfo.write("    idmap config {} : backend = ad\n".format(workgroup))
                 tfo.write(
-                    "    idmap config %s : range = %s\n"
-                    % (workgroup, smb_config["idmap_range"])
+                    "    idmap config {} : range = {}\n".format(
+                        workgroup, smb_config["idmap_range"]
+                    )
                 )
-                tfo.write("    idmap config %s : schema_mode = rfc2307\n" % workgroup)
+                tfo.write(
+                    "    idmap config {} : schema_mode = rfc2307\n".format(workgroup)
+                )
                 tfo.write("    winbind nss info = rfc2307\n")
             else:
-                tfo.write("    idmap config %s : backend = rid\n" % workgroup)
+                tfo.write("    idmap config {} : backend = rid\n".format(workgroup))
                 tfo.write(
-                    "    idmap config %s : range = %s\n"
-                    % (workgroup, smb_config["idmap_range"])
+                    "    idmap config {} : range = {}\n".format(
+                        workgroup, smb_config["idmap_range"]
+                    )
                 )
-            tfo.write("%s\n\n" % RS_AD_FOOTER)
+            tfo.write("{}\n\n".format(RS_AD_FOOTER))
 
         # After default [global], custom [global] and AD writes
         # finally add smb shares
@@ -276,7 +279,7 @@ def refresh_smb_discovery(exports):
         define_avahi_service("timemachine", share_names=tm_exports)
 
     # Reload avahi config / or restart it
-    run_command([AVAHID, '--reload', ], log=True)
+    run_command([AVAHID, "--reload", ], log=True)
 
 
 def update_samba_discovery():

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -27,14 +27,14 @@ from django.conf import settings
 from osi import run_command
 
 CHKCONFIG_BIN = settings.CHKCONFIG_BIN
-AUTHCONFIG = '/usr/sbin/authconfig'
-SSHD_CONFIG = '/etc/ssh/sshd_config'
-SYSTEMCTL_BIN = '/usr/bin/systemctl'
-SUPERCTL_BIN = ('%s/bin/supervisorctl' % settings.ROOT_DIR)
-SUPERVISORD_CONF = ('%s/etc/supervisord.conf' % settings.ROOT_DIR)
-NET = '/usr/bin/net'
-WBINFO = '/usr/bin/wbinfo'
-AFP_CONFIG = '/etc/netatalk/afp.conf'
+AUTHCONFIG = "/usr/sbin/authconfig"
+SSHD_CONFIG = "/etc/ssh/sshd_config"
+SYSTEMCTL_BIN = "/usr/bin/systemctl"
+SUPERCTL_BIN = "%s/bin/supervisorctl" % settings.ROOT_DIR
+SUPERVISORD_CONF = "%s/etc/supervisord.conf" % settings.ROOT_DIR
+NET = "/usr/bin/net"
+WBINFO = "/usr/bin/wbinfo"
+AFP_CONFIG = "/etc/netatalk/afp.conf"
 
 
 def init_service_op(service_name, command, throw=True):
@@ -47,12 +47,26 @@ def init_service_op(service_name, command, throw=True):
     :param throw:
     :return: out err rc
     """
-    supported_services = ('nfs', 'smb', 'sshd', 'ypbind', 'rpcbind', 'ntpd',
-                          'nslcd', 'netatalk', 'snmpd', 'docker', 'smartd',
-                          'shellinaboxd', 'nut-server', 'rockstor-bootstrap',
-                          'rockstor', 'systemd-shutdownd')
-    if (service_name not in supported_services):
-        raise Exception('unknown service: %s' % service_name)
+    supported_services = (
+        "nfs",
+        "smb",
+        "sshd",
+        "ypbind",
+        "rpcbind",
+        "ntpd",
+        "nslcd",
+        "netatalk",
+        "snmpd",
+        "docker",
+        "smartd",
+        "shellinaboxd",
+        "nut-server",
+        "rockstor-bootstrap",
+        "rockstor",
+        "systemd-shutdownd",
+    )
+    if service_name not in supported_services:
+        raise Exception("unknown service: {}".format(service_name))
 
     return run_command([SYSTEMCTL_BIN, command, service_name], throw=throw)
 
@@ -75,24 +89,23 @@ def set_autostart(service, switch):
     :param switch:
     :return:
     """
-    switch_map = {'start': 'true',
-                  'stop': 'false'}
-    if (switch not in switch_map):
+    switch_map = {"start": "true", "stop": "false"}
+    if switch not in switch_map:
         return
     switch = switch_map[switch]
     fo, npath = mkstemp()
-    with open(SUPERVISORD_CONF) as sfo, open(npath, 'w') as tfo:
+    with open(SUPERVISORD_CONF) as sfo, open(npath, "w") as tfo:
         start = False
         stop = False
         for line in sfo.readlines():
-            if (re.match('\[program:%s\]' % service, line) is not None):
+            if re.match("\[program:{}\]".format(service), line) is not None:
                 start = True
-            elif (start is True and len(line.strip()) == 0):
+            elif start is True and len(line.strip()) == 0:
                 stop = True
 
-            if (start is True and stop is False):
-                if (re.match('autostart', line) is not None):
-                    tfo.write('autostart=%s\n' % switch)
+            if start is True and stop is False:
+                if re.match("autostart", line) is not None:
+                    tfo.write("autostart={}\n".format(switch))
                 else:
                     tfo.write(line)
             else:
@@ -103,9 +116,9 @@ def set_autostart(service, switch):
 def superctl(service, switch):
     out, err, rc = run_command([SUPERCTL_BIN, switch, service])
     set_autostart(service, switch)
-    if (switch == 'status'):
+    if switch == "status":
         status = out[0].split()[1]
-        if (status != 'RUNNING'):
+        if status != "RUNNING":
             rc = 1
     return out, err, rc
 
@@ -119,88 +132,93 @@ def service_status(service_name, config=None):
     :param service_name:
     :return:
     """
-    if (service_name == 'nis' or service_name == 'nfs'):
-        out, err, rc = init_service_op('rpcbind', 'status', throw=False)
-        if (rc != 0):
+    if service_name == "nis" or service_name == "nfs":
+        out, err, rc = init_service_op("rpcbind", "status", throw=False)
+        if rc != 0:
             return out, err, rc
-        if (service_name == 'nis'):
-            return init_service_op('ypbind', 'status', throw=False)
+        if service_name == "nis":
+            return init_service_op("ypbind", "status", throw=False)
         else:
-            return init_service_op('nfs', 'status', throw=False)
-    elif (service_name == 'ldap'):
-        return init_service_op('nslcd', 'status', throw=False)
-    elif (service_name == 'sftp'):
-        out, err, rc = init_service_op('sshd', 'status', throw=False)
+            return init_service_op("nfs", "status", throw=False)
+    elif service_name == "ldap":
+        return init_service_op("nslcd", "status", throw=False)
+    elif service_name == "sftp":
+        out, err, rc = init_service_op("sshd", "status", throw=False)
         # initial check on sshd status: 0 = OK 3 = stopped
-        if (rc != 0):
+        if rc != 0:
             return out, err, rc
         # sshd has sftp subsystem so we check for it's config line which is
         # inserted or deleted to enable or disable the sftp service.
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
-                if (re.match("Subsystem\s+sftp", line) is not
-                        None):
+                if re.match("Subsystem\s+sftp", line) is not None:
                     return out, err, rc
             # -1 not appropriate as inconsistent with bash return codes
             # Returning 1 as Catchall for general errors.  the calling system
             # interprets -1 as enabled, 1 works for disabled.
             return out, err, 1
-    elif (service_name in ('replication', 'data-collector', 'ztask-daemon')):
-        return superctl(service_name, 'status')
-    elif (service_name == 'smb'):
-        out, err, rc = run_command([SYSTEMCTL_BIN, 'status', 'smb'],
-                                   throw=False)
-        if (rc != 0):
+    elif service_name in ("replication", "data-collector", "ztask-daemon"):
+        return superctl(service_name, "status")
+    elif service_name == "smb":
+        out, err, rc = run_command([SYSTEMCTL_BIN, "status", "smb"], throw=False)
+        if rc != 0:
             return out, err, rc
-        return run_command([SYSTEMCTL_BIN, 'status', 'nmb'], throw=False)
-    elif (service_name == 'nut'):
+        return run_command([SYSTEMCTL_BIN, "status", "nmb"], throw=False)
+    elif service_name == "nut":
         # Establish if nut is running by lowest common denominator nut-monitor
         # In netclient mode it is all that is required, however we don't then
         # reflect the state of the other services of nut-server and nut-driver.
-        return run_command([SYSTEMCTL_BIN, 'status', 'nut-monitor'],
-                           throw=False)
-    elif (service_name == 'active-directory'):
-        if (config is not None):
+        return run_command([SYSTEMCTL_BIN, "status", "nut-monitor"], throw=False)
+    elif service_name == "active-directory":
+        if config is not None:
             # 2 steps Active Directory status check
             # First checks secret via rpc callable
             # Second checks via auth for admin username
             # If both give us 0 rc Active Directory is running
-            wbinfo_trust_cmd = [WBINFO, '-t', '--domain', config.get('domain')]
-            wbinfo_auth_credentials = '{}@{}%{}'.format(
-                config.get('username'), config.get('domain'),
-                config.get('password'))
-            wbinfo_auth_cmd = [WBINFO, '-a', wbinfo_auth_credentials,
-                               '--domain', config.get('domain')]
+            wbinfo_trust_cmd = [WBINFO, "-t", "--domain", config.get("domain")]
+            wbinfo_auth_credentials = "{}@{}%{}".format(
+                config.get("username"), config.get("domain"), config.get("password")
+            )
+            wbinfo_auth_cmd = [
+                WBINFO,
+                "-a",
+                wbinfo_auth_credentials,
+                "--domain",
+                config.get("domain"),
+            ]
             wbinfo_trust = run_command(wbinfo_trust_cmd, throw=False)
             wbinfo_auth = run_command(wbinfo_auth_cmd, throw=False)
             active_directory_rc = 1
-            if (wbinfo_trust[2] == 0 and wbinfo_auth[2] == 0):
+            if wbinfo_trust[2] == 0 and wbinfo_auth[2] == 0:
                 active_directory_rc = 0
 
-            return '', '', active_directory_rc
+            return "", "", active_directory_rc
         # bootstrap switch subsystem interprets -1 as ON so returning 1 instead
-        return '', '', 1
+        return "", "", 1
 
-    return init_service_op(service_name, 'status', throw=False)
+    return init_service_op(service_name, "status", throw=False)
 
 
 def ldap_input(config, command):
     ac_cmd = []
-    if (command == 'stop'):
-        ac_cmd.extend(['--disableldap', '--disableldapauth'])
+    if command == "stop":
+        ac_cmd.extend(["--disableldap", "--disableldapauth"])
     else:
-        ac_cmd.extend(['--enableldap', '--enableldapauth'])
-        ac_cmd.append('--ldapserver=%s' % config['server'])
-        ac_cmd.append('--ldapbasedn=%s' % config['basedn'])
-        if (config['enabletls'] is True):
-            ac_cmd.append('--enableldaptls')
-            ac_cmd.append('--ldaploadcacert=%s' % config['cert'])
+        ac_cmd.extend(["--enableldap", "--enableldapauth"])
+        ac_cmd.append("--ldapserver={}".format(config["server"]))
+        ac_cmd.append("--ldapbasedn={}".format(config["basedn"]))
+        if config["enabletls"] is True:
+            ac_cmd.append("--enableldaptls")
+            ac_cmd.append("--ldaploadcacert={}".format(config["cert"]))
     return ac_cmd
 
 
 def toggle_auth_service(service, command, config=None):
-    ac_cmd = [AUTHCONFIG, '--update', ]
-    if (service == 'ldap'):
+    ac_cmd = [
+        AUTHCONFIG,
+        "--update",
+    ]
+    if service == "ldap":
         ac_cmd.extend(ldap_input(config, command))
     else:
         return None
@@ -208,32 +226,31 @@ def toggle_auth_service(service, command, config=None):
 
 
 def rockstor_afp_config(fo, afpl):
-    fo.write(';####BEGIN: Rockstor AFP CONFIG####\n')
+    fo.write(";####BEGIN: Rockstor AFP CONFIG####\n")
     for c in afpl:
         vol_size = int(c.vol_size / 1024)
-        fo.write('[%s]\n' % c.description)
-        fo.write('  path = %s\n' % c.path)
-        fo.write('  time machine = %s\n' % c.time_machine)
-        fo.write('  vol size limit = %d\n\n' % vol_size)
-    fo.write(';####END: Rockstor AFP CONFIG####\n')
+        fo.write("[{}]\n".format(c.description))
+        fo.write("  path = {}\n".format(c.path))
+        fo.write("  time machine = {}\n".format(c.time_machine))
+        fo.write("  vol size limit = {}\n\n".format(vol_size))
+    fo.write(";####END: Rockstor AFP CONFIG####\n")
 
 
 def refresh_afp_config(afpl):
     fo, npath = mkstemp()
-    with open(AFP_CONFIG) as afo, open(npath, 'w') as tfo:
+    with open(AFP_CONFIG) as afo, open(npath, "w") as tfo:
         rockstor_section = False
-        tfo.write('; Netatalk 3.x configuration file\n\n')
-        tfo.write('[Global]\n')
-        tfo.write('mimic model = RackMac\n')
-        tfo.write('uam list = uams_dhx.so,uams_dhx2.so\n')
-        tfo.write('save password = no\n\n')
+        tfo.write("; Netatalk 3.x configuration file\n\n")
+        tfo.write("[Global]\n")
+        tfo.write("mimic model = RackMac\n")
+        tfo.write("uam list = uams_dhx.so,uams_dhx2.so\n")
+        tfo.write("save password = no\n\n")
         for line in afo.readlines():
-            if (re.match(';####BEGIN: Rockstor AFP CONFIG####', line)
-                    is not None):
+            if re.match(";####BEGIN: Rockstor AFP CONFIG####", line) is not None:
                 rockstor_section = True
                 rockstor_afp_config(tfo, afpl)
                 break
-        if (rockstor_section is False):
+        if rockstor_section is False:
             rockstor_afp_config(tfo, afpl)
     shutil.move(npath, AFP_CONFIG)
     os.chmod(AFP_CONFIG, 644)
@@ -241,29 +258,32 @@ def refresh_afp_config(afpl):
 
 def update_nginx(ip, port):
     port = int(port)
-    conf = '%s/etc/nginx/nginx.conf' % settings.ROOT_DIR
+    conf = "{}/etc/nginx/nginx.conf".format(settings.ROOT_DIR)
     fo, npath = mkstemp()
-    with open(conf) as ifo, open(npath, 'w') as tfo:
+    with open(conf) as ifo, open(npath, "w") as tfo:
         http_server = False
         lines = ifo.readlines()
         for i in range(len(lines)):
-            if ((re.search('server {', lines[i]) is not None and
-                 re.search('listen.*80 default_server', lines[i+1]) is not
-                 None)):
+            if (
+                re.search("server {", lines[i]) is not None
+                and re.search("listen.*80 default_server", lines[i + 1]) is not None
+            ):
                 # found legacy http server section. don't rewrite it.
                 http_server = True
-            if ((not http_server and
-                 re.search('listen.*default_server', lines[i]) is not None)):
-                substr = 'listen %d default_server' % port
-                if (ip is not None):
-                    substr = 'listen %s:%d default_server' % (ip, port)
-                lines[i] = re.sub(r'listen.* default_server', substr, lines[i])
-            if (not http_server):
+            if (
+                not http_server
+                and re.search("listen.*default_server", lines[i]) is not None
+            ):
+                substr = "listen {} default_server".format(port)
+                if ip is not None:
+                    substr = "listen {}:{} default_server".format(ip, port)
+                lines[i] = re.sub(r"listen.* default_server", substr, lines[i])
+            if not http_server:
                 tfo.write(lines[i])
-            if (http_server is True and lines[i].strip() == '}'):
+            if http_server is True and lines[i].strip() == "}":
                 http_server = False
     shutil.move(npath, conf)
-    superctl('nginx', 'restart')
+    superctl("nginx", "restart")
 
 
 def define_avahi_service(service_name, share_names=None):
@@ -288,7 +308,7 @@ def define_avahi_service(service_name, share_names=None):
 
     # Write to file
     fh, npath = mkstemp()
-    with open(npath, 'w') as tfo:
+    with open(npath, "w") as tfo:
         write_avahi_headers(tfo)
         for s in avahi_service:
             write_avahi_service(tfo, **s)
@@ -305,9 +325,9 @@ def write_avahi_headers(tfo):
     :return:
     """
     tfo.write("<?xml version=\"1.0\" standalone='no'?>\n")
-    tfo.write("<!DOCTYPE service-group SYSTEM \"avahi-service.dtd\">\n")
+    tfo.write('<!DOCTYPE service-group SYSTEM "avahi-service.dtd">\n')
     tfo.write("<service-group>\n")
-    tfo.write(" <name replace-wildcards=\"yes\">%h</name>\n")
+    tfo.write(' <name replace-wildcards="yes">%h</name>\n')
 
 
 def write_avahi_footer(tfo):


### PR DESCRIPTION
Fixes #1910.
@phillxnet: ready for review.

This pull request (PR) proposes to support Time Machine via Samba by surfacing a simple check-box while exporting a share via Samba. By checking this checkbox, Time Machine specific options are automatically applied to this share's section in `smb.conf`. Finally, the new Time Machine-enabled export is added to a dedicated Avahi static service file to be advertised.
Notably, a new field has been added to the `SambaShare` model to store this new Time Machine option. The existing Samba unit tests were thus slightly modified to ensure compatibility.

### Aims & Logic
While exporting a share, a new checkbox is displayed to enable compatibility with Time Machine. Upon form submission, the value of this checkbox is stored in the `SambaShare` model under the new `time_machine` boolean field. Thanks to this new field, we can now detect if a Samba export needs to be compatible with Time Machine when writing `smb.conf` and write specific options in the share's section. 
Then, we check for the presence of Time Machine-enabled shares and advertise them through Avahi by writing a dedicated `/etc/avahi/services/timemachine.service` file.


### Database migrations
A new migration file was created as follows:
```shell script
[root@rockdev ~]# /opt/build/bin/django makemigrations storageadmin
Migrations for 'storageadmin':
  0010_sambashare_time_machine.py:
    - Add field time_machine to sambashare
```
... and first applied as:
```shell script
[root@rockdev ~]# /opt/build/bin/django migrate storageadmin
Operations to perform:
  Apply all migrations: storageadmin
Running migrations:
  Rendering model states... DONE
  Applying storageadmin.0010_sambashare_time_machine... OK
The following content types are stale and need to be deleted:

    storageadmin | networkinterface
    storageadmin | poolstatistic
    storageadmin | sharestatistic

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

    Type 'yes' to continue, or 'no' to cancel: no
```

When building the current branch on a fresh Leap 15.1 install, it does install/migrate as needed:
```shell script
rockdev:~ # /opt/build/bin/django showmigrations storageadmin
storageadmin
 [X] 0001_initial
 [X] 0002_auto_20161125_0051
 [X] 0003_auto_20170114_1332
 [X] 0004_auto_20170523_1140
 [X] 0005_auto_20180913_0923
 [X] 0006_dcontainerargs
 [X] 0007_auto_20181210_0740
 [X] 0008_auto_20190115_1637
 [X] 0009_auto_20200210_1948
 [X] 0010_sambashare_time_machine
```

### Demonstration
1. On a freshly built Leap 15.1, the Samba service is configured and turned ON.

2. Then, start the process to create a new share and enable compatibility with Time Machine. Note how checking the Time Machine checkbox disables the Shadow copy option as I believe enabling these two options on the same export would be prone to conflicts.
![image](https://user-images.githubusercontent.com/30297881/76167101-9c823d80-613a-11ea-8d89-e6630590850d.png)


3. The resulting `smb.conf` is then written with the time machine-specific options.
```shell script
rockdev:~ # cat /etc/samba/smb.conf 
[global]
    log level = 3
    map to guest = Bad User
    cups options = raw
    log file = /var/log/samba/log.%m
    printcap name = /dev/null
    load printers = no

####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####
    workgroup = MYROCKYGROUP
####END: Rockstor SAMBA GLOBAL CUSTOM####

####BEGIN: Rockstor SAMBA CONFIG####
[test_share01]
    root preexec = "/opt/build/bin/mnt-share test_share01"
    root preexec close = yes
    comment = Samba-Export
    path = /mnt2/test_share01
    browseable = yes
    read only = no
    guest ok = no
    admin users = test 
    vfs objects = catia fruit streams_xattr
    fruit:timemachine = yes
    fruit:metadata = stream
    fruit:veto_appledouble = no
    fruit:posix_rename = no
    fruit:wipe_intentionally_left_blank_rfork = yes
    fruit:delete_empty_adfiles = yes
    fruit:encoding = private
    fruit:locking = none
    fruit:resource = file
####END: Rockstor SAMBA CONFIG####
```

4. Furthermore, a corresponding Avahi service file is created to advertise this share.
```shell script
rockdev:~ # cat /etc/avahi/services/timemachine.service 
<?xml version="1.0" standalone='no'?>
<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
<service-group>
 <name replace-wildcards="yes">%h</name>
 <service>
   <type>_smb._tcp</type>
   <port>445</port>
 </service>
 <service>
   <txt-record>sys=waMa=0,adVF=0x100</txt-record>
   <txt-record>dk0=adVN=test_share01,adVF=0x82</txt-record>
   <type>_adisk._tcp</type>
 </service>
</service-group>
```


5. A second Time Machine-enabled share is then created, and we can see it correctly added to `smb.conf` as well as the avahi service file.
```shell script
rockdev:~ # cat /etc/samba/smb.conf 
[global]
    log level = 3
    map to guest = Bad User
    cups options = raw
    log file = /var/log/samba/log.%m
    printcap name = /dev/null
    load printers = no

####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####
    workgroup = MYROCKYGROUP
####END: Rockstor SAMBA GLOBAL CUSTOM####

####BEGIN: Rockstor SAMBA CONFIG####
[test_share01]
    root preexec = "/opt/build/bin/mnt-share test_share01"
    root preexec close = yes
    comment = Samba-Export
    path = /mnt2/test_share01
    browseable = yes
    read only = no
    guest ok = no
    admin users = test 
    vfs objects = catia fruit streams_xattr
    fruit:timemachine = yes
    fruit:metadata = stream
    fruit:veto_appledouble = no
    fruit:posix_rename = no
    fruit:wipe_intentionally_left_blank_rfork = yes
    fruit:delete_empty_adfiles = yes
    fruit:encoding = private
    fruit:locking = none
    fruit:resource = file
[test_share02]
    root preexec = "/opt/build/bin/mnt-share test_share02"
    root preexec close = yes
    comment = Samba-Export
    path = /mnt2/test_share02
    browseable = yes
    read only = no
    guest ok = no
    admin users = test 
    vfs objects = catia fruit streams_xattr
    fruit:timemachine = yes
    fruit:metadata = stream
    fruit:veto_appledouble = no
    fruit:posix_rename = no
    fruit:wipe_intentionally_left_blank_rfork = yes
    fruit:delete_empty_adfiles = yes
    fruit:encoding = private
    fruit:locking = none
    fruit:resource = file
####END: Rockstor SAMBA CONFIG####
```

```shell script
rockdev:~ # cat /etc/avahi/services/timemachine.service 
<?xml version="1.0" standalone='no'?>
<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
<service-group>
 <name replace-wildcards="yes">%h</name>
 <service>
   <type>_smb._tcp</type>
   <port>445</port>
 </service>
 <service>
   <txt-record>sys=waMa=0,adVF=0x100</txt-record>
   <txt-record>dk0=adVN=test_share01,adVF=0x82</txt-record>
   <txt-record>dk1=adVN=test_share02,adVF=0x82</txt-record>
   <type>_adisk._tcp</type>
 </service>
</service-group>
```

6. As we delete these samba exports, the corresponding files are updated.
```shell script
rockdev:~ # cat /etc/samba/smb.conf 
[global]
    log level = 3
    map to guest = Bad User
    cups options = raw
    log file = /var/log/samba/log.%m
    printcap name = /dev/null
    load printers = no

####BEGIN: Rockstor SAMBA GLOBAL CUSTOM####
    workgroup = MYROCKYGROUP
####END: Rockstor SAMBA GLOBAL CUSTOM####

####BEGIN: Rockstor SAMBA CONFIG####
####END: Rockstor SAMBA CONFIG####
```
```shell script
rockdev:~ # cat /etc/avahi/services/timemachine.service 
cat: /etc/avahi/services/timemachine.service: No such file or directory
```


### Summary of commits
I have left three main commits:
- main changes related to feature implementation (see below)
- Black formatting and change to string.format for all files modified in this PR
- Django migration file

The commits related to the main changes are:
- First working draft of support for Time Machine via Samba (related to #1910).
- Add infotip for Time Machine option.
- Begin work on advertising TimeMachine exports
- Clean existing timemachine.service only if one exists.
- Reload avahi-daemon static service files instead of restarting the its systemd service.
- Detect and store path to avahi-daemon binary at build time and source it
from Django settings when needed.
- Trigger refresh_smb_discovery() upon Samba export edit (PUT) and DELETE as well.
- Update test_samba to succeed with the newly-added "time_machine" field in the model.
- Disable shadow_copy when time-machine is checked (and vice-versa) to prevent incompatibility.
- Fix service file permissions before moving it to avahi service files directory.
- Add incremental txt-record for each share to be advertised by Avahi as Time Machine destination disk (See http://netatalk.sourceforge.net/wiki/index.php/Bonjour_record_adisk_adVF_values)
- Add an avahi static service file writer.
- Fix logic for adding txt-record keys.
- Code cleanup & Develop docstrings
- Fix redundant import of shutil.move in system.services


### Testing
Existing unit tests were altered for compatibility with code changes. 


#### CentOS

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
```

#### Leap15.1 

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
```

#### Tumbleweed 

```
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
```

### Caveats & shortcomings
@phillxnet, due to my limited options for testing, I was not able to conduct a long term test and exhaustive test for these Samba options, but they represent a consensus between the Apple documentation, the samba vfs fruit module, as well as user reports.


### Full Testing Outputs
<details><summary>CentOS</summary>

```
[root@rockdev build]# ./bin/test -v 3
/opt/build/eggs/setuptools-45.3.0-py2.7.egg/pkg_resources/py2_warn.py:22: UserWarning: Setuptools will stop working on Python 2
************************************************************
You are running Setuptools on Python 2, which is no longer
supported and
>>> SETUPTOOLS WILL STOP WORKING <<<
in a subsequent release (no sooner than 2020-04-20).
Please ensure you are installing
Setuptools using pip 9.x or later or pin to `setuptools<45`
in your environment.
If you have done those things and are still encountering
this message, please comment in
https://github.com/pypa/setuptools/issues/1458
about the steps that led to this unsupported combination.
************************************************************
  sys.version_info < (3,) and warnings.warn(pre + "*" * 60 + msg + "*" * 60)
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (15.493s)
  Applying contenttypes.0001_initial... OK (0.071s)
  Applying auth.0001_initial... OK (0.366s)
  Applying admin.0001_initial... OK (0.104s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.134s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.072s)
  Applying auth.0003_alter_user_email_max_length... OK (0.052s)
  Applying auth.0004_alter_user_username_opts... OK (0.047s)
  Applying auth.0005_alter_user_last_login_null... OK (0.065s)
  Applying auth.0006_require_contenttypes_0002... OK (0.014s)
  Applying oauth2_provider.0001_initial... OK (0.517s)
  Applying oauth2_provider.0002_08_updates... OK (0.438s)
  Applying sessions.0001_initial... OK (0.078s)
  Applying sites.0001_initial... OK (0.048s)
  Applying smart_manager.0001_initial... OK (0.720s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.045s)
  Applying storageadmin.0001_initial... OK (11.884s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.160s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.049s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.409s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.576s)
  Applying storageadmin.0006_dcontainerargs... OK (0.471s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.035s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.719s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.408s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.477s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.910s)
  Applying contenttypes.0001_initial... OK (0.105s)
  Applying auth.0001_initial... OK (0.071s)
  Applying admin.0001_initial... OK (0.047s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.113s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.049s)
  Applying auth.0003_alter_user_email_max_length... OK (0.060s)
  Applying auth.0004_alter_user_username_opts... OK (0.057s)
  Applying auth.0005_alter_user_last_login_null... OK (0.053s)
  Applying auth.0006_require_contenttypes_0002... OK (0.019s)
  Applying oauth2_provider.0001_initial... OK (0.213s)
  Applying oauth2_provider.0002_08_updates... OK (0.176s)
  Applying sessions.0001_initial... OK (0.020s)
  Applying sites.0001_initial... OK (0.022s)
  Applying smart_manager.0001_initial... OK (1.686s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.044s)
  Applying storageadmin.0001_initial... OK (9.303s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.771s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.745s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.442s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.650s)
  Applying storageadmin.0006_dcontainerargs... OK (0.448s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.795s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.416s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.401s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.386s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 310, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 199, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 540, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'time_machine': False, 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Error running a command. cmd = /usr/sbin/usermod -s /bin/bash admin. rc = 6. stdout = [\'\']. stderr = ["usermod: user \'admin\' does not exist", \'\']' != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 21.428s

FAILED (failures=22, errors=6)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```

</details>














<details><summary>Leap15.1</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (13.322s)
  Applying contenttypes.0001_initial... OK (0.055s)
  Applying auth.0001_initial... OK (0.441s)
  Applying admin.0001_initial... OK (0.115s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.106s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.055s)
  Applying auth.0003_alter_user_email_max_length... OK (0.058s)
  Applying auth.0004_alter_user_username_opts... OK (0.050s)
  Applying auth.0005_alter_user_last_login_null... OK (0.059s)
  Applying auth.0006_require_contenttypes_0002... OK (0.013s)
  Applying oauth2_provider.0001_initial... OK (0.616s)
  Applying oauth2_provider.0002_08_updates... OK (0.431s)
  Applying sessions.0001_initial... OK (0.222s)
  Applying sites.0001_initial... OK (0.041s)
  Applying smart_manager.0001_initial... OK (0.601s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.041s)
  Applying storageadmin.0001_initial... OK (12.669s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.764s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.092s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.329s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.211s)
  Applying storageadmin.0006_dcontainerargs... OK (0.403s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.718s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.149s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.528s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.404s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (13.139s)
  Applying contenttypes.0001_initial... OK (0.048s)
  Applying auth.0001_initial... OK (0.074s)
  Applying admin.0001_initial... OK (0.045s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.121s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.044s)
  Applying auth.0003_alter_user_email_max_length... OK (0.050s)
  Applying auth.0004_alter_user_username_opts... OK (0.065s)
  Applying auth.0005_alter_user_last_login_null... OK (0.053s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.170s)
  Applying oauth2_provider.0002_08_updates... OK (0.149s)
  Applying sessions.0001_initial... OK (0.023s)
  Applying sites.0001_initial... OK (0.187s)
  Applying smart_manager.0001_initial... OK (2.052s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.039s)
  Applying storageadmin.0001_initial... OK (8.835s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.675s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.694s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.321s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.226s)
  Applying storageadmin.0006_dcontainerargs... OK (0.347s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.800s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.144s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.436s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.386s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 310, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 199, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 540, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'time_machine': False, 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 26.986s

FAILED (failures=23, errors=6)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```


</details>
























<details><summary>Tumbleweed</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (16.407s)
  Applying contenttypes.0001_initial... OK (0.086s)
  Applying auth.0001_initial... OK (0.380s)
  Applying admin.0001_initial... OK (0.128s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.161s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.069s)
  Applying auth.0003_alter_user_email_max_length... OK (0.090s)
  Applying auth.0004_alter_user_username_opts... OK (0.057s)
  Applying auth.0005_alter_user_last_login_null... OK (0.066s)
  Applying auth.0006_require_contenttypes_0002... OK (0.011s)
  Applying oauth2_provider.0001_initial... OK (0.532s)
  Applying oauth2_provider.0002_08_updates... OK (0.385s)
  Applying sessions.0001_initial... OK (0.088s)
  Applying sites.0001_initial... OK (0.052s)
  Applying smart_manager.0001_initial... OK (0.811s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.042s)
  Applying storageadmin.0001_initial... OK (14.142s)
  Applying storageadmin.0002_auto_20161125_0051... OK (1.086s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.908s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.384s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.498s)
  Applying storageadmin.0006_dcontainerargs... OK (0.542s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.029s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.608s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.515s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.582s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | netatalk share | Can add netatalk share'
Adding permission 'storageadmin | netatalk share | Can change netatalk share'
Adding permission 'storageadmin | netatalk share | Can delete netatalk share'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (12.666s)
  Applying contenttypes.0001_initial... OK (0.032s)
  Applying auth.0001_initial... OK (0.070s)
  Applying admin.0001_initial... OK (0.051s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.118s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.042s)
  Applying auth.0003_alter_user_email_max_length... OK (0.042s)
  Applying auth.0004_alter_user_username_opts... OK (0.040s)
  Applying auth.0005_alter_user_last_login_null... OK (0.038s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.177s)
  Applying oauth2_provider.0002_08_updates... OK (0.166s)
  Applying sessions.0001_initial... OK (0.019s)
  Applying sites.0001_initial... OK (0.020s)
  Applying smart_manager.0001_initial... OK (1.477s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.056s)
  Applying storageadmin.0001_initial... OK (9.089s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.685s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.660s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.340s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.285s)
  Applying storageadmin.0006_dcontainerargs... OK (0.339s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.673s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.124s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.392s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.426s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_get (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_afp.AFPTests) ... FAIL
test_put_requests_1 (storageadmin.tests.test_afp.AFPTests) ... ok
test_put_requests_2 (storageadmin.tests.test_afp.AFPTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
ERROR
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests) ... FAIL
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... FAIL
ERROR
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... FAIL
test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... ERROR
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests) ... FAIL
ERROR
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... FAIL
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... FAIL
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... FAIL
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests) ... ERROR
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name1 (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: setUpClass (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 33, in setUpClass
    cls.mock_get_pool_info = cls.patch_get_pool_info.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.command' from '/opt/build/src/rockstor/storageadmin/views/command.pyc'> does not have the attribute 'get_pool_info'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_network.NetworkTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_network.py", line 47, in setUpClass
    cls.mock_devices = cls.patch_devices.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'system.network' from '/opt/build/src/rockstor/system/network.pyc'> does not have the attribute 'devices'

======================================================================
ERROR: test_delete_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 88, in test_delete_requests
    msg=response.data)
AttributeError: 'HttpResponseNotFound' object has no attribute 'data'

======================================================================
ERROR: setUpClass (storageadmin.tests.test_pools.PoolTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_pools.py", line 54, in setUpClass
    cls.mock_resize_pool = cls.patch_resize_pool.start()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1396, in start
    result = self.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.pool' from '/opt/build/src/rockstor/storageadmin/views/pool.pyc'> does not have the attribute 'resize_pool'

======================================================================
ERROR: test_get (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 310, in test_get
    response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 160, in get
    response = super(APIClient, self).get(path, data=data, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 86, in get
    return self.generic('GET', path, **r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 199, in get
    return Response(serialized_data.data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 1188, in __get__
    through=self.related.field.rel.through,
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/fields/related.py", line 880, in __init__
    (instance, source_field_name))
ValueError: "<SambaShare: SambaShare object>" needs to have a value for field "sambashare" before this many-to-many relationship can be used.

======================================================================
ERROR: test_post_requests (storageadmin.tests.test_share_acl.ShareAclTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'storageadmin.views.share_acl' from '/opt/build/src/rockstor/storageadmin/views/share_acl.pyc'> does not have the attribute 'Snapshot'

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_afp.AFPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_afp.py", line 113, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share1) does not exist.' != 'Time_machine must be yes or no. Not (invalid).'

======================================================================
FAIL: test_btrfs_disk_import (storageadmin.tests.test_disks.DiskTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_disks.py", line 136, in test_btrfs_disk_import
    self.assertEqual(response.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 129, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Group (admin2) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_login.LoginTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_login.py", line 53, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: 401 != 200

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 311, in test_delete_requests
    msg=response.data)
AssertionError: 200 != 500

======================================================================
FAIL: test_get (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 84, in test_get
    msg=response)
AssertionError: Vary: Accept
Content-Type: application/json
Allow: GET, POST, PUT, DELETE, HEAD, OPTIONS

{"detail":"Not found."}

======================================================================
FAIL: test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 208, in test_invalid_admin_host1
    self.assertEqual(response.data[0], e_msg)
AssertionError: "{'share': [u'share instance with id 22 does not exist.']}" != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 225, in test_invalid_admin_host2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'

======================================================================
FAIL: test_invalid_nfs_client2 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 170, in test_invalid_nfs_client2
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (clone1) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_invalid_nfs_client3 (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 189, in test_invalid_nfs_client3
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'Share with name (share2) does not exist.' != 'Invalid Hostname or IP: host%%%edu'

======================================================================
FAIL: test_no_nfs_client (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 152, in test_no_nfs_client
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['Share with name (clone1) does not exist.', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/share_helpers.py", line 51, in validate_share\n    return Share.objects.get(name=sname)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/manager.py", line 127, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 334, in get\n    self.model._meta.object_name\nDoesNotExist: Share matching query does not exist.\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 121, in test_post_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 172, in post\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'share\': [u\'share instance with id 22 does not exist.\']}\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_nfs_export.py", line 262, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["{'export_group': [u'This field cannot be null.'], 'share': [u'share instance with id 21 does not exist.']}", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/nfs_exports.py", line 249, in put\n    export.full_clean()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 1171, in full_clean\n    raise ValidationError(errors)\nValidationError: {\'export_group\': [u\'This field cannot be null.\'], \'share\': [u\'share instance with id 21 does not exist.\']}\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_oauth_app.OauthAppTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_oauth_app.py", line 72, in test_post_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User with name (admin) does not exist.' != 'Application with name (cliapp) already exists. Choose a different name.'

======================================================================
FAIL: test_put_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 540, in test_put_requests_2
    msg=response.data,
AssertionError: {'comment': u'foo bar', 'read_only': 'yes', 'share_id': u'23', 'browsable': 'yes', 'time_machine': False, 'snapshot_prefix': None, 'share': u'share-smb', 'custom_config': [], 'guest_ok': 'yes', 'shadow_copy': False, 'admin_users': [], 'path': u'', u'id': 4}

======================================================================
FAIL: test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_sftp.py", line 132, in test_post_requests_2
    self.assertEqual(response.data[0], e_msg)
AssertionError: "[Errno 2] No such file or directory: '/lib64/libacl.so.1'" != 'Share (share-sftp) is already exported via SFTP.'

======================================================================
FAIL: test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_shares.py", line 688, in test_delete_share_with_snapshot
    self.assertEqual(response5.data[0], e_msg)
AssertionError: 'Share (rootshare) cannot be deleted as it has replication related snapshots.' != 'Share (rootshare) cannot be deleted as it has snapshots. Delete snapshots and try again.'

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_snapshot.py", line 283, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n', 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/rest_framework_custom/generic_view.py", line 41, in _handle_exception\n    yield\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 262, in delete\n    self._delete_snapshot(request, sid, snap_name=snap_name)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner\n    return func(*args, **kwargs)\n  File "/opt/build/src/rockstor/storageadmin/views/snapshot.py", line 248, in _delete_snapshot\n    snapshot.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/base.py", line 896, in delete\n    collector.delete()\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/deletion.py", line 292, in delete\n    qs._raw_delete(using=self.using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/query.py", line 549, in _raw_delete\n    sql.DeleteQuery(self.model).delete_qs(self, using)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/subqueries.py", line 78, in delete_qs\n    self.get_compiler(using).execute_sql(NO_RESULTS)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/models/sql/compiler.py", line 840, in execute_sql\n    cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/utils.py", line 98, in __exit__\n    six.reraise(dj_exc_type, dj_exc_value, traceback)\n  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/db/backends/utils.py", line 64, in execute\n    return self.cursor.execute(sql, params)\nProgrammingError: relation "storageadmin_mocksnapshot" does not exist\nLINE 1: DELETE FROM "storageadmin_mocksnapshot" WHERE "storageadmin_...\n                    ^\n\n']

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 359, in test_delete_requests
    self.assertEqual(response.data[0], e_msg)
AssertionError: 'User (admin2) does not exist.' != 'A low level error occurred while deleting the user (admin2).'

======================================================================
FAIL: test_duplicate_name1 (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 234, in test_duplicate_name1
    msg=response.data)
AssertionError: {'username': u'admin2', 'public_key': None, 'shell': u'/bin/bash', 'group': 2, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/admin2', 'email': None, 'groupname': u'admin2', 'gid': 5, 'user': 104, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 161, in test_post_requests
    msg=response.data)
AssertionError: ['UID (0) already exists. Please choose a different one.', 'None\n']

======================================================================
FAIL: test_put_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 311, in test_put_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (admin2) does not exist.', 'None\n']

----------------------------------------------------------------------
Ran 189 tests in 35.489s

FAILED (failures=23, errors=6)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```


</details>


