### PR TITLE
remark out all currently failing unit tests. Fixes #2137

### DIFF
--- a/src/rockstor/storageadmin/tests/test_commands.py
+++ b/src/rockstor/storageadmin/tests/test_commands.py
@@ -29,7 +29,7 @@ class CommandTests(APITestMixin, APITestCase):
         super(CommandTests, cls).setUpClass()
 
         cls.patch_get_pool_info = patch(
-            'storageadmin.views.command.get_pool_info')
+            'fs.btrfs.get_pool_info')
         cls.mock_get_pool_info = cls.patch_get_pool_info.start()
         cls.mock_get_pool_info.return_value = {'disks': [], 'label': 'pool2'}
 
@@ -52,7 +52,7 @@ class CommandTests(APITestMixin, APITestCase):
         cls.mock_update_run = cls.patch_update_run.start()
 
         cls.patch_update_check = patch(
-            'storageadmin.views.command.update_check')
+            'storageadmin.views.command.rockstor_pkg_update_check')
         cls.mock_update_check = cls.patch_update_check.start()
         cls.mock_update_check.return_value = 1, 1, 1
 

--- a/src/rockstor/storageadmin/tests/test_disks.py
+++ b/src/rockstor/storageadmin/tests/test_disks.py
@@ -126,14 +126,15 @@ class DiskTests(APITestMixin, APITestCase):
         self.assertEqual(response.data[0], e_msg)
         self.mock_wipe_disk.side_effect = None
 
-    @mock.patch("storageadmin.views.disk.Disk")
-    def test_btrfs_disk_import(self, mock_disk):
-
-        mock_disk.objects.get.return_value = self.temp_disk
-
-        url = "{}/2/btrfs-disk-import".format(self.BASE_URL)
-        response = self.client.post(url, data=None, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    # # TODO: FAIL AssertionError: 500 != 200
+    # @mock.patch("storageadmin.views.disk.Disk")
+    # def test_btrfs_disk_import(self, mock_disk):
+    #
+    #     mock_disk.objects.get.return_value = self.temp_disk
+    #
+    #     url = "{}/2/btrfs-disk-import".format(self.BASE_URL)
+    #     response = self.client.post(url, data=None, format="json")
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @mock.patch("storageadmin.views.disk.Disk")
     def test_btrfs_disk_import_fail(self, mock_disk):

--- a/src/rockstor/storageadmin/tests/test_group.py
+++ b/src/rockstor/storageadmin/tests/test_group.py
@@ -123,7 +123,8 @@ class GroupTests(APITestMixin, APITestCase):
         err_msg = 'Delete of restricted group (root) is not supported.'
         self.assertEqual(response.data[0], err_msg)
 
-        # happy path
-        response = self.client.delete('{}/admin2'.format(self.BASE_URL))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # TODO: FAIL AssertionError: ['Group (admin2) does not exist.', 'None\n']
+        # # happy path
+        # response = self.client.delete('{}/admin2'.format(self.BASE_URL))
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/tests/test_login.py
+++ b/src/rockstor/storageadmin/tests/test_login.py
@@ -46,8 +46,8 @@ class LoginTests(APITestMixin, APITestCase):
         # https://127.0.0.1:443/api/login
         # logs 200 in "/var/log/nginx/access.log"
 
-        # happy path
-        data = {'username': 'admin', 'password': 'admin'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # happy path
+        # data = {'username': 'admin', 'password': 'admin'}
+        # response = self.client.post(self.BASE_URL, data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/tests/test_network.py
+++ b/src/rockstor/storageadmin/tests/test_network.py
@@ -43,7 +43,7 @@ class NetworkTests(APITestMixin, APITestCase):
         # post mocks
 
         # devices map dictionary
-        cls.patch_devices = patch('system.network.devices')
+        cls.patch_devices = patch('system.network.get_dev_config')
         cls.mock_devices = cls.patch_devices.start()
         cls.mock_devices.return_value = {
             'lo': {'dtype': 'loopback', 'mac': '00:00:00:00:00:00',
@@ -53,7 +53,7 @@ class NetworkTests(APITestMixin, APITestCase):
                      'mtu': '1500'}}
 
         # connections map dictionary
-        cls.patch_connections = patch('system.network.connections')
+        cls.patch_connections = patch('system.network.get_con_config')
         cls.mock_connections = cls.patch_connections.start()
         cls.mock_connections.return_value = {
             '8dca3630-8c54-4ad7-8421-327cc2d3d14a':
@@ -123,114 +123,119 @@ class NetworkTests(APITestMixin, APITestCase):
         super(NetworkTests, cls).tearDownClass()
 
     # TODO: Probably needs a re-write from here down due to API change.
+    # N.B. There are working and current system level unit tests in:
+    # src/rockstor/system/tests/test_system_network.py
+    # Added via pr: "Add unit testing for core network functions" #2045 on GitHub
 
     # Fixture fix1.json has the test data. networks already exits in data are
     # 'enp0s3' and 'enp0s8'
-    def test_get(self):
-        """
-        unauthorized access
-        """
-        # get base URL
-        response = self.client.get(self.BASE_URL)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+    # TODO: AttributeError: 'HttpResponseNotFound' object has no attribute 'data'
+    #  received on both below tests. Suspected as due to above referenced API change.
+    # def test_get(self):
+    #     """
+    #     unauthorized access
+    #     """
+    #     # get base URL
+    #     response = self.client.get(self.BASE_URL)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #
+    #     # get with iname
+    #     response = self.client.get('%s/enp0s3' % self.BASE_URL)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
 
-        # get with iname
-        response = self.client.get('%s/enp0s3' % self.BASE_URL)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-
-    def test_put(self):
-        """
-        put, change itype
-        """
-        # TODO: test needs updating, interface now different.
-        # invalid network interface
-        data = {'itype': 'management'}
-        response = self.client.put('%s/invalid' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Network connection (invalid) does not exist.'
-        self.assertEqual(response.data['detail'], e_msg)
-
-        # edit configuration with out providing config method
-        data = {'method': '', 'itype': 'management'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Method must be auto(for dhcp) or manual(for static IP). not: '
-        self.assertEqual(response.data['detail'], e_msg)
-
-        # happy path
-        data = {'method': 'auto', 'itype': 'management'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response.data['itype'], 'management')
-
-        # netmask set to None
-        data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-                'netmask': None, 'gateway': '', 'dns_servers': '',
-                'itype': 'io'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Provided netmask value(None) is invalid. You can provide '
-                 'it in a IP address format(eg: 255.255.255.0) or number of '
-                 'bits(eg: 24)')
-        self.assertEqual(response.data['detail'], e_msg)
-
-        # Invalid netmask
-        data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-                'netmask': '111', 'gateway': '',
-                'dns_servers': '', 'itype': 'io'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Provided netmask value(111) is invalid. Number of bits in '
-                 'netmask must be between 1-32')
-        self.assertEqual(response.data['detail'], e_msg)
-
-        # happy path
-        data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-                'netmask': '225.225.225.0', 'gateway': '',
-                'dns_servers': '', 'itype': 'io'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response.data['itype'], 'io')
-
-        # happy path
-        data = {'method': 'auto', 'itype': 'management'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response.data['itype'], 'management')
-
-        # Setting network interface itype to management when the othet network
-        # is already set to management
-        data = {'method': 'auto', 'itype': 'management'}
-        response = self.client.put('%s/enp0s8' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Another interface(enp0s3) is already configured for '
-                 'management. You must disable it first before making this '
-                 'change.')
-        self.assertEqual(response.data['detail'], e_msg)
-
-        # provide ipaddress thats already been used by another interface
-        data = {'method': 'manual', 'ipaddr': '10.0.3.15',
-                'netmask': '225.225.225.0', 'gateway': '',
-                'dns_servers': '', 'itype': 'io'}
-        response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('IP: 192.168.56.101 already in use by another '
-                 'interface: enp0s8')
-        self.assertEqual(response.data['detail'], e_msg)
+    # def test_put(self):
+    #     """
+    #     put, change itype
+    #     """
+    #     # TODO: test needs updating, interface now different.
+    #     # invalid network interface
+    #     data = {'itype': 'management'}
+    #     response = self.client.put('%s/invalid' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = 'Network connection (invalid) does not exist.'
+    #     self.assertEqual(response.data['detail'], e_msg)
+    #
+    #     # edit configuration with out providing config method
+    #     data = {'method': '', 'itype': 'management'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = 'Method must be auto(for dhcp) or manual(for static IP). not: '
+    #     self.assertEqual(response.data['detail'], e_msg)
+    #
+    #     # happy path
+    #     data = {'method': 'auto', 'itype': 'management'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #     self.assertEqual(response.data['itype'], 'management')
+    #
+    #     # netmask set to None
+    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
+    #             'netmask': None, 'gateway': '', 'dns_servers': '',
+    #             'itype': 'io'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = ('Provided netmask value(None) is invalid. You can provide '
+    #              'it in a IP address format(eg: 255.255.255.0) or number of '
+    #              'bits(eg: 24)')
+    #     self.assertEqual(response.data['detail'], e_msg)
+    #
+    #     # Invalid netmask
+    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
+    #             'netmask': '111', 'gateway': '',
+    #             'dns_servers': '', 'itype': 'io'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = ('Provided netmask value(111) is invalid. Number of bits in '
+    #              'netmask must be between 1-32')
+    #     self.assertEqual(response.data['detail'], e_msg)
+    #
+    #     # happy path
+    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
+    #             'netmask': '225.225.225.0', 'gateway': '',
+    #             'dns_servers': '', 'itype': 'io'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #     self.assertEqual(response.data['itype'], 'io')
+    #
+    #     # happy path
+    #     data = {'method': 'auto', 'itype': 'management'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #     self.assertEqual(response.data['itype'], 'management')
+    #
+    #     # Setting network interface itype to management when the othet network
+    #     # is already set to management
+    #     data = {'method': 'auto', 'itype': 'management'}
+    #     response = self.client.put('%s/enp0s8' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = ('Another interface(enp0s3) is already configured for '
+    #              'management. You must disable it first before making this '
+    #              'change.')
+    #     self.assertEqual(response.data['detail'], e_msg)
+    #
+    #     # provide ipaddress thats already been used by another interface
+    #     data = {'method': 'manual', 'ipaddr': '10.0.3.15',
+    #             'netmask': '225.225.225.0', 'gateway': '',
+    #             'dns_servers': '', 'itype': 'io'}
+    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = ('IP: 192.168.56.101 already in use by another '
+    #              'interface: enp0s8')
+    #     self.assertEqual(response.data['detail'], e_msg)

--- a/src/rockstor/storageadmin/tests/test_nfs_export.py
+++ b/src/rockstor/storageadmin/tests/test_nfs_export.py
@@ -68,20 +68,21 @@ class NFSExportTests(APITestMixin, APITestCase):
     def tearDownClass(cls):
         super(NFSExportTests, cls).tearDownClass()
 
-    def test_get(self):
-        """
-        Test GET request
-        1. Get base URL
-        2. Get request with id
-        """
-        # get base URL
-        self.get_base(self.BASE_URL)
-
-        # get nfs-export with id
-        nfs_id = self.temp_nfsexport.id
-        response = self.client.get('{}/{}'.format(self.BASE_URL, nfs_id))
-        self.assertEqual(response.status_code, status.HTTP_200_OK,
-                         msg=response)
+    # TODO: FAIL {"detail":"Not found."}
+    # def test_get(self):
+    #     """
+    #     Test GET request
+    #     1. Get base URL
+    #     2. Get request with id
+    #     """
+    #     # get base URL
+    #     self.get_base(self.BASE_URL)
+    #
+    #     # get nfs-export with id
+    #     nfs_id = self.temp_nfsexport.id
+    #     response = self.client.get('{}/{}'.format(self.BASE_URL, nfs_id))
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK,
+    #                      msg=response)
 
     def test_invalid_get(self):
         # get nfs-export with invalid id
@@ -113,22 +114,23 @@ class NFSExportTests(APITestMixin, APITestCase):
 
         mock_share.objects.get.return_value = self.temp_share2
 
-        # happy path
-        data1 = {'shares': ('share2',), 'host_str': '*.edu',
-                 'mod_choice': 'rw', 'sync_choice': 'async', }
-        response = self.client.post(self.BASE_URL, data=data1)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # AssertionError: ["{'share': [u'share instance with id 22 does not exist.']}",
+        # # happy path
+        # data1 = {'shares': ('share2',), 'host_str': '*.edu',
+        #          'mod_choice': 'rw', 'sync_choice': 'async', }
+        # response = self.client.post(self.BASE_URL, data=data1)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
-        # Add nfs-export for the share that is already been exported
-        data1 = {'shares': ('share1',), 'host_str': '*', 'mod_choice': 'rw',
-                 'sync_choice': 'async', }
-        response = self.client.post(self.BASE_URL, data=data1)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'An export already exists for the host string: (*).'
-        self.assertEqual(response.data[0], e_msg)
+        # # Add nfs-export for the share that is already been exported
+        # data1 = {'shares': ('share1',), 'host_str': '*', 'mod_choice': 'rw',
+        #          'sync_choice': 'async', }
+        # response = self.client.post(self.BASE_URL, data=data1)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response.data)
+        # e_msg = 'An export already exists for the host string: (*).'
+        # self.assertEqual(response.data[0], e_msg)
 
         # Add nfs-export with invalid nfs-client
         data1 = {'shares': ('share1',), 'host_str': '*', 'mod_choice': 'rw',
@@ -137,57 +139,60 @@ class NFSExportTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR,
                          msg=response.data)
-        e_msg = 'An export already exists for the host string: (*).'
-        self.assertEqual(response.data[0], e_msg)
+        # TODO: AssertionError: "{'share': [u'share instance with id 22 does not exist.']}
+        # e_msg = 'An export already exists for the host string: (*).'
+        # self.assertEqual(response.data[0], e_msg)
 
-    def test_no_nfs_client(self):
-        # Add nfs-export without specifying nfs-clients(host string). The
-        # server side defaults the host string to * so test for this.
+    # TODO: Test needs updating
+    #  AssertionError: ['Share with name (clone1) does not exist.',
+    # def test_no_nfs_client(self):
+    #     # Add nfs-export without specifying nfs-clients(host string). The
+    #     # server side defaults the host string to * so test for this.
+    #
+    #     self.mock_refresh_nfs_exports.side_effect = None
+    #     data1 = {'shares': ('clone1',), 'mod_choice': 'rw',
+    #              'sync_choice': 'async', }
+    #     response = self.client.post(self.BASE_URL, data=data1)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #     self.assertEqual(response.data['host_str'], '*')
 
-        self.mock_refresh_nfs_exports.side_effect = None
-        data1 = {'shares': ('clone1',), 'mod_choice': 'rw',
-                 'sync_choice': 'async', }
-        response = self.client.post(self.BASE_URL, data=data1)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response.data['host_str'], '*')
-
-    def test_invalid_nfs_client2(self):
-
-        # TODO: Test needs updating
-        # invalid post request
-        # Add nfs-export providing invalid nfs client
-        self.mock_refresh_nfs_exports.side_effect = Exception()
-
-        data1 = {'shares': ('clone1',), 'host_str': 'host%%%edu',
-                 'mod_choice': 'rw', 'sync_choice': 'async', }
-        response = self.client.post(self.BASE_URL, data=data1)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-
-        e_msg = 'Invalid Hostname or IP: host%%%edu'
-        self.assertEqual(response.data[0], e_msg)
-        self.mock_refresh_nfs_exports.side_effect = None
-
-    def test_invalid_nfs_client3(self):
-
-        # TODO: Test needs updating
-        # invalid put request
-        # edit nfs-export providing invalid nfs-client
-        self.mock_refresh_nfs_exports.side_effect = Exception()
-        nfs_id = 11
-        data = {'shares': ('share2',), 'host_str': 'host%%%edu',
-                'admin_host': ' ', 'mod_choice': 'rw',
-                'sync_choice': 'async', }
-        response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Invalid Hostname or IP: host%%%edu'
-        self.assertEqual(response.data[0], e_msg)
-        self.mock_refresh_nfs_exports.side_effect = None
+    # def test_invalid_nfs_client2(self):
+    #
+    #     # TODO: Test needs updating
+    #     # invalid post request
+    #     # Add nfs-export providing invalid nfs client
+    #     self.mock_refresh_nfs_exports.side_effect = Exception()
+    #
+    #     data1 = {'shares': ('clone1',), 'host_str': 'host%%%edu',
+    #              'mod_choice': 'rw', 'sync_choice': 'async', }
+    #     response = self.client.post(self.BASE_URL, data=data1)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #
+    #     e_msg = 'Invalid Hostname or IP: host%%%edu'
+    #     self.assertEqual(response.data[0], e_msg)
+    #     self.mock_refresh_nfs_exports.side_effect = None
+    #
+    # def test_invalid_nfs_client3(self):
+    #
+    #     # TODO: Test needs updating
+    #     # invalid put request
+    #     # edit nfs-export providing invalid nfs-client
+    #     self.mock_refresh_nfs_exports.side_effect = Exception()
+    #     nfs_id = 11
+    #     data = {'shares': ('share2',), 'host_str': 'host%%%edu',
+    #             'admin_host': ' ', 'mod_choice': 'rw',
+    #             'sync_choice': 'async', }
+    #     response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
+    #                                data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = 'Invalid Hostname or IP: host%%%edu'
+    #     self.assertEqual(response.data[0], e_msg)
+    #     self.mock_refresh_nfs_exports.side_effect = None
 
     @mock.patch('storageadmin.views.share_helpers.Share')
     def test_invalid_admin_host1(self, mock_share):
@@ -204,8 +209,11 @@ class NFSExportTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR,
                          msg=response.data)
-        e_msg = 'Invalid admin host: admin%host'
-        self.assertEqual(response.data[0], e_msg)
+        # TODO: FAIL AssertionError:
+        #  "{'share': [u'share instance with id 22 does not exist.']}"
+        #  != 'Invalid admin host: admin%host'
+        # e_msg = 'Invalid admin host: admin%host'
+        # self.assertEqual(response.data[0], e_msg)
         self.mock_refresh_nfs_exports.side_effect = None
 
     def test_invalid_admin_host2(self):
@@ -221,8 +229,10 @@ class NFSExportTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR,
                          msg=response.data)
-        e_msg = 'Invalid admin host: admin%host'
-        self.assertEqual(response.data[0], e_msg)
+        # TODO: FAIL AssertionError:
+        #  'Share with name (share2) does not exist.' != 'Invalid admin host: admin%host'
+        # e_msg = 'Invalid admin host: admin%host'
+        # self.assertEqual(response.data[0], e_msg)
         self.mock_refresh_nfs_exports.side_effect = None
 
     @mock.patch('storageadmin.views.nfs_exports.NFSExportGroup')
@@ -252,36 +262,42 @@ class NFSExportTests(APITestMixin, APITestCase):
         mock_share.objects.get.return_value = self.temp_share_nfs
         mock_nfsexportgroup.objects.get.return_value = self.temp_nfsexportgroup
 
-        # happy path of editing existing nfs export
-        nfs_id = self.temp_nfsexport.id
-        data = {'shares': ('share-nfs',), 'host_str': '*.edu',
-                'mod_choice': 'rw', 'sync_choice': 'async', }
-        response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # TODO: FAIL AssertionError: ["{'export_group': [u'This field cannot be null.'],
+        #  'share': [u'share instance with id 21 does not exist.']}",
+        # # happy path of editing existing nfs export
+        # nfs_id = self.temp_nfsexport.id
+        # data = {'shares': ('share-nfs',), 'host_str': '*.edu',
+        #         'mod_choice': 'rw', 'sync_choice': 'async', }
+        # response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
-        # happy path2 with admin host
-        nfs_id = 11
-        data = {'shares': ('share2',), 'host_str': '*.edu',
-                'admin_host': 'host', 'mod_choice': 'rw',
-                'sync_choice': 'async', }
-        response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # TODO: FAIL AssertionError: ["{'export_group': [u'This field cannot be null.'],
+        #  'share': [u'share instance with id 21 does not exist.']}",
+        # # happy path2 with admin host
+        # nfs_id = 11
+        # data = {'shares': ('share2',), 'host_str': '*.edu',
+        #         'admin_host': 'host', 'mod_choice': 'rw',
+        #         'sync_choice': 'async', }
+        # response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
-        # edit nfs-export that does not exist
-        nfs_id = 99999
-        data = {'shares': ('share2',), 'host_str': '*.edu',
-                'mod_choice': 'rw', 'sync_choice': 'async', }
-        response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'NFS export with id ({}) does not exist.'.format(nfs_id)
-        self.assertEqual(response.data[0], e_msg)
+        # TODO: FAIL AssertionError: "{'export_group': [u'This field cannot be null.'],
+        #  'share': [u'share instance with id 21 does not exist.']}"
+        # # edit nfs-export that does not exist
+        # nfs_id = 99999
+        # data = {'shares': ('share2',), 'host_str': '*.edu',
+        #         'mod_choice': 'rw', 'sync_choice': 'async', }
+        # response = self.client.put('{}/{}'.format(self.BASE_URL, nfs_id),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response.data)
+        # e_msg = 'NFS export with id ({}) does not exist.'.format(nfs_id)
+        # self.assertEqual(response.data[0], e_msg)
 
     @mock.patch('storageadmin.views.nfs_exports.NFSExport')
     @mock.patch('storageadmin.views.nfs_exports.NFSExportGroup')
@@ -301,16 +317,17 @@ class NFSExportTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK, msg=response.data)
 
-        mock_nfsexport.objects.get.side_effect = NFSExport.DoesNotExist
-
-        # Delete nfs-export that does nor exists
-        nfs_id = 99999
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, nfs_id))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'NFS export with id ({}) does not exist.'.format(nfs_id)
-        self.assertEqual(response.data[0], e_msg)
+        # TODO: FAIL
+        # mock_nfsexport.objects.get.side_effect = NFSExport.DoesNotExist
+        #
+        # # Delete nfs-export that does nor exists
+        # nfs_id = 99999
+        # response = self.client.delete('{}/{}'.format(self.BASE_URL, nfs_id))
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response.data)
+        # e_msg = 'NFS export with id ({}) does not exist.'.format(nfs_id)
+        # self.assertEqual(response.data[0], e_msg)
 
     def test_adv_nfs_get(self):
         """

--- a/src/rockstor/storageadmin/tests/test_oauth_app.py
+++ b/src/rockstor/storageadmin/tests/test_oauth_app.py
@@ -50,71 +50,71 @@ class OauthAppTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK, msg=response.data)
 
-    def test_post_requests(self):
-
-        # # TODO: Attempt to mock User and create an 'admin' instance.
-        # # mock user 'admin' as that is the logged in test user.
-        # temp_d_user = DjangoUser(username='test')
-        # temp_user = User(id=1, username='admin', user=temp_d_user)
-        # mock_user.objects.get.return_value = temp_user
-
-        # TODO: "Existing application name" and "happy path" fail with:
-        # 'User with name (admin) does not exist.'
-
-        # Existing application name
-        data = {'name': 'cliapp'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Application with name (cliapp) already exists. Choose a '
-                 'different name.')
-        self.assertEqual(response.data[0], e_msg)
-
-        # happy path
-        data = {'name': 'AccessKey1'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-
-    def test_delete_requests(self):
-
-        # delete application that does not exist
-        access_key = 'invalid'
-        response = self.client.delete('{}/{}'.format(self.BASE_URL,
-                                                     access_key))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Application with id ({}) does not exist.'.format(access_key)
-        self.assertEqual(response.data[0], e_msg)
-
-        # invalid delete operation
-        access_key = 'cliapp'
-        response = self.client.delete('{}/{}'.format(self.BASE_URL,
-                                                     access_key))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Application with id ({}) cannot be deleted because '
-                 'it is '
-                 'used internally by Rockstor. If you really need to '
-                 'delete it, login as root and use '
-                 '/opt/rock-dep/delete-api-key command. If you do delete it, '
-                 'please create another one with the same name as it '
-                 'is required by Rockstor '
-                 'internally.').format(access_key)
-        self.assertEqual(response.data[0], e_msg)
-
-        # happy path
-        # create before you delete
-        data = {'name': 'AccessKey2'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-
-        access_key = 'AccessKey2'
-        response = self.client.delete('{}/{}'.format(self.BASE_URL,
-                                                     access_key))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+    # def test_post_requests(self):
+    #
+    #     # # TODO: Attempt to mock User and create an 'admin' instance.
+    #     # # mock user 'admin' as that is the logged in test user.
+    #     # temp_d_user = DjangoUser(username='test')
+    #     # temp_user = User(id=1, username='admin', user=temp_d_user)
+    #     # mock_user.objects.get.return_value = temp_user
+    #
+    #     # # TODO: "Existing application name" and "happy path" fail with:
+    #     # # 'User with name (admin) does not exist.'
+    #     #
+    #     # # Existing application name
+    #     # data = {'name': 'cliapp'}
+    #     # response = self.client.post(self.BASE_URL, data=data)
+    #     # self.assertEqual(response.status_code,
+    #     #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #     #                  msg=response.data)
+    #     # e_msg = ('Application with name (cliapp) already exists. Choose a '
+    #     #          'different name.')
+    #     # self.assertEqual(response.data[0], e_msg)
+    #
+    #     # # happy path
+    #     # data = {'name': 'AccessKey1'}
+    #     # response = self.client.post(self.BASE_URL, data=data)
+    #     # self.assertEqual(response.status_code,
+    #     #                  status.HTTP_200_OK, msg=response.data)
+    # TODO: ERROR AttributeError: 'HttpResponseNotFound' object has no attribute 'data'
+    # def test_delete_requests(self):
+    #
+    #     # delete application that does not exist
+    #     access_key = 'invalid'
+    #     response = self.client.delete('{}/{}'.format(self.BASE_URL,
+    #                                                  access_key))
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = 'Application with id ({}) does not exist.'.format(access_key)
+    #     self.assertEqual(response.data[0], e_msg)
+    #
+    #     # invalid delete operation
+    #     access_key = 'cliapp'
+    #     response = self.client.delete('{}/{}'.format(self.BASE_URL,
+    #                                                  access_key))
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #                      msg=response.data)
+    #     e_msg = ('Application with id ({}) cannot be deleted because '
+    #              'it is '
+    #              'used internally by Rockstor. If you really need to '
+    #              'delete it, login as root and use '
+    #              '/opt/rock-dep/delete-api-key command. If you do delete it, '
+    #              'please create another one with the same name as it '
+    #              'is required by Rockstor '
+    #              'internally.').format(access_key)
+    #     self.assertEqual(response.data[0], e_msg)
+    #
+    #     # happy path
+    #     # create before you delete
+    #     data = {'name': 'AccessKey2'}
+    #     response = self.client.post(self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)
+    #
+    #     access_key = 'AccessKey2'
+    #     response = self.client.delete('{}/{}'.format(self.BASE_URL,
+    #                                                  access_key))
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -290,26 +290,29 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
         mock_logger.error.assert_called()
         # mock_logger.error.assert_called_with(e_msg)
 
-    @mock.patch("storageadmin.views.samba.SambaShare")
-    def test_get(self, mock_sambashare):
-        """
-        Test GET request
-        1. Get base URL
-        2. Get request with valid id
-        """
-        self.get_base(self.BASE_URL)
-
-        # Create mock SambaShare
-        # smb_id = self.temp_sambashare.id
-        # Some conflict exists from a previous mock_sambashare, so set smb_id manually
-        smb_id = 1
-        # print("smb_id is {}".format(smb_id))
-        mock_sambashare.objects.get.return_value = self.temp_sambashare
-
-        # test get of detailed view for a valid smb_id
-        response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
-        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response.data["id"], smb_id)
+    # TODO: ERROR: ValueError: "<SambaShare:
+    #  SambaShare object>" needs to have a value for field "sambashare" before this
+    #  many-to-many relationship can be used.
+    # @mock.patch("storageadmin.views.samba.SambaShare")
+    # def test_get(self, mock_sambashare):
+    #     """
+    #     Test GET request
+    #     1. Get base URL
+    #     2. Get request with valid id
+    #     """
+    #     self.get_base(self.BASE_URL)
+    #
+    #     # Create mock SambaShare
+    #     # smb_id = self.temp_sambashare.id
+    #     # Some conflict exists from a previous mock_sambashare, so set smb_id manually
+    #     smb_id = 1
+    #     # print("smb_id is {}".format(smb_id))
+    #     mock_sambashare.objects.get.return_value = self.temp_sambashare
+    #
+    #     # test get of detailed view for a valid smb_id
+    #     response = self.client.get("{}/{}".format(self.BASE_URL, smb_id))
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+    #     self.assertEqual(response.data["id"], smb_id)
 
     def test_get_non_existent(self):
         """
@@ -530,44 +533,50 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
 
         self.mock_mount_status.return_value = False
 
-        smb_id = 1
-        data = {"browsable": "yes", "guest_ok": "yes", "read_only": "yes"}
-        self.mock_mount_share.side_effect = KeyError("error")
-        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
-        self.assertEqual(
-            response.status_code,
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
-            msg=response.data,
-        )
-        e_msg = "Failed to mount share (share-smb) due to a low level error."
-        self.assertEqual(response.data[0], e_msg)
+        # # TODO: mocking issue as associated share is not found to be unmounted.
+        # smb_id = 1
+        # data = {"browsable": "yes", "guest_ok": "yes", "read_only": "yes"}
+        # self.mock_mount_share.side_effect = KeyError("error")
+        # response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        # self.assertEqual(
+        #     response.status_code,
+        #     status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #     msg=response.data,
+        # )
+        # e_msg = "Failed to mount share (share-smb) due to a low level error."
+        # self.assertEqual(response.data[0], e_msg)
+
         # Return share mock mounted_state to mounted
         self.mock_mount_status.return_value = True
 
-        # happy path
-        smb_id = 1
-        self.mock_mount_share.side_effect = None
-        data = {
-            "browsable": "yes",
-            "guest_ok": "yes",
-            "read_only": "yes",
-            "admin_users": ("admin",),
-            "custom_config": ("CONFIG", "XYZ"),
-        }
-        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+        # # TODO: AssertionError: ["local variable 'auo' referenced before assignment" ...
+        # #  storageadmin/views/samba.py", line 139, in _set_admin_users\n
+        # #  auo.smb_shares.add(smb_share)\nUnboundLocalError: local variable \'auo\'
+        # #  referenced before assignment\n']
+        # # happy path
+        # smb_id = 1
+        # self.mock_mount_share.side_effect = None
+        # data = {
+        #     "browsable": "yes",
+        #     "guest_ok": "yes",
+        #     "read_only": "yes",
+        #     "admin_users": ("admin",),
+        #     "custom_config": ("CONFIG", "XYZ"),
+        # }
+        # response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        # self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
-        # edit samba export with admin user other than admin
-        smb_id = 1
-        data = {
-            "browsable": "yes",
-            "guest_ok": "yes",
-            "read_only": "yes",
-            "admin_users": ("admin2",),
-            "custom_config": ("CONFIG", "XYZ"),
-        }
-        response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+        # # edit samba export with admin user other than admin
+        # smb_id = 1
+        # data = {
+        #     "browsable": "yes",
+        #     "guest_ok": "yes",
+        #     "read_only": "yes",
+        #     "admin_users": ("admin2",),
+        #     "custom_config": ("CONFIG", "XYZ"),
+        # }
+        # response = self.client.put("{}/{}".format(self.BASE_URL, smb_id), data=data)
+        # self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
         # edit samba export passing no admin users
         smb_id = 1

--- a/src/rockstor/storageadmin/tests/test_sftp.py
+++ b/src/rockstor/storageadmin/tests/test_sftp.py
@@ -97,6 +97,7 @@ class SFTPTests(APITestMixin, APITestCase):
         e_msg = 'Must provide share names.'
         self.assertEqual(response.data[0], e_msg)
 
+    # TODO: FAIL repair needed.
     @mock.patch('storageadmin.views.share_helpers.Share')
     def test_post_requests_2(self, mock_share):
         """
@@ -119,25 +120,30 @@ class SFTPTests(APITestMixin, APITestCase):
 
         # TODO: the rest of this test fails with
         # 'Share matching query does not exist.'
+        # and later:
+        # AssertionError: "[Errno 2] No such file or directory:
+        # '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'
 
-        mock_share.objects.get.return_value = self.temp_share_sftp
+        # mock_share.objects.get.return_value = self.temp_share_sftp
+        #
+        # # create sftp with already existing and sftp exported share.
+        # data = {'shares': ('share-sftp',)}
+        # response = self.client.post(self.BASE_URL, data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response.data)
+        # e_msg = 'Share (share-sftp) is already exported via SFTP.'
+        # self.assertEqual(response.data[0], e_msg)
 
-        # create sftp with already existing and sftp exported share.
-        data = {'shares': ('share-sftp',)}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Share (share-sftp) is already exported via SFTP.'
-        self.assertEqual(response.data[0], e_msg)
-
-        mock_share.objects.get.return_value = self.temp_share_user_owned
-
-        # happy path
-        data = {'shares': ('share-user-owned',), 'read_only': 'true', }
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # TODO: FAIL:
+        # #  stderr = ["usermod: user \'admin\' does not exist", \'\']\n']
+        # mock_share.objects.get.return_value = self.temp_share_user_owned
+        #
+        # # happy path
+        # data = {'shares': ('share-user-owned',), 'read_only': 'true', }
+        # response = self.client.post(self.BASE_URL, data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
     def test_delete_requests_1(self):
         """

--- a/src/rockstor/storageadmin/tests/test_share_acl.py
+++ b/src/rockstor/storageadmin/tests/test_share_acl.py
@@ -16,6 +16,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework import status
 from rest_framework.test import APITestCase
+from rest_framework import serializers
 import mock
 from mock import patch
 
@@ -50,63 +51,64 @@ class ShareAclTests(APITestMixin, APITestCase):
     def tearDownClass(cls):
         super(ShareAclTests, cls).tearDownClass()
 
-    # May need to moc the ShareSerializer
-    @mock.patch('storageadmin.views.share_acl.ShareSerializer')
-    # we require Snapshot mock as ShareSerializer includes a snapshots field,
-    # see: storageadmin/serializers.py
-    @mock.patch('storageadmin.views.share_acl.Pool')
-    @mock.patch('storageadmin.views.share_acl.Snapshot')
-    @mock.patch('storageadmin.views.share_acl.Share')
-    def test_post_requests(self, mock_share, mock_snapshot, mock_pool,
-                           mock_share_serializer):
-
-        class MockShareSerializer(serializers.ModelSerializer):
-            mount_status = serializers.CharField()
-            is_mounted = serializers.BooleanField()
-            pqgroup_exist = serializers.BooleanField()
-
-            class Meta:
-                model = Share
-
-            def __init__(self, **kwargs):
-                pass
-
-        # Mocking from object avoids having to also mock a pool instance
-        # for self.pool.
-        class MockShare(object):
-            def __init__(self, **kwargs):
-                self.id = 55
-                self.name = 'share3'
-                self.subvol_name = 'share3'
-                self.pool = 1
-                self.size = 8924160
-                self.is_mounted = True
-                self.snapshot_set = None
-                # self.snapshots = []
-
-            def save(self):
-                pass
-
-        class MockPool(object):
-            def __init__(self, **kwargs):
-                self.id = 1
-                self.name = 'rockstor_rockstor'
-                self.disk_set = None
-
-        mock_share.objects.get.side_effect = MockShare
-        mock_snapshot.objects.get.side_effect = Snapshot.DoesNotExist
-
-        mock_pool.objects.get.side_effect = MockPool
-        mock_pool.objects.get.disk_set.side_effect = None
-
-        # happy path
-        shareId = 12
-        data = {'owner': 'root'}
-        # in fix2.json we have a share with id=12: "owner": "admin"
-        response = self.client.post('{}/{}/acl'.format(self.BASE_URL, shareId),
-                                    data=data)
-        # TODO: The following FAIL due to:
-        # "Exception: Share matching query does not exist."
-        # but shareId is in fix2.json !
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+    # # May need to moc the ShareSerializer
+    # @mock.patch('storageadmin.views.share_acl.ShareSerializer')
+    # # we require Snapshot mock as ShareSerializer includes a snapshots field,
+    # # see: storageadmin/serializers.py
+    # @mock.patch('storageadmin.serializers.Pool')
+    # @mock.patch('storageadmin.serializers.Snapshot')
+    # @mock.patch('storageadmin.views.share_acl.Share')
+    # def test_post_requests(self, mock_share, mock_snapshot, mock_pool,
+    #                        mock_share_serializer):
+    #
+    #     class MockShareSerializer(serializers.ModelSerializer):
+    #         mount_status = serializers.CharField()
+    #         is_mounted = serializers.BooleanField()
+    #         pqgroup_exist = serializers.BooleanField()
+    #
+    #         class Meta:
+    #             model = Share
+    #
+    #         def __init__(self, **kwargs):
+    #             pass
+    #
+    #     # Mocking from object avoids having to also mock a pool instance
+    #     # for self.pool.
+    #     class MockShare(object):
+    #         def __init__(self, **kwargs):
+    #             self.id = 55
+    #             self.name = 'share3'
+    #             self.subvol_name = 'share3'
+    #             self.pool = 1
+    #             self.size = 8924160
+    #             self.is_mounted = True
+    #             self.snapshot_set = None
+    #             # self.snapshots = []
+    #
+    #         def save(self):
+    #             pass
+    #
+    #     class MockPool(object):
+    #         def __init__(self, **kwargs):
+    #             self.id = 1
+    #             self.name = 'rockstor_rockstor'
+    #             self.disk_set = None
+    #
+    #     mock_share.objects.get.side_effect = MockShare
+    #     mock_snapshot.objects.get.side_effect = Snapshot.DoesNotExist
+    #     mock_share_serializer.objects.get.side_effect = MockShareSerializer
+    #
+    #     mock_pool.objects.get.side_effect = MockPool
+    #     mock_pool.objects.get.disk_set.side_effect = None
+    #
+    #     # happy path
+    #     shareId = 12
+    #     data = {'owner': 'root'}
+    #     # in fix2.json we have a share with id=12: "owner": "admin"
+    #     response = self.client.post('{}/{}/acl'.format(self.BASE_URL, shareId),
+    #                                 data=data)
+    #     # TODO: The following FAIL due to:
+    #     # "Exception: Share matching query does not exist."
+    #     # but shareId is in fix2.json !
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -672,22 +672,22 @@ class ShareTests(APITestMixin, APITestCase):
         # print(Snapshot.objects.filter(share=share, snap_type='admin').exists())
         # print('Our temp snap.name={}'.format(temp_snapshot.name))
 
-        # Delete share with snapshots
-        # TODO this test get triggered by check for snap_type='replication'
-        mock_snapshot.objects.filter(
-            share=share, snap_type='admin').exists.return_value = True
-
-        # print(Snapshot.objects.filter(share=share, snap_type='admin').exists())
-
-        e_msg = ('Share (rootshare) cannot be deleted as it has snapshots. '
-                 'Delete snapshots and try again.')
-        response5 = self.client.delete('{}/{}'.format(self.BASE_URL, sId))
-        self.assertEqual(response5.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response5.data)
-        self.assertEqual(response5.data[0], e_msg)
-        mock_snapshot.objects.filter(
-            share=share, snap_type='admin').exists.return_value = False
+        # # Delete share with snapshots
+        # # TODO this test get triggered by check for snap_type='replication'
+        # mock_snapshot.objects.filter(
+        #     share=share, snap_type='admin').exists.return_value = True
+        #
+        # # print(Snapshot.objects.filter(share=share, snap_type='admin').exists())
+        #
+        # e_msg = ('Share (rootshare) cannot be deleted as it has snapshots. '
+        #          'Delete snapshots and try again.')
+        # response5 = self.client.delete('{}/{}'.format(self.BASE_URL, sId))
+        # self.assertEqual(response5.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response5.data)
+        # self.assertEqual(response5.data[0], e_msg)
+        # mock_snapshot.objects.filter(
+        #     share=share, snap_type='admin').exists.return_value = False
 
     @mock.patch('storageadmin.views.share.Pool')
     @mock.patch('storageadmin.views.share.Service')

--- a/src/rockstor/storageadmin/tests/test_snapshot.py
+++ b/src/rockstor/storageadmin/tests/test_snapshot.py
@@ -253,31 +253,31 @@ class SnapshotTests(APITestMixin, APITestCase):
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK, msg=response.data)
 
-        # Delete snapshot happy path
-        # creating a snapshot just for the next test.
-        # TODO: replace this repeat post test with a proper mock of a snapshot
-        # ie attempted to use:
-
-        # temp_snap = Snapshot(id=2, name='snap2', share=temp_share2,
-        #                      snap_type='admin')
-        # mock_snapshot.objects.get.return_value = temp_snap
-        # mock_snapshot.objects.filter(share='share2', name='snap2'
-        #                              ).exists.return_value = True
-        # but received:
-        # 'Snapshot name (snap2) does not exist.'
-
-        data = {'snapshot-name': 'snap2', 'shares': 'share2',
-                'writable': False, 'uvisible': False}
-        snap_name = 'snap2'
-        share = 'share2'
-        share_id = 4
-        response = self.client.post(
-            '{}/{}/snapshots/{}'.format(self.BASE_URL, share_id, snap_name),
-            data=data, sname=share, snap_name=snap_name)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
-        # now move to our happy path delete test of just created 'snap2'
-        response = self.client.delete(
-            '{}/{}/snapshots/{}'.format(self.BASE_URL, share_id, snap_name))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # Delete snapshot happy path
+        # # creating a snapshot just for the next test.
+        # # TODO: replace this repeat post test with a proper mock of a snapshot
+        # # ie attempted to use:
+        #
+        # # temp_snap = Snapshot(id=2, name='snap2', share=temp_share2,
+        # #                      snap_type='admin')
+        # # mock_snapshot.objects.get.return_value = temp_snap
+        # # mock_snapshot.objects.filter(share='share2', name='snap2'
+        # #                              ).exists.return_value = True
+        # # but received:
+        # # 'Snapshot name (snap2) does not exist.'
+        #
+        # data = {'snapshot-name': 'snap2', 'shares': 'share2',
+        #         'writable': False, 'uvisible': False}
+        # snap_name = 'snap2'
+        # share = 'share2'
+        # share_id = 4
+        # response = self.client.post(
+        #     '{}/{}/snapshots/{}'.format(self.BASE_URL, share_id, snap_name),
+        #     data=data, sname=share, snap_name=snap_name)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
+        # # now move to our happy path delete test of just created 'snap2'
+        # response = self.client.delete(
+        #     '{}/{}/snapshots/{}'.format(self.BASE_URL, share_id, snap_name))
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/tests/test_user.py
+++ b/src/rockstor/storageadmin/tests/test_user.py
@@ -153,15 +153,17 @@ class UserTests(APITestMixin, APITestCase):
         #          "username.")
         # self.assertEqual(response.data, e_msg)
 
-        # create user with existing username admin2 and uid
-        data = {'username': 'admin2', 'password': 'pwadmin2', 'uid': '0000'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_400_BAD_REQUEST,
-                         msg=response.data)
-        e_msg = ("User (admin2) already exists. Please choose a different "
-                 "username.")
-        self.assertEqual(response.data[0], e_msg)
+        # # TODO: FAIL AssertionError: ['UID (0) already exists.
+        # #  Please choose a different one.', 'None\n']
+        # # create user with existing username admin2 and uid
+        # data = {'username': 'admin2', 'password': 'pwadmin2', 'uid': '0000'}
+        # response = self.client.post(self.BASE_URL, data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_400_BAD_REQUEST,
+        #                  msg=response.data)
+        # e_msg = ("User (admin2) already exists. Please choose a different "
+        #          "username.")
+        # self.assertEqual(response.data[0], e_msg)
 
         # create a user with existing uid ('nobody' has a uid 99)
         # TODO: We are not limiting user id to >= 1000.
@@ -223,18 +225,19 @@ class UserTests(APITestMixin, APITestCase):
                  "username.")
         self.assertEqual(response.data[0], e_msg)
 
-    def test_duplicate_name1(self):
-
-        # create user with existing username admin2 (throwing appropriate error
-        # if uid sent in data)
-        data = {'username': 'admin2', 'password': 'pwadmin2'}
-        response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_400_BAD_REQUEST,
-                         msg=response.data)
-        e_msg = ("User (admin2) already exists. Please choose a different "
-                 "username.")
-        self.assertEqual(response.data[0], e_msg)
+    # # TODO: FAIL: We look to have a mocking issue hear as response is a normal page.
+    # def test_duplicate_name1(self):
+    #
+    #     # create user with existing username admin2 (throwing appropriate error
+    #     # if uid sent in data)
+    #     data = {'username': 'admin2', 'password': 'pwadmin2'}
+    #     response = self.client.post(self.BASE_URL, data=data)
+    #     self.assertEqual(response.status_code,
+    #                      status.HTTP_400_BAD_REQUEST,
+    #                      msg=response.data)
+    #     e_msg = ("User (admin2) already exists. Please choose a different "
+    #              "username.")
+    #     self.assertEqual(response.data[0], e_msg)
 
     def test_email_validation(self):
 
@@ -303,27 +306,30 @@ class UserTests(APITestMixin, APITestCase):
         #          "provide a new password.")
         # self.assertEqual(response.data[0], e_msg)
 
-        # happy path
-        data = {'password': 'admin2', 'group': 'admin', 'admin': True}
-        response = self.client.put('{}/admin2'.format(self.BASE_URL),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # TODO: FAIL AssertionError: ['User (admin2) does not exist.', 'None\n']
+        # # happy path
+        # data = {'password': 'admin2', 'group': 'admin', 'admin': True}
+        # response = self.client.put('{}/admin2'.format(self.BASE_URL),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
-        data = {'password': 'admin2', 'group': 'admin', 'admin': True,
-                'user': 'uadmin2', 'public_key': self.valid_pubkey}
-        response = self.client.put('{}/admin2'.format(self.BASE_URL),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # TODO: FAIL:AssertionError: ['User (admin2) does not exist.', 'None\n']
+        # data = {'password': 'admin2', 'group': 'admin', 'admin': True,
+        #         'user': 'uadmin2', 'public_key': self.valid_pubkey}
+        # response = self.client.put('{}/admin2'.format(self.BASE_URL),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
-        data = {'password': 'admin2', 'group': 'admin', 'user': 'uadmin2',
-                'shell': '/bin/xyz', 'email': 'admin2@xyz.com'}
-        # TODO: note user: uadmin2 yet we access /admin2 here !!
-        response = self.client.put('{}/admin2'.format(self.BASE_URL),
-                                   data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # TODO: FAIL: AssertionError: ['User (admin2) does not exist.', 'None\n']
+        # data = {'password': 'admin2', 'group': 'admin', 'user': 'uadmin2',
+        #         'shell': '/bin/xyz', 'email': 'admin2@xyz.com'}
+        # # TODO: note user: uadmin2 yet we access /admin2 here !!
+        # response = self.client.put('{}/admin2'.format(self.BASE_URL),
+        #                            data=data)
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
     def test_delete_requests(self):
 
@@ -349,14 +355,16 @@ class UserTests(APITestMixin, APITestCase):
         e_msg = "Delete of restricted user (bin) is not supported."
         self.assertEqual(response.data[0], e_msg)
 
-        username = 'admin2'
-        self.mock_userdel.side_effect = KeyError('error')
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, username))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = "A low level error occurred while deleting the user (admin2)."
-        self.assertEqual(response.data[0], e_msg)
+        # # TODO: AssertionError: 'User (admin2) does not exist.' !=
+        # #  'A low level error occurred while deleting the user (admin2).'
+        # username = 'admin2'
+        # self.mock_userdel.side_effect = KeyError('error')
+        # response = self.client.delete('{}/{}'.format(self.BASE_URL, username))
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
+        #                  msg=response.data)
+        # e_msg = "A low level error occurred while deleting the user (admin2)."
+        # self.assertEqual(response.data[0], e_msg)
 
         # delete currently logged in user (admin44) from APITestMixin
         self.mock_userdel.side_effect = None
@@ -368,12 +376,13 @@ class UserTests(APITestMixin, APITestCase):
         e_msg = "Cannot delete the currently logged in user."
         self.assertEqual(response.data[0], e_msg)
 
-        # happy path
-        # delete user
-        username = 'admin2'
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, username))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # # happy path
+        # # TODO: AssertionError: ['User (admin2) does not exist.', 'None\n']
+        # # delete user
+        # username = 'admin2'
+        # response = self.client.delete('{}/{}'.format(self.BASE_URL, username))
+        # self.assertEqual(response.status_code,
+        #                  status.HTTP_200_OK, msg=response.data)
 
         username = 'admin3'
         response = self.client.delete('{}/{}'.format(self.BASE_URL, username))


### PR DESCRIPTION
All currently failing unit tests on our to-be-legacy but still reference CentOS source build are remarked out in order that we can more readily use the existing tests as indicators of disparity between our ditro bases. In almost all cases the fail/error message of the test is noted in TODO's. The vast majority failures are suspected as being caused by a lack of maintenance within the tests and several major changes such as disk/share/pool/network API changes.

Fixes #2137

See issue text for context.

Includes:
- Remark out 2 sftp sub tests, broken/out of sync with core code.
- Remark out test_btrfs_disk_import: 500 not 200.
- Fix broken test_commands.py CommandTests - core refactor bit rot. see: "[openSUSE] use zypper for package installs. Fixes #2071" (pr #2081) in 3.9.2-51. The unrelated get_pool_info() breakage was not tracked down.
- Update patch targets due to core refactoring. In pr: "Add unit testing for core network functions" #2045 at least a couple of functions were renamed. Updated these in our network API test setup.
- Remark out all network API tests as this API changed long ago.
- Remark out many whole and sub-parts of the nfs tests. Many of the failures here are likely down to disk / share API changes after these tests were written. Specifically Shares API in this case as there are many (noted in TODO: comments): "share instance ... does not exist." which suggests a failure of the mocking arrangement.
- Remark out test_share_acl as currently non working and need work.
- An attempt was made to fix the mocking required to have this test work but it was not a success. Minor minification were left in place never-the-less.
- Remark out test within test_oauth_apply - Needs updating.
- Update to account for refactoring in tested & add new needed mocks.
- Since this test was update there have been a few pool model changes. The added mocks mostly move this test back to where it was prior to the pool management code changes.
- Remove overly ambitious/broad test_raid_migration - failing.
- Fix missing space in expected error message test_raid6_crud.
- Remark out currently unworkable sub tests within test_raid6_crud.
- Our pool / disk member mocking is currently insufficient and so a range of tests now fail. Remove for to use what we can.
- Remark out currently unworkable sub tests within test_raid1_crud.
- Our pool / disk member mocking is currently insufficient and so a range of tests now fail. Remove for to use what we can.
- Remark out several sub tests within test_samba.py as need fixing.
- Remark out a sub test within test_group as need fixing or OOD.
- Remark out a sub test within test_login as non representative.
- Remark out a sub test within test_shares as incorrectly triggered.
- Remark out all but on test in test_oauth as test seem broken.
- Remark out one more test in test_snapshots as known to be duff.
- Remark out several more test in test_user as known to be duff.

# Tested on a source build via our CentOS variant via: 
```
./bin/test -v 3 -p test_*
```
with the following summary:
```
Ran 203 tests in 32.252s

OK
```
and the following test output:

> test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
> test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
> test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
> test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
> test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
> test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
> test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
> test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
> test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
> test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
> test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
> test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
> test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
> test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
> test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
> test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
> test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
> test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
> test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
> test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
> test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
> test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
> test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
> test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
> test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
> test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
> test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
> test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
> test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
> test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
> test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
> test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
> test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
> test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
> test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
> test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
> test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
> test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
> test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
> test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
> test_get (storageadmin.tests.test_pools.PoolTests) ... ok
> test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
> test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
> test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
> test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
> test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
> test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
> test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
> test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
> test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
> test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
> test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
> test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
> test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
> test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
> test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
> test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
> test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
> test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
> test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
> test_create (storageadmin.tests.test_shares.ShareTests) ... ok
> test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
> test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
> test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
> test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
> test_get (storageadmin.tests.test_shares.ShareTests) ... ok
> test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
> test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
> test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
> test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
> test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
> test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
> test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
> test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
> test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
> test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
> test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
> test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
> test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
> test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
> test_get (storageadmin.tests.test_user.UserTests) ... ok
> test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
> test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
> test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
> test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
> test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
> test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
> test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
> Test to see if balance_status() correctly identifies a Paused balance ... ok
> test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
> test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
> test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
> test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
> test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
> test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
> test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
> test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
> test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
> test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
> test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
> test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
> test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
> test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
> test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
> test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
> test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
> test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
> 

