### PR TITLE
add recognition of system disk & pool when on SD or MicroSD card. Fixes #2192

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1031,7 +1031,7 @@ def root_disk():
     Returns the base drive device name where / mount point is found.
     Works by parsing /proc/mounts. Eg if the root entry was as follows:
     /dev/sdc3 / btrfs rw,noatime,ssd,space_cache,subvolid=258,subvol=/root 0 0
-    the returned value is sdc
+    the returned value is /dev/sdc
     The assumption with non md devices is that the partition number will be a
     single character.
     :return: /dev/sdX type device name (with path) where root is mounted.
@@ -1055,7 +1055,7 @@ def root_disk():
                     return fields[0]
                 # resolve symbolic links to their targets.
                 disk = os.path.realpath(fields[0])
-                if re.match("/dev/md", disk) is not None:
+                if re.match("/dev/mmcblk|/dev/md", disk) is not None:
                     # We have an Multi Device naming scheme which is a little
                     # different ie 3rd partition = md126p3 on the md126 device,
                     # or md0p3 as third partition on md0 device.  As md devs
@@ -1066,6 +1066,9 @@ def root_disk():
                     # device name without the partition.  Search for where the
                     # numbers after "md" end.  N.B. the following will also
                     # work if root is not in a partition ie on md126 directly.
+                    # Note: this same pattern is also shared by mmcblk (sdcard) devices.
+                    # Base device examples: mmcblk1 or mmcblk2
+                    # First partition on the first device would be mmcblk1p1
                     end = re.search("\d+", disk).end()
                     return disk[:end]
                 if re.match("/dev/nvme", disk) is not None:

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -1762,3 +1762,59 @@ class OSITests(unittest.TestCase):
 #             #         print("each line = {}".format(each_line))
 #             mocked_open.assert_called_once_with("/proc/mounts")
 #         self.assertEqual(returned, expected[1])
+#
+#     def test_root_disk(self):
+#         """
+#         test root_disk() for expected function of identifying the base device name for the
+#         root mount point by mocking a variety of outputs from "/proc/mounts"
+#         Test earmarked for post Python 3 move as some changes were made to how read call
+#         is interpreted in mock re readlines() and mock_open()
+#         https://docs.python.org/3/library/unittest.mock.html#mock-open
+#         :param self:
+#         :return:
+#         """
+#
+#         # common SD/microSD card reader/driver device name:
+#         proc_mount_out = [
+#             """
+# /dev/mmcblk1p3 / btrfs rw,noatime,compress=lzo,ssd,space_cache,subvolid=258,subvol=/@/.snapshots/1/snapshot 0 0
+# """
+#         ]
+#         expected_result = ["/dev/mmcblk1"]
+#         # nvme device:
+#         proc_mount_out.append("""
+# /dev/nvme0n1p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
+# """)
+#         expected_result.append("/dev/nvme0n1")
+#         # md device, typically md126p3 or md0p3
+#         proc_mount_out.append("""
+# /dev/md126p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
+# """)
+#         expected_result.append("/dev/md126")
+#         # Regular virtio device:
+#         proc_mount_out.append("""
+# /dev/vda3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
+# """)
+#         expected_result.append("/dev/vda")
+#         # root in luks device:
+#         proc_mount_out.append("""
+# /dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
+# """)
+#         expected_result.append("/dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7")
+#
+#         # Based on the following article:
+#         # https://nickolaskraus.org/articles/how-to-mock-the-built-in-function-open/
+#         # Python 3 has "builtins.open" note the "s"
+#         # TODO: This mock of open is currently failing with empty reads of /proc/mounts
+#         for proc_out, expected in zip(proc_mount_out, expected_result):
+#             mock_open = mock.mock_open(read_data=proc_out)
+#             with mock.patch("__builtin__.open", mock_open) as mocked_open:
+#                 returned = root_disk()
+#                 # We assert a single call was made on "/proc/mounts"
+#                 mocked_open.assert_called_once_with("/proc/mounts")
+#
+#                 # The following shows that a handle.read().splitlines() works
+#                 # ... but not handle.readlines() such as we use in root_disk()
+#                 # But readlines() != splitlines() on break !!! readlines splits on \n only.
+#                 # https://discuss.python.org/t/changing-str-splitlines-to-match-file-readlines/174
+#             self.mocked_open.assertEqual(returned, expected)


### PR DESCRIPTION
For installs using an SD or MicroSD card as the system disk there is a failure to recognise this device as hosting the system with a consequent failure to surface the system pool. Further to this the user is presented with inappropriate choices; as if this disk was a regular data device.

Fix by adding the necessary device name match, and appropriate base name extraction filter, too root_disk(). In this case our existing mdraid device name treatment shares the same name structure assumptions with regard to base device name ("mmcblk1") in relation to partition name ("mmcblk1p3"). And so this patch proposes that an 'or' match is added to this existing section.

Fixes #2192
Ready for Review

## Testing
A unit test was developed for the existing and new functionality but as there is currently difficulty in mocking 'open' in Python 2 it has been included to avoid duplication of effort but remarked out as it was non functional. Functional tests were performed on a bare metal install using a MicroSD card as the system disk. Post proposed patch the system disk appeared, along with it's pool, as expected. Images of before and after will be attached in comments.