### PR TITLE
[NG] ROOT pool user share not displayed on page refresh. Fixes #2156

### DIFF
--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -160,7 +160,7 @@ class BTRFSTests(unittest.TestCase):
             # assert get_pool_raid_level returns what we expect.
             self.assertEqual(pool_raid(mount_point), expected_result,
                              msg='get_pool_raid_level() miss identified raid '
-                                 'level %s' % raid_level)
+                                 'level {}'.format(raid_level))
 
     def test_is_subvol_exists(self):
         mount_point = '/mnt2/test-pool/test-share'

--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -24,7 +24,7 @@ from fs.btrfs import (
     are_quotas_enabled,
     is_pool_missing_dev,
     dev_stats_zero,
-)
+    default_subvol)
 from system.osi import mount_status
 
 RETURN_BOOLEAN = True
@@ -68,7 +68,7 @@ class Pool(models.Model):
         # this serves as a mechanism by which we can 'special case' our ROOT/system
         # pool and avoid mounting it again at the usual /mnt2/pool-name as it is already
         # mounted (or it's boot to snapshot instance) at "/".
-        if self.role == "root":
+        if self.role == "root" and not default_subvol().boot_to_snap:
             self.mnt_pt_var = "/"
         else:
             self.mnt_pt_var = "{}{}".format(settings.MNT_PT, self.name)

--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -18,15 +18,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from django.db import models
 from django.conf import settings
-from fs.btrfs import pool_usage, usage_bound, \
-    are_quotas_enabled, is_pool_missing_dev, dev_stats_zero
+from fs.btrfs import (
+    pool_usage,
+    usage_bound,
+    are_quotas_enabled,
+    is_pool_missing_dev,
+    dev_stats_zero,
+)
 from system.osi import mount_status
 
 RETURN_BOOLEAN = True
 
 
 class Pool(models.Model):
-    """Name of the pool"""
+    # Name of the pool
     name = models.CharField(max_length=4096, unique=True)
     """uuid given automatically by the client"""
     uuid = models.CharField(max_length=100, null=True)
@@ -102,9 +107,10 @@ class Pool(models.Model):
         return 0
 
     def usage_bound(self):
-        disk_sizes = [int(size) for size in self.disk_set
-                      .values_list('size', flat=True)
-                      .order_by('-size')]
+        disk_sizes = [
+            int(size)
+            for size in self.disk_set.values_list("size", flat=True).order_by("-size")
+        ]
         return usage_bound(disk_sizes, len(disk_sizes), self.raid)
 
     @property
@@ -132,4 +138,4 @@ class Pool(models.Model):
             return False
 
     class Meta:
-        app_label = 'storageadmin'
+        app_label = "storageadmin"

--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -42,6 +42,7 @@ class Pool(models.Model):
     def __init__(self, *args, **kwargs):
         super(Pool, self).__init__(*args, **kwargs)
         self.update_missing_dev()
+        self.update_mnt_pt_var()
         self.update_device_stats()
 
     def update_missing_dev(self, *args, **kwargs):
@@ -57,14 +58,27 @@ class Pool(models.Model):
     def has_missing_dev(self, *args, **kwargs):
         return self.missing_dev
 
+    def update_mnt_pt_var(self, *args, **kwargs):
+        # Establish an instance variable of our mnt_pt. Primarily, at least initially,
+        # this serves as a mechanism by which we can 'special case' our ROOT/system
+        # pool and avoid mounting it again at the usual /mnt2/pool-name as it is already
+        # mounted (or it's boot to snapshot instance) at "/".
+        if self.role == "root":
+            self.mnt_pt_var = "/"
+        else:
+            self.mnt_pt_var = "{}{}".format(settings.MNT_PT, self.name)
+
+    @property
+    def mnt_pt(self, *args, **kwargs):
+        return self.mnt_pt_var
+
     def update_device_stats(self, *args, **kwargs):
         # Establish an instance variable to represent non zero stats.
         # Currently Boolean and may be updated during instance life by
         # calling this method again or directly setting the field.
         try:
             if self.is_mounted:
-                mnt_pt = '%s%s' % (settings.MNT_PT, self.name)
-                self.dev_stats_zero = dev_stats_zero(mnt_pt)
+                self.dev_stats_zero = dev_stats_zero(self.mnt_pt_var)
             else:
                 self.dev_stats_zero = True
         except:
@@ -81,7 +95,7 @@ class Pool(models.Model):
         # less code. For share usage, this type of logic could slow things
         # down quite a bit because there can be 100's of Shares, but number
         # of Pools even on a large instance is usually no more than a few.
-        return self.size - pool_usage('%s%s' % (settings.MNT_PT, self.name))
+        return self.size - pool_usage(self.mnt_pt_var)
 
     @property
     def reclaimable(self, *args, **kwargs):
@@ -97,7 +111,7 @@ class Pool(models.Model):
     def mount_status(self, *args, **kwargs):
         # Presents raw string of active mount options akin to mnt_options field
         try:
-            return mount_status('%s%s' % (settings.MNT_PT, self.name))
+            return mount_status(self.mnt_pt_var)
         except:
             return None
 
@@ -105,8 +119,7 @@ class Pool(models.Model):
     def is_mounted(self, *args, **kwargs):
         # Calls mount_status in return boolean mode.
         try:
-            return mount_status('%s%s' % (settings.MNT_PT, self.name),
-                                RETURN_BOOLEAN)
+            return mount_status(self.mnt_pt_var, RETURN_BOOLEAN)
         except:
             return False
 
@@ -114,7 +127,7 @@ class Pool(models.Model):
     def quotas_enabled(self, *args, **kwargs):
         # Calls are_quotas_enabled for boolean response
         try:
-            return are_quotas_enabled('%s%s' % (settings.MNT_PT, self.name))
+            return are_quotas_enabled(self.mnt_pt_var)
         except:
             return False
 

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -27,22 +27,21 @@ RETURN_BOOLEAN = True
 
 
 class Share(models.Model):
-    "pool that this share is part of"""
+    # pool that this share is part of
     pool = models.ForeignKey(Pool)
     """auto created 0/x qgroup"""
     qgroup = models.CharField(max_length=100)
     """quota group y/x explicitly created for this Share"""
-    pqgroup = models.CharField(max_length=32,
-                               default=settings.MODEL_DEFS['pqgroup'])
+    pqgroup = models.CharField(max_length=32, default=settings.MODEL_DEFS["pqgroup"])
     """name of the share, kind of like id"""
     name = models.CharField(max_length=4096, unique=True)
     """id of the share. numeric in case of btrfs"""
     uuid = models.CharField(max_length=100, null=True)
     """total size in KB"""
     size = models.BigIntegerField(default=0)
-    owner = models.CharField(max_length=4096, default='root')
-    group = models.CharField(max_length=4096, default='root')
-    perms = models.CharField(max_length=9, default='755')
+    owner = models.CharField(max_length=4096, default="root")
+    group = models.CharField(max_length=4096, default="root")
+    perms = models.CharField(max_length=9, default="755")
     toc = models.DateTimeField(auto_now=True)
     subvol_name = models.CharField(max_length=4096)
     replica = models.BooleanField(default=False)
@@ -101,12 +100,12 @@ class Share(models.Model):
     def pqgroup_exist(self, *args, **kwargs):
         # Returns boolean status of pqgroup existence
         try:
-            if str(self.pqgroup) == '-1/-1':
+            if str(self.pqgroup) == "-1/-1":
                 return False
             else:
-                return qgroup_exists(self.mnt_pt_var, '{}'.format(self.pqgroup))
+                return qgroup_exists(self.mnt_pt_var, "{}".format(self.pqgroup))
         except:
             return False
 
     class Meta:
-        app_label = 'storageadmin'
+        app_label = "storageadmin"

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -61,16 +61,8 @@ class Share(models.Model):
         self.update_mnt_pt_var()
 
     def update_mnt_pt_var(self, *args, **kwargs):
-        # Establish an instance variable of our mnt_pt. Primarily, at least initially,
-        # this serves as a mechanism by which we can 'special case' our ROOT/system
-        # pool shares, the natively (fstab) mounted of those (home) is not mounted by
-        # us and so lives in "/" + pool name (with some @/ fudging). Where as rockstor
-        # created shares are mount
-        # mounted (or it's boot to snapshot instance) at "/".
-        if self.name == "home":
-            self.mnt_pt_var = "{}{}".format(self.pool.mnt_pt, self.name)
-        else:
-            self.mnt_pt_var = "{}{}".format(settings.MNT_PT, self.name)
+        # Establish an instance variable of our mnt_pt.
+        self.mnt_pt_var = "{}{}".format(settings.MNT_PT, self.name)
 
     @property
     def mnt_pt(self, *args, **kwargs):

--- a/src/rockstor/storageadmin/views/clone_helpers.py
+++ b/src/rockstor/storageadmin/views/clone_helpers.py
@@ -1,13 +1,13 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
-This file is part of RockStor.
+Copyright (c) 2012-2020 Rockstor, Inc. <http://rockstor.com>
+This file is part of Rockstor.
 
-RockStor is free software; you can redistribute it and/or modify
+Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-RockStor is distributed in the hope that it will be useful, but
+Rockstor is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
@@ -16,11 +16,19 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from storageadmin.models import (Share, Snapshot)
+from storageadmin.models import Share, Snapshot
 from storageadmin.util import handle_exception
-from fs.btrfs import (add_clone, share_id, update_quota, mount_share,
-                      qgroup_create, set_property, remove_share,
-                      share_pqgroup_assign, is_subvol)
+from fs.btrfs import (
+    add_clone,
+    share_id,
+    update_quota,
+    mount_share,
+    qgroup_create,
+    set_property,
+    remove_share,
+    share_pqgroup_assign,
+    is_subvol,
+)
 from rest_framework.response import Response
 from storageadmin.serializers import ShareSerializer
 import re
@@ -29,7 +37,7 @@ from django.conf import settings
 from system.osi import run_command
 
 # The following model/db default setting is also used when quotas are disabled.
-PQGROUP_DEFAULT = settings.MODEL_DEFS['pqgroup']
+PQGROUP_DEFAULT = settings.MODEL_DEFS["pqgroup"]
 
 
 def create_repclone(share, request, logger, snapshot):
@@ -51,8 +59,10 @@ def create_repclone(share, request, logger, snapshot):
     :return: response of serialized share (in it's updated form)
     """
     try:
-        logger.info('Supplanting share ({}) with '
-                     'snapshot ({}).'.format(share.name, snapshot.name))
+        logger.info(
+            "Supplanting share ({}) with "
+            "snapshot ({}).".format(share.name, snapshot.name)
+        )
         # We first strip our snapshot.name of any path as when we encounter the
         # initially created receive subvol it is identified as a share with a
         # snapshots location as it's subvol name (current quirk of import sys).
@@ -63,29 +73,35 @@ def create_repclone(share, request, logger, snapshot):
         # The 19 in the above names is the generation of the replication task.
         #
         # Normalise source name across initial quirk share & subsequent snaps.
-        source_name = snapshot.name.split('/')[-1]
+        source_name = snapshot.name.split("/")[-1]
         # Note in the above we have to use Object.name for polymorphism, but
         # our share is passed by it's subvol (potential fragility point).
-        snap_path = '{}{}/.snapshots/{}/{}'.format(settings.MNT_PT,
-                                                   share.pool.name, share.name,
-                                                   source_name)
-        # eg /mnt2/poolname/.snapshots/sharename/snapname
-        share_path = ('{}{}/{}'.format(settings.MNT_PT, share.pool.name,
-                                       share.name))
-        # eg /mnt2/poolname/sharename
+        snap_path = "{}/.snapshots/{}/{}".format(
+            share.pool.mnt_pt, share.name, source_name
+        ).replace("//", "/")
+        # e.g. for above: /mnt2/poolname/.snapshots/sharename/snapname
+        # or /.snapshots/sharename/snapname for system pool shares
+        share_path = ("{}/{}".format(share.pool.mnt_pt, share.name)).replace("//", "/")
+        # e.g. for above: /mnt2/poolname/sharename or /sharename for system pool shares
         # Passed db snap assured by caller but this does not guarantee on disk.
         if not is_subvol(snap_path):
-            raise Exception('Subvol with path ({}) does not exist. Aborting '
-                            'replacement of share ({}).'.format(snap_path,
-                                                                share.name))
+            raise Exception(
+                "Subvol with path ({}) does not exist. Aborting "
+                "replacement of share with path ({}).".format(snap_path, share_path)
+            )
         # unmounts and then subvol deletes our on disk share
         remove_share(share.pool, share.name, PQGROUP_DEFAULT)
         # Remove read only flag on our snapshot subvol
-        set_property(snap_path, 'ro', 'false', mount=False)
+        set_property(snap_path, "ro", "false", mount=False)
         # Ensure removed share path is clean, ie remove mount point.
-        run_command(['/usr/bin/rm', '-rf', share_path], throw=False)
+        run_command(["/usr/bin/rm", "-rf", share_path], throw=False)
         # Now move snapshot to prior shares location. Given both a share and
         # a snapshot are subvols, we effectively promote the snap to a share.
+        logger.info(
+            "Moving snapshot ({}) to prior share's pool location ({})".format(
+                snap_path, share_path
+            )
+        )
         shutil.move(snap_path, share_path)
         # This should have re-established our just removed subvol.
         # Supplant share db info with snap info to reflect new on disk state.
@@ -98,7 +114,8 @@ def create_repclone(share, request, logger, snapshot):
         # update our share's quota
         update_quota(share.pool, share.pqgroup, share.size * 1024)
         # mount our newly supplanted share
-        mnt_pt = '{}{}'.format(settings.MNT_PT, share.name)
+        # We independently mount all shares, data pool or system pool, in /mnt2/name
+        mnt_pt = "{}{}".format(settings.MNT_PT, share.name)
         mount_share(share, mnt_pt)
         return Response(ShareSerializer(share).data)
     except Exception as e:
@@ -108,36 +125,46 @@ def create_repclone(share, request, logger, snapshot):
 def create_clone(share, new_name, request, logger, snapshot=None):
     # if snapshot is None, create clone of the share.
     # If it's not, then clone it.
-    if (re.match(settings.SHARE_REGEX + '$', new_name) is None):
-        e_msg = ('Clone name is invalid. It must start with a letter and can '
-                 'contain letters, digits, _, . and - characters.')
+    if re.match(settings.SHARE_REGEX + "$", new_name) is None:
+        e_msg = (
+            "Clone name is invalid. It must start with a letter and can "
+            "contain letters, digits, _, . and - characters."
+        )
         handle_exception(Exception(e_msg), request)
-    if (Share.objects.filter(name=new_name).exists()):
-        e_msg = 'Another share with name ({}) already exists.'.format(new_name)
+    if Share.objects.filter(name=new_name).exists():
+        e_msg = "Another share with name ({}) already exists.".format(new_name)
         handle_exception(Exception(e_msg), request)
-    if (Snapshot.objects.filter(share=share, name=new_name).exists()):
-        e_msg = ('Snapshot with name ({}) already exists for the '
-                 'share ({}). Choose a different name.').format(new_name,
-                                                                share.name)
+    if Snapshot.objects.filter(share=share, name=new_name).exists():
+        e_msg = (
+            "Snapshot with name ({}) already exists for the "
+            "share ({}). Choose a different name."
+        ).format(new_name, share.name)
         handle_exception(Exception(e_msg), request)
 
     try:
         share_name = share.subvol_name
         snap = None
-        if (snapshot is not None):
+        if snapshot is not None:
             snap = snapshot.real_name
         add_clone(share.pool, share_name, new_name, snapshot=snap)
         snap_id = share_id(share.pool, new_name)
-        qgroup_id = ('0/%s' % snap_id)
+        qgroup_id = "0/{}".format(snap_id)
         pqid = qgroup_create(share.pool)
-        new_share = Share(pool=share.pool, qgroup=qgroup_id, pqgroup=pqid,
-                          name=new_name, size=share.size, subvol_name=new_name)
+        new_share = Share(
+            pool=share.pool,
+            qgroup=qgroup_id,
+            pqgroup=pqid,
+            name=new_name,
+            size=share.size,
+            subvol_name=new_name,
+        )
         new_share.save()
         if pqid != PQGROUP_DEFAULT:
             update_quota(new_share.pool, pqid, new_share.size * 1024)
             share_pqgroup_assign(pqid, new_share)
         # Mount our new clone share.
-        mnt_pt = '{}{}'.format(settings.MNT_PT, new_name)
+        # We independently mount all shares, data pool or system pool, in /mnt2/name
+        mnt_pt = "{}{}".format(settings.MNT_PT, new_name)
         mount_share(new_share, mnt_pt)
         return Response(ShareSerializer(new_share).data)
     except Exception as e:

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -67,9 +67,9 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 continue
             # Log if no attached members are found, ie all devs are detached.
             if p.disk_set.attached().count() == 0:
-                logger.error('Skipping Pool (%s) mount as there '
-                             'are no attached devices. Moving on.' %
-                             p.name)
+                logger.error('Skipping Pool ({}) mount as there '
+                             'are no attached devices. Moving on.'.format(p.name)
+                             )
                 continue
             try:
                 # Get and save what info we can prior to mount.
@@ -98,8 +98,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 p.save()
             except Exception as e:
                 logger.error('Exception while refreshing state for '
-                             'Pool(%s). Moving on: %s' %
-                             (p.name, e.__str__()))
+                             'Pool({}). Moving on: {}'.format(p.name, e.__str__()))
                 logger.exception(e)
 
     @transaction.atomic
@@ -130,7 +129,8 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                     continue
                 try:
                     if not share.is_mounted:
-                        mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
+                        # System mounted shares i.e. home will already be mounted.
+                        mnt_pt = ('{}{}'.format(settings.MNT_PT, share.name))
                         mount_share(share, mnt_pt)
                 except Exception as e:
                     e_msg = ('Exception while mounting a share ({}) during '

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -18,38 +18,56 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.authentication import (BasicAuthentication,
-                                           SessionAuthentication)
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
 from storageadmin.views import DiskMixin
-from system.osi import (uptime, kernel_info, get_device_mapper_map)
-from fs.btrfs import (mount_share, mount_root, get_dev_pool_info,
-                      pool_raid, mount_snap)
-from system.ssh import (sftp_mount_map, sftp_mount)
+from system.osi import uptime, kernel_info, get_device_mapper_map
+from fs.btrfs import mount_share, mount_root, get_dev_pool_info, pool_raid, mount_snap
+from system.ssh import sftp_mount_map, sftp_mount
 from system.services import systemctl
-from system.osi import (system_shutdown, system_reboot,
-                        system_suspend, set_system_rtc_wake)
-from storageadmin.models import (Share, NFSExport, SFTP, Pool, Snapshot,
-                                 UpdateSubscription, AdvancedNFSExport)
+from system.osi import (
+    system_shutdown,
+    system_reboot,
+    system_suspend,
+    set_system_rtc_wake,
+)
+from storageadmin.models import (
+    Share,
+    NFSExport,
+    SFTP,
+    Pool,
+    Snapshot,
+    UpdateSubscription,
+    AdvancedNFSExport,
+)
 from storageadmin.util import handle_exception
 from datetime import datetime
 from django.utils.timezone import utc
 from django.conf import settings
 from django.db import transaction
-from share_helpers import (sftp_snap_toggle, import_shares, import_snapshots)
+from share_helpers import sftp_snap_toggle, import_shares, import_snapshots
 from rest_framework_custom.oauth_wrapper import RockstorOAuth2Authentication
-from system.pkg_mgmt import (auto_update, current_version, rockstor_pkg_update_check,
-                             update_run, auto_update_status)
+from system.pkg_mgmt import (
+    auto_update,
+    current_version,
+    rockstor_pkg_update_check,
+    update_run,
+    auto_update_status,
+)
 from nfs_exports import NFSExportMixin
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class CommandView(DiskMixin, NFSExportMixin, APIView):
-    authentication_classes = (DigestAuthentication, SessionAuthentication,
-                              BasicAuthentication,
-                              RockstorOAuth2Authentication,)
+    authentication_classes = (
+        DigestAuthentication,
+        SessionAuthentication,
+        BasicAuthentication,
+        RockstorOAuth2Authentication,
+    )
     permission_classes = (IsAuthenticated,)
 
     @staticmethod
@@ -62,48 +80,55 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
         for p in Pool.objects.all():
             # If our pool has no disks, detached included, then delete it.
             # We leave pools with all detached members in place intentionally.
-            if (p.disk_set.count() == 0):
+            if p.disk_set.count() == 0:
                 p.delete()
                 continue
             # Log if no attached members are found, ie all devs are detached.
             if p.disk_set.attached().count() == 0:
-                logger.error('Skipping Pool ({}) mount as there '
-                             'are no attached devices. Moving on.'.format(p.name)
-                             )
+                logger.error(
+                    "Skipping Pool ({}) mount as there "
+                    "are no attached devices. Moving on.".format(p.name)
+                )
                 continue
             try:
                 # Get and save what info we can prior to mount.
                 first_dev = p.disk_set.attached().first()
                 # Use target_name to account for redirect role.
                 if first_dev.target_name == first_dev.temp_name:
-                    logger.error('Skipping pool ({}) mount as attached disk '
-                                 '({}) has no by-id name (no serial # ?)'.
-                                 format(p.name, first_dev.target_name))
+                    logger.error(
+                        "Skipping pool ({}) mount as attached disk "
+                        "({}) has no by-id name (no serial # ?)".format(
+                            p.name, first_dev.target_name
+                        )
+                    )
                     continue
                 if first_dev.temp_name in mapped_devs:
-                    dev_tmp_name = '/dev/mapper/{}'.format(
-                        mapped_devs[first_dev.temp_name])
+                    dev_tmp_name = "/dev/mapper/{}".format(
+                        mapped_devs[first_dev.temp_name]
+                    )
                 else:
-                    dev_tmp_name = '/dev/{}'.format(first_dev.temp_name)
+                    dev_tmp_name = "/dev/{}".format(first_dev.temp_name)
                 # For now we call get_dev_pool_info() once for each pool.
                 pool_info = dev_pool_info[dev_tmp_name]
                 p.name = pool_info.label
                 p.uuid = pool_info.uuid
                 p.save()
                 mount_root(p)
-                p.raid = pool_raid(p.mnt_pt)['data']
+                p.raid = pool_raid(p.mnt_pt)["data"]
                 p.size = p.usage_bound()
                 # Consider using mount_status() parse to update root pool db on
                 # active (fstab initiated) compression setting.
                 p.save()
             except Exception as e:
-                logger.error('Exception while refreshing state for '
-                             'Pool({}). Moving on: {}'.format(p.name, e.__str__()))
+                logger.error(
+                    "Exception while refreshing state for "
+                    "Pool({}). Moving on: {}".format(p.name, e.__str__())
+                )
                 logger.exception(e)
 
     @transaction.atomic
     def post(self, request, command, rtcepoch=None):
-        if (command == 'bootstrap'):
+        if command == "bootstrap":
             self._update_disk_state()
             self._refresh_pool_state()
             for p in Pool.objects.all():
@@ -111,10 +136,12 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                     continue
                 if not p.is_mounted:
                     # Prior _refresh_pool_state() should have ensure a mount.
-                    logger.error('Skipping import/update of prior known '
-                                 'shares for pool ({}) as it is not mounted. '
-                                 '(see previous errors)'
-                                 '.'.format(p.name))
+                    logger.error(
+                        "Skipping import/update of prior known "
+                        "shares for pool ({}) as it is not mounted. "
+                        "(see previous errors)"
+                        ".".format(p.name)
+                    )
                     continue
                 # Import / update db shares counterpart for managed pool.
                 import_shares(p, request)
@@ -123,38 +150,43 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 if share.pool.disk_set.attached().count() == 0:
                     continue
                 if not share.pool.is_mounted:
-                    logger.error('Skipping mount of share ({}) as pool () is '
-                                 'not mounted (see previous errors)'
-                                 '.'.format(share.name, share.pool.name))
+                    logger.error(
+                        "Skipping mount of share ({}) as pool () is "
+                        "not mounted (see previous errors)"
+                        ".".format(share.name, share.pool.name)
+                    )
                     continue
                 try:
                     if not share.is_mounted:
                         # System mounted shares i.e. home will already be mounted.
-                        mnt_pt = ('{}{}'.format(settings.MNT_PT, share.name))
+                        mnt_pt = "{}{}".format(settings.MNT_PT, share.name)
                         mount_share(share, mnt_pt)
                 except Exception as e:
-                    e_msg = ('Exception while mounting a share ({}) during '
-                             'bootstrap: ({}).').format(share.name,
-                                                        e.__str__())
+                    e_msg = (
+                        "Exception while mounting a share ({}) during "
+                        "bootstrap: ({})."
+                    ).format(share.name, e.__str__())
                     logger.error(e_msg)
                     logger.exception(e)
 
                 try:
                     import_snapshots(share)
                 except Exception as e:
-                    e_msg = ('Exception while importing snapshots of share '
-                             '({}): ({}).').format(share.name, e.__str__())
+                    e_msg = (
+                        "Exception while importing snapshots of share " "({}): ({})."
+                    ).format(share.name, e.__str__())
                     logger.error(e_msg)
                     logger.exception(e)
 
             for snap in Snapshot.objects.all():
-                if (snap.uvisible):
+                if snap.uvisible:
                     try:
                         mount_snap(snap.share, snap.real_name, snap.qgroup)
                     except Exception as e:
-                        e_msg = ('Failed to make the snapshot ({}) visible. '
-                                 'Exception: ({}).').format(snap.real_name,
-                                                            e.__str__())
+                        e_msg = (
+                            "Failed to make the snapshot ({}) visible. "
+                            "Exception: ({})."
+                        ).format(snap.real_name, e.__str__())
                         logger.error(e_msg)
 
             mnt_map = sftp_mount_map(settings.SFTP_MNT_ROOT)
@@ -162,75 +194,86 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 # The following may be buggy when used with system mounted (fstab) /home
                 # but we currently don't allow /home to be exported.
                 try:
-                    sftp_mount(sftpo.share, settings.MNT_PT,
-                               settings.SFTP_MNT_ROOT, mnt_map, sftpo.editable)
+                    sftp_mount(
+                        sftpo.share,
+                        settings.MNT_PT,
+                        settings.SFTP_MNT_ROOT,
+                        mnt_map,
+                        sftpo.editable,
+                    )
                     sftp_snap_toggle(sftpo.share)
                 except Exception as e:
-                    e_msg = ('Exception while exporting a SFTP share during '
-                             'bootstrap: ({}).').format(e.__str__())
+                    e_msg = (
+                        "Exception while exporting a SFTP share during "
+                        "bootstrap: ({})."
+                    ).format(e.__str__())
                     logger.error(e_msg)
 
             try:
-                adv_entries = [a.export_str for a in
-                               AdvancedNFSExport.objects.all()]
-                exports_d = self.create_adv_nfs_export_input(adv_entries,
-                                                             request)
+                adv_entries = [a.export_str for a in AdvancedNFSExport.objects.all()]
+                exports_d = self.create_adv_nfs_export_input(adv_entries, request)
                 exports = self.create_nfs_export_input(NFSExport.objects.all())
                 exports.update(exports_d)
                 self.refresh_wrapper(exports, request, logger)
             except Exception as e:
-                e_msg = ('Exception while bootstrapping NFS: '
-                         '({}).').format(e.__str__())
+                e_msg = ("Exception while bootstrapping NFS: " "({}).").format(
+                    e.__str__()
+                )
                 logger.error(e_msg)
 
             #  bootstrap services
             try:
-                systemctl('firewalld', 'stop')
-                systemctl('firewalld', 'disable')
-                systemctl('nginx', 'stop')
-                systemctl('nginx', 'disable')
-                systemctl('atd', 'enable')
-                systemctl('atd', 'start')
+                systemctl("firewalld", "stop")
+                systemctl("firewalld", "disable")
+                systemctl("nginx", "stop")
+                systemctl("nginx", "disable")
+                systemctl("atd", "enable")
+                systemctl("atd", "start")
             except Exception as e:
-                e_msg = ('Exception while setting service statuses during '
-                         'bootstrap: ({}).').format(e.__str__())
+                e_msg = (
+                    "Exception while setting service statuses during "
+                    "bootstrap: ({})."
+                ).format(e.__str__())
                 logger.error(e_msg)
                 handle_exception(Exception(e_msg), request)
 
-            logger.debug('Bootstrap operations completed')
+            logger.debug("Bootstrap operations completed")
             return Response()
 
-        if (command == 'utcnow'):
+        if command == "utcnow":
             return Response(datetime.utcnow().replace(tzinfo=utc))
 
-        if (command == 'uptime'):
+        if command == "uptime":
             return Response(uptime())
 
-        if (command == 'kernel'):
+        if command == "kernel":
             try:
                 return Response(kernel_info(settings.SUPPORTED_KERNEL_VERSION))
             except Exception as e:
                 handle_exception(e, request)
 
-        if (command == 'update-check'):
+        if command == "update-check":
             try:
                 subo = None
                 try:
-                    subo = UpdateSubscription.objects.get(name='Stable',
-                                                          status='active')
+                    subo = UpdateSubscription.objects.get(
+                        name="Stable", status="active"
+                    )
                 except UpdateSubscription.DoesNotExist:
                     try:
-                        subo = UpdateSubscription.objects.get(name='Testing',
-                                                              status='active')
+                        subo = UpdateSubscription.objects.get(
+                            name="Testing", status="active"
+                        )
                     except UpdateSubscription.DoesNotExist:
                         pass
                 return Response(rockstor_pkg_update_check(subscription=subo))
             except Exception as e:
-                e_msg = ('Unable to check update due to a system error: '
-                         '({}).').format(e.__str__())
+                e_msg = (
+                    "Unable to check update due to a system error: " "({})."
+                ).format(e.__str__())
                 handle_exception(Exception(e_msg), request)
 
-        if (command == 'update'):
+        if command == "update":
             try:
                 # Once again, like on system shutdown/reboot, we filter
                 # incoming requests with request.auth: every update from
@@ -241,18 +284,20 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                     update_run()
                 else:
                     update_run(update_all_other=True)
-                return Response('Done')
+                return Response("Done")
             except Exception as e:
-                e_msg = ('Update failed due to this exception: '
-                         '({}).').format(e.__str__())
+                e_msg = ("Update failed due to this exception: " "({}).").format(
+                    e.__str__()
+                )
                 handle_exception(Exception(e_msg), request)
 
-        if (command == 'current-version'):
+        if command == "current-version":
             try:
                 return Response(current_version())
             except Exception as e:
-                e_msg = ('Unable to check current version due to this '
-                         'exception: ({}).').format(e.__str__())
+                e_msg = (
+                    "Unable to check current version due to this " "exception: ({})."
+                ).format(e.__str__())
                 handle_exception(Exception(e_msg), request)
 
         # default has shutdown and reboot with delay set to now
@@ -261,12 +306,12 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
         # while same requests over rest api (ex. scheduled tasks) have
         # an auth token, so if we detect a token we delay with 3 mins
         # to grant connected WebUI user to close it or cancel shutdown/reboot
-        delay = 'now'
+        delay = "now"
         if request.auth is not None:
             delay = 3
 
-        if (command == 'shutdown'):
-            msg = 'The system will now be shutdown.'
+        if command == "shutdown":
+            msg = "The system will now be shutdown."
             try:
                 # if shutdown request coming from a scheduled task
                 # with rtc wake up time on we set it before
@@ -276,81 +321,86 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 request.session.flush()
                 system_shutdown(delay)
             except Exception as e:
-                msg = ('Failed to shutdown the system due to a low level '
-                       'error: ({}).').format(e.__str__())
+                msg = (
+                    "Failed to shutdown the system due to a low level " "error: ({})."
+                ).format(e.__str__())
                 handle_exception(Exception(msg), request)
             finally:
                 return Response(msg)
 
-        if (command == 'reboot'):
-            msg = 'The system will now reboot.'
+        if command == "reboot":
+            msg = "The system will now reboot."
             try:
                 request.session.flush()
                 system_reboot(delay)
             except Exception as e:
-                msg = ('Failed to reboot the system due to a low level '
-                       'error: ({}).').format(e.__str__())
+                msg = (
+                    "Failed to reboot the system due to a low level " "error: ({})."
+                ).format(e.__str__())
                 handle_exception(Exception(msg), request)
             finally:
                 return Response(msg)
 
-        if (command == 'suspend'):
-            msg = 'The system will now be suspended to RAM.'
+        if command == "suspend":
+            msg = "The system will now be suspended to RAM."
             try:
                 request.session.flush()
                 set_system_rtc_wake(rtcepoch)
                 system_suspend()
             except Exception as e:
-                msg = ('Failed to suspend the system due to a low level '
-                       'error: ({}).').format(e.__str__())
+                msg = (
+                    "Failed to suspend the system due to a low level " "error: ({})."
+                ).format(e.__str__())
                 handle_exception(Exception(msg), request)
             finally:
                 return Response(msg)
 
-        if (command == 'current-user'):
+        if command == "current-user":
             return Response(request.user.username)
 
-        if (command == 'auto-update-status'):
+        if command == "auto-update-status":
             status = True
             try:
                 status = auto_update_status()
             except:
                 status = False
             finally:
-                return Response({'enabled': status, })
+                return Response({"enabled": status})
 
-        if (command == 'enable-auto-update'):
+        if command == "enable-auto-update":
             try:
                 auto_update(enable=True)
-                return Response({'enabled': True, })
+                return Response({"enabled": True})
             except Exception as e:
-                msg = ('Failed to enable auto update due to this exception: '
-                       '({}).').format(e.__str__())
+                msg = (
+                    "Failed to enable auto update due to this exception: " "({})."
+                ).format(e.__str__())
                 handle_exception(Exception(msg), request)
 
-        if (command == 'disable-auto-update'):
+        if command == "disable-auto-update":
             try:
                 auto_update(enable=False)
-                return Response({'enabled': False, })
+                return Response({"enabled": False})
             except Exception as e:
-                msg = ('Failed to disable auto update due to this exception:  '
-                       '({}).').format(e.__str__())
+                msg = (
+                    "Failed to disable auto update due to this exception:  " "({})."
+                ).format(e.__str__())
                 handle_exception(Exception(msg), request)
 
-        if (command == 'refresh-disk-state'):
+        if command == "refresh-disk-state":
             self._update_disk_state()
             return Response()
 
-        if (command == 'refresh-pool-state'):
+        if command == "refresh-pool-state":
             self._refresh_pool_state()
             return Response()
 
-        if (command == 'refresh-share-state'):
+        if command == "refresh-share-state":
             for p in Pool.objects.all():
                 import_shares(p, request)
             return Response()
 
-        if (command == 'refresh-snapshot-state'):
+        if command == "refresh-snapshot-state":
             for share in Share.objects.all():
                 import_snapshots(share)
             return Response()

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -91,7 +91,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 p.uuid = pool_info.uuid
                 p.save()
                 mount_root(p)
-                p.raid = pool_raid('%s%s' % (settings.MNT_PT, p.name))['data']
+                p.raid = pool_raid(p.mnt_pt)['data']
                 p.size = p.usage_bound()
                 # Consider using mount_status() parse to update root pool db on
                 # active (fstab initiated) compression setting.
@@ -159,6 +159,8 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
             mnt_map = sftp_mount_map(settings.SFTP_MNT_ROOT)
             for sftpo in SFTP.objects.all():
+                # The following may be buggy when used with system mounted (fstab) /home
+                # but we currently don't allow /home to be exported.
                 try:
                     sftp_mount(sftpo.share, settings.MNT_PT,
                                settings.SFTP_MNT_ROOT, mnt_map, sftpo.editable)

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -19,12 +19,21 @@ import re
 from datetime import datetime
 from django.utils.timezone import utc
 from django.conf import settings
-from storageadmin.models import (Share, Snapshot, SFTP)
+from storageadmin.models import Share, Snapshot, SFTP
 from smart_manager.models import ShareUsage
-from fs.btrfs import (mount_share, mount_snap, is_mounted,
-                      umount_root, shares_info, volume_usage, snaps_info,
-                      qgroup_create, update_quota, share_pqgroup_assign,
-                      qgroup_assign)
+from fs.btrfs import (
+    mount_share,
+    mount_snap,
+    is_mounted,
+    umount_root,
+    shares_info,
+    volume_usage,
+    snaps_info,
+    qgroup_create,
+    update_quota,
+    share_pqgroup_assign,
+    qgroup_assign,
+)
 from storageadmin.util import handle_exception
 from copy import deepcopy
 
@@ -36,13 +45,13 @@ NEW_ENTRY = True
 UPDATE_TS = False
 # The following model/db default setting is also used when quotas are disabled
 # or when a Read-only state prevents creation of a new pqgroup.
-PQGROUP_DEFAULT = settings.MODEL_DEFS['pqgroup']
+PQGROUP_DEFAULT = settings.MODEL_DEFS["pqgroup"]
 
 
 def helper_mount_share(share, mnt_pt=None):
     if not share.is_mounted:
         if mnt_pt is None:
-            mnt_pt = ('{}{}'.format(settings.MNT_PT, share.name))
+            mnt_pt = "{}{}".format(settings.MNT_PT, share.name)
         mount_share(share, mnt_pt)
 
 
@@ -50,29 +59,30 @@ def validate_share(sname, request):
     try:
         return Share.objects.get(name=sname)
     except:
-        e_msg = 'Share with name ({}) does not exist.'.format(sname)
+        e_msg = "Share with name ({}) does not exist.".format(sname)
         handle_exception(Exception(e_msg), request)
 
 
 def sftp_snap_toggle(share, mount=True):
     for snap in Snapshot.objects.filter(share=share, uvisible=True):
-        mnt_pt = ('{}/{}/{}/.{}'.format(settings.SFTP_MNT_ROOT,
-                                    share.owner, share.name,
-                                    snap.name))
-        if (mount and not is_mounted(mnt_pt)):
+        mnt_pt = "{}/{}/{}/.{}".format(
+            settings.SFTP_MNT_ROOT, share.owner, share.name, snap.name
+        )
+        if mount and not is_mounted(mnt_pt):
             mount_snap(share, snap.name, snap.qgroup, mnt_pt)
-        elif (is_mounted(mnt_pt) and not mount):
+        elif is_mounted(mnt_pt) and not mount:
             umount_root(mnt_pt)
 
 
 def toggle_sftp_visibility(share, snap_name, snap_qgroup, on=True):
-    if (not SFTP.objects.filter(share=share).exists()):
+    if not SFTP.objects.filter(share=share).exists():
         return
 
-    mnt_pt = ('{}/{}/{}/.{}'.format(settings.SFTP_MNT_ROOT, share.owner,
-                                share.name, snap_name))
-    if (on):
-        if (not is_mounted(mnt_pt)):
+    mnt_pt = "{}/{}/{}/.{}".format(
+        settings.SFTP_MNT_ROOT, share.owner, share.name, snap_name
+    )
+    if on:
+        if not is_mounted(mnt_pt):
             mount_snap(share, snap_name, snap_qgroup, mnt_pt)
     else:
         umount_root(mnt_pt)
@@ -91,14 +101,16 @@ def import_shares(pool, request):
     # Delete db Share object if it is no longer found on disk.
     for s_in_pool_db in shares_in_pool_db:
         if s_in_pool_db not in shares_in_pool:
-            logger.debug('Removing, missing on disk, share db entry ({}) from '
-                         'pool ({}).'.format(s_in_pool_db, pool.name))
+            logger.debug(
+                "Removing, missing on disk, share db entry ({}) from "
+                "pool ({}).".format(s_in_pool_db, pool.name)
+            )
             Share.objects.get(pool=pool, name=s_in_pool_db).delete()
     # Check if each share in pool also has a db counterpart.
     for s_in_pool in shares_in_pool:
-        logger.debug('---- Share name = {}.'.format(s_in_pool))
+        logger.debug("---- Share name = {}.".format(s_in_pool))
         if s_in_pool in shares_in_pool_db:
-            logger.debug('Updating pre-existing same pool db share entry.')
+            logger.debug("Updating pre-existing same pool db share entry.")
             # We have a pool db share counterpart so retrieve and update it.
             share = Share.objects.get(name=s_in_pool, pool=pool)
             # Initially default our pqgroup value to db default of '-1/-1'
@@ -107,12 +119,16 @@ def import_shares(pool, request):
             pqgroup = PQGROUP_DEFAULT
             if share.pool.quotas_enabled:
                 # Quotas are enabled on our pool so we can validate pqgroup.
-                if share.pqgroup == pqgroup or not share.pqgroup_exist \
-                        or share.pqgroup in share_pqgroups_used:
+                if (
+                    share.pqgroup == pqgroup
+                    or not share.pqgroup_exist
+                    or share.pqgroup in share_pqgroups_used
+                ):
                     # we have a void '-1/-1' or non existent pqgroup or
                     # this pqgroup has already been seen / used in this pool.
-                    logger.debug('#### replacing void, non-existent, or '
-                                 'duplicate pqgroup.')
+                    logger.debug(
+                        "#### replacing void, non-existent, or " "duplicate pqgroup."
+                    )
                     pqgroup = qgroup_create(pool)
                     if pqgroup != PQGROUP_DEFAULT:
                         update_quota(pool, pqgroup, share.size * 1024)
@@ -127,11 +143,15 @@ def import_shares(pool, request):
                 share.pqgroup = pqgroup
                 share.save()
             share.qgroup = shares_in_pool[s_in_pool]
-            rusage, eusage, pqgroup_rusage, pqgroup_eusage = \
-                volume_usage(pool, share.qgroup, pqgroup)
-            if (rusage != share.rusage or eusage != share.eusage or
-               pqgroup_rusage != share.pqgroup_rusage or
-               pqgroup_eusage != share.pqgroup_eusage):
+            rusage, eusage, pqgroup_rusage, pqgroup_eusage = volume_usage(
+                pool, share.qgroup, pqgroup
+            )
+            if (
+                rusage != share.rusage
+                or eusage != share.eusage
+                or pqgroup_rusage != share.pqgroup_rusage
+                or pqgroup_eusage != share.pqgroup_eusage
+            ):
                 share.rusage = rusage
                 share.eusage = eusage
                 share.pqgroup_rusage = pqgroup_rusage
@@ -142,86 +162,110 @@ def import_shares(pool, request):
             share.save()
             continue
         try:
-            logger.debug('No prior entries in scanned pool trying all pools.')
+            logger.debug("No prior entries in scanned pool trying all pools.")
             # Test (Try) for an existing system wide Share db entry.
             cshare = Share.objects.get(name=s_in_pool)
             # Get a list of Rockstor relevant subvols (ie shares and clones)
             # for the prior existing db share entry's pool.
             cshares_d = shares_info(cshare.pool)
             if s_in_pool in cshares_d:
-                e_msg = ('Another pool ({}) has a share with this same '
-                         'name ({}) as this pool ({}). This configuration '
-                         'is not supported. You can delete one of them '
-                         'manually with the following command: '
-                         '"btrfs subvol delete {}[pool name]/{}" WARNING this '
-                         'will remove the entire contents of that '
-                         'subvolume.').format(cshare.pool.name, s_in_pool,
-                                              pool.name, settings.MNT_PT,
-                                              s_in_pool)
+                e_msg = (
+                    "Another pool ({}) has a share with this same "
+                    "name ({}) as this pool ({}). This configuration "
+                    "is not supported. You can delete one of them "
+                    "manually with the following command: "
+                    '"btrfs subvol delete {}[pool name]/{}" WARNING this '
+                    "will remove the entire contents of that "
+                    "subvolume."
+                ).format(
+                    cshare.pool.name, s_in_pool, pool.name, settings.MNT_PT, s_in_pool
+                )
                 handle_exception(Exception(e_msg), request)
             else:
                 # Update the prior existing db share entry previously
                 # associated with another pool.
-                logger.debug('Updating prior db entry from another pool.')
+                logger.debug("Updating prior db entry from another pool.")
                 cshare.pool = pool
                 cshare.qgroup = shares_in_pool[s_in_pool]
                 cshare.size = pool.size
                 cshare.subvol_name = s_in_pool
-                (cshare.rusage, cshare.eusage, cshare.pqgroup_rusage,
-                 cshare.pqgroup_eusage) = volume_usage(pool, cshare.qgroup,
-                                                       cshare.pqgroup)
+                (
+                    cshare.rusage,
+                    cshare.eusage,
+                    cshare.pqgroup_rusage,
+                    cshare.pqgroup_eusage,
+                ) = volume_usage(pool, cshare.qgroup, cshare.pqgroup)
                 cshare.save()
                 update_shareusage_db(s_in_pool, cshare.rusage, cshare.eusage)
         except Share.DoesNotExist:
-            logger.debug('Db share entry does not exist - creating.')
+            logger.debug("Db share entry does not exist - creating.")
             # We have a share on disk that has no db counterpart so create one.
             # Retrieve new pool quota id for use in db Share object creation.
             # As the replication receive share is 'special' we tag it as such.
             replica = False
             share_name = s_in_pool
-            if re.match('.snapshot', s_in_pool) is not None:
+            if re.match(".snapshot", s_in_pool) is not None:
                 # We have an initial replication share, non snap in .snapshots.
                 # We could change it's name here but still a little mixing
                 # of name and subvol throughout project.
                 replica = True
-                logger.debug('Initial receive quirk-subvol found: Importing '
-                             'as share and setting replica flag.')
+                logger.debug(
+                    "Initial receive quirk-subvol found: Importing "
+                    "as share and setting replica flag."
+                )
             qid = shares_in_pool[s_in_pool]
             pqid = qgroup_create(pool)
             if pqid != PQGROUP_DEFAULT:
                 update_quota(pool, pqid, pool.size * 1024)
                 qgroup_assign(qid, pqid, pool.mnt_pt)
-            rusage, eusage, pqgroup_rusage, pqgroup_eusage = \
-                volume_usage(pool, qid, pqid)
-            nso = Share(pool=pool, qgroup=qid, pqgroup=pqid, name=share_name,
-                        size=pool.size, subvol_name=s_in_pool, rusage=rusage,
-                        eusage=eusage, pqgroup_rusage=pqgroup_rusage,
-                        pqgroup_eusage=pqgroup_eusage,
-                        replica=replica)
+            rusage, eusage, pqgroup_rusage, pqgroup_eusage = volume_usage(
+                pool, qid, pqid
+            )
+            nso = Share(
+                pool=pool,
+                qgroup=qid,
+                pqgroup=pqid,
+                name=share_name,
+                size=pool.size,
+                subvol_name=s_in_pool,
+                rusage=rusage,
+                eusage=eusage,
+                pqgroup_rusage=pqgroup_rusage,
+                pqgroup_eusage=pqgroup_eusage,
+                replica=replica,
+            )
             nso.save()
             update_shareusage_db(s_in_pool, rusage, eusage)
-            mount_share(nso, '{}{}'.format(settings.MNT_PT, s_in_pool))
+            mount_share(nso, "{}{}".format(settings.MNT_PT, s_in_pool))
 
 
 def import_snapshots(share):
-    snaps_d = snaps_info(share.pool.mnt_pt,
-                         share.name)
+    snaps_d = snaps_info(share.pool.mnt_pt, share.name)
     snaps = [s.name for s in Snapshot.objects.filter(share=share)]
     for s in snaps:
-        if (s not in snaps_d):
-            logger.debug('Removing, missing on disk, snapshot db entry ({}) '
-                         'from share ({}).'.format(s, share.name))
+        if s not in snaps_d:
+            logger.debug(
+                "Removing, missing on disk, snapshot db entry ({}) "
+                "from share ({}).".format(s, share.name)
+            )
             Snapshot.objects.get(share=share, name=s).delete()
     for s in snaps_d:
-        if (s in snaps):
+        if s in snaps:
             so = Snapshot.objects.get(share=share, name=s)
         else:
-            logger.debug('Adding, missing in db, on disk snapshot ({}) '
-                         'against share ({}).'.format(s, share.name))
-            so = Snapshot(share=share, name=s, real_name=s,
-                          writable=snaps_d[s][1], qgroup=snaps_d[s][0])
+            logger.debug(
+                "Adding, missing in db, on disk snapshot ({}) "
+                "against share ({}).".format(s, share.name)
+            )
+            so = Snapshot(
+                share=share,
+                name=s,
+                real_name=s,
+                writable=snaps_d[s][1],
+                qgroup=snaps_d[s][0],
+            )
         rusage, eusage = volume_usage(share.pool, snaps_d[s][0])
-        if (rusage != so.rusage or eusage != so.eusage):
+        if rusage != so.rusage or eusage != so.eusage:
             so.rusage = rusage
             so.eusage = eusage
             update_shareusage_db(s, rusage, eusage)
@@ -243,16 +287,14 @@ def update_shareusage_db(subvol_name, rusage, eusage, new_entry=True):
     """
     ts = datetime.utcnow().replace(tzinfo=utc)
     if new_entry:
-        su = ShareUsage(name=subvol_name, r_usage=rusage, e_usage=eusage,
-                        ts=ts)
+        su = ShareUsage(name=subvol_name, r_usage=rusage, e_usage=eusage, ts=ts)
         su.save()
     else:
         try:
-            su = ShareUsage.objects.filter(name=subvol_name).latest('id')
+            su = ShareUsage.objects.filter(name=subvol_name).latest("id")
             su.ts = ts
             su.count += 1
         except ShareUsage.DoesNotExist:
-            su = ShareUsage(name=subvol_name, r_usage=rusage, e_usage=eusage,
-                            ts=ts)
+            su = ShareUsage(name=subvol_name, r_usage=rusage, e_usage=eusage, ts=ts)
         finally:
             su.save()

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -190,8 +190,7 @@ def import_shares(pool, request):
             pqid = qgroup_create(pool)
             if pqid != PQGROUP_DEFAULT:
                 update_quota(pool, pqid, pool.size * 1024)
-                pool_mnt_pt = '{}{}'.format(settings.MNT_PT, pool.name)
-                qgroup_assign(qid, pqid, pool_mnt_pt)
+                qgroup_assign(qid, pqid, pool.mnt_pt)
             rusage, eusage, pqgroup_rusage, pqgroup_eusage = \
                 volume_usage(pool, qid, pqid)
             nso = Share(pool=pool, qgroup=qid, pqgroup=pqid, name=share_name,
@@ -205,7 +204,7 @@ def import_shares(pool, request):
 
 
 def import_snapshots(share):
-    snaps_d = snaps_info('%s%s' % (settings.MNT_PT, share.pool.name),
+    snaps_d = snaps_info(share.pool.mnt_pt,
                          share.name)
     snaps = [s.name for s in Snapshot.objects.filter(share=share)]
     for s in snaps:

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -42,7 +42,7 @@ PQGROUP_DEFAULT = settings.MODEL_DEFS['pqgroup']
 def helper_mount_share(share, mnt_pt=None):
     if not share.is_mounted:
         if mnt_pt is None:
-            mnt_pt = ('%s%s' % (settings.MNT_PT, share.name))
+            mnt_pt = ('{}{}'.format(settings.MNT_PT, share.name))
         mount_share(share, mnt_pt)
 
 
@@ -56,7 +56,7 @@ def validate_share(sname, request):
 
 def sftp_snap_toggle(share, mount=True):
     for snap in Snapshot.objects.filter(share=share, uvisible=True):
-        mnt_pt = ('%s/%s/%s/.%s' % (settings.SFTP_MNT_ROOT,
+        mnt_pt = ('{}/{}/{}/.{}'.format(settings.SFTP_MNT_ROOT,
                                     share.owner, share.name,
                                     snap.name))
         if (mount and not is_mounted(mnt_pt)):
@@ -69,7 +69,7 @@ def toggle_sftp_visibility(share, snap_name, snap_qgroup, on=True):
     if (not SFTP.objects.filter(share=share).exists()):
         return
 
-    mnt_pt = ('%s/%s/%s/.%s' % (settings.SFTP_MNT_ROOT, share.owner,
+    mnt_pt = ('{}/{}/{}/.{}'.format(settings.SFTP_MNT_ROOT, share.owner,
                                 share.name, snap_name))
     if (on):
         if (not is_mounted(mnt_pt)):
@@ -200,7 +200,7 @@ def import_shares(pool, request):
                         replica=replica)
             nso.save()
             update_shareusage_db(s_in_pool, rusage, eusage)
-            mount_share(nso, '%s%s' % (settings.MNT_PT, s_in_pool))
+            mount_share(nso, '{}{}'.format(settings.MNT_PT, s_in_pool))
 
 
 def import_snapshots(share):

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -19,10 +19,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from rest_framework.response import Response
 from django.db import transaction
 from django.conf import settings
-from storageadmin.models import (Snapshot, Share, NFSExport,
-                                 NFSExportGroup, AdvancedNFSExport)
-from fs.btrfs import (add_snap, share_id, volume_usage, remove_snap,
-                      umount_root, mount_snap, qgroup_assign)
+from storageadmin.models import (
+    Snapshot,
+    Share,
+    NFSExport,
+    NFSExportGroup,
+    AdvancedNFSExport,
+)
+from fs.btrfs import (
+    add_snap,
+    share_id,
+    volume_usage,
+    remove_snap,
+    umount_root,
+    mount_snap,
+    qgroup_assign,
+)
 from system.osi import refresh_nfs_exports
 from storageadmin.serializers import SnapshotSerializer
 from storageadmin.util import handle_exception
@@ -32,6 +44,7 @@ from clone_helpers import create_clone, create_repclone
 from nfs_exports import NFSExportMixin
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,48 +54,50 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
     def get_queryset(self, *args, **kwargs):
         with self._handle_exception(self.request):
             try:
-                share = Share.objects.get(id=self.kwargs['sid'])
+                share = Share.objects.get(id=self.kwargs["sid"])
             except:
-                if ('sid' not in self.kwargs):
-                    return Snapshot.objects.filter().order_by('-id')
+                if "sid" not in self.kwargs:
+                    return Snapshot.objects.filter().order_by("-id")
 
-                e_msg = ('Share id ({}) does '
-                         'not exist.').format(self.kwargs['sid'])
+                e_msg = ("Share id ({}) does " "not exist.").format(self.kwargs["sid"])
                 handle_exception(Exception(e_msg), self.request)
 
-            if ('snap_name' in self.kwargs):
+            if "snap_name" in self.kwargs:
                 self.paginate_by = 0
                 try:
-                    return Snapshot.objects.get(share=share,
-                                                name=self.kwargs['snap_name'])
+                    return Snapshot.objects.get(
+                        share=share, name=self.kwargs["snap_name"]
+                    )
                 except:
                     return []
 
-            snap_type = self.request.query_params.get('snap_type', None)
-            if (snap_type is not None and snap_type != ''):
+            snap_type = self.request.query_params.get("snap_type", None)
+            if snap_type is not None and snap_type != "":
                 return Snapshot.objects.filter(
-                    share=share, snap_type=snap_type).order_by('-id')
+                    share=share, snap_type=snap_type
+                ).order_by("-id")
 
-            return Snapshot.objects.filter(share=share).order_by('-id')
+            return Snapshot.objects.filter(share=share).order_by("-id")
 
     @transaction.atomic
     def _toggle_visibility(self, share, snap_name, snap_qgroup, on=True):
         cur_exports = list(NFSExport.objects.all())
         # The following may be buggy when used with system mounted (fstab) /home
         # but we currently don't allow /home to be exported.
-        snap_mnt_pt = ('{}{}/.{}'.format(settings.MNT_PT, share.name, snap_name))
-        export_pt = snap_mnt_pt.replace(settings.MNT_PT,
-                                        settings.NFS_EXPORT_ROOT)
-        if (on):
+        snap_mnt_pt = "{}{}/.{}".format(settings.MNT_PT, share.name, snap_name)
+        export_pt = snap_mnt_pt.replace(settings.MNT_PT, settings.NFS_EXPORT_ROOT)
+        if on:
             mount_snap(share, snap_name, snap_qgroup)
 
-            if (NFSExport.objects.filter(share=share).exists()):
+            if NFSExport.objects.filter(share=share).exists():
                 se = NFSExport.objects.filter(share=share)[0]
                 export_group = NFSExportGroup(
-                    host_str=se.export_group.host_str, nohide=True)
+                    host_str=se.export_group.host_str, nohide=True
+                )
                 export_group.save()
-                export = NFSExport(share=share, export_group=export_group,
-                                   mount=export_pt)
+                export = NFSExport(
+                    share=share, export_group=export_group, mount=export_pt
+                )
                 export.full_clean()
                 export.save()
                 cur_exports.append(export)
@@ -107,28 +122,34 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         refresh_nfs_exports(exports)
 
     @transaction.atomic
-    def _create(self, share, snap_name, request, uvisible,
-                snap_type, writable):
-        if (Snapshot.objects.filter(share=share, name=snap_name).exists()):
+    def _create(self, share, snap_name, request, uvisible, snap_type, writable):
+        if Snapshot.objects.filter(share=share, name=snap_name).exists():
             # Note e_msg is consumed by replication/util.py create_snapshot()
-            e_msg = ('Snapshot ({}) already exists for '
-                     'the share ({}).').format(snap_name, share.name)
+            e_msg = ("Snapshot ({}) already exists for " "the share ({}).").format(
+                snap_name, share.name
+            )
             handle_exception(Exception(e_msg), request)
 
         snap_size = 0
-        qgroup_id = '0/na'
-        if (snap_type == 'replication'):
+        qgroup_id = "0/na"
+        if snap_type == "replication":
             writable = False
         add_snap(share, snap_name, writable)
         snap_id = share_id(share.pool, snap_name)
-        qgroup_id = ('0/{}'.format(snap_id))
-        if share.pqgroup != settings.MODEL_DEFS['pqgroup']:
+        qgroup_id = "0/{}".format(snap_id)
+        if share.pqgroup != settings.MODEL_DEFS["pqgroup"]:
             qgroup_assign(qgroup_id, share.pqgroup, share.pool.mnt_pt)
         snap_size, eusage = volume_usage(share.pool, qgroup_id)
-        s = Snapshot(share=share, name=snap_name, real_name=snap_name,
-                     size=snap_size, qgroup=qgroup_id,
-                     uvisible=uvisible, snap_type=snap_type,
-                     writable=writable)
+        s = Snapshot(
+            share=share,
+            name=snap_name,
+            real_name=snap_name,
+            size=snap_size,
+            qgroup=qgroup_id,
+            uvisible=uvisible,
+            snap_type=snap_type,
+            writable=writable,
+        )
         # The following share.save() was informed by test_snapshot.py
         share.save()
         s.save()
@@ -137,52 +158,62 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
     def post(self, request, sid, snap_name, command=None):
         with self._handle_exception(request):
             share = self._validate_share(sid, request)
-            uvisible = request.data.get('uvisible', False)
-            if (type(uvisible) != bool):
+            uvisible = request.data.get("uvisible", False)
+            if type(uvisible) != bool:
                 # N.B. quote type important - test string involves ('unicode')
-                e_msg = ("Element 'uvisible' must be a boolean, "
-                         "not ({}).").format(type(uvisible))
+                e_msg = ("Element 'uvisible' must be a boolean, " "not ({}).").format(
+                    type(uvisible)
+                )
                 handle_exception(Exception(e_msg), request)
 
-            snap_type = request.data.get('snap_type', 'admin')
-            writable = request.data.get('writable', False)
-            if (type(writable) != bool):
-                e_msg = ('Element "writable" must be a boolean, '
-                         'not ({}).').format(type(writable))
+            snap_type = request.data.get("snap_type", "admin")
+            writable = request.data.get("writable", False)
+            if type(writable) != bool:
+                e_msg = ('Element "writable" must be a boolean, ' "not ({}).").format(
+                    type(writable)
+                )
                 handle_exception(Exception(e_msg), request)
-            if (command is None):
-                ret = self._create(share, snap_name, request,
-                                   uvisible=uvisible, snap_type=snap_type,
-                                   writable=writable)
+            if command is None:
+                ret = self._create(
+                    share,
+                    snap_name,
+                    request,
+                    uvisible=uvisible,
+                    snap_type=snap_type,
+                    writable=writable,
+                )
 
-                if (uvisible):
+                if uvisible:
                     try:
-                        self._toggle_visibility(share, ret.data['real_name'],
-                                                ret.data['qgroup'])
+                        self._toggle_visibility(
+                            share, ret.data["real_name"], ret.data["qgroup"]
+                        )
                     except Exception as e:
-                        msg = ('Failed to make the snapshot ({}) visible. '
-                               'Exception: ({}).').format(snap_name,
-                                                          e.__str__())
+                        msg = (
+                            "Failed to make the snapshot ({}) visible. "
+                            "Exception: ({})."
+                        ).format(snap_name, e.__str__())
                         logger.error(msg)
                         logger.exception(e)
 
                     try:
-                        toggle_sftp_visibility(share, ret.data['real_name'],
-                                               ret.data['qgroup'])
+                        toggle_sftp_visibility(
+                            share, ret.data["real_name"], ret.data["qgroup"]
+                        )
                     except Exception as e:
-                        msg = ('Failed to make the snapshot ({}) visible for '
-                               'SFTP. Exception: ({}).').format(snap_name,
-                                                                e.__str__())
+                        msg = (
+                            "Failed to make the snapshot ({}) visible for "
+                            "SFTP. Exception: ({})."
+                        ).format(snap_name, e.__str__())
                         logger.error(msg)
                         logger.exception(e)
 
                 return ret
-            if (command == 'clone'):
-                new_name = request.data.get('name', None)
+            if command == "clone":
+                new_name = request.data.get("name", None)
                 snapshot = Snapshot.objects.get(share=share, name=snap_name)
-                return create_clone(share, new_name, request, logger,
-                                    snapshot=snapshot)
-            if (command == 'repclone'):
+                return create_clone(share, new_name, request, logger, snapshot=snapshot)
+            if command == "repclone":
                 # When repclone is first called the oldest snapshot is
                 # actually a share. This is an artifact of import_shares()
                 # identifying the first snapshot incorrectly as a share.
@@ -194,20 +225,17 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
                 # TODO: Note: this snap as share quirk is temporary as once a
                 # TODO: replication cycle has completed it is removed.
                 try:
-                    snapshot = Snapshot.objects.get(share=share,
-                                                    name=snap_name)
+                    snapshot = Snapshot.objects.get(share=share, name=snap_name)
                 except Snapshot.DoesNotExist:
                     # Here we rely on the polymorphism of Share/Snap and that
                     # this quirky share is located as per regular snapshots.
                     # The subvol of our snap-as-share-quirk is as per a snap:
                     # ".snapshots/sharename/snapname"
-                    quirk_snap_share = '.snapshots/{}/{}'.format(share.name,
-                                                                 snap_name)
-                    logger.debug('Fail through for snap-as-share-quirk')
+                    quirk_snap_share = ".snapshots/{}/{}".format(share.name, snap_name)
+                    logger.debug("Fail through for snap-as-share-quirk")
                     snapshot = Share.objects.get(subvol_name=quirk_snap_share)
-                return create_repclone(share, request, logger,
-                                       snapshot=snapshot)
-            e_msg = 'Unknown command: ({}).'.format(command)
+                return create_repclone(share, request, logger, snapshot=snapshot)
+            e_msg = "Unknown command: ({}).".format(command)
             handle_exception(Exception(e_msg), request)
 
     @staticmethod
@@ -215,7 +243,7 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         try:
             return Share.objects.get(id=sid)
         except:
-            e_msg = 'Share with id ({}) does not exist.'.format(sid)
+            e_msg = "Share with id ({}) does not exist.".format(sid)
             handle_exception(Exception(e_msg), request)
 
     @transaction.atomic
@@ -223,27 +251,27 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         share = self._validate_share(sid, request)
         try:
             snapshot = None
-            if (id is not None):
+            if id is not None:
                 snapshot = Snapshot.objects.get(id=id)
-            elif (snap_name is not None):
+            elif snap_name is not None:
                 snapshot = Snapshot.objects.get(share=share, name=snap_name)
             else:
                 return True
         except:
-            e_msg = ''
-            if (id is not None):
-                e_msg = 'Snapshot id ({}) does not exist.'.format(id)
+            e_msg = ""
+            if id is not None:
+                e_msg = "Snapshot id ({}) does not exist.".format(id)
             else:
                 # Note e_msg consumed by replication/util.py update_repclone()
                 # and delete_snapshot()
-                e_msg = 'Snapshot name ({}) does not exist.'.format(snap_name)
+                e_msg = "Snapshot name ({}) does not exist.".format(snap_name)
             handle_exception(Exception(e_msg), request)
 
-        if (snapshot.uvisible):
-            self._toggle_visibility(share, snapshot.real_name, snapshot.qgroup,
-                                    on=False)
-            toggle_sftp_visibility(share, snapshot.real_name, snapshot.qgroup,
-                                   on=False)
+        if snapshot.uvisible:
+            self._toggle_visibility(
+                share, snapshot.real_name, snapshot.qgroup, on=False
+            )
+            toggle_sftp_visibility(share, snapshot.real_name, snapshot.qgroup, on=False)
 
         remove_snap(share.pool, share.name, snapshot.name, snapshot.qgroup)
         snapshot.delete()
@@ -254,10 +282,10 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         deletes a snapshot
         """
         with self._handle_exception(request):
-            if (snap_name is None):
-                snap_qp = self.request.query_params.get('id', None)
-                if (snap_qp is not None):
-                    for si in snap_qp.split(','):
+            if snap_name is None:
+                snap_qp = self.request.query_params.get("id", None)
+                if snap_qp is not None:
+                    for si in snap_qp.split(","):
                         self._delete_snapshot(request, sid, id=si)
             else:
                 self._delete_snapshot(request, sid, snap_name=snap_name)

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -121,7 +121,7 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
             writable = False
         add_snap(share, snap_name, writable)
         snap_id = share_id(share.pool, snap_name)
-        qgroup_id = ('0/%s' % snap_id)
+        qgroup_id = ('0/{}'.format(snap_id))
         if share.pqgroup != settings.MODEL_DEFS['pqgroup']:
             qgroup_assign(qgroup_id, share.pqgroup, share.pool.mnt_pt)
         snap_size, eusage = volume_usage(share.pool, qgroup_id)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -903,6 +903,8 @@ def mount_status(mnt_pt, return_boolean=False):
     mount options, or 'unmounted' if no relevant /proc/mounts entry was found.
     """
     with open("/proc/mounts") as pfo:
+        # See in-developemnt test_mount_status() re the following line:
+        # for each_line in pfo.read().splitlines():
         for each_line in pfo.readlines():
             line_fields = each_line.split()
             if len(line_fields) < 4:

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -1685,3 +1685,80 @@ class OSITests(unittest.TestCase):
         returned = get_byid_name_map()
         self.maxDiff = None
         self.assertDictEqual(returned, expected)
+
+#     def test_mount_status(self):
+#         """
+#         Test mount_status with some real system data to assure expected output
+#         mount_status() parses cat /proc/mounts and is used primarily by the pool & share
+#         models.
+#         Test earmarked for post Python 3 move as some changes were made to how read call
+#         is interpreted in mock re readlines() and mock_open()
+#         https://docs.python.org/3/library/unittest.mock.html#mock-open
+#         """
+#         # Leap 15.2 boot-to-snap config with /@ pool mount
+#         proc_mount_out = """
+# sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+# proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+# devtmpfs /dev devtmpfs rw,nosuid,size=1261576k,nr_inodes=315394,mode=755 0 0
+# securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
+# tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
+# devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+# tmpfs /run tmpfs rw,nosuid,nodev,mode=755 0 0
+# tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
+# cgroup /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
+# cgroup /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0
+# pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
+# cgroup /sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0
+# cgroup /sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0
+# cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
+# cgroup /sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0
+# cgroup /sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0
+# cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
+# cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
+# cgroup /sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0
+# cgroup /sys/fs/cgroup/rdma cgroup rw,nosuid,nodev,noexec,relatime,rdma 0 0
+# cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
+# cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
+# /dev/vda3 / btrfs rw,relatime,space_cache,subvolid=456,subvol=/@/.snapshots/117/snapshot 0 0
+# systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=30,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=1843 0 0
+# debugfs /sys/kernel/debug debugfs rw,relatime 0 0
+# hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=2M 0 0
+# mqueue /dev/mqueue mqueue rw,relatime 0 0
+# /dev/vda3 /.snapshots btrfs rw,relatime,space_cache,subvolid=258,subvol=/@/.snapshots 0 0
+# /dev/vda3 /boot/grub2/i386-pc btrfs rw,relatime,space_cache,subvolid=267,subvol=/@/boot/grub2/i386-pc 0 0
+# /dev/vda3 /tmp btrfs rw,relatime,space_cache,subvolid=264,subvol=/@/tmp 0 0
+# /dev/vda3 /root btrfs rw,relatime,space_cache,subvolid=262,subvol=/@/root 0 0
+# /dev/vda3 /srv btrfs rw,relatime,space_cache,subvolid=263,subvol=/@/srv 0 0
+# /dev/vda3 /usr/local btrfs rw,relatime,space_cache,subvolid=266,subvol=/@/usr/local 0 0
+# /dev/vda3 /home btrfs rw,relatime,space_cache,subvolid=484,subvol=/@/home 0 0
+# /dev/vda3 /boot/grub2/x86_64-efi btrfs rw,relatime,space_cache,subvolid=268,subvol=/@/boot/grub2/x86_64-efi 0 0
+# /dev/vda3 /opt btrfs rw,relatime,space_cache,subvolid=261,subvol=/@/opt 0 0
+# /dev/vda3 /var btrfs rw,relatime,space_cache,subvolid=265,subvol=/@/var 0 0
+# /dev/vda2 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
+# tmpfs /run/user/0 tmpfs rw,nosuid,nodev,relatime,size=253996k,mode=700 0 0
+# /dev/vda3 /mnt2/ROOT btrfs rw,relatime,space_cache,subvolid=257,subvol=/@ 0 0
+# /dev/vda3 /mnt2/home btrfs rw,relatime,space_cache,subvolid=484,subvol=/@/home 0 0
+# /dev/vda3 /mnt2/sys-share btrfs rw,relatime,space_cache,subvolid=482,subvol=/@/sys-share 0 0
+# /dev/vda3 /mnt2/another-sys-share btrfs rw,relatime,space_cache,subvolid=485,subvol=/@/another-sys-share 0 0
+# /dev/vda3 /mnt2/another-sys-share/.another-sys-share-writable-visible btrfs rw,relatime,space_cache,subvolid=489,subvol=/@/.snapshots/another-sys-share/another-sys-share-writable-visible 0 0
+# /dev/vda3 /mnt2/another-sys-share/.another-sys-share-visible btrfs rw,relatime,space_cache,subvolid=488,subvol=/@/.snapshots/another-sys-share/another-sys-share-visible 0 0
+# tracefs /sys/kernel/debug/tracing tracefs rw,relatime 0 0
+# """
+#         expected = ["rw,relatime,space_cache,subvolid=484,subvol=/@/home",
+#                     "rw,relatime,space_cache,subvolid=482,subvol=/@/sys-share"]
+#         # Based on the following article:
+#         # https://nickolaskraus.org/articles/how-to-mock-the-built-in-function-open/
+#         # Python 3 has "builtins.open" note the "s"
+#         with mock.patch("__builtin__.open",
+#                         mock.mock_open(
+#                             read_data=proc_mount_out)) as mocked_open:
+#             returned = mount_status("/mnt2/sys-share")
+#             # The following shows that a handle.read().splitlines() works
+#             # ... but not handle.readlines() such as we use in mount_status()
+#             # But readlines() != splitlines() on break !!! readlines splits on \n only.
+#             # https://discuss.python.org/t/changing-str-splitlines-to-match-file-readlines/174
+#             # with open("foo") as test_open:
+#             #     for each_line in test_open.read().splitlines():
+#             #         print("each line = {}".format(each_line))
+#             mocked_open.assert_called_once_with("/proc/mounts")
+#         self.assertEqual(returned, expected[1])


### PR DESCRIPTION
As detailed in issue #2156, when running on an openSUSE boot to snapshot configuration, user created shares on the system pool (label ROOT) disappear on page refresh. The initial fix for this was addressed in this pull requests first commit:

### add observability clause for subvol of snapshot for boot to snap:
By refactoring our existing call to default_subvolid() and introducing an additional clause for subvols that we do surface to the Web-UI we fix the 'disappearing' system pool user share on page refresh and reduce the total number of calls to default_subvolid(). An additional btrfs unit
test was added for this additional clause based on real boot to snapshot data.

However, it was then discovered that snapshots of these shares and a collection of other btrfs related commands would fail with errors indicating that our overall pool access approach was inappropriate in a boot-to-shapshot configuration, ie 'is not a subvol' etc. On further exploration the solution was to address system pool related btrfs commands to the fstab initiated mount point "/" not our additional, and now redundant, mount of /mnt2/ROOT. This minor re-architecture of how we treat the system pool was addressed in the second commit of this pull request:

### add mount point instance variable/property to Pool & Share models:
Instantiating the mount point for Pool related operations at the Pool/Share model level allows for contextual treatment of the system pool which in turn facilitates the removal of the prior double mount of '/': once as '/' via fstab and again as /mnt2/ROOT. And given the latter was our prior mount point of pool related operations, where some btrfs commands fail on boot-to-snapshot configurations, we return full function, as per non boot-to-snapshot configs, by addressing all pool
related btrfs operations (ie some subvol and quota related calls) to the otherwise functional primary mount point (fstab managed) of '/'. Effectively fixing a host of boot-to-snapshot issues that arose re a subset of btrfs calls and removing the redundant, in the case of the system pool, /mnt2/ROOT mount point.

Note however that this does not alter how we treat non system pools. Also, how and where we mount user shares is also not affected by these changes as many other code areas are expecting rockstor managed subvol mounts to be located in /mnt2/share-name. Hence many existing subvol code paths are unchanged and remain 'hard wired'. It may be prudent in the future to further rationalise / centralise these subvol path calculations but for this issue the minimum changes were thought to be enacted to produce the result of full share/clone/snap functionality such as was previously seen on our now legacy CentOS base and within non boot-to-snapshot openSUSE configurations.

Further to the above 2 functional changes there are the last 2 commits:
- move to string.format() in all files changed by issue
- black format all files, bar unit test, changed by issue

Fixes #2156 

Ready for review.

@FroggyFlox If you could take a quick look at what I've done that would be much appreciated. And a functional check that we have a return of our expected behaviour on a boot-to-snapshot configuration, ie what we had before on a non boot-to-snapshot config, is the main aim here. We can address other not strickly related issues in their own focused issues/pull requests. Most notably here is the behaviour of user created shares under a root rollback scenario. I intend to create an additional issue that addresses this side of things. Here I was attempting to achieve feature parity with our non boot-to-snapshot configurations. Note however that a full check, when using a prior rockstor instance, will require a reboot post new source build to remove the prior, now redundant mount point of /mnt2/ROOT. I also, for good measure, removed the mount point as well. No worries if you dont' have the time, I've tested it fairly extensively and it will only be published in the testing channel for a bit anyway.

## Testing:
Bar the additional unit test, was functional via the Web-UI and involved ensuring a system and data pool could create a share, clone that same share, and make all types of snapshot from the original share and it's clone, i.e. default, writable, visible, both. And each of the resulting writable snapshots taken in the above was also successfully, in turn, cloned. These functions were tested on both boot-to-shapshot and non boot-to-snapshot configurations on the openSUSE distros of Leap15.1 & Leap15.2 beta.


### rockstor btrfs subsystem related unit test results post pr:
```
leap15-2:/opt/rockstor-dev # ./bin/test --settings=test-settings -v 3 -p test_btrfs*
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                           
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                              
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                      
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                               
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                                    
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                               
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                              
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                         
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                            
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                        
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                       
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                         
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                           
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                          
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                                      
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                          
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                           
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                      
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                   
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                  
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                  
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                             
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                       
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                   
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                                  
                                                                                                                                                                           
----------------------------------------------------------------------                                                                                                     
Ran 38 tests in 0.046s                                                                                                                                                     
                                                                                                                                                                           
OK 
```

## EDIT V2

Fix for @FroggyFlox find re rollback regression in pr v1 for issue #2156

Rollback within Web-UI to writable snapshot fails due to requirement oversights within pr #2169 v1:

Includes:
- New mechanism to identify boot-to-snap pool config via extending/refactoring default_subvol(). Unit test added.
- Use above to identify need to mount system pool independently of fstab’s “/”, ie in boot-to-snap scenarios, at the required /@ subvol.
- Correct more path calculations, re snap-to-share (rollback) and snap mounting, via newly added pool/share model properties.
- Above changes re-enables share rollback capability via dir mv within a boot-to-snap configuration.
- Remove potential “//” path content: emergent property of system pool mount potentially being either “/mnt2/ROOT” or “/”.
- Remove hack to account for prior inadequate system pool mount, i.e in boot-to-snap we now mount subvol /@ independently at /mnt2/ROOT.
- Includes black formatting and transition to string.formt() of newly edited (for our associated pull request) clone_helpers.py.
- Update various code comments re dual system pool mount personality depending on boot-to-snap configuration.

### Additional unit test output:
```
./bin/test --settings=test-settings -v 3 -p test_btrfs*
...
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok                                                                                                                 
...
Ran 39 tests in 0.051s                                                                                                                                                                                                                                                         
```
Additionally, via included commit:
"improve share rollback robustness re missing qgroup. Fixes #2171"

Fixes #2171 

See issue text for context.
