### PR TITLE
ssh: use correct ld-linux for chroot on arm64

### DIFF
--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import re
+import platform
 from shutil import move, copy
 from tempfile import mkstemp
 
@@ -152,9 +153,13 @@ def rsync_for_sftp(chroot_loc):
     copy("/bin/bash", "{}/bin".format(chroot_loc))
     copy("/usr/bin/rsync", "{}/usr/bin".format(chroot_loc))
 
+    ld_linux_so = "/lib64/ld-linux-x86-64.so.2"
+    if platform.machine() == "aarch64":
+        ld_linux_so = "/lib64/ld-linux-aarch64.so.1"
+
     libs_d = {
         "rockstor": [
-            "/lib64/ld-linux-x86-64.so.2",
+            ld_linux_so,
             "/lib64/libacl.so.1",
             "/lib64/libattr.so.1",
             "/lib64/libc.so.6",
@@ -171,7 +176,7 @@ def rsync_for_sftp(chroot_loc):
             "/lib64/libattr.so.1",
             "/usr/lib64/libcrypto.so.1.1",
             "/lib64/libpthread.so.0",
-            "/lib64/ld-linux-x86-64.so.2",
+            ld_linux_so,
             "/lib64/libdl.so.2",
             "/lib64/libreadline.so.7",
             "/lib64/libtinfo.so.6",
@@ -182,7 +187,7 @@ def rsync_for_sftp(chroot_loc):
             "/lib64/libz.so.1",
             "/usr/lib64/libpopt.so.0",
             "/usr/lib64/libslp.so.1",
-            "/lib64/ld-linux-x86-64.so.2",
+            ld_linux_so,
             "/usr/lib64/libcrypto.so.1.1",
             "/lib64/libpthread.so.0",
             "/lib64/libdl.so.2",


### PR DESCRIPTION
The ld-linux filename is architecture dependent so we need to use
the correct one for the system.

Fixes #2183 

One possible improvement could be to find the dependencies for sftp-server,rsync and bash at runtime by invoking ldd on each binary, the ldd results combined match up with the hardcoded list:
```
 ldd /usr/bin/rsync
        linux-vdso.so.1 (0x0000ffff9a787000)
        libacl.so.1 => /lib64/libacl.so.1 (0x0000ffff9a691000)
        libz.so.1 => /lib64/libz.so.1 (0x0000ffff9a660000)
        libpopt.so.0 => /usr/lib64/libpopt.so.0 (0x0000ffff9a63f000)
        libslp.so.1 => /usr/lib64/libslp.so.1 (0x0000ffff9a60e000)
        libc.so.6 => /lib64/libc.so.6 (0x0000ffff9a488000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffff9a759000)
        libattr.so.1 => /lib64/libattr.so.1 (0x0000ffff9a467000)
        libcrypto.so.1.1 => /usr/lib64/libcrypto.so.1.1 (0x0000ffff9a1e8000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x0000ffff9a1b3000)
        libdl.so.2 => /lib64/libdl.so.2 (0x0000ffff9a192000)
```


“opensuse-leap” list | sftp | rsync | bash
-- | -- | -- | --
libacl |   | x |  
libz | x | x |  
libpopt |   | x |  
libslp |   | x |  
libc | x | x | x
libattr |   | x |  
libcrypto | x | x |  
libpthread | x | x |  
Ld-linux | x | x |  
libdl | x |   | x
libreadline |   |   | x
libtinfo |   |   | x


