### PR TITLE
Vagrant/Ansible to auto-build a test server and/or provision a real host.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ node_modules/
 
 # VS Code
 .vscode
+
+# Vagrant working files.
+.vagrant/

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,89 @@
+Introduction
+------------
+You can use this ansible environment to provision a VM or physical hose with a confirmed working 
+specification with rockstor.
+
+Pre-requesits
+-------------
+It is assumped that you have the follow software packages install on you host machine:
+
+- ansible
+
+There are a number of ways to install this depending on your Host OS.
+ 
+####Mac OSX
+
+1. Install [brew](https://brew.sh)
+    ```
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    ```
+2. [option 1] Install ansible from brew:
+    ```
+    brew install ansible
+    ```
+    or
+   
+   [option 2] If you feel like running ansible from 'pip' under python 3:
+    ```
+    brew install pyenv
+    pyenv install 3.8.5
+    pyenv local 3.8.5
+    pip install ansible
+    ```
+    Note: you may find you need to install the OSX Xcode commandline build tools for pyenv to build your python version.
+    
+####Linux
+
+Working under linux will be slightly distribution dependent but similar to Mac OSX options.
+
+OpenSUSE:
+1. Install from your package manager:
+    ```
+    zypper install ansible
+    ```
+2. Install through 'pip':
+    ```
+    pip install ansible
+    ```
+
+####Windows
+
+Follow this [guide](https://www.jeffgeerling.com/blog/2017/using-ansible-through-windows-10s-subsystem-linux) by Jeff Geerling.
+
+
+It is also assumed that you have a local copy of this repository [rockstor-core](https://github.com/rockstor/rockstor-core) 
+on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the 
+Vagrantfile is located.
+
+The Inventory
+-------------
+The file inventory/hosts.yml contains details of the host you are provisioning with ansible. You will need to add your
+hosts IP to this line:
+```
+rockstor ansible_ssh_host=<your_host_ip>
+```
+If your host has a different user from 'root' for provisioning you can also set that in the hosts.yml on this line:
+```
+[all:vars]
+ansible_ssh_user=root
+```
+Running the Ansible
+-------------------
+To run the provisioner:
+```
+ansible-playbook Rockstor.yml --ask-pass
+```
+This will prompt you for the password of the user defined in the 'ansible_ssh_user' in the inventory/hosts.yml.
+
+If you would like a little debug for the ansible execution (and this is my normal level of debug) try:
+```
+ansible-playbook Rockstor.yml --ask-pass -vv
+```
+
+If you happen to already have an authorised ssh key added to the 'ansible_ssh_user' on the rockstor host
+then you can just type the following:
+```
+ansible-playbook Rockstor.yml
+```
+
+

--- a/ansible/Rockstor.yml
+++ b/ansible/Rockstor.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  become: yes
+  become_user: root
+
+  roles:
+    - role: rockstor_installer

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+inventory = inventory
+roles_path=./installed_roles:./roles
+nocows = 1
+host_key_checking = False
+transport = paramiko
+#interpreter_python = python # Forces the ansible python interpret to follow pyenv
+
+[ssh_connection]
+ssh_args=-o ForwardAgent=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,0 +1,5 @@
+rockstor ansible_ssh_host=<your_host_ip>
+
+[all:vars]
+ansible_ssh_user=root
+

--- a/ansible/roles/rockstor_installer/README.md
+++ b/ansible/roles/rockstor_installer/README.md
@@ -1,0 +1,73 @@
+This role has is a refactoring of the good work by Stephen Brown in his repo 
+here: https://gitlab.com/StephenBrown2/rockstor-opensuse
+
+Kudos to him for this excellent work.
+
+## Main variables
+
+There are some variables in default/main.yml which can (or need to) be overridden:
+
+* `rs_inst_update_repo_key`: The URL for the Rockstor update repo GPG Key.
+* `rs_inst_update_repo_url`: The URL for the Rockstor update repo"
+* `rs_inst_update_repo_name`: The name of the Rockstor update repo"
+* `rs_inst_useful_server_packages`: A list of useful addition packages to install on the server (eg. to support a Rock-On).
+* `rs_inst_experimental`: no[default] or yes. Controls whether the latest BTRFS is included.
+* `rs_inst_root_password`: The root password to be set. Must be encrypted eg. 
+    ```yaml
+    rs_inst_root_password: "{{ 'root' | password_hash('sha512', 'mysecretsalt') }}"
+    ```
+ * `rs_inst_set_root_pass`: false[default] or true. Sometimes needed on first time installs of OpenSUSE.
+
+## Vars in role configuration
+Including an example of how to use your role (for instance, with variables passed in as parameters):
+```yaml
+    - hosts: all
+      roles:
+         - role: rockstor-installer
+           rs_inst_experimental: yes
+           rs_inst_set_root_pass: true
+```           
+# rockstor-opensuse
+
+1. A typical rockstor OpenSUSE Leap 15.x host should be configure following the "Installer options" instructions 
+here: https://forum.rockstor.com/t/built-on-opensuse-dev-notes-and-status/5662. eg:
+   - Use at least a 20 GB system disk, this auto enables boot to snapshot functionality.
+   - Server (non transactional)
+   - Default partitioning
+   - Skip user creation (then only root password to enter and leaves all additional users as Rockstor managed)
+   - (Optional) Load ssh key from thumb drive for root user access via ansible
+*(Note: if using vagrant this is typically already available for the vagrant user)*
+   - Click "Software" heading, then uncheck "AppArmor", then click Next or Apply (I forget which it is specifically)
+   - Disable Firewall
+   - Leave SSH service enabled
+   - Switch to NetworkManager
+2. After the install and initial reboot, make sure you can log in using the previously created SSH Key, or 
+create one now and load it via `ssh-copy-id`
+*(Note: if using vagrant this is typically already available for the vagrant user)*
+3. Create an inventory file for ansible, something like the following in `hosts.yml`:
+    ```yaml
+    ---
+    all:
+        hosts:
+            rockstor:
+                # Use your server's IP
+                ansible_ssh_host: 192.168.88.100
+                # Use the path to your local SSH Private Key
+                ansible_ssh_private_key_file: /home/youruser/.ssh/id_rsa_ansible
+                ansible_user: root
+    ```
+4. Create a playbook called 'main.yml'
+    ```yaml
+    ---
+    - hosts: rockstor
+      become: yes
+      become_user: root
+    
+      roles:
+        - role: rockstor_installer
+    ```
+5. Run the ansible playbook:
+    ```sh
+    ansible-playbook -i hosts.yml main.yml
+    ```
+6. Enjoy your OpenSUSE-based Rockstor!

--- a/ansible/roles/rockstor_installer/defaults/main.yml
+++ b/ansible/roles/rockstor_installer/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+rs_inst_update_repo_key: "https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY"
+rs_inst_update_repo_url: "http://updates.rockstor.com:8999/rockstor-testing/leap/{{ distro_ver }}/"
+rs_inst_update_repo_name: "Rockstor-Testing"
+rs_inst_useful_server_packages:
+    - ffmpeg
+    - mediainfo
+    - mosh
+    - tmux
+    - tree
+rs_inst_experimental: no
+rs_inst_set_root_pass: 'false' # Assume the host already has one set.
+rs_inst_root_password: "{{ 'password' | password_hash('sha512', 'mysecretsalt') }}"

--- a/ansible/roles/rockstor_installer/meta/main.yml
+++ b/ansible/roles/rockstor_installer/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+galaxy_info:
+  role_name: rockstor_installer
+  author: mikemonkers
+  description: "OpenSUSE - This role has is a refactoring of the playbook written by Stephen Brown in his repo: https://gitlab.com/StephenBrown2/rockstor-opensuse"
+  license: GPLv3
+  min_ansible_version: 2.9
+  platforms:
+    - name: opensuse
+      versions:
+        - 15.1
+        - 15.2
+  galaxy_tags:
+    - rockstor
+...
+

--- a/ansible/roles/rockstor_installer/tasks/main.yml
+++ b/ansible/roles/rockstor_installer/tasks/main.yml
@@ -1,0 +1,215 @@
+---
+- name: Set distro_ver
+  set_fact:
+    distro_ver: "{{ ansible_facts.distribution_version }}"
+
+- name: Disable non-OSS repos
+  zypper_repository:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - repo-non-oss
+    - repo-update-non-oss
+  when: distro_ver == "15.2"
+
+- name: Apply all upstream updates
+  zypper:
+    name: "*"
+    state: latest
+    update_cache: yes
+    disable_recommends: yes
+
+- name: Verify installer options
+  block:
+  - name: Ensure firewalld is disabled (Installer option)
+    systemd:
+      name: firewalld
+      enabled: no
+      state: stopped
+
+  - name: Ensure openssh is installed (Installer option)
+    zypper:
+      name: openssh
+      state: present
+      update_cache: no
+  - name: Ensure sshd is enabled (Installer option)
+    systemd:
+      name: sshd
+      enabled: yes
+      state: started
+
+  - name: ensure wicked is disabled (Installer option)
+    systemd:
+      name: wickedd
+      enabled: no
+      state: stopped
+
+  - name: Ensure NetworkManager is installed (Installer option)
+    zypper:
+      name: NetworkManager
+      state: present
+      update_cache: no
+  - name: Ensure NetworkManager is enabled (Installer option)
+    systemd:
+      name: NetworkManager
+      enabled: yes
+      state: started
+
+  - name: Stop and Disable AppArmor
+    systemd:
+      name: apparmor
+      enabled: no
+      state: stopped
+    ignore_errors: yes
+
+- name: Disable IPv6 in sysctl
+  block:
+    - name: Check /proc/sys/net/ipv6 exists
+      stat:
+        path: /proc/sys/net/ipv6
+      register: sysctl_ipv6
+
+    - name: Disable IPv6 in sysctl
+      sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        state: present
+        reload: yes
+      loop:
+        - { name: "net.ipv6.conf.all.autoconf", value: "0" }
+        - { name: "net.ipv6.conf.all.disable_ipv6", value: "1" }
+        - { name: "net.ipv6.conf.default.autoconf", value: "0" }
+        - { name: "net.ipv6.conf.default.disable_ipv6", value: "1" }
+        - { name: "net.ipv6.conf.lo.autoconf", value: "0" }
+        - { name: "net.ipv6.conf.lo.disable_ipv6", value: "1" }
+      when: sysctl_ipv6.stat.exists and sysctl_ipv6.stat.isdir
+
+- name: Disable IPv6 in grub
+  block:
+    - name: Set GRUB_CMDLINE_LINUX_DEFAULT
+      replace:
+        dest: /etc/default/grub
+        regexp: ^GRUB_CMDLINE_LINUX_DEFAULT=["'](.*)["']$
+        replace: 'GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1 \1"'
+        backup: yes
+
+    - name: grub2-mkconfig
+      command: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+    - name: Reboot to ensure IPv6 disabled
+      reboot:
+        msg: "Reboot initiated by Ansible"
+        connect_timeout: 5
+        reboot_timeout: 300
+        pre_reboot_delay: 0
+        post_reboot_delay: 30
+        test_command: uptime
+  when: ("ipv6.disable" not in ansible_facts.cmdline) or
+        ("ipv6.disable" in ansible_facts.cmdline and ansible_facts.cmdline["ipv6.disable"] != "1")
+
+- name: Install useful server admin packages
+  zypper:
+    name: "{{ item }}"
+    state: present
+    update_cache: no
+  loop: "{{ rs_inst_useful_server_packages }}"
+
+- name: Update btrfsprogs to 5.x
+  block:
+    - name: Check filesystems repo file
+      stat:
+        path: /etc/zypp/repos.d/filesystems.repo
+      register: filesystems_repo
+
+    - name: Add filesystems repo
+      zypper_repository:
+        repo: https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_{{ distro_ver }}/filesystems.repo
+        enabled: yes
+        state: present
+        runrefresh: no
+      when: not filesystems_repo.stat.exists
+
+    - name: Update btrfsprogs
+      zypper:
+        name: btrfsprogs
+        state: latest
+        refresh: yes
+        extra_args_precommand: --gpg-auto-import-keys
+  when:
+    - rs_inst_experimental
+    - "'Leap' in ansible_facts.distribution"
+
+- name: Add ‘shells’ OBS repo
+  block:
+    - name: Check shells repo file
+      stat:
+        path: /etc/zypp/repos.d/shells.repo
+      register: shells_repo
+
+    - name: Add shells repo
+      zypper_repository:
+        repo: https://download.opensuse.org/repositories/shells/openSUSE_Leap_{{ distro_ver }}/shells.repo
+        enabled: yes
+        priority: 105
+        state: present
+      when: not shells_repo.stat.exists
+
+    - name: Refresh zypper to import shells GPG key
+      command:
+        cmd: zypper --quiet --non-interactive --gpg-auto-import-keys refresh
+        warn: no
+
+- name: Set up Rockstor
+  block:
+    - name: Import Rockstor’s public key
+      rpm_key:
+        state: present
+        key: "{{ rs_inst_update_repo_key }}"
+
+    - name: Add rockstor testing channel repository
+      zypper_repository:
+        repo: "{{ rs_inst_update_repo_url }}"
+        name: "{{ rs_inst_update_repo_name }}"
+        enabled: yes
+        state: present
+        runrefresh: yes
+
+    - name: Install Rockstor testing rpm
+      zypper:
+        name: rockstor
+        state: present
+        disable_recommends: yes
+
+    - name: Start the relevant rockstor related systemd services
+      systemd:
+        name: rockstor
+        enabled: yes
+        daemon_reload: yes
+        state: started
+
+- debug: msg="rs_inst_set_root_pass={{ rs_inst_set_root_pass }}"
+- name: Set the Root password
+  user:
+    name: "root"
+    password: "{{ rs_inst_root_password }}"
+  when: rs_inst_set_root_pass != 'false'
+
+# This is needed because Rockstors installer locks down sshd to allow only the user 'root'.
+# Unfortunately, this breaks vagrant which relies on ssh via the user 'vagrant'. This will
+# be fairly problematic for any provisioners like ansible, salt, etc which will rely on ssh
+# access. Forcing the use of root for provisioning is probably a 'discussion' point!
+- name: Ensure vagrant can still ssh in (add vagrant to sshd AllowUsers)
+  lineinfile:
+    path: "/etc/ssh/sshd_config"
+    backrefs: yes
+    regexp: "^(.*AllowUsers.*)$"
+    line: '\1 vagrant'
+
+- name: Reboot to ensure Rockstor resiliency
+  reboot:
+    msg: "Reboot initiated by Ansible"
+    connect_timeout: 5
+    reboot_timeout: 300
+    pre_reboot_delay: 0
+    post_reboot_delay: 30
+    test_command: uptime

--- a/vagrant_env/README.md
+++ b/vagrant_env/README.md
@@ -1,0 +1,108 @@
+Introduction
+------------
+You can use this vagrant environment to build a vagrant box VM of a confirmed working 
+specification with rockstor for testing.
+
+It will use the ansible playbooks and roles in this repository to perform the VM provisioning of Rockstor. Howver,
+Vagrant generates it's own host inventory since it operates using the vagrant user. eg.
+
+```yaml
+ANSIBLE_GROUPS = {
+  "all_groups" => ["rockstor"],
+  "all_groups:vars" => {
+        "rs_inst_set_root_pass" => "true"
+        }
+}
+```
+
+Pre-requesits
+-------------
+It is assumped that you have the follow software packages install on you host machine:
+- Vagrant (https://www.vagrantup.com/downloads)
+- VirtualBox (https://www.virtualbox.org/wiki/Downloads)
+
+Both packages are available on Linux, Mac OSX and Windows.
+
+It is also assumed that you have a local copy of this repository [rockstor-core](https://github.com/rockstor/rockstor-core) 
+on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the 
+Vagrantfile is located.
+
+Vagrant Boxes for OpenSUSE Leap
+-------------------------------
+
+This vagrant file uses the vagrant box: [bento/opensuse-leap-15](https://app.vagrantup.com/bento/boxes/opensuse-leap-15) 
+
+```
+v.vm.box = bento/opensuse-leap-15 
+```
+
+Explanantion:
+
+*Bento*: is a provider of many base boxes for vagrant, based on official images with the virtualisation tools added.  
+
+*opensuse-leap-15*: is a 'tag' for 'Leap 15 latest' and will track the latest release of leap 15. Should you require 
+a fixed version of leap there are specific tags available. eg. 
+
+```
+v.vm.box = bento/opensuse-leap-15.2 
+```
+
+Building the VM
+-----------------------------------
+On Mac OSX, Linux and Windows:
+
+```shell script
+vagrant up
+
+```
+
+This will also build and provision the vagrant box. It will then provision the VM with Rockstor as per the install 
+guide in the top level README.md.
+
+The VM window should have popped up and show the usual Rockstor messages regarding how to reach the Web UI. eg.
+
+```
+Rockstor is successfully installed.
+
+web-ui is accessible with the follow links:
+https://127.0.0.1
+https://10.0.2.15
+https://172.28.128.101
+https://172.28.128.100
+rockstor login:
+```  
+
+Note: your IPs may well vary.
+
+Managing the Virtual Machine
+----------------------------
+To manage the Vagrant box VM simple type the following from this directory...
+
+- Bring up a vagrant box VM
+```shell script
+vagrant up
+```
+
+- Reconfigure the vagrant box VM following a change to the Vagrantfile:
+
+```shell script
+vagrant reload
+```
+
+- If you change the provisioner section of the Vagrantfile, you can rerun just that part as follows:
+
+```shell script
+vagrant provision
+```
+
+- Destroy the vagrant box VM:
+
+```shell script
+vagrant destroy
+```
+
+- If you wish to ssh into the vagrant box VM to poke around, try this:
+
+```shell script
+vagrant ssh
+```

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Requires vagrant-host-shell and vagrant-vbguest
+required_plugins = %w(
+    vagrant-host-shell
+    vagrant-sshfs
+    )
+    #vagrant-vbguest
+required_plugins.each do |plugin|
+  system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
+end
+
+NAS_MEM = 2048
+NAS_CPU = 2
+
+# Vagrant uses it's own build in host inventory.
+ANSIBLE_GROUPS = {
+  "all_groups" => ["rockstor"],
+  "all_groups:vars" => {
+        "rs_inst_set_root_pass" => "true"
+        }
+}
+
+VAGRANTFILE_API_VERSION = '2'
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    config.vm.network "private_network", type: "dhcp"
+    # We don't need this directory syncing in this usage.
+    config.vm.synced_folder('.', '/vagrant', disabled: true)
+
+    config.vm.provider 'virtualbox' do |vb|
+    # Uncomment this to use linked clones and save space and spead up subsequent bring ups.
+    #     vb.linked_clone = true
+    end
+
+    config.vm.define "rockstor" do |v|
+        v.vm.hostname = "rockstor"
+        v.vm.box = 'bento/opensuse-leap-15'
+
+        # VirtualBox provider is pretty standard.
+        # (Other providers could be added later - eg. libvirt, kvm, esxi...)
+        v.vm.provider :virtualbox do |vb|
+            vb.memory = NAS_MEM
+            vb.cpus = NAS_CPU
+            # To force the console to pop up. If 'false' it will run headless.
+            vb.gui = true
+        end
+
+        # Provisioner using the external stand-alone ansible.
+        # (Other provisions could be added later - eg. salt, puppet...)
+        config.vm.provision "rockstor", type: "ansible" do |ansible|
+            ansible.config_file = "../ansible/ansible.cfg"
+            ansible.playbook = "../ansible/Rockstor.yml"
+            ansible.verbose = "vv"
+            ansible.groups = ANSIBLE_GROUPS
+        end
+    end
+end


### PR DESCRIPTION
Ansible to deploy/provision Rockstor to a host (refactored from Stephen Brown II work reported here: https://forum.rockstor.com/t/opensuse-ansible-playbook-to-get-rockstor-installed-on-fresh-system/7185 - accredited in the role README.md)

Vagrant to create a test host and use the ansible provisioner part of vagrant to join them together.

One command to build a VM with Rockstor installed ready to go.
```
Vagrant up
```
Or you can use the ansible directly on you own VM/physical host.