### PR TITLE
Configure SFTP server at buildtime and update customization settings. Fixes #2168

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -365,7 +365,9 @@ MODEL_DEFS = {
 	   'pqgroup': '-1/-1',
 }
 
+# Begin SFTP-related variables
 SSHD_HEADER = '###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###'
+SFTP_STR = 'Subsystem\tsftp\tinternal-sftp'
 
 OAUTH_INTERNAL_APP = 'cliapp'
 

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -1,13 +1,13 @@
 """
-Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
-This file is part of RockStor.
+Copyright (c) 2012-2020 Rockstor, Inc. <http://rockstor.com>
+This file is part of Rockstor.
 
-RockStor is free software; you can redistribute it and/or modify
+Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-RockStor is distributed in the hope that it will be useful, but
+Rockstor is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.

--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -19,16 +19,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.ssh import toggle_sftp_service
-from django.db import transaction
-from base_service import BaseServiceDetailView
-from smart_manager.models import Service
 
-import logging
 logger = logging.getLogger(__name__)
 
 
 class SFTPServiceView(BaseServiceDetailView):
-
     @transaction.atomic
     def post(self, request, command):
         """

--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -1,13 +1,13 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
-This file is part of RockStor.
+Copyright (c) 2012-2020 Rockstor, Inc. <http://rockstor.com>
+This file is part of Rockstor.
 
-RockStor is free software; you can redistribute it and/or modify
+Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-RockStor is distributed in the hope that it will be useful, but
+Rockstor is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
@@ -16,7 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import logging
+
+from django.db import transaction
 from rest_framework.response import Response
+
+from base_service import BaseServiceDetailView
+from smart_manager.models import Service
 from storageadmin.util import handle_exception
 from system.ssh import toggle_sftp_service
 
@@ -29,26 +35,26 @@ class SFTPServiceView(BaseServiceDetailView):
         """
         execute a command on the service
         """
-        service_name = 'sftp'
+        service_name = "sftp"
         service = Service.objects.get(name=service_name)
-        if (command == 'config'):
+        if command == "config":
             #  nothing to really configure atm. just save the model
             try:
-                config = request.data['config']
+                config = request.data["config"]
                 self._save_config(service, config)
             except Exception as e:
                 logger.exception(e)
-                e_msg = ('SFTP could not be configured. Try again')
+                e_msg = "SFTP could not be configured. Try again"
                 handle_exception(Exception(e_msg), request)
 
         else:
             try:
-                if (command == 'start'):
+                if command == "start":
                     toggle_sftp_service()
                 else:
                     toggle_sftp_service(switch=False)
             except Exception as e:
                 logger.exception(e)
-                e_msg = ('Failed to %s SFTP due to a system error.' % command)
+                e_msg = "Failed to {} SFTP due to a system error.".format(command)
                 handle_exception(Exception(e_msg), request)
         return Response()

--- a/src/rockstor/storageadmin/views/sftp.py
+++ b/src/rockstor/storageadmin/views/sftp.py
@@ -1,13 +1,13 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
-This file is part of RockStor.
+Copyright (c) 2012-2020 Rockstor, Inc. <http://rockstor.com>
+This file is part of Rockstor.
 
-RockStor is free software; you can redistribute it and/or modify
+Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-RockStor is distributed in the hope that it will be useful, but
+Rockstor is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
@@ -16,22 +16,22 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from rest_framework.response import Response
-from django.db import transaction
-from django.conf import settings
-from storageadmin.models import SFTP
-from storageadmin.util import handle_exception
-from storageadmin.serializers import SFTPSerializer
-from fs.btrfs import (is_share_mounted, umount_root)
-from system.ssh import (update_sftp_config, sftp_mount_map, sftp_mount,
-                        rsync_for_sftp)
-from share_helpers import (helper_mount_share, validate_share,
-                           sftp_snap_toggle)
-import rest_framework_custom as rfc
-import shutil
-import os
-
 import logging
+import os
+import shutil
+
+from django.conf import settings
+from django.db import transaction
+from rest_framework.response import Response
+
+import rest_framework_custom as rfc
+from fs.btrfs import is_share_mounted, umount_root
+from share_helpers import helper_mount_share, validate_share, sftp_snap_toggle
+from storageadmin.models import SFTP
+from storageadmin.serializers import SFTPSerializer
+from storageadmin.util import handle_exception
+from system.ssh import update_sftp_config, sftp_mount_map, sftp_mount, rsync_for_sftp
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,27 +44,28 @@ class SFTPListView(rfc.GenericView):
     @transaction.atomic
     def post(self, request):
         with self._handle_exception(request):
-            if ('shares' not in request.data):
-                e_msg = 'Must provide share names.'
+            if "shares" not in request.data:
+                e_msg = "Must provide share names."
                 handle_exception(Exception(e_msg), request)
-            shares = [validate_share(s, request) for s in
-                      request.data['shares']]
-            editable = 'rw'
-            if ('read_only' in request.data and
-                    request.data['read_only'] is True):
-                editable = 'ro'
+            shares = [validate_share(s, request) for s in request.data["shares"]]
+            editable = "rw"
+            if "read_only" in request.data and request.data["read_only"] is True:
+                editable = "ro"
 
             mnt_map = sftp_mount_map(settings.SFTP_MNT_ROOT)
             input_map = {}
             for share in shares:
-                if (SFTP.objects.filter(share=share).exists()):
-                    e_msg = ('Share ({}) is already exported '
-                             'via SFTP.').format(share.name)
+                if SFTP.objects.filter(share=share).exists():
+                    e_msg = ("Share ({}) is already exported via SFTP.").format(
+                        share.name
+                    )
                     handle_exception(Exception(e_msg), request)
-                if (share.owner == 'root'):
-                    e_msg = ('Share ({}) is owned by root. It cannot be '
-                             'exported via SFTP with '
-                             'root ownership.').format(share.name)
+                if share.owner == "root":
+                    e_msg = (
+                        "Share ({}) is owned by root. It cannot be "
+                        "exported via SFTP with "
+                        "root ownership."
+                    ).format(share.name)
                     handle_exception(Exception(e_msg), request)
             for share in shares:
                 sftpo = SFTP(share=share, editable=editable)
@@ -72,26 +73,27 @@ class SFTPListView(rfc.GenericView):
                 #  mount if not already mounted
                 helper_mount_share(share)
                 #  bindmount if not already
-                sftp_mount(share, settings.MNT_PT, settings.SFTP_MNT_ROOT,
-                           mnt_map, editable)
+                sftp_mount(
+                    share, settings.MNT_PT, settings.SFTP_MNT_ROOT, mnt_map, editable
+                )
                 sftp_snap_toggle(share)
 
-                chroot_loc = ('%s%s' % (settings.SFTP_MNT_ROOT, share.owner))
+                chroot_loc = "{}{}".format(settings.SFTP_MNT_ROOT, share.owner)
                 rsync_for_sftp(chroot_loc)
                 input_map[share.owner] = chroot_loc
             for sftpo in SFTP.objects.all():
-                if (sftpo.share not in shares):
-                    input_map[sftpo.share.owner] = (
-                        '%s%s' % (settings.SFTP_MNT_ROOT, sftpo.share.owner))
+                if sftpo.share not in shares:
+                    input_map[sftpo.share.owner] = "{}{}".format(
+                        settings.SFTP_MNT_ROOT, sftpo.share.owner,
+                    )
             update_sftp_config(input_map)
             return Response()
 
 
 class SFTPDetailView(rfc.GenericView):
-
     def get(self, *args, **kwargs):
         try:
-            data = SFTP.objects.get(id=self.kwargs['id'])
+            data = SFTP.objects.get(id=self.kwargs["id"])
             serialized_data = SFTPSerializer(data)
             return Response(serialized_data.data)
         except:
@@ -103,24 +105,23 @@ class SFTPDetailView(rfc.GenericView):
             try:
                 sftpo = SFTP.objects.get(id=id)
             except:
-                e_msg = ('SFTP config for the id ({}) '
-                         'does not exist.').format(id)
+                e_msg = ("SFTP config for the id ({}) does not exist.").format(id)
                 handle_exception(Exception(e_msg), request)
 
-            mnt_prefix = ('%s%s/' % (settings.SFTP_MNT_ROOT,
-                                     sftpo.share.owner))
+            mnt_prefix = "{}{}/".format(settings.SFTP_MNT_ROOT, sftpo.share.owner)
 
-            if (is_share_mounted(sftpo.share.name, mnt_prefix)):
+            if is_share_mounted(sftpo.share.name, mnt_prefix):
                 sftp_snap_toggle(sftpo.share, mount=False)
-                mnt_pt = ('%s%s' % (mnt_prefix, sftpo.share.name))
+                mnt_pt = "{}{}".format(mnt_prefix, sftpo.share.name)
                 umount_root(mnt_pt)
-                if (os.path.isdir(mnt_pt)):
+                if os.path.isdir(mnt_pt):
                     shutil.rmtree(mnt_pt)
             sftpo.delete()
             input_map = {}
             for so in SFTP.objects.all():
-                if (so.id != sftpo.id):
-                    input_map[so.share.owner] = (
-                        '%s%s' % (settings.SFTP_MNT_ROOT, so.share.owner))
+                if so.id != sftpo.id:
+                    input_map[so.share.owner] = "{}{}".format(
+                        settings.SFTP_MNT_ROOT, so.share.owner,
+                    )
             update_sftp_config(input_map)
             return Response()

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -145,11 +145,11 @@ def service_status(service_name, config=None):
         # initial check on sshd status: 0 = OK 3 = stopped
         if rc != 0:
             return out, err, rc
-        # sshd has sftp subsystem so we check for it's config line which is
+        # sshd has sftp subsystem so we check for its config line which is
         # inserted or deleted to enable or disable the sftp service.
         with open(SSHD_CONFIG) as sfo:
             for line in sfo.readlines():
-                if re.match("Subsystem\s+sftp", line) is not None:
+                if re.match(settings.SFTP_STR, line) is not None:
                     return out, err, rc
             # -1 not appropriate as inconsistent with bash return codes
             # Returning 1 as Catchall for general errors.  the calling system

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -1,13 +1,13 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
-This file is part of RockStor.
+Copyright (c) 2012-2020 Rockstor, Inc. <http://rockstor.com>
+This file is part of Rockstor.
 
-RockStor is free software; you can redistribute it and/or modify
+Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
 by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-RockStor is distributed in the hope that it will be useful, but
+Rockstor is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
@@ -40,7 +40,7 @@ def update_sftp_config(input_map):
     :return:
     """
     fo, npath = mkstemp()
-    userstr = "AllowUsers root %s" % " ".join(input_map.keys())
+    userstr = "AllowUsers root {}".format(" ".join(input_map.keys()))
     with open(SSHD_CONFIG) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
             if re.match(settings.SSHD_HEADER, line) is None:


### PR DESCRIPTION
Fixes #2168
@phillxnet , ready for review.

As detailed in #2168, the SFTP service is ON by default using the wrong subsystem (the default one) and is corrected (correctly configured) only after toggling the service OFF and then back ON.

This PR thus proposes to fix this by defining the correct subsystem during Rockstor's initiation procedure, and ensuring we search for such correct definition while probing for the SFTP service status. 

 
### Aims & logic  
we currently search for the presence of the `Subsystem sftp` string in `/etc/ssh/sshd_config` to assess the current status of the SFTP service. Unfortunately, this does not allow for the detection of the correct SFTP subsystem used and leads to surfacing the SFTP service as ON in the webUI despite running with the wrong sftp subsystem (defined by default).

This PR proposes to fix this by:  
1. searching for the full subsystem definition line, to ensure the intended subsystem is used to determine the ON/OFF status of the SFTP service.
2. ensuring the default (and incorrect) subsystem definition is disabled during Rockstor's initrock and that the correct one is used instead.

In addition, this PR also takes the opportunity to add per-user customization settings to be in accordance with the settings recommended on hte openSUSE wiki:
[https://en.opensuse.org/SDB:SFTP_server_with_Chroot#Match_rule_block](https://en.opensuse.org/SDB:SFTP_server_with_Chroot#Match_rule_block)
```
   ForceCommand internal-sftp
   ChrootDirectory /home/%u 
   X11Forwarding no
   AllowTcpForwarding no
```

### Points of interest  
To the best of my tests, `/etc/ssh/sshd_config` is configured with the following line by default: 
```
Subsystem   sftp    /usr/lib/ssh/sftp-server
```
Rather than removing it or replacing it with the correct subsystem, I chose to simply comment it out and leave the definition of the correct subsystem to our custom section (below our ROCKSTOR header). This leaves all Rockstor-related customizations together at the end of the file and clearly labeled as such thanks to our header.

Given the string configuring the sftp server in `sshd_config` is reused at multiple places in the project, I set it as a build-time variable in the django settings:
https://github.com/FroggyFlox/rockstor-core/blob/d8290e52a863ab13683486d311955073e5c02f41/conf/settings.conf.in#L370


### Demonstration and functional testing  
Upon a fresh build on top of 15.2 ISO Rockstor install, we have the following at the end of `sshd_config`:
```shell script
rockdev:~ # tail -n 18 /etc/ssh/sshd_config 

# override default of no subsystems
#Subsystem      sftp    /usr/lib/ssh/sftp-server

# This enables accepting locale enviroment variables LC_* LANG, see sshd_config(5).
AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
AcceptEnv LC_IDENTIFICATION LC_ALL

# Example of overriding settings on a per-user basis
#Match User anoncvs
#       X11Forwarding no
#       AllowTcpForwarding no
#       PermitTTY no
#       ForceCommand cvs server
###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###
Subsystem       sftp    internal-sftp
AllowUsers root 
```
Accordingly, the SFTP service is detected as ON in the webUI:
![image](https://user-images.githubusercontent.com/30297881/82585206-a4f7eb00-9b63-11ea-9388-0b6926c98798.png)


In order to test the export of shares via SFTP, three new shares are created, each owned by a different user (created through Rockstor):

| Share name | Owner |
| ----- | ----- | 
| sftp_test | test |
| sftp_test1 | test1 |
| sftp_test2 | test2 |

These three shares are then exported all at once via SFTP. In turn, `sshd_config` is updated accordingly:
```
rockdev:~ # tail -n 32 /etc/ssh/sshd_config 
# override default of no subsystems
#Subsystem      sftp    /usr/lib/ssh/sftp-server

# This enables accepting locale enviroment variables LC_* LANG, see sshd_config(5).
AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
AcceptEnv LC_IDENTIFICATION LC_ALL

# Example of overriding settings on a per-user basis
#Match User anoncvs
#       X11Forwarding no
#       AllowTcpForwarding no
#       PermitTTY no
#       ForceCommand cvs server
###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###
Subsystem       sftp    internal-sftp
AllowUsers root test test1 test2
Match User test
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test
        X11Forwarding no
        AllowTcpForwarding no
Match User test1
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test1
        X11Forwarding no
        AllowTcpForwarding no
Match User test2
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test2
        X11Forwarding no
        AllowTcpForwarding no
```

All three shares can be access via SFTP:
```shell script
 ~  sftp test@<rockstor-ip>
Password: 
Connected to test@<rockstor-ip>.
sftp> ls
bin        lib64      sftp_test  usr        
sftp> exit
 
~  sftp test1@<rockstor-ip>
Password: 
Connected to test1@<rockstor-ip>.
sftp> ls
bin         lib64       sftp_test1  usr         
sftp> exit

 ~  sftp test2@<rockstor-ip>
Password: 
Connected to test2@<rockstor-ip>.
sftp> ls
bin         lib64       sftp_test2  usr         
sftp> exit
```

As a verification, all shares are created with the respective user as owner:
```
rockdev:~ # ls -lhtr /mnt3/*
/mnt3/test:
total 0
drwxr-xr-x 1 root root   16 May 18 20:09 usr
drwxr-xr-x 1 root root    8 May 18 20:09 bin
drwxr-xr-x 1 root root  230 May 18 20:09 lib64
drwxr-xr-x 1 test users   0 May 19 11:42 sftp_test

/mnt3/test1:
total 0
drwxr-xr-x 1 test1 users   0 May 19 11:49 sftp_test1
drwxr-xr-x 1 root  root   16 May 19 11:50 usr
drwxr-xr-x 1 root  root    8 May 19 11:50 bin
drwxr-xr-x 1 root  root  230 May 19 11:50 lib64

/mnt3/test2:
total 0
drwxr-xr-x 1 test2 users   0 May 19 11:49 sftp_test2
drwxr-xr-x 1 root  root   16 May 19 11:50 usr
drwxr-xr-x 1 root  root    8 May 19 11:50 bin
drwxr-xr-x 1 root  root  230 May 19 11:50 lib64
```

At that point, turning the SFTP service OFF in the webUI removes the sftp subsystem definition in `/etc/ssh/sshd_config`, but leaves all customizations intact:
```
rockdev:~ # tail -n 32 /etc/ssh/sshd_config 

# override default of no subsystems
#Subsystem      sftp    /usr/lib/ssh/sftp-server

# This enables accepting locale enviroment variables LC_* LANG, see sshd_config(5).
AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
AcceptEnv LC_IDENTIFICATION LC_ALL

# Example of overriding settings on a per-user basis
#Match User anoncvs
#       X11Forwarding no
#       AllowTcpForwarding no
#       PermitTTY no
#       ForceCommand cvs server
###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###
AllowUsers root test test1 test2
Match User test
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test
        X11Forwarding no
        AllowTcpForwarding no
Match User test1
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test1
        X11Forwarding no
        AllowTcpForwarding no
Match User test2
        ForceCommand internal-sftp
        ChrootDirectory /mnt3/test2
        X11Forwarding no
        AllowTcpForwarding no
```

I further tested share export additions and deletions and verified them to be working as intended, maintaining the SFTP service status throughout.

All steps above were also successfully run on Tumbleweed.

### Caveats and limitations  
As discussed in https://github.com/rockstor/rockstor-core/issues/2168#issuecomment-630793709, the rsync over ssh functionality is disabled by our enforcing of `ForceCommand internal-sftp` for all exports. I did add a TODO and comment in the code to help with future work to re-enable this feature as custom option surfaced in the webUI:  


https://github.com/FroggyFlox/rockstor-core/blob/d8290e52a863ab13683486d311955073e5c02f41/src/rockstor/system/ssh.py#L57-L58


@phillxnet, notably, all the work done in `initrock.py` was done assuming the presence of the default (and incorrect) subsystem line in `sshd_config` as well as the absence of any previous Rockstor customizations:
https://github.com/FroggyFlox/rockstor-core/blob/d8290e52a863ab13683486d311955073e5c02f41/src/rockstor/scripts/initrock.py#L248

This was done with having in mind the fact that the initrock with this code will be run on system during first time install (and thus free of any prior Rockstor customization). Current Testing users on "Built on openSUSE" might suffer from that, but a toggle OFF/ON of the service should set things in order. 

Moreover, in line with the previous paragraph, this part might need further verification of correct behavior at rpm-build time as I'm always nervous about touching `initrock.py` and unsure of how it might behave.  

### Testing

**_CentOS_**:  
not tested  

**_Leap 15.2 (ISO install)_**:  

```shell script
Ran 205 tests in 82.488s

FAILED (failures=5, errors=1)
```

**_Tumbleweed (ISO install)_**:  

```shell script
Ran 205 tests in 67.063s

FAILED (failures=7, errors=1)
```


### Full Testing Outputs

<details><summary>Leap15.2 (ISO install)</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (17.171s)
  Applying contenttypes.0001_initial... OK (0.063s)
  Applying auth.0001_initial... OK (0.319s)
  Applying admin.0001_initial... OK (0.104s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.144s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.054s)
  Applying auth.0003_alter_user_email_max_length... OK (0.055s)
  Applying auth.0004_alter_user_username_opts... OK (0.047s)
  Applying auth.0005_alter_user_last_login_null... OK (0.200s)
  Applying auth.0006_require_contenttypes_0002... OK (0.010s)
  Applying oauth2_provider.0001_initial... OK (0.721s)
  Applying oauth2_provider.0002_08_updates... OK (0.328s)
  Applying sessions.0001_initial... OK (0.059s)
  Applying sites.0001_initial... OK (0.037s)
  Applying smart_manager.0001_initial... OK (0.753s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.038s)
  Applying storageadmin.0001_initial... OK (12.440s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.935s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.201s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.426s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.290s)
  Applying storageadmin.0006_dcontainerargs... OK (0.470s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.908s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.749s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.449s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.496s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.533s)
  Applying storageadmin.0012_auto_20200429_1428... OK (1.335s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (17.763s)
  Applying contenttypes.0001_initial... OK (0.029s)
  Applying auth.0001_initial... OK (0.065s)
  Applying admin.0001_initial... OK (0.054s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.128s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.043s)
  Applying auth.0003_alter_user_email_max_length... OK (0.042s)
  Applying auth.0004_alter_user_username_opts... OK (0.043s)
  Applying auth.0005_alter_user_last_login_null... OK (0.050s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.212s)
  Applying oauth2_provider.0002_08_updates... OK (0.182s)
  Applying sessions.0001_initial... OK (0.019s)
  Applying sites.0001_initial... OK (0.019s)
  Applying smart_manager.0001_initial... OK (1.426s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.045s)
  Applying storageadmin.0001_initial... OK (10.714s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.826s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.816s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.409s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.531s)
  Applying storageadmin.0006_dcontainerargs... OK (0.414s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.869s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.295s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.439s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.443s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.471s)
  Applying storageadmin.0012_auto_20200429_1428... OK (1.558s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 421, in test_post_requests_2
    response = self.client.post(self.BASE_URL, data=data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 168, in post
    path, data=data, format=format, content_type=content_type, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 90, in post
    return self.generic('POST', path, data, content_type, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 155, in post
    return Response(SambaShareSerializer(smb_share).data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 435, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 568, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 316, in get_attribute
    raise type(exc)(msg)
KeyError: u"Got KeyError when attempting to get a value for field `groupname` on serializer `SUserSerializer`.\nThe serializer field might be named incorrectly and not match any attribute or key on the `User` instance.\nOriginal exception text was: 'getgrgid(): gid not found: 1'."

======================================================================
FAIL: test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 152, in test_disable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to disable auto update due to this exception:  ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 382, in post\n    auto_update(enable=False)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 61, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

======================================================================
FAIL: test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 144, in test_enable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to enable auto update due to this exception: ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 372, in post\n    auto_update(enable=True)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 61, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 396, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (games) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 175, in test_post_requests
    msg=response.data)
AssertionError: {'username': u'newUser', 'public_key': None, 'shell': u'/bin/bash', 'group': 3, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/newUser', 'email': None, 'groupname': u'admin', 'gid': 5, 'user': 124, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

----------------------------------------------------------------------
Ran 205 tests in 82.488s

FAILED (failures=5, errors=1)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```













</details>


<details><summary>Tumbleweed (ISO install)</summary>

```
rockdev:/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (14.524s)
  Applying contenttypes.0001_initial... OK (0.060s)
  Applying auth.0001_initial... OK (0.293s)
  Applying admin.0001_initial... OK (0.111s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.107s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.046s)
  Applying auth.0003_alter_user_email_max_length... OK (0.055s)
  Applying auth.0004_alter_user_username_opts... OK (0.044s)
  Applying auth.0005_alter_user_last_login_null... OK (0.049s)
  Applying auth.0006_require_contenttypes_0002... OK (0.009s)
  Applying oauth2_provider.0001_initial... OK (0.644s)
  Applying oauth2_provider.0002_08_updates... OK (0.287s)
  Applying sessions.0001_initial... OK (0.066s)
  Applying sites.0001_initial... OK (0.040s)
  Applying smart_manager.0001_initial... OK (0.570s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.034s)
  Applying storageadmin.0001_initial... OK (11.700s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.885s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.492s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.437s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.098s)
  Applying storageadmin.0006_dcontainerargs... OK (0.366s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.727s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.379s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.359s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.384s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.409s)
  Applying storageadmin.0012_auto_20200429_1428... OK (1.040s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (15.272s)
  Applying contenttypes.0001_initial... OK (0.034s)
  Applying auth.0001_initial... OK (0.053s)
  Applying admin.0001_initial... OK (0.039s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.110s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.057s)
  Applying auth.0003_alter_user_email_max_length... OK (0.056s)
  Applying auth.0004_alter_user_username_opts... OK (0.050s)
  Applying auth.0005_alter_user_last_login_null... OK (0.044s)
  Applying auth.0006_require_contenttypes_0002... OK (0.012s)
  Applying oauth2_provider.0001_initial... OK (0.214s)
  Applying oauth2_provider.0002_08_updates... OK (0.181s)
  Applying sessions.0001_initial... OK (0.019s)
  Applying sites.0001_initial... OK (0.025s)
  Applying smart_manager.0001_initial... OK (1.783s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.038s)
  Applying storageadmin.0001_initial... OK (8.697s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.775s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.813s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.394s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.393s)
  Applying storageadmin.0006_dcontainerargs... OK (0.377s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.784s)
  Applying storageadmin.0008_auto_20190115_1637... OK (1.296s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.670s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.443s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.464s)
  Applying storageadmin.0012_auto_20200429_1428... OK (1.868s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ERROR
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... FAIL
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... FAIL
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok

======================================================================
ERROR: test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/smart_manager/tests/test_task_scheduler.py", line 218, in test_delete_valid
    response = self.client.delete("{}/{}".format(self.BASE_URL, tdid), data=data)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 192, in delete
    path, data=data, format=format, content_type=content_type, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 102, in delete
    return self.generic('DELETE', path, data, content_type, **extra)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/build/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/build/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/opt/build/src/rockstor/smart_manager/views/task_scheduler.py", line 189, in delete
    self._refresh_crontab()
  File "/opt/build/src/rockstor/smart_manager/views/task_scheduler.py", line 90, in _refresh_crontab
    with open('/etc/cron.d/rockstortab', 'w') as cfo:
IOError: [Errno 2] No such file or directory: '/etc/cron.d/rockstortab'

======================================================================
FAIL: test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 152, in test_disable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to disable auto update due to this exception:  ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 382, in post\n    auto_update(enable=False)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 61, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

======================================================================
FAIL: test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 144, in test_enable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to enable auto update due to this exception: ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 372, in post\n    auto_update(enable=True)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 61, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 396, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (games) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 175, in test_post_requests
    msg=response.data)
AssertionError: {'username': u'newUser', 'public_key': None, 'shell': u'/bin/bash', 'group': 3, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/newUser', 'email': None, 'groupname': u'admin', 'gid': 5, 'user': 124, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/smart_manager/tests/test_task_scheduler.py", line 101, in test_post_valid
    response.status_code, status.HTTP_200_OK, msg=response.content
AssertionError: ["[Errno 2] No such file or directory: '/etc/cron.d/rockstortab'","Traceback (most recent call last):\n  File \"/opt/build/src/rockstor/rest_framework_custom/generic_view.py\", line 41, in _handle_exception\n    yield\n  File \"/opt/build/src/rockstor/smart_manager/views/task_scheduler.py\", line 157, in post\n    self._refresh_crontab()\n  File \"/opt/build/src/rockstor/smart_manager/views/task_scheduler.py\", line 90, in _refresh_crontab\n    with open('/etc/cron.d/rockstortab', 'w') as cfo:\nIOError: [Errno 2] No such file or directory: '/etc/cron.d/rockstortab'\n"]

======================================================================
FAIL: test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/smart_manager/tests/test_task_scheduler.py", line 169, in test_put_valid
    self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
AssertionError: ["[Errno 2] No such file or directory: '/etc/cron.d/rockstortab'","Traceback (most recent call last):\n  File \"/opt/build/src/rockstor/rest_framework_custom/generic_view.py\", line 41, in _handle_exception\n    yield\n  File \"/opt/build/src/rockstor/smart_manager/views/task_scheduler.py\", line 182, in put\n    self._refresh_crontab()\n  File \"/opt/build/src/rockstor/smart_manager/views/task_scheduler.py\", line 90, in _refresh_crontab\n    with open('/etc/cron.d/rockstortab', 'w') as cfo:\nIOError: [Errno 2] No such file or directory: '/etc/cron.d/rockstortab'\n"]

----------------------------------------------------------------------
Ran 205 tests in 67.063s

FAILED (failures=7, errors=1)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```


</details>
