### PR TITLE
add architecture aware repo configuration. Fixes #2188

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -167,6 +167,7 @@ def switch_repo(subscription, on=True):
     # Historically our base subscription url denotes our CentOS rpm repo.
     subscription_distro_url = subscription.url
     distro_id = distro.id()
+    machine_arch = platform.machine()
     use_zypper = True
     repo_alias = "Rockstor-{}".format(subscription.name)
     logger.debug("########### SWITCH REPO repo-alias = {}".format(repo_alias))
@@ -176,6 +177,8 @@ def switch_repo(subscription, on=True):
         subscription_distro_url += "/tumbleweed"
     else:
         use_zypper = False
+    if machine_arch != "x86_64":
+        subscription_distro_url += "_{}".format(machine_arch)
     # Check if dir /etc/yum.repos.d exists and if not create.
     if not os.path.isdir(repos_dir):
         # Can use os.makedirs(path) if intermediate levels also don't exist.
@@ -301,7 +304,6 @@ def rockstor_pkg_update_check(subscription=None):
         if not available:
             continue
         if new_version is None:
-            machine_arch = platform.machine()
             if re.match("rockstor-", l) is not None:  # legacy yum
                 # eg: "rockstor-3.9.2-51.2089.x86_64"
                 new_version = (


### PR DESCRIPTION
Provide additional independent repositories configuration for non x86_64 architectures by appending the output of platform.machine() to the existing x86_64 repo url. An underscore is used in this concatenation to aid in url readability.

Fixes #2188

See issue text for context.

- Includes unrelated removal of redundant call to platform.machine().

Ready for review.

## Testing:

On a 15.2 aarch64 install the resulting yum and zypper repo urls were as follows:
```
cat /etc/yum.repos.d/Rockstor-Testing.repo | grep baseurl
baseurl=http://updates.rockstor.com:8999/rockstor-testing/leap/15.2_aarch64

zypper repos -u | grep Rockstor
2 | Rockstor-Testing     | Rockstor-Testing          | Yes     | ( p) Yes  | Yes     | http://updates.rockstor.com:8999/rockstor-testing/leap/15.2_aarch64
```
While on an existing x86_64 install the urls are unaffected, as intended:
```
cat /etc/yum.repos.d/Rockstor-Testing.repo | grep baseurl
baseurl=http://updates.rockstor.com:8999/rockstor-testing/leap/15.2

zypper repos -u | grep Rockstor
 2 | Rockstor-Testing          | Rockstor-Testing                   | Yes     | (r ) Yes  | Yes     | http://updates.rockstor.com:8999/rockstor-testing/leap/15.2
```
And to account for any potentially stray/non-visible characters or the like the resulting repos were tested for activity, respectively, via:
```
yum --showduplicates list rockstor

zypper search -s rockstor
```
Both of which functioned as expected in that existing populated repositories (x86_64 in this case) were showing as functioning as their hosted rpms were indicated.

### Caveat
Ancillary note on testing via Web-UI: when subscribed to the testing channel and the stable channel is selected and activated with an empty activation code (produces an explanatory error), we are removing the existing testing channel config for both zypper and yum. Visiting the dashboard and returning to the Software Updates page re-asserts both the yum and zypper repos (to testing).

### This pull request represents an extension to:
"add non legacy distro aware repo configuration. Fixes #1991" #1992
