### PR TITLE
inadvertent use of internal -1/-1 pool quote group flag. Fixes #2158

### DIFF
--- a/src/rockstor/storageadmin/views/clone_helpers.py
+++ b/src/rockstor/storageadmin/views/clone_helpers.py
@@ -133,7 +133,7 @@ def create_clone(share, new_name, request, logger, snapshot=None):
         new_share = Share(pool=share.pool, qgroup=qgroup_id, pqgroup=pqid,
                           name=new_name, size=share.size, subvol_name=new_name)
         new_share.save()
-        if pqid is not PQGROUP_DEFAULT:
+        if pqid != PQGROUP_DEFAULT:
             update_quota(new_share.pool, pqid, new_share.size * 1024)
             share_pqgroup_assign(pqid, new_share)
         # Mount our new clone share.

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -186,7 +186,7 @@ class ShareListView(ShareMixin, rfc.GenericView):
             # The following pool.save() was informed by test_share.py
             pool.save()
             s.save()
-            if pqid is not PQGROUP_DEFAULT:
+            if pqid != PQGROUP_DEFAULT:
                 update_quota(pool, pqid, size * 1024)
                 share_pqgroup_assign(pqid, s)
             mnt_pt = '%s%s' % (settings.MNT_PT, sname)
@@ -239,7 +239,7 @@ class ShareDetailView(ShareMixin, rfc.GenericView):
                         # if quotas were disabled or pqgroup non-existent.
                         share.pqgroup = qgroup_create(share.pool)
                         share.save()
-                    if share.pqgroup is not PQGROUP_DEFAULT:
+                    if share.pqgroup != PQGROUP_DEFAULT:
                         # Only update quota and assign if now non default as
                         # default can also indicate Read-only fs at this point.
                         update_quota(share.pool, share.pqgroup,

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -114,7 +114,7 @@ def import_shares(pool, request):
                     logger.debug('#### replacing void, non-existent, or '
                                  'duplicate pqgroup.')
                     pqgroup = qgroup_create(pool)
-                    if pqgroup is not PQGROUP_DEFAULT:
+                    if pqgroup != PQGROUP_DEFAULT:
                         update_quota(pool, pqgroup, share.size * 1024)
                         share_pqgroup_assign(pqgroup, share)
                 else:
@@ -188,7 +188,7 @@ def import_shares(pool, request):
                              'as share and setting replica flag.')
             qid = shares_in_pool[s_in_pool]
             pqid = qgroup_create(pool)
-            if pqid is not PQGROUP_DEFAULT:
+            if pqid != PQGROUP_DEFAULT:
                 update_quota(pool, pqid, pool.size * 1024)
                 pool_mnt_pt = '{}{}'.format(settings.MNT_PT, pool.name)
                 qgroup_assign(qid, pqid, pool_mnt_pt)

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -120,7 +120,7 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         add_snap(share.pool, share.subvol_name, snap_name, writable)
         snap_id = share_id(share.pool, snap_name)
         qgroup_id = ('0/%s' % snap_id)
-        if share.pqgroup is not settings.MODEL_DEFS['pqgroup']:
+        if share.pqgroup != settings.MODEL_DEFS['pqgroup']:
             pool_mnt_pt = '{}{}'.format(settings.MNT_PT, share.pool.name)
             qgroup_assign(qgroup_id, share.pqgroup, pool_mnt_pt)
         snap_size, eusage = volume_usage(share.pool, qgroup_id)


### PR DESCRIPTION
Correct programming error re misuse of identity test where equality test should have been used.

When comparing our internal flag of pool quota group value of "-1/-1" the wrong test was applied. This resulted in inadvertent execution of "btrfs qgroup assign" with target qgroups of the flag value; as detailed in the issue text.

Fixes #2158 

Please see linked issue text for more context.
