### PR TITLE
hide non functional auto update button until post re-launch fix. Fixes #2196

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -140,11 +140,11 @@ $(document).ready(function(){
     <h3>System is running Rockstor version: {{currentVersion}}</h3>
     <p>If you've updated recently, reload the browser<b>(Ctrl+Shift+R)</b> for latest UI changes.</p><br>
 
-    {{#if autoUpdateEnabled}}
-    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor is configured to check for available system updates and automatically upgrade all packages on a daily basis. This will keep your entire system up to date. While it's not recommended, you can disable this feature and only update when you want to.">Disable auto update</a>
-    {{else}}
-    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor can be configured to check for available system updates and automatically upgrade all packages on a daily basis. We recommend you enable this feature to keep your entire system up to date without delay.">Enable auto update</a>
-    {{/if}}
+<!--    {{#if autoUpdateEnabled}}-->
+<!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor is configured to check for available system updates and automatically upgrade all packages on a daily basis. This will keep your entire system up to date. While it's not recommended, you can disable this feature and only update when you want to.">Disable auto update</a>-->
+<!--    {{else}}-->
+<!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor can be configured to check for available system updates and automatically upgrade all packages on a daily basis. We recommend you enable this feature to keep your entire system up to date without delay.">Enable auto update</a>-->
+<!--    {{/if}}-->
   </div>
 </div>
 {{/update_available}}


### PR DESCRIPTION
Pending the transition to a yast2-online-update-configuration integration, compatible with our current openSUSE target distro, remark out the Web-UI element to our legacy yum-cron based system. This enables our existing related structures to serve as a guide for the transition and removes a non functional element that will ultimately only contribute to confusion and frustration if left in it's current visible and non functional form.

Fixes #2196 
