### PR TITLE
failure to remove detached disks via pool resize. Fixes #2099

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -25,11 +25,22 @@ from rest_framework import status
 from rest_framework.decorators import api_view
 from django.db import transaction
 from storageadmin.serializers import PoolInfoSerializer
-from storageadmin.models import (Disk, Pool, Share, PoolBalance)
-from fs.btrfs import (add_pool, pool_usage, resize_pool_cmd, umount_root,
-                      btrfs_uuid, mount_root, start_balance, usage_bound,
-                      remove_share, enable_quota, disable_quota, rescan_quotas,
-                      start_resize_pool)
+from storageadmin.models import Disk, Pool, Share, PoolBalance
+from fs.btrfs import (
+    add_pool,
+    pool_usage,
+    resize_pool_cmd,
+    umount_root,
+    btrfs_uuid,
+    mount_root,
+    start_balance,
+    usage_bound,
+    remove_share,
+    enable_quota,
+    disable_quota,
+    rescan_quotas,
+    start_resize_pool,
+)
 from system.osi import remount, trigger_udev_update
 from storageadmin.util import handle_exception
 from django.conf import settings
@@ -38,12 +49,13 @@ from django_ztask.models import Task
 import json
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 class PoolMixin(object):
     serializer_class = PoolInfoSerializer
-    RAID_LEVELS = ('single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6')
+    RAID_LEVELS = ("single", "raid0", "raid1", "raid10", "raid5", "raid6")
 
     @staticmethod
     def _validate_disk(d, request):
@@ -51,7 +63,7 @@ class PoolMixin(object):
         try:
             return Disk.objects.get(name=d)
         except:
-            e_msg = 'Disk with name ({}) does not exist.'.format(d)
+            e_msg = "Disk with name ({}) does not exist.".format(d)
             handle_exception(Exception(e_msg), request)
 
     @staticmethod
@@ -59,7 +71,7 @@ class PoolMixin(object):
         try:
             return Disk.objects.get(id=diskId)
         except:
-            e_msg = 'Disk with id ({}) does not exist.'.format(diskId)
+            e_msg = "Disk with id ({}) does not exist.".format(diskId)
             handle_exception(Exception(e_msg), request)
 
     @staticmethod
@@ -80,100 +92,111 @@ class PoolMixin(object):
             # Build a dictionary of redirected disk names with their
             # associated redirect role values.
             # By using only role_disks we avoid json.load(None)
-            redirect_disks = {d.name: json.loads(d.role).get("redirect", None)
-                              for d in role_disks if
-                              'redirect' in json.loads(d.role)}
+            redirect_disks = {
+                d.name: json.loads(d.role).get("redirect", None)
+                for d in role_disks
+                if "redirect" in json.loads(d.role)
+            }
             # Replace d.name with redirect role value for redirect role disks.
             # Our role system stores the /dev/disk/by-id name (without path)
             # for redirected disks so use that value instead as our disk name:
             dnames = [
-                d.name if d.name not in redirect_disks else redirect_disks[
-                    d.name] for d in disks]
+                d.name if d.name not in redirect_disks else redirect_disks[d.name]
+                for d in disks
+            ]
             return dnames
         except:
-            e_msg = 'Problem with role filter of disks.'
+            e_msg = "Problem with role filter of disks."
             handle_exception(Exception(e_msg), request)
 
     @staticmethod
     def _validate_new_quota_state(request):
-        logger.debug('#### validate_new_quota_state received new_state '
-                     '=({}).'.format(request.data.get('quotas')))
-        new_val = request.data.get('quotas', 'Enabled')
+        logger.debug(
+            "#### validate_new_quota_state received new_state "
+            "=({}).".format(request.data.get("quotas"))
+        )
+        new_val = request.data.get("quotas", "Enabled")
         if new_val is None:
             # We default to Quotas enabled if input is in doubt.
-            new_val = 'Enabled'
-        if new_val != 'Enabled' and new_val != 'Disabled':
-            e_msg = ('Unsupported quotas request ({}). '
-                     'Expecting "Enabled" or "Disabled"'.format(new_val))
+            new_val = "Enabled"
+        if new_val != "Enabled" and new_val != "Disabled":
+            e_msg = (
+                "Unsupported quotas request ({}). "
+                'Expecting "Enabled" or "Disabled"'.format(new_val)
+            )
             handle_exception(Exception(e_msg), request)
         return new_val
 
     @staticmethod
     def _validate_compression(request):
         # Define default compression value, if not entered, as 'no'.
-        compression = request.data.get('compression', 'no')
-        if (compression is None or compression == ''):
-            compression = 'no'
-        if (compression not in settings.COMPRESSION_TYPES):
-            e_msg = ('Unsupported compression algorithm ({}). Use one of '
-                     '{}.').format(compression, settings.COMPRESSION_TYPES)
+        compression = request.data.get("compression", "no")
+        if compression is None or compression == "":
+            compression = "no"
+        if compression not in settings.COMPRESSION_TYPES:
+            e_msg = (
+                "Unsupported compression algorithm ({}). Use one of " "{}."
+            ).format(compression, settings.COMPRESSION_TYPES)
             handle_exception(Exception(e_msg), request)
         return compression
 
     @staticmethod
     def _validate_mnt_options(request):
-        mnt_options = request.data.get('mnt_options', None)
-        if (mnt_options is None):
-            return ''
+        mnt_options = request.data.get("mnt_options", None)
+        if mnt_options is None:
+            return ""
         allowed_options = {
-            'alloc_start': int,
-            'autodefrag': None,
-            'clear_cache': None,
-            'commit': int,
-            'compress-force': settings.COMPRESSION_TYPES,
-            'degraded': None,
-            'discard': None,
-            'fatal_errors': None,
-            'inode_cache': None,
-            'max_inline': int,
-            'metadata_ratio': int,
-            'noacl': None,
-            'noatime': None,
-            'nodatacow': None,
-            'nodatasum': None,
-            'nospace_cache': None,
-            'nossd': None,
-            'ro': None,
-            'rw': None,
-            'skip_balance': None,
-            'space_cache': None,
-            'ssd': None,
-            'ssd_spread': None,
-            'thread_pool': int,
-            '': None,
+            "alloc_start": int,
+            "autodefrag": None,
+            "clear_cache": None,
+            "commit": int,
+            "compress-force": settings.COMPRESSION_TYPES,
+            "degraded": None,
+            "discard": None,
+            "fatal_errors": None,
+            "inode_cache": None,
+            "max_inline": int,
+            "metadata_ratio": int,
+            "noacl": None,
+            "noatime": None,
+            "nodatacow": None,
+            "nodatasum": None,
+            "nospace_cache": None,
+            "nossd": None,
+            "ro": None,
+            "rw": None,
+            "skip_balance": None,
+            "space_cache": None,
+            "ssd": None,
+            "ssd_spread": None,
+            "thread_pool": int,
+            "": None,
         }
-        o_fields = mnt_options.split(',')
+        o_fields = mnt_options.split(",")
         for o in o_fields:
             v = None
-            if (re.search('=', o) is not None):
-                o, v = o.split('=')
-            if (o not in allowed_options):
-                e_msg = ('mount option ({}) not allowed. Make sure there are '
-                         'no whitespaces in the input. Allowed options: '
-                         '({}).').format(o, sorted(allowed_options.keys()))
+            if re.search("=", o) is not None:
+                o, v = o.split("=")
+            if o not in allowed_options:
+                e_msg = (
+                    "mount option ({}) not allowed. Make sure there are "
+                    "no whitespaces in the input. Allowed options: "
+                    "({})."
+                ).format(o, sorted(allowed_options.keys()))
                 handle_exception(Exception(e_msg), request)
-            if ((o == 'compress-force' and
-                 v not in allowed_options['compress-force'])):
-                e_msg = ('compress-force is only allowed with '
-                         '{}.').format(settings.COMPRESSION_TYPES)
+            if o == "compress-force" and v not in allowed_options["compress-force"]:
+                e_msg = ("compress-force is only allowed with " "{}.").format(
+                    settings.COMPRESSION_TYPES
+                )
                 handle_exception(Exception(e_msg), request)
             # changed conditional from "if (type(allowed_options[o]) is int):"
-            if (allowed_options[o] is int):
+            if allowed_options[o] is int:
                 try:
                     int(v)
                 except:
-                    e_msg = ('Value for mount option ({}) must be an '
-                             'integer.').format(o)
+                    e_msg = (
+                        "Value for mount option ({}) must be an " "integer."
+                    ).format(o)
                     handle_exception(Exception(e_msg), request)
         return mnt_options
 
@@ -181,8 +204,7 @@ class PoolMixin(object):
     def _remount(cls, request, pool):
         compression = cls._validate_compression(request)
         mnt_options = cls._validate_mnt_options(request)
-        if ((compression == pool.compression and
-             mnt_options == pool.mnt_options)):
+        if compression == pool.compression and mnt_options == pool.mnt_options:
             return Response()
 
         with transaction.atomic():
@@ -190,48 +212,53 @@ class PoolMixin(object):
             pool.mnt_options = mnt_options
             pool.save()
 
-        if (re.search('noatime', mnt_options) is None):
-            mnt_options = ('{},relatime,atime'.format(mnt_options))
+        if re.search("noatime", mnt_options) is None:
+            mnt_options = "{},relatime,atime".format(mnt_options)
 
-        if (re.search('compress-force', mnt_options) is None):
-            mnt_options = ('{},compress={}'.format(mnt_options, compression))
+        if re.search("compress-force", mnt_options) is None:
+            mnt_options = "{},compress={}".format(mnt_options, compression)
 
-        with open('/proc/mounts') as mfo:
+        with open("/proc/mounts") as mfo:
             mount_map = {}
             for l in mfo.readlines():
                 share_name = None
-                if (re.search(
-                        '{}|{}'.format(settings.NFS_EXPORT_ROOT, settings.MNT_PT),
-                        l) is not None):
-                    share_name = l.split()[1].split('/')[2]
-                elif (re.search(settings.SFTP_MNT_ROOT, l) is not None):
-                    share_name = l.split()[1].split('/')[3]
+                if (
+                    re.search(
+                        "{}|{}".format(settings.NFS_EXPORT_ROOT, settings.MNT_PT), l
+                    )
+                    is not None
+                ):
+                    share_name = l.split()[1].split("/")[2]
+                elif re.search(settings.SFTP_MNT_ROOT, l) is not None:
+                    share_name = l.split()[1].split("/")[3]
                 else:
                     continue
-                if (share_name not in mount_map):
-                    mount_map[share_name] = [l.split()[1], ]
+                if share_name not in mount_map:
+                    mount_map[share_name] = [l.split()[1]]
                 else:
                     mount_map[share_name].append(l.split()[1])
         failed_remounts = []
         try:
-            pool_mnt = '/mnt2/{}'.format(pool.name)
+            pool_mnt = "/mnt2/{}".format(pool.name)
             remount(pool_mnt, mnt_options)
         except:
             failed_remounts.append(pool_mnt)
         for share in mount_map.keys():
-            if (Share.objects.filter(pool=pool, name=share).exists()):
+            if Share.objects.filter(pool=pool, name=share).exists():
                 for m in mount_map[share]:
                     try:
                         remount(m, mnt_options)
                     except Exception as e:
                         logger.exception(e)
                         failed_remounts.append(m)
-        if (len(failed_remounts) > 0):
-            e_msg = ('Failed to remount the following mounts.\n {}.\n '
-                     'Try again or do the following as root (may cause '
-                     'downtime):\n1. systemctl stop rockstor.\n'
-                     '2. unmount manually.\n'
-                     '3. systemctl start rockstor.\n').format(failed_remounts)
+        if len(failed_remounts) > 0:
+            e_msg = (
+                "Failed to remount the following mounts.\n {}.\n "
+                "Try again or do the following as root (may cause "
+                "downtime):\n1. systemctl stop rockstor.\n"
+                "2. unmount manually.\n"
+                "3. systemctl start rockstor.\n"
+            ).format(failed_remounts)
             handle_exception(Exception(e_msg), request)
         return Response(PoolInfoSerializer(pool).data)
 
@@ -239,13 +266,13 @@ class PoolMixin(object):
     def _quotas(cls, request, pool):
         new_quota_state = cls._validate_new_quota_state(request)
         # If no change from current pool quota state then do nothing
-        current_state = 'Enabled'
+        current_state = "Enabled"
         if not pool.quotas_enabled:
-            current_state = 'Disabled'
+            current_state = "Disabled"
         if new_quota_state == current_state:
             return Response()
         try:
-            if new_quota_state == 'Enabled':
+            if new_quota_state == "Enabled":
                 # Current issue with requiring enable to be executed twice !!!
                 # As of 4.12.4-1.el7.elrepo.x86_64
                 # this avoids "ERROR: quota rescan failed: Invalid argument"
@@ -262,31 +289,32 @@ class PoolMixin(object):
             else:
                 disable_quota(pool)
         except:
-            e_msg = 'Failed to Enable (and rescan) / Disable Quotas for ' \
-                    'Pool ({}). Requested quota state ' \
-                    'was ({}).'.format(pool.name, new_quota_state)
+            e_msg = (
+                "Failed to Enable (and rescan) / Disable Quotas for "
+                "Pool ({}). Requested quota state "
+                "was ({}).".format(pool.name, new_quota_state)
+            )
             handle_exception(Exception(e_msg), request)
         return Response(PoolInfoSerializer(pool).data)
 
     def _balance_start(self, pool, force=False, convert=None):
         mnt_pt = mount_root(pool)
-        if convert is None and pool.raid == 'single':
+        if convert is None and pool.raid == "single":
             # Btrfs balance without convert filters will convert dup level
             # metadata on a single level data pool to raid1 on multi disk
             # pools. Avoid by explicit convert in this instance.
-            logger.info('Preserve single data, dup metadata by explicit '
-                        'convert.')
-            convert = 'single'
+            logger.info("Preserve single data, dup metadata by explicit " "convert.")
+            convert = "single"
         start_balance.async(mnt_pt, force=force, convert=convert)
         tid = 0
         count = 0
-        while (tid == 0 and count < 25):
+        while tid == 0 and count < 25:
             for t in Task.objects.all():
-                if (pickle.loads(t.args)[0] == mnt_pt):
+                if pickle.loads(t.args)[0] == mnt_pt:
                     tid = t.uuid
             time.sleep(0.2)  # 200 milliseconds
             count += 1
-        logger.debug('balance tid = ({}).'.format(tid))
+        logger.debug("balance tid = ({}).".format(tid))
         return tid
 
     def _resize_pool_start(self, pool, dnames, add=True):
@@ -304,8 +332,10 @@ class PoolMixin(object):
         cmd = resize_pool_cmd(pool, dnames, add)
         if cmd is None:
             return tid
-        logger.info('Beginning device resize on pool ({}). '
-                    'Changed member devices:({}).'.format(pool.name, dnames))
+        logger.info(
+            "Beginning device resize on pool ({}). "
+            "Changed member devices:({}).".format(pool.name, dnames)
+        )
         if add:
             # Mostly instantaneous so avoid complexity/overhead of django ztask
             start_resize_pool(cmd)
@@ -320,20 +350,22 @@ class PoolMixin(object):
                     tid = t.uuid
             time.sleep(0.2)  # 200 milliseconds
             count += 1
-        logger.debug('Pool resize tid = ({}).'.format(tid))
+        logger.debug("Pool resize tid = ({}).".format(tid))
         return tid
+
 
 class PoolListView(PoolMixin, rfc.GenericView):
     def get_queryset(self, *args, **kwargs):
-        sort_col = self.request.query_params.get('sortby', None)
-        if (sort_col is not None and sort_col == 'usage'):
-            reverse = self.request.query_params.get('reverse', 'no')
-            if (reverse == 'yes'):
+        sort_col = self.request.query_params.get("sortby", None)
+        if sort_col is not None and sort_col == "usage":
+            reverse = self.request.query_params.get("reverse", "no")
+            if reverse == "yes":
                 reverse = True
             else:
                 reverse = False
-            return sorted(Pool.objects.all(), key=lambda u: u.cur_usage(),
-                          reverse=reverse)
+            return sorted(
+                Pool.objects.all(), key=lambda u: u.cur_usage(), reverse=reverse
+            )
         return Pool.objects.all()
 
     @transaction.atomic
@@ -342,67 +374,82 @@ class PoolListView(PoolMixin, rfc.GenericView):
         input is a list of disks, raid_level and name of the pool.
         """
         with self._handle_exception(request):
-            disks = [self._validate_disk(d, request) for d in
-                     request.data.get('disks')]
-            pname = request.data['pname']
-            if (re.match('{}$'.format(settings.POOL_REGEX), pname) is None):
-                e_msg = ('Invalid characters in pool name. Following '
-                         'characters are allowed: letter(a-z or A-Z), '
-                         'digit(0-9), '
-                         'hyphen(-), underscore(_) or a period(.).')
+            disks = [self._validate_disk(d, request) for d in request.data.get("disks")]
+            pname = request.data["pname"]
+            if re.match("{}$".format(settings.POOL_REGEX), pname) is None:
+                e_msg = (
+                    "Invalid characters in pool name. Following "
+                    "characters are allowed: letter(a-z or A-Z), "
+                    "digit(0-9), "
+                    "hyphen(-), underscore(_) or a period(.)."
+                )
                 handle_exception(Exception(e_msg), request)
 
-            if (len(pname) > 255):
-                e_msg = 'Pool name must be less than 255 characters.'
+            if len(pname) > 255:
+                e_msg = "Pool name must be less than 255 characters."
                 handle_exception(Exception(e_msg), request)
 
-            if (Pool.objects.filter(name=pname).exists()):
-                e_msg = ('Pool ({}) already exists. '
-                         'Choose a different name.').format(pname)
+            if Pool.objects.filter(name=pname).exists():
+                e_msg = (
+                    "Pool ({}) already exists. " "Choose a different name."
+                ).format(pname)
                 handle_exception(Exception(e_msg), request)
 
-            if (Share.objects.filter(name=pname).exists()):
-                e_msg = ('A share with this name ({}) exists. Pool and share '
-                         'names must be distinct. '
-                         'Choose a different name.').format(pname)
+            if Share.objects.filter(name=pname).exists():
+                e_msg = (
+                    "A share with this name ({}) exists. Pool and share "
+                    "names must be distinct. "
+                    "Choose a different name."
+                ).format(pname)
                 handle_exception(Exception(e_msg), request)
 
             for d in disks:
-                if (d.btrfs_uuid is not None):
-                    e_msg = ('Another BTRFS filesystem exists on this '
-                             'disk ({}). '
-                             'Erase the disk and try again.').format(d.name)
+                if d.btrfs_uuid is not None:
+                    e_msg = (
+                        "Another BTRFS filesystem exists on this "
+                        "disk ({}). "
+                        "Erase the disk and try again."
+                    ).format(d.name)
                     handle_exception(Exception(e_msg), request)
 
-            raid_level = request.data['raid_level']
-            if (raid_level not in self.RAID_LEVELS):
-                e_msg = ('Unsupported raid level. Use one of: '
-                         '{}.').format(self.RAID_LEVELS)
+            raid_level = request.data["raid_level"]
+            if raid_level not in self.RAID_LEVELS:
+                e_msg = ("Unsupported raid level. Use one of: " "{}.").format(
+                    self.RAID_LEVELS
+                )
                 handle_exception(Exception(e_msg), request)
             # consolidated raid0 & raid 1 disk check
-            if (raid_level in self.RAID_LEVELS[1:3] and len(disks) <= 1):
-                e_msg = ('At least 2 disks are required for the raid level: '
-                         '{}.').format(raid_level)
+            if raid_level in self.RAID_LEVELS[1:3] and len(disks) <= 1:
+                e_msg = (
+                    "At least 2 disks are required for the raid level: " "{}."
+                ).format(raid_level)
                 handle_exception(Exception(e_msg), request)
-            if (raid_level == self.RAID_LEVELS[3]):
-                if (len(disks) < 4):
-                    e_msg = ('A minimum of 4 drives are required for the '
-                             'raid level: {}.').format(raid_level)
+            if raid_level == self.RAID_LEVELS[3]:
+                if len(disks) < 4:
+                    e_msg = (
+                        "A minimum of 4 drives are required for the " "raid level: {}."
+                    ).format(raid_level)
                     handle_exception(Exception(e_msg), request)
-            if (raid_level == self.RAID_LEVELS[4] and len(disks) < 2):
-                e_msg = ('2 or more disks are required for the raid '
-                         'level: {}.').format(raid_level)
+            if raid_level == self.RAID_LEVELS[4] and len(disks) < 2:
+                e_msg = (
+                    "2 or more disks are required for the raid " "level: {}."
+                ).format(raid_level)
                 handle_exception(Exception(e_msg), request)
-            if (raid_level == self.RAID_LEVELS[5] and len(disks) < 3):
-                e_msg = ('3 or more disks are required for the raid '
-                         'level: {}.').format(raid_level)
+            if raid_level == self.RAID_LEVELS[5] and len(disks) < 3:
+                e_msg = (
+                    "3 or more disks are required for the raid " "level: {}."
+                ).format(raid_level)
                 handle_exception(Exception(e_msg), request)
 
             compression = self._validate_compression(request)
             mnt_options = self._validate_mnt_options(request)
             dnames = self._role_filter_disk_names(disks, request)
-            p = Pool(name=pname, raid=raid_level, compression=compression,
-                     mnt_options=mnt_options)
+            p = Pool(
+                name=pname,
+                raid=raid_level,
+                compression=compression,
+                mnt_options=mnt_options,
+            )
             p.save()
             p.disk_set.add(*disks)
             # added for loop to save disks appears p.disk_set.add(*disks) was
@@ -423,7 +470,7 @@ class PoolListView(PoolMixin, rfc.GenericView):
 class PoolDetailView(PoolMixin, rfc.GenericView):
     def get(self, *args, **kwargs):
         try:
-            pool = Pool.objects.get(id=self.kwargs['pid'])
+            pool = Pool.objects.get(id=self.kwargs["pid"])
             serialized_data = PoolInfoSerializer(pool)
             return Response(serialized_data.data)
         except Pool.DoesNotExist:
@@ -443,19 +490,21 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
             try:
                 pool = Pool.objects.get(id=pid)
             except:
-                e_msg = 'Pool with id ({}) does not exist.'.format(pid)
+                e_msg = "Pool with id ({}) does not exist.".format(pid)
                 handle_exception(Exception(e_msg), request)
 
-            if (pool.role == 'root' and command != 'quotas'):
-                e_msg = ('Edit operations are not allowed on this pool ({}) '
-                         'as it contains the operating '
-                         'system.').format(pool.name)
+            if pool.role == "root" and command != "quotas":
+                e_msg = (
+                    "Edit operations are not allowed on this pool ({}) "
+                    "as it contains the operating "
+                    "system."
+                ).format(pool.name)
                 handle_exception(Exception(e_msg), request)
 
-            if (command == 'remount'):
+            if command == "remount":
                 return self._remount(request, pool)
 
-            if (command == 'quotas'):
+            if command == "quotas":
                 # There is a pending btrfs change that allows for quota state
                 # change on unmounted Volumes (pools).
                 return self._quotas(request, pool)
@@ -463,10 +512,12 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
             # Establish missing and detached disk removal request flag defaults:
             remove_missing_disk_request = False
             all_members_detached = False
-            if command == 'remove' and \
-                    request.data.get('disks', []) == ['missing']:
+            if command == "remove" and request.data.get("disks", []) == ["missing"]:
                 remove_missing_disk_request = True
-            if pool.disk_set.filter(name__startswith="detached-").count() == pool.disk_set.count():
+            if (
+                pool.disk_set.filter(name__startswith="detached-").count()
+                == pool.disk_set.count()
+            ):
                 all_members_detached = True
 
             if not pool.is_mounted:
@@ -476,68 +527,89 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 # re-attached and we have already indicated that possible path.
                 # All works accounts for all pool members in detached state.
                 if all_members_detached:
-                    logger.info("Skipping mount requirement: all pool's member are detached.")
+                    logger.info(
+                        "Skipping mount requirement: all pool's member are detached."
+                    )
                 else:
-                    e_msg = ('Pool member / raid edits require an active mount. '
-                             'Please see the "Maintenance required" section.')
+                    e_msg = (
+                        "Pool member / raid edits require an active mount. "
+                        'Please see the "Maintenance required" section.'
+                    )
                     handle_exception(Exception(e_msg), request)
 
             if remove_missing_disk_request:
                 disks = []
-                logger.debug('Remove missing request, so skipping disk validation')
+                logger.debug("Remove missing request, so skipping disk validation")
             else:
-                disks = [self._validate_disk_id(diskId, request) for diskId in
-                         request.data.get('disks', [])]
+                disks = [
+                    self._validate_disk_id(diskId, request)
+                    for diskId in request.data.get("disks", [])
+                ]
 
             num_disks_selected = len(disks)
             dnames = self._role_filter_disk_names(disks, request)
-            new_raid = request.data.get('raid_level', pool.raid)
+            new_raid = request.data.get("raid_level", pool.raid)
 
-            if (command == 'add'):
+            if command == "add":
                 # Only attached disks can be selected during an add operation.
-                num_total_attached_disks = pool.disk_set.attached().count() \
-                                  + num_disks_selected
+                num_total_attached_disks = (
+                    pool.disk_set.attached().count() + num_disks_selected
+                )
                 for d in disks:
-                    if (d.pool is not None):
-                        e_msg = ('Disk ({}) cannot be added to this pool ({}) '
-                                 'because it belongs to another pool ({})'
-                                 '.').format(d.name, pool.name, d.pool.name)
+                    if d.pool is not None:
+                        e_msg = (
+                            "Disk ({}) cannot be added to this pool ({}) "
+                            "because it belongs to another pool ({})"
+                            "."
+                        ).format(d.name, pool.name, d.pool.name)
                         handle_exception(Exception(e_msg), request)
-                    if (d.btrfs_uuid is not None):
-                        e_msg = ('Disk ({}) has a BTRFS filesystem from the '
-                                 'past. If you really like to add it, wipe it '
-                                 'from the Storage -> Disks screen of the '
-                                 'web-ui.').format(d.name)
+                    if d.btrfs_uuid is not None:
+                        e_msg = (
+                            "Disk ({}) has a BTRFS filesystem from the "
+                            "past. If you really like to add it, wipe it "
+                            "from the Storage -> Disks screen of the "
+                            "web-ui."
+                        ).format(d.name)
                         handle_exception(Exception(e_msg), request)
 
-                if pool.raid == 'single' and new_raid == 'raid10':
+                if pool.raid == "single" and new_raid == "raid10":
                     # TODO: Consider removing once we have better space calc.
                     # Avoid extreme raid level change upwards (space issues).
-                    e_msg = ('Pool migration from {} to {} is not '
-                             'supported.').format(pool.raid, new_raid)
+                    e_msg = (
+                        "Pool migration from {} to {} is not " "supported."
+                    ).format(pool.raid, new_raid)
                     handle_exception(Exception(e_msg), request)
 
-                if (new_raid == 'raid10' and num_total_attached_disks < 4):
-                    e_msg = ('A minimum of 4 drives are required for the '
-                             'raid level: raid10.')
+                if new_raid == "raid10" and num_total_attached_disks < 4:
+                    e_msg = (
+                        "A minimum of 4 drives are required for the "
+                        "raid level: raid10."
+                    )
                     handle_exception(Exception(e_msg), request)
 
-                if (new_raid == 'raid6' and num_total_attached_disks < 3):
-                    e_msg = ('A minimum of 3 drives are required for the '
-                             'raid level: raid6.')
+                if new_raid == "raid6" and num_total_attached_disks < 3:
+                    e_msg = (
+                        "A minimum of 3 drives are required for the "
+                        "raid level: raid6."
+                    )
                     handle_exception(Exception(e_msg), request)
 
-                if (new_raid == 'raid5' and num_total_attached_disks < 2):
-                    e_msg = ('A minimum of 2 drives are required for the '
-                             'raid level: raid5.')
+                if new_raid == "raid5" and num_total_attached_disks < 2:
+                    e_msg = (
+                        "A minimum of 2 drives are required for the "
+                        "raid level: raid5."
+                    )
                     handle_exception(Exception(e_msg), request)
 
-                if (PoolBalance.objects.filter(
-                        pool=pool,
-                        status__regex=r'(started|running|cancelling|pausing|paused)').exists()):  # noqa E501
-                    e_msg = ('A Balance process is already running or paused '
-                             'for this pool ({}). Resize is not supported '
-                             'during a balance process.').format(pool.name)
+                if PoolBalance.objects.filter(
+                    pool=pool,
+                    status__regex=r"(started|running|cancelling|pausing|paused)",
+                ).exists():  # noqa E501
+                    e_msg = (
+                        "A Balance process is already running or paused "
+                        "for this pool ({}). Resize is not supported "
+                        "during a balance process."
+                    ).format(pool.name)
                     handle_exception(Exception(e_msg), request)
 
                 # _resize_pool_start() add dev mode is quick so no async or tid
@@ -559,19 +631,22 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 # Now we ensure udev info is updated via system wide trigger
                 trigger_udev_update()
 
-            elif (command == 'remove'):
-                if (new_raid != pool.raid):
-                    e_msg = ('Raid configuration cannot be changed while '
-                             'removing disks.')
+            elif command == "remove":
+                if new_raid != pool.raid:
+                    e_msg = (
+                        "Raid configuration cannot be changed while " "removing disks."
+                    )
                     handle_exception(Exception(e_msg), request)
                 detached_disks_selected = 0
                 for d in disks:  # to be removed
-                    if (d.pool is None or d.pool != pool):
-                        e_msg = ('Disk ({}) cannot be removed because it does '
-                                 'not belong to this '
-                                 'pool ({}).').format(d.name, pool.name)
+                    if d.pool is None or d.pool != pool:
+                        e_msg = (
+                            "Disk ({}) cannot be removed because it does "
+                            "not belong to this "
+                            "pool ({})."
+                        ).format(d.name, pool.name)
                         handle_exception(Exception(e_msg), request)
-                    if re.match('detached-', d.name) is not None:
+                    if re.match("detached-", d.name) is not None:
                         detached_disks_selected += 1
                 if detached_disks_selected >= 2:
                     # We translate the removal of a detached device into:
@@ -579,61 +654,77 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                     # but only when appropriate, this removes the first 'missing' dev.
                     # A detached disk is not necessarily missing, but an indication of
                     # prior pool association.
-                    e_msg = ('Detached disk selection is limited to a single device. '
-                             'If all Pool members are detached all will be removed '
-                             'and their pool automatically deleted there after.')
+                    e_msg = (
+                        "Detached disk selection is limited to a single device. "
+                        "If all Pool members are detached all will be removed "
+                        "and their pool automatically deleted there after."
+                    )
                     handle_exception(Exception(e_msg), request)
-                attached_disks_selected = (
-                            num_disks_selected - detached_disks_selected)
+                attached_disks_selected = num_disks_selected - detached_disks_selected
                 remaining_attached_disks = (
-                            pool.disk_set.attached().count() - attached_disks_selected)
+                    pool.disk_set.attached().count() - attached_disks_selected
+                )
                 # Add check for attempt to remove detached & attached disks concurrently
                 if detached_disks_selected > 0 and attached_disks_selected > 0:
-                    e_msg = ('Mixed detached and attached disk selection is '
-                             'not supported. Limit your selection to only attached '
-                             'disks, or a single detached disk.')
+                    e_msg = (
+                        "Mixed detached and attached disk selection is "
+                        "not supported. Limit your selection to only attached "
+                        "disks, or a single detached disk."
+                    )
                     handle_exception(Exception(e_msg), request)
                 # Skip all further sanity checks when all members are detached.
                 if not all_members_detached:
-                    if pool.raid == 'raid0':
-                        e_msg = ('Disks cannot be removed from a pool with this '
-                                 'raid ({}) configuration.').format(pool.raid)
+                    if pool.raid == "raid0":
+                        e_msg = (
+                            "Disks cannot be removed from a pool with this "
+                            "raid ({}) configuration."
+                        ).format(pool.raid)
                         handle_exception(Exception(e_msg), request)
 
-                    if (pool.raid == 'raid1' and remaining_attached_disks < 2):
-                        e_msg = ('Disks cannot be removed from this pool '
-                                 'because its raid configuration (raid1) '
-                                 'requires a minimum of 2 disks.')
+                    if pool.raid == "raid1" and remaining_attached_disks < 2:
+                        e_msg = (
+                            "Disks cannot be removed from this pool "
+                            "because its raid configuration (raid1) "
+                            "requires a minimum of 2 disks."
+                        )
                         handle_exception(Exception(e_msg), request)
 
-                    if (pool.raid == 'raid10' and remaining_attached_disks < 4):
-                        e_msg = ('Disks cannot be removed from this pool '
-                                 'because its raid configuration (raid10) '
-                                 'requires a minimum of 4 disks.')
+                    if pool.raid == "raid10" and remaining_attached_disks < 4:
+                        e_msg = (
+                            "Disks cannot be removed from this pool "
+                            "because its raid configuration (raid10) "
+                            "requires a minimum of 4 disks."
+                        )
                         handle_exception(Exception(e_msg), request)
 
-                    if (pool.raid == 'raid5' and remaining_attached_disks < 2):
-                        e_msg = ('Disks cannot be removed from this pool because '
-                                 'its raid configuration (raid5) requires a '
-                                 'minimum of 2 disks.')
+                    if pool.raid == "raid5" and remaining_attached_disks < 2:
+                        e_msg = (
+                            "Disks cannot be removed from this pool because "
+                            "its raid configuration (raid5) requires a "
+                            "minimum of 2 disks."
+                        )
                         handle_exception(Exception(e_msg), request)
 
-                    if (pool.raid == 'raid6' and remaining_attached_disks < 3):
-                        e_msg = ('Disks cannot be removed from this pool because '
-                                 'its raid configuration (raid6) requires a '
-                                 'minimum of 3 disks.')
+                    if pool.raid == "raid6" and remaining_attached_disks < 3:
+                        e_msg = (
+                            "Disks cannot be removed from this pool because "
+                            "its raid configuration (raid6) requires a "
+                            "minimum of 3 disks."
+                        )
                         handle_exception(Exception(e_msg), request)
 
-                    usage = pool_usage('/{}/{}'.format(settings.MNT_PT, pool.name))
+                    usage = pool_usage("/{}/{}".format(settings.MNT_PT, pool.name))
                     size_cut = 0
                     for d in disks:  # to be removed
                         size_cut += d.allocated
                     available_free = pool.size - usage
                     if size_cut >= available_free:
-                        e_msg = ('Removing disks ({}) may shrink the pool by '
-                                 '{} KB, which is greater than available free '
-                                 'space {} KB. This is '
-                                 'not supported.').format(dnames, size_cut, available_free)
+                        e_msg = (
+                            "Removing disks ({}) may shrink the pool by "
+                            "{} KB, which is greater than available free "
+                            "space {} KB. This is "
+                            "not supported."
+                        ).format(dnames, size_cut, available_free)
                         handle_exception(Exception(e_msg), request)
 
                     # Unlike resize_pool_start() with add=True a remove has an
@@ -662,37 +753,40 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                         d.save()
 
             else:
-                e_msg = 'Command ({}) is not supported.'.format(command)
+                e_msg = "Command ({}) is not supported.".format(command)
                 handle_exception(Exception(e_msg), request)
             pool.size = pool.usage_bound()
             pool.save()
             return Response(PoolInfoSerializer(pool).data)
 
     @transaction.atomic
-    def delete(self, request, pid, command=''):
-        force = True if (command == 'force') else False
+    def delete(self, request, pid, command=""):
+        force = True if (command == "force") else False
         with self._handle_exception(request):
             try:
                 pool = Pool.objects.get(id=pid)
             except:
-                e_msg = 'Pool with id ({}) does not exist.'.format(pid)
+                e_msg = "Pool with id ({}) does not exist.".format(pid)
                 handle_exception(Exception(e_msg), request)
 
-            if (pool.role == 'root'):
-                e_msg = ('Deletion of pool ({}) is not allowed as it contains '
-                         'the operating system.').format(pool.name)
+            if pool.role == "root":
+                e_msg = (
+                    "Deletion of pool ({}) is not allowed as it contains "
+                    "the operating system."
+                ).format(pool.name)
                 handle_exception(Exception(e_msg), request)
 
-            if (Share.objects.filter(pool=pool).exists()):
+            if Share.objects.filter(pool=pool).exists():
                 if not force:
-                    e_msg = ('Pool ({}) is not empty. Delete is not allowed '
-                             'until all shares in the pool '
-                             'are deleted.').format(pool.name)
+                    e_msg = (
+                        "Pool ({}) is not empty. Delete is not allowed "
+                        "until all shares in the pool "
+                        "are deleted."
+                    ).format(pool.name)
                     handle_exception(Exception(e_msg), request)
                 for so in Share.objects.filter(pool=pool):
-                    remove_share(so.pool, so.subvol_name, so.pqgroup,
-                                 force=force)
-            pool_path = ('{}{}'.format(settings.MNT_PT, pool.name))
+                    remove_share(so.pool, so.subvol_name, so.pqgroup, force=force)
+            pool_path = "{}{}".format(settings.MNT_PT, pool.name)
             umount_root(pool_path)
             pool.delete()
             try:
@@ -700,15 +794,17 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 # We need another method to invoke this as self no good now.
                 self._update_disk_state()
             except Exception as e:
-                logger.error(('Exception while updating disk state: '
-                             '({}).').format(e.__str__()))
+                logger.error(
+                    ("Exception while updating disk state: " "({}).").format(
+                        e.__str__()
+                    )
+                )
             return Response()
 
 
 @api_view()
 def get_usage_bound(request):
     """Simple view to relay the computed usage bound to the front end."""
-    disk_sizes = [int(size) for size in
-                  request.query_params.getlist('disk_sizes[]')]
-    raid_level = request.query_params.get('raid_level', 'single')
+    disk_sizes = [int(size) for size in request.query_params.getlist("disk_sizes[]")]
+    raid_level = request.query_params.get("raid_level", "single")
     return Response(usage_bound(disk_sizes, len(disk_sizes), raid_level))

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -599,11 +599,12 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 size_cut = 0
                 for d in disks:
                     size_cut += d.allocated
-                if size_cut >= (pool.size - usage):
+                available_free = pool.size - usage
+                if size_cut >= available_free:
                     e_msg = ('Removing disks ({}) may shrink the pool by '
                              '{} KB, which is greater than available free '
                              'space {} KB. This is '
-                             'not supported.').format(dnames, size_cut, usage)
+                             'not supported.').format(dnames, size_cut, available_free)
                     handle_exception(Exception(e_msg), request)
 
                 # Unlike resize_pool_start() with add=True a remove has an

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -191,17 +191,17 @@ class PoolMixin(object):
             pool.save()
 
         if (re.search('noatime', mnt_options) is None):
-            mnt_options = ('%s,relatime,atime' % mnt_options)
+            mnt_options = ('{},relatime,atime'.format(mnt_options))
 
         if (re.search('compress-force', mnt_options) is None):
-            mnt_options = ('%s,compress=%s' % (mnt_options, compression))
+            mnt_options = ('{},compress={}'.format(mnt_options, compression))
 
         with open('/proc/mounts') as mfo:
             mount_map = {}
             for l in mfo.readlines():
                 share_name = None
                 if (re.search(
-                        '%s|%s' % (settings.NFS_EXPORT_ROOT, settings.MNT_PT),
+                        '{}|{}'.format(settings.NFS_EXPORT_ROOT, settings.MNT_PT),
                         l) is not None):
                     share_name = l.split()[1].split('/')[2]
                 elif (re.search(settings.SFTP_MNT_ROOT, l) is not None):
@@ -214,7 +214,7 @@ class PoolMixin(object):
                     mount_map[share_name].append(l.split()[1])
         failed_remounts = []
         try:
-            pool_mnt = '/mnt2/%s' % pool.name
+            pool_mnt = '/mnt2/{}'.format(pool.name)
             remount(pool_mnt, mnt_options)
         except:
             failed_remounts.append(pool_mnt)
@@ -345,7 +345,7 @@ class PoolListView(PoolMixin, rfc.GenericView):
             disks = [self._validate_disk(d, request) for d in
                      request.data.get('disks')]
             pname = request.data['pname']
-            if (re.match('%s$' % settings.POOL_REGEX, pname) is None):
+            if (re.match('{}$'.format(settings.POOL_REGEX), pname) is None):
                 e_msg = ('Invalid characters in pool name. Following '
                          'characters are allowed: letter(a-z or A-Z), '
                          'digit(0-9), '
@@ -624,7 +624,7 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                                  'minimum of 3 disks.')
                         handle_exception(Exception(e_msg), request)
 
-                    usage = pool_usage('/%s/%s' % (settings.MNT_PT, pool.name))
+                    usage = pool_usage('/{}/{}'.format(settings.MNT_PT, pool.name))
                     size_cut = 0
                     for d in disks:  # to be removed
                         size_cut += d.allocated
@@ -692,7 +692,7 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                 for so in Share.objects.filter(pool=pool):
                     remove_share(so.pool, so.subvol_name, so.pqgroup,
                                  force=force)
-            pool_path = ('%s%s' % (settings.MNT_PT, pool.name))
+            pool_path = ('{}{}'.format(settings.MNT_PT, pool.name))
             umount_root(pool_path)
             pool.delete()
             try:


### PR DESCRIPTION
Fixes #2099 
"failure to remove detached disks via pool resize"
Fixes #2077
"remove/resize pool for detached single dev pool fails"

Additional unrelated trivial fix included:
Fixes #2182
"Usage displayed instead of available free space Issue" #2182

## Detached disk management changes proposed:
- When a pool has no missing members remove db held pool associations from all prior ‘detached’ members. These disks then show up as regular detached devices and can be removed by their ‘bin’ icons. This allows for continued surfacing of prior attached status for these devices while returning source of truth to the pool itself re detached members. Issue #2099
- Special-case the removal of a detached device from a pool that has only detached members. Issue #2077
- Restrict detached device removal selection: one-at-a-time and with no detached/attached mixing. This reduces our problem space and so eases sanity checking. Attempted multi detached device selection informs that all detached will be removed on pools with only detached members anyway.
- Improve error message and log entry on missing device removal failure: reiterating degraded,rw advise and reboot suggestion.

## Note on interplay between the first two elements of above.
For pools with only detached members, we preserve the function of maintaining the members pool association (in light of the first element above), even though we normally assess missing device status via a pool model property (has_missing_dev) which can’t in the case of no attached members be known. This functionality is due to a prior check where, in the case of zero attached members, we proceed no further as no mount is then possible, and so do not inadvertently remove that pools single disk association. This maintains the possibility to detach all of a pools members and then re-attach them ‘hole sale’ (in powered off state) and for all associated configs (shares, exports, etc) to be re-established automatically. As if we were to remove all disk pool associations automatically in the case of all detached members, all it’s associated shares/exports would also be removed. (TEST THIS).

## Testing:

Changing all serials for all drives, during power down in KVM, results in none of the ‘detached’ former members having a pool association. This means these prior detached pool associated members are then removable via their bin icon, and as such we still surface their prior attached status. #2099

Removing a single detached member from pools that have only detached members results, by design, in all detached members having their pool association removed, and on next pool state refresh, the pool itself being removed. See #2077 detailed caveat below.

## Caveats:
N.B. as is common on a few of our Web-UI ‘operations’ two pool details page refreshes are often required for final pool state to be displayed. I.e. a removed detached disk entry will linger, post the completion of the operation, until this double refresh has been performed. And in the case of detached disk removal from pools that have only detached member, we have the ‘Ragged Edge’ issue detailed in my comments on issue #2077 which can be addressed in a future pull request.

Ready for review, requesting @FroggyFlox .
I have separated out the various main elements, as detailed above, into their own commits to aid review and have also ensured our project goals of string.format() and black formatting to all modified files.
