### PR TITLE
Implement docker networks. Fixes #1982.

### DIFF
--- a/src/rockstor/cli/disks_console.py
+++ b/src/rockstor/cli/disks_console.py
@@ -90,6 +90,6 @@ class DisksConsole(BaseConsole):
     def help_wipe(self):
         snps = "Wipe the partition table of a disk"
         params = {
-            "disk_name": "Name of the disk to be wiped of it's data",
+            "disk_name": "Name of the disk to be wiped of its data",
         }
         self.print_help(snps, "wipe", args=("disk_name",), params=params)

--- a/src/rockstor/storageadmin/migrations/0013_auto_20200815_2004.py
+++ b/src/rockstor/storageadmin/migrations/0013_auto_20200815_2004.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0012_auto_20200429_1428'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BridgeConnection',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('docker_name', models.CharField(max_length=64, null=True)),
+                ('usercon', models.BooleanField(default=False)),
+                ('aux_address', models.CharField(max_length=2048, null=True)),
+                ('dgateway', models.CharField(max_length=64, null=True)),
+                ('host_binding', models.CharField(max_length=64, null=True)),
+                ('icc', models.BooleanField(default=False)),
+                ('internal', models.BooleanField(default=False)),
+                ('ip_masquerade', models.BooleanField(default=False)),
+                ('ip_range', models.CharField(max_length=64, null=True)),
+                ('subnet', models.CharField(max_length=64, null=True)),
+                ('connection', models.ForeignKey(to='storageadmin.NetworkConnection', null=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='DContainerNetwork',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('connection', models.ForeignKey(to='storageadmin.BridgeConnection')),
+                ('container', models.ForeignKey(to='storageadmin.DContainer')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='dport',
+            name='publish',
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='dcontainerlink',
+            unique_together=set([('source', 'destination', 'name')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='dcontainernetwork',
+            unique_together=set([('container', 'connection')]),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -24,13 +24,9 @@ from nfs_export_group import NFSExportGroup  # noqa E501
 from nfs_export import NFSExport  # noqa E501
 from iscsi_target import IscsiTarget  # noqa E501
 from api_keys import APIKeys  # noqa E501
-from network_interface import (
-    NetworkConnection,
-    NetworkDevice,  # noqa E501
-    EthernetConnection,
-    TeamConnection,
-    BondConnection,
-)  # noqa E501
+from network_interface import (NetworkConnection, NetworkDevice,  # noqa E501
+                               EthernetConnection, TeamConnection, BondConnection,
+                               BridgeConnection)  # noqa E501
 from appliance import Appliance  # noqa E501
 from support_case import SupportCase  # noqa E501
 from dashboard_config import DashboardConfig  # noqa E501
@@ -47,30 +43,13 @@ from adv_nfs_exports import AdvancedNFSExport  # noqa E501
 from oauth_app import OauthApp  # noqa E501
 from pool_balance import PoolBalance  # noqa E501
 from tls_certificate import TLSCertificate  # noqa E501
-from rockon import (
-    RockOn,
-    DImage,
-    DContainer,
-    DPort,
-    DVolume,  # noqa E501
-    ContainerOption,
-    DCustomConfig,
-    DContainerLink,  # noqa E501
-    DContainerEnv,
-    DContainerDevice,
-    DContainerArgs,
-    DContainerLabel,
-)  # noqa E501
-from smart import (
-    SMARTAttribute,
-    SMARTCapability,
-    SMARTErrorLog,  # noqa E501
-    SMARTErrorLogSummary,
-    SMARTTestLog,
-    SMARTTestLogDetail,  # noqa E501
-    SMARTIdentity,
-    SMARTInfo,
-)  # noqa E501
+from rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
+                    ContainerOption, DCustomConfig, DContainerLink,  # noqa E501
+                    DContainerEnv, DContainerDevice, DContainerArgs,
+                    DContainerLabel, DContainerNetwork)  # noqa E501
+from smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
+                   SMARTErrorLogSummary, SMARTTestLog, SMARTTestLogDetail,  # noqa E501
+                   SMARTIdentity, SMARTInfo)  # noqa E501
 from config_backup import ConfigBackup  # noqa E501
 from email import EmailClient  # noqa E501
 from update_subscription import UpdateSubscription  # noqa E501

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -49,6 +49,7 @@ from storageadmin.models import (
     DContainerEnv,
     DContainerDevice,
     DContainerLabel,
+    DContainerNetwork,
     SMARTAttribute,
     SMARTCapability,
     SMARTInfo,
@@ -201,6 +202,7 @@ class DashboardConfigSerializer(serializers.ModelSerializer):
 
 class NetworkDeviceSerializer(serializers.ModelSerializer):
     cname = serializers.CharField()
+    dev_name = serializers.CharField()
 
     class Meta:
         model = NetworkDevice
@@ -211,6 +213,9 @@ class NetworkConnectionSerializer(serializers.ModelSerializer):
     mtu = serializers.IntegerField()
     team_profile = serializers.CharField()
     bond_profile = serializers.CharField()
+    docker_name = serializers.CharField()
+    user_dnet = serializers.BooleanField()
+    docker_options = serializers.DictField()
 
     class Meta:
         model = NetworkConnection
@@ -254,6 +259,8 @@ class TLSCertificateSerializer(serializers.ModelSerializer):
 
 class RockOnSerializer(serializers.ModelSerializer):
     ui_port = serializers.IntegerField()
+    ui_publish = serializers.BooleanField()
+    host_network = serializers.BooleanField()
 
     class Meta:
         model = RockOn
@@ -272,6 +279,8 @@ class RockOnVolumeSerializer(serializers.ModelSerializer):
 
 
 class RockOnPortSerializer(serializers.ModelSerializer):
+    container_name = serializers.CharField()
+
     class Meta:
         model = DPort
 
@@ -294,6 +303,14 @@ class RockOnDeviceSerializer(serializers.ModelSerializer):
 class RockOnLabelSerializer(serializers.ModelSerializer):
     class Meta:
         model = DContainerLabel
+
+
+class RockOnNetworkSerializer(serializers.ModelSerializer):
+    docker_name = serializers.CharField()
+    container_name = serializers.CharField()
+
+    class Meta:
+        model = DContainerNetwork
 
 
 class SMARTCapabilitySerializer(serializers.ModelSerializer):

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -784,6 +784,26 @@ var RockOnLabelCollection = RockStorPaginatedCollection.extend({
     }
 });
 
+var RockOnNetwork = Backbone.Model.extend({
+    urlRoot: '/api/rockon/networks/' + this.rid
+});
+
+var RockOnNetworkCollection = RockStorPaginatedCollection.extend({
+    model: RockOnNetwork,
+    initialize: function(models, options) {
+        this.constructor.__super__.initialize.apply(this, arguments);
+        if (options) {
+            this.rid = options.rid;
+        }
+    },
+    baseUrl: function() {
+        if (this.rid) {
+            return '/api/rockons/networks/' + this.rid;
+        }
+        return '/api/rockons/networks';
+    }
+});
+
 var RockOnCustomConfig = Backbone.Model.extend({
     urlRoot: '/api/rockon/customconfig/' + this.rid
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/network/network.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/network/network.jst
@@ -35,6 +35,7 @@
                 <th scope="col" abbr="UUID">UUID</th>
                 <th scope="col" abbr="Type">Type</th>
                 <th scope="col" abbr="State">State</th>
+                <th scope="col" abbr="Docker Name">Docker name</th>
                 <th scope="col" abbr="Method">Connection method</th>
                 <th scope="col" abbr="Address">IP Address</th>
                 <th scope="col" abbr="Gateway">Gateway</th>
@@ -49,17 +50,26 @@
                 <td class="accordion-toggle" data-toggle="collapse"
                     data-parent="#connections"
                     data-target="#accordion-{{this.id}}"><a> {{this.name}}</a>&nbsp;&nbsp;
+                    {{#unless this.docker_name}}
                     <a href="#network/edit/{{this.id}}"><i
                             class="glyphicon glyphicon-pencil"></i></a>
                     <a id="{{this.id}}" data-action="delete" rel="tooltip"
                        title="Delete connection"><i
                             class="glyphicon glyphicon-trash"></i></a></td>
+                    {{/unless}}
+                    {{#if this.user_dnet}}
+                    <a href="#network/edit/{{this.id}}"><i
+                            class="glyphicon glyphicon-pencil"></i></a>
+                    <a id="{{this.id}}" data-action="delete" rel="tooltip"
+                       title="Delete connection"><i
+                            class="glyphicon glyphicon-trash"></i></a></td>
+                    {{/if}}
                 <td>{{this.uuid}}</td>
                 <td>{{this.ctype}} {{#if
                     this.team_profile}}[{{this.team_profile}}]{{/if}}{{#if
                     this.bond_profile}}[{{this.bond_profile}}]{{/if}}
                 </td>
-                <td>{{this.state}}&nbsp;&nbsp;
+                <td>{{this.state}}&nbsp;&nbsp;{{#unless this.docker_name}}
                     <input type="checkbox" data-connection-id="{{this.id}}"
                            data-name="{{this.name}}" data-size="mini"
                            {{getState this.state}}>
@@ -68,10 +78,12 @@
                     <div class="simple-overlay" id="{{this.id}}-err-popup">
                         <div class="overlay-content"></div>
                     </div>
+                    {{/unless}}
                 </td>
+                <td>{{this.docker_name}}</td>
                 <td>{{this.ipv4_method}}</td>
                 <td>{{this.ipv4_addresses}}</td>
-                <td>{{this.ipv4_gw}}</td>
+                <td>{{#if this.ipv4_gw}}{{this.ipv4_gw}}{{else}}{{this.docker_options.dgateway}}{{/if}}</td>
                 <td>{{this.ipv4_dns}}</td>
                 <td>{{this.ipv4_dns_search}}</td>
                 <td>{{this.mtu}}</td>
@@ -105,6 +117,33 @@
                             {{/each}}
                         </table>
                         {{/hasChildren}}
+                        {{#if this.docker_name}}
+                        <p>Rocknet details</p>
+                        <table class="table table-bordered">
+                            <tr>
+                                <th>Name</th>
+                                <th>Auxiliary addresses</th>
+                                <th>Inter-containers communication</th>
+                                <th>Internal</th>
+                                <th>Host binding</th>
+                                <th>IP range</th>
+                                <th>IP masquerade</th>
+                                <th>Subnet</th>
+                                <th>Containers (Rock-on)</th>
+                            </tr>
+                            <tr>
+                                <td>{{this.docker_name}}</td>
+                                <td>{{this.docker_options.aux_address}}</td>
+                                <td>{{#if this.docker_options.icc}}Yes{{else}}No{{/if}}</td>
+                                <td>{{#if this.docker_options.internal}}Yes{{else}}No{{/if}}</td>
+                                <td>{{this.docker_options.host_binding}}</td>
+                                <td>{{this.docker_options.ip_range}}</td>
+                                <td>{{#if this.docker_options.ip_masquerade}}Yes{{else}}No{{/if}}</td>
+                                <td>{{this.docker_options.subnet}}</td>
+                                <td>{{this.docker_options.containers}}</td>
+                            </tr>
+                        </table>
+                        {{else}}
                         <p>member Devices</p>
                         <table class="table table-bordered">
                             <tr>
@@ -129,6 +168,7 @@
                             {{/if}}
                             {{/each}}
                         </table>
+                        {{/if}}
                     </div>
                 </td>
             </tr>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/network/new_connection.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/network/new_connection.jst
@@ -35,6 +35,14 @@
             <input class="form-control" type="text" id="name" name="name" {{#if connection}}value="{{connection.name}}" disabled{{/if}}>
           </div>
 	</div>
+          {{#if connection.docker_name}}
+      	<div class="form-group">
+          <label class="col-sm-4 control-label" for="dname">Docker Name<span class="required"> *</span></label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text" id="dname" name="dname" {{#if connection}}value="{{connection.docker_name}}"{{/if}}>
+          </div>
+    	</div>
+        {{/if}}
         <div class="form-group">
           <label class="col-sm-4 control-label" for="ctype">Connection Type<span class="required"> *</span></label>
           <div class="col-sm-4">
@@ -135,6 +143,56 @@
           </div>
         </div>
         </div><!--close methodOptionalFields-->
+            <div id="methodOptionalFieldsDocker" {{#if connection}}{{#isAuto connection}}style="display:none;"{{/isAuto}}{{else}}style="display:none;"{{/if}}>
+          <div class="form-group">
+          <label class="col-sm-4 control-label" for="aux_address">Auxilliary IP</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text"  id="aux_address" name="aux_address" {{#if connection}}value="{{connection.docker_options.aux_address}}"{{/if}} placeholder="Auxiliary IP Address">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="dgateway">Gateway</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text" id="dgateway" name="dgateway" {{#if connection}}value="{{connection.docker_options.dgateway}}"{{/if}} placeholder="Gateway">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="ip_range">IP range</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text" id="ip_range" name="ip_range" {{#if connection}}value="{{connection.docker_options.ip_range}}"{{/if}} placeholder="IP range">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="subnet">Subnet</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text" id="subnet" name="subnet" {{#if connection}}value="{{connection.docker_options.subnet}}"{{/if}} placeholder="Subnet">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="host_binding">Host IP binding</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="text" id="host_binding" name="host_binding" {{#if connection}}value="{{connection.docker_options.host_binding}}"{{/if}} placeholder="Host IPv4 binding address">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="internal">Internal Network</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="checkbox" id="internal" name="internal" {{#if connection}}{{#if connection.docker_options.internal}}checked{{/if}}{{/if}}>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="ip_masquerade">IP Masquerading</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="checkbox" id="ip_masquerade" name="ip_masquerade" {{#if connection}}{{#if connection.docker_options.ip_masquerade}}checked{{/if}}{{/if}}>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-4 control-label" for="icc">Inter-Containers Connectivity</label>
+          <div class="col-sm-4">
+            <input class="form-control" type="checkbox" id="icc" name="icc" {{#if connection}}{{#if connection.docker_options.icc}}checked{{/if}}{{/if}}>
+          </div>
+        </div>
+        </div><!--close methodOptionalFieldsDocker-->
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
 	    <button id="cancel" class="btn btn-default">Cancel</button>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports.jst
@@ -1,0 +1,1 @@
+<div id="ph-edit-ports-form"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports_form.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports_form.jst
@@ -1,0 +1,66 @@
+<div class="row">
+    <div class="col-md-10">
+        <div class="alert alert-warning">
+            <p>
+                You can choose to unpublish any port currently exported by this rock-on. Be aware,
+                however, that this is likely to interfere with its proper function, so change these settings
+                only if you know what it implies.
+            </p>
+        </div>
+        <form id="edit-ports-form" name="ports-form" class="form-horizontal">
+            <table class="table table-condensed table-bordered table-hover table-striped tablesorter">
+                <thead>
+                <tr>
+                    <th>Container</th>
+                    <th>Description</th>
+                    <th>Host &nbsp<i class="fa fa-info-circle fa-lg" title="Port number on the host" rel="tooltip"></i></th>
+                    <th>Mapped Port&nbsp;&nbsp<i class="fa fa-info-circle fa-lg"
+                                                 title="Port number mapped on the container" rel="tooltip"></i></th>
+                    <th>Publish&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Publish / Unpublish port"
+                                             rel="tooltip"></i></th>
+                </tr>
+                </thead>
+                {{#each ports}}
+                <tr>
+                    <td>{{this.container_name}}</td>
+                    <td>{{this.label}}</td>
+                    <td>{{this.hostp}}</td>
+                    <td>{{this.containerp}}</td>
+                    <td><input class="checkbox-inline ports-group" type="checkbox" id="{{this.id}}" name="{{this.id}}" {{#if
+                               this.publish}}checked{{/if}}>{{#if this.uiport}}&nbsp<i
+                            class="glyphicon glyphicon-exclamation-sign"
+                            title="This port is used to access the Rock-on's webUI. If you unpublish it, you won't be able to access it directly."
+                            rel="tooltip"></i>{{/if}}
+                    </td>
+                </tr>
+                {{/each}}
+            </table>
+                {{#unless ports}}
+                    <div class="alert alert-success">
+                        <p>This rock-on does not have any port exposed to modify.</p>
+                    </div>
+                {{/unless}}
+        </form>
+        <h3>Rocknets (optional)&nbsp;<a href="http://rockstor.com/docs/" target="_blank"
+                                        title="See Rockstor's documentation" rel="tooltip"><i
+                class="glyphicon glyphicon-question-sign"></i></a></h3>
+        <p>Select one or more rocknet(s) to join for each container of this rock-on:</p>
+        <div class="form-box">
+            <form id="join-networks" name="aform" class="form-horizontal">
+                {{#each containers}}
+                <div class="form-group">
+                    <label class="col-sm-3 control-label" for="containers">Container: {{name}}</label>
+                    <div class="controls col-sm-8">
+                        <select class="form-control" id="{{name}}" name="{{name}}" size="20"
+                                data-placeholder="select networks" multiple="multiple">
+                            {{#each ../user_dnets}}
+                            <option value="{{docker_name}}">{{docker_name}}</option>
+                            {{/each}}
+                        </select>
+                    </div>
+                </div>
+                {{/each}}
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
@@ -19,9 +19,21 @@
     <tr>
         <td>Port</td>
         <td>{{this.hostp}}</td>
-        <td>{{this.containerp}}</td>
+        <td>{{this.containerp}}{{isPublished this.id this.publish}}</td>
+        <!--<td>{{this.containerp}}{{isPublished this.id}}</td>-->
     </tr>
 {{/each}}
+{{#if new_cnets}}
+    {{display_newCnets}}
+{{else}}
+{{#each rocknets}}
+    <tr>
+        <td>Network</td>
+        <td>{{this.container_name}}</td>
+        <td>{{this.docker_name}}</td>
+    </tr>
+{{/each}}
+{{/if}}
 {{#each cc}}
     <tr>
         <td>Custom</td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/wizard_summary.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/wizard_summary.jst
@@ -29,6 +29,7 @@
     <div id="ph-wizard-buttons" class="col-md-12">
       <button id="next-page" class="btn btn-primary wizard-btn">Next</button>
       <button id="add-label" class="btn btn-primary wizard-btn">Label</button>
+      <button id="edit-ports" class="btn btn-primary wizard-btn">Networking</button>
       <button id="prev-page" class="btn wizard-btn">Back</button>
     </div>
   </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -76,7 +76,7 @@
       </div>
       <div class="modal-body">
         <div class="messages"></div>
-        <p>Deleting <strong><em><span class="pass-share-name"></span></em></strong> will destroy all of it's data (<strong><span id="pass-share-usage"></span></strong>). Are you sure?</p>
+        <p>Deleting <strong><em><span class="pass-share-name"></span></em></strong> will destroy all of its data (<strong><span id="pass-share-usage"></span></strong>). Are you sure?</p>
 	<label><input type="checkbox" id="force-delete" name="force-delete"> Force Delete &nbsp;<i class="fa fa-info-circle fa-lg"
 	title="Forces the deletion of undetected Snapshots and then deletes the Share. Useful to forcefully delete the Rock-on root share, for example." rel="tooltip"></i></label>
       </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/network_utilization.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/dashboard/network_utilization.js
@@ -168,7 +168,7 @@ NetworkUtilizationWidget = RockStorWidgetView.extend({
         this.networkInterfaces.each(function(ni, i) {
             var opt = $('<option/>');
             opt.val(ni.get('name'));
-            opt.text(ni.get('name'));
+            opt.text(ni.get('dev_name'));
             if (i == 0) {
                 opt.attr({
                     selected: 'selected'

--- a/src/rockstor/storageadmin/tests/test_network.py
+++ b/src/rockstor/storageadmin/tests/test_network.py
@@ -16,19 +16,21 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import mock
 from rest_framework import status
 from rest_framework.test import APITestCase
 from mock import patch
 from storageadmin.tests.test_api import APITestMixin
+from storageadmin.models import NetworkConnection, NetworkDevice
 
 
 class NetworkTests(APITestMixin, APITestCase):
     # Fixture from single ethernet KVM instance for now to start off new
     # mocking required after recent api change.
-    fixtures = ['test_network.json']
+    # fixtures = ["test_network2.json"]
     # TODO: Needs changing as API url different ie connection|devices|refresh
     # see referenced pr in setUpClass
-    BASE_URL = '/api/network'
+    BASE_URL = "/api/network"
 
     @classmethod
     def setUpClass(cls):
@@ -43,199 +45,441 @@ class NetworkTests(APITestMixin, APITestCase):
         # post mocks
 
         # devices map dictionary
-        cls.patch_devices = patch('system.network.get_dev_config')
+        cls.patch_devices = patch("system.network.get_dev_config")
         cls.mock_devices = cls.patch_devices.start()
         cls.mock_devices.return_value = {
-            'lo': {'dtype': 'loopback', 'mac': '00:00:00:00:00:00',
-                   'state': '10 (unmanaged)', 'mtu': '65536'},
-            'eth0': {'dtype': 'ethernet', 'mac': '52:54:00:58:5D:66',
-                     'connection': 'eth0', 'state': '100 (connected)',
-                     'mtu': '1500'}}
+            "lo": {
+                "dtype": "loopback",
+                "mac": "00:00:00:00:00:00",
+                "state": "10 (unmanaged)",
+                "mtu": "65536",
+            },
+            "eth0": {
+                "dtype": "ethernet",
+                "mac": "52:54:00:58:5D:66",
+                "connection": "eth0",
+                "state": "100 (connected)",
+                "mtu": "1500",
+            },
+        }
 
         # connections map dictionary
-        cls.patch_connections = patch('system.network.get_con_config')
+        cls.patch_connections = patch("system.network.get_con_config")
         cls.mock_connections = cls.patch_connections.start()
         cls.mock_connections.return_value = {
-            '8dca3630-8c54-4ad7-8421-327cc2d3d14a':
-                {'ctype': '802-3-ethernet',
-                 'ipv6_addresses': None,
-                 'ipv4_method': 'auto',
-                 'ipv6_method': None,
-                 'ipv6_dns': None,
-                 'name': 'eth0',
-                 'ipv4_addresses': '192.168.124.235/24',
-                 'ipv6_gw': None,
-                 'ipv4_dns': '192.168.124.1',
-                 'state': 'activated',
-                 'ipv6_dns_search': None,
-                 '802-3-ethernet': {
-                     'mac': '52:54:00:58:5D:66',
-                     'mtu': 'auto',
-                     'cloned_mac': None},
-                 'ipv4_gw': '192.168.124.1',
-                 'ipv4_dns_search': None}}
-
+            "8dca3630-8c54-4ad7-8421-327cc2d3d14a": {
+                "ctype": "802-3-ethernet",
+                "ipv6_addresses": None,
+                "ipv4_method": "auto",
+                "ipv6_method": None,
+                "ipv6_dns": None,
+                "name": "eth0",
+                "ipv4_addresses": "192.168.124.235/24",
+                "ipv6_gw": None,
+                "ipv4_dns": "192.168.124.1",
+                "state": "activated",
+                "ipv6_dns_search": None,
+                "802-3-ethernet": {
+                    "mac": "52:54:00:58:5D:66",
+                    "mtu": "auto",
+                    "cloned_mac": None,
+                },
+                "ipv4_gw": "192.168.124.1",
+                "ipv4_dns_search": None,
+            }
+        }
 
         # valid_connection
-        cls.patch_valid_connection = patch('system.network.valid_connection')
+        cls.patch_valid_connection = patch("system.network.valid_connection")
         cls.mock_valid_connection = cls.patch_valid_connection.start()
         cls.mock_valid_connection.return_value = True
 
         # toggle_connection
-        cls.patch_toggle_connection = patch('system.network.toggle_connection')
+        cls.patch_toggle_connection = patch("system.network.toggle_connection")
         cls.mock_toggle_connection = cls.patch_toggle_connection.start()
-        cls.mock_toggle_connection.return_value = [''], [''], 0
+        cls.mock_toggle_connection.return_value = [""], [""], 0
 
         # delete_connection
-        cls.patch_delete_connection = patch('system.network.delete_connection')
+        cls.patch_delete_connection = patch("system.network.delete_connection")
         cls.mock_delete_connection = cls.patch_delete_connection.start()
-        cls.mock_delete_connection.return_value = [''], [''], 0
+        cls.mock_delete_connection.return_value = [""], [""], 0
 
         # reload_connection
-        cls.patch_reload_connection = patch('system.network.reload_connection')
+        cls.patch_reload_connection = patch("system.network.reload_connection")
         cls.mock_reload_connection = cls.patch_reload_connection.start()
-        cls.mock_reload_connection.return_value = [''], [''], 0
+        cls.mock_reload_connection.return_value = [""], [""], 0
 
         # new_connection_helper
-        cls.patch_new_con_helper = patch(
-            'system.network.new_connection_helper')
+        cls.patch_new_con_helper = patch("system.network.new_connection_helper")
         cls.mock_new_con_helper = cls.patch_new_con_helper.start()
-        cls.mock_new_con_helper.return_value = [''], [''], 0
+        cls.mock_new_con_helper.return_value = [""], [""], 0
 
         # new_ethernet_connection
-        cls.patch_new_eth_conn = patch(
-            'system.network.new_ethernet_connection')
+        cls.patch_new_eth_conn = patch("system.network.new_ethernet_connection")
         cls.mock_new_eth_conn = cls.patch_new_eth_conn.start()
-        cls.mock_new_eth_conn.return_value = [''], [''], 0
+        cls.mock_new_eth_conn.return_value = [""], [""], 0
 
         # new_member_helper
-        cls.patch_new_mem_helper = patch('system.network.new_member_helper')
+        cls.patch_new_mem_helper = patch("system.network.new_member_helper")
         cls.mock_new_mem_helper = cls.patch_new_mem_helper.start()
-        cls.mock_new_mem_helper.return_value = [''], [''], 0
+        cls.mock_new_mem_helper.return_value = [""], [""], 0
 
         # TODO: Also need to mock
         # system.network.new_team_connection
         # and
         # system.network.new_bond_connection
 
+        # Set temp models entries as per fixtures
+        cls.temp_ethernet = NetworkConnection(id=1, name="Wired connection 1")
+        cls.temp_device_eth0 = NetworkDevice(id=2, name="eth0")
+        cls.temp_rocknet = NetworkConnection(id=17, name="br-6088a34098e0")
+        cls.temp_device = NetworkDevice(id=12, name="br-6088a34098e0")
+
     @classmethod
     def tearDownClass(cls):
         super(NetworkTests, cls).tearDownClass()
 
-    # TODO: Probably needs a re-write from here down due to API change.
     # N.B. There are working and current system level unit tests in:
     # src/rockstor/system/tests/test_system_network.py
     # Added via pr: "Add unit testing for core network functions" #2045 on GitHub
 
     # Fixture fix1.json has the test data. networks already exits in data are
     # 'enp0s3' and 'enp0s8'
-    # TODO: AttributeError: 'HttpResponseNotFound' object has no attribute 'data'
-    #  received on both below tests. Suspected as due to above referenced API change.
-    # def test_get(self):
-    #     """
-    #     unauthorized access
-    #     """
-    #     # get base URL
-    #     response = self.client.get(self.BASE_URL)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_200_OK, msg=response.data)
-    #
-    #     # get with iname
-    #     response = self.client.get('%s/enp0s3' % self.BASE_URL)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_200_OK, msg=response.data)
 
-    # def test_put(self):
-    #     """
-    #     put, change itype
-    #     """
-    #     # TODO: test needs updating, interface now different.
-    #     # invalid network interface
-    #     data = {'itype': 'management'}
-    #     response = self.client.put('%s/invalid' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = 'Network connection (invalid) does not exist.'
-    #     self.assertEqual(response.data['detail'], e_msg)
-    #
-    #     # edit configuration with out providing config method
-    #     data = {'method': '', 'itype': 'management'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = 'Method must be auto(for dhcp) or manual(for static IP). not: '
-    #     self.assertEqual(response.data['detail'], e_msg)
-    #
-    #     # happy path
-    #     data = {'method': 'auto', 'itype': 'management'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_200_OK, msg=response.data)
-    #     self.assertEqual(response.data['itype'], 'management')
-    #
-    #     # netmask set to None
-    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-    #             'netmask': None, 'gateway': '', 'dns_servers': '',
-    #             'itype': 'io'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = ('Provided netmask value(None) is invalid. You can provide '
-    #              'it in a IP address format(eg: 255.255.255.0) or number of '
-    #              'bits(eg: 24)')
-    #     self.assertEqual(response.data['detail'], e_msg)
-    #
-    #     # Invalid netmask
-    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-    #             'netmask': '111', 'gateway': '',
-    #             'dns_servers': '', 'itype': 'io'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = ('Provided netmask value(111) is invalid. Number of bits in '
-    #              'netmask must be between 1-32')
-    #     self.assertEqual(response.data['detail'], e_msg)
-    #
-    #     # happy path
-    #     data = {'method': 'manual', 'ipaddr': '192.168.56.101',
-    #             'netmask': '225.225.225.0', 'gateway': '',
-    #             'dns_servers': '', 'itype': 'io'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_200_OK, msg=response.data)
-    #     self.assertEqual(response.data['itype'], 'io')
-    #
-    #     # happy path
-    #     data = {'method': 'auto', 'itype': 'management'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_200_OK, msg=response.data)
-    #     self.assertEqual(response.data['itype'], 'management')
-    #
-    #     # Setting network interface itype to management when the othet network
-    #     # is already set to management
-    #     data = {'method': 'auto', 'itype': 'management'}
-    #     response = self.client.put('%s/enp0s8' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = ('Another interface(enp0s3) is already configured for '
-    #              'management. You must disable it first before making this '
-    #              'change.')
-    #     self.assertEqual(response.data['detail'], e_msg)
-    #
-    #     # provide ipaddress thats already been used by another interface
-    #     data = {'method': 'manual', 'ipaddr': '10.0.3.15',
-    #             'netmask': '225.225.225.0', 'gateway': '',
-    #             'dns_servers': '', 'itype': 'io'}
-    #     response = self.client.put('%s/enp0s3' % self.BASE_URL, data=data)
-    #     self.assertEqual(response.status_code,
-    #                      status.HTTP_500_INTERNAL_SERVER_ERROR,
-    #                      msg=response.data)
-    #     e_msg = ('IP: 192.168.56.101 already in use by another '
-    #              'interface: enp0s8')
-    #     self.assertEqual(response.data['detail'], e_msg)
+    # def session_login(self):
+    #     self.client.login(username='admin', password='admin')
+
+    def test_get_base(self):
+        """
+        unauthorized access
+        """
+        # get base URL
+        response = self.client.get("{}/connections".format(self.BASE_URL))
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            msg="Un-expected get() result:\n"
+            "response.status_code = ({}).\n "
+            "response.data = ({}).\n ".format(response.status_code, response.data),
+        )
+
+    def test_put_invalid_id(self):
+        """
+        test with invalid connection id
+        :return:
+        """
+        data = {"id": 99}
+        response = self.client.put("{}/connections/99".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Network connection (99) does not exist."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+    @mock.patch("storageadmin.views.network.NetworkConnectionDetailView._nco")
+    def test_put(self, mock_nco):
+        """
+        test put with valid connection id
+        """
+        mock_nco.return_value = self.temp_rocknet
+
+        # Valid rocknet edit
+        data = {"id": 17}
+        response = self.client.put("{}/connections/17".format(self.BASE_URL), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+
+        # Invalid MTU
+        data = {"id": 17, "mtu": 10000}
+        response = self.client.put("{}/connections/17".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.status_code returned was {}".format(response.status_code),
+        )
+        e_msg = "The mtu must be an integer in 1500 - 9000 range."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        data = {"id": 17, "mtu": 100}
+        response = self.client.put("{}/connections/17".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.status_code returned was {}".format(response.status_code),
+        )
+        e_msg = "The mtu must be an integer in 1500 - 9000 range."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+    @mock.patch("storageadmin.views.network.NetworkConnectionDetailView._nco")
+    def test_delete(self, mock_nco):
+        """
+        test put with valid connection id
+        """
+        mock_nco.return_value = self.temp_rocknet
+
+        data = {"id": 17}
+        response = self.client.put("{}/connections/17".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            msg="response.data = {}\n"
+            "reponse.status_code = {}".format(response.data, response.status_code),
+        )
+
+    @mock.patch("storageadmin.views.network.NetworkConnection.objects")
+    def test_nclistview_post_invalid(self, mock_networkconnection):
+        """
+        test NetworkConnectionListView.post with invalid settings
+        :return:
+        """
+        # A NetworkConnection object with the same name already exists
+        mock_networkconnection.filter.return_value = mock_networkconnection
+        mock_networkconnection.exists.return_value = True
+
+        data = {"id": 17, "name": "br-6088a34098e0"}
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Connection name (br-6088a34098e0) is already in use. Choose a different name."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # No method is defined
+        mock_networkconnection.filter.return_value = mock_networkconnection
+        mock_networkconnection.exists.return_value = False
+
+        data = {"id": 17, "name": "br-6088a34098e0"}
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Unsupported config method (None). Supported ones include: (('auto', 'manual'))."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # Invalid connection type
+        mock_networkconnection.filter.return_value = mock_networkconnection
+        mock_networkconnection.exists.return_value = False
+
+        data = {
+            "id": 17,
+            "name": "br-6088a34098e0",
+            "method": "auto",
+            "ctype": "invalid_ctype",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Unsupported connection type (invalid_ctype). Supported ones include: (('ethernet', 'team', 'bond', 'docker'))."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # Invalid team profile
+        mock_networkconnection.filter.return_value = mock_networkconnection
+        mock_networkconnection.exists.return_value = False
+
+        data = {
+            "id": 17,
+            "name": "br-6088a34098e0",
+            "method": "auto",
+            "ctype": "team",
+            "team_profile": "invalid_profile",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Unsupported team profile (invalid_profile). Supported ones include: (('broadcast', 'roundrobin', 'activebackup', 'loadbalance', 'lacp'))."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # Invalid bond profile
+        mock_networkconnection.filter.return_value = mock_networkconnection
+        mock_networkconnection.exists.return_value = False
+
+        data = {
+            "id": 17,
+            "name": "br-6088a34098e0",
+            "method": "auto",
+            "ctype": "bond",
+            "bond_profile": "invalid_profile",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Unsupported bond profile (invalid_profile). Supported ones include: (('balance-rr', 'active-backup', 'balance-xor', 'broadcast', '802.3ad', 'balance-tlb', 'balance-alb'))."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+    # TODO: write test for NetworkConnectionListView._validate_devices
+
+    def test_nclistview_post_devices(self):
+        """
+        test NetworkConnectionListView.post devices combinations
+        :return:
+        """
+        # Unknown device for ethernet connection
+        data = {
+            "id": 99,
+            "name": "Wired connection 99",
+            "device": "eth0",
+            "method": "auto",
+            "ctype": "ethernet",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "Unknown network device (eth0)."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+    @mock.patch("storageadmin.views.network.NetworkDevice.objects")
+    def test_nclistview_post_devices_not_list(self, mock_networkdevice):
+
+        mock_networkdevice.get.return_value = self.temp_device_eth0
+        ## Team
+        # Devices not a list for team connection
+        data = {
+            "id": 99,
+            "name": "Wired connection 99",
+            "devices": "eth0",
+            "method": "auto",
+            "ctype": "team",
+            "team_profile": "broadcast",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "devices must be a list"
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # Not enough devices for team connection
+        data = {
+            "id": 99,
+            "name": "Wired connection 99",
+            "devices": ["eth0",],
+            "method": "auto",
+            "ctype": "team",
+            "team_profile": "broadcast",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "A minimum of 2 devices are required."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        ## Bond
+        # Devices not a list for team connection
+        data = {
+            "id": 99,
+            "name": "Wired connection 99",
+            "devices": "eth0",
+            "method": "auto",
+            "ctype": "bond",
+            "bond_profile": "balance-rr",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "devices must be a list"
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )
+
+        # Not enough devices for team connection
+        data = {
+            "id": 99,
+            "name": "Wired connection 99",
+            "devices": ["eth0",],
+            "method": "auto",
+            "ctype": "bond",
+            "bond_profile": "balance-rr",
+        }
+        response = self.client.post("{}/connections".format(self.BASE_URL), data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg="response.data = {}\n"
+            "response.status_code = {}".format(response.data, response.status_code),
+        )
+        e_msg = "A minimum of 2 devices are required."
+        self.assertEqual(
+            response.data[0],
+            e_msg,
+            msg="response.data[0] = {}".format(response.data[0]),
+        )

--- a/src/rockstor/storageadmin/urls/rockons.py
+++ b/src/rockstor/storageadmin/urls/rockons.py
@@ -27,6 +27,7 @@ from storageadmin.views import (
     RockOnDeviceView,
     RockOnContainerView,
     RockOnLabelView,
+    RockOnNetworkView,
 )
 
 urlpatterns = patterns(
@@ -39,6 +40,7 @@ urlpatterns = patterns(
     url(r"^/environment/(?P<rid>\d+)$", RockOnEnvironmentView.as_view(),),
     url(r"^/devices/(?P<rid>\d+)$", RockOnDeviceView.as_view(),),
     url(r"^/labels/(?P<rid>\d+)$", RockOnLabelView.as_view(),),
+    url(r"^/networks/(?P<rid>\d+)$", RockOnNetworkView.as_view(),),
     url(r"^/(?P<command>update)$", RockOnView.as_view(),),
     url(r"^/(?P<rid>\d+)$", RockOnIdView.as_view(),),
     url(

--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -27,8 +27,8 @@ from appliances import ApplianceListView, ApplianceDetailView  # noqa F401
 from login import LoginView  # noqa F401
 from user import UserListView, UserDetailView  # noqa F401
 from dashboardconfig import DashboardConfigView  # noqa F401
-from network import (
-    NetworkDeviceListView,  # noqa F401
+from storageadmin.views.network import (
+    NetworkDeviceListView,
     NetworkConnectionListView,
     NetworkStateView,
     NetworkConnectionDetailView,
@@ -57,6 +57,7 @@ from rockon_custom_config import RockOnCustomConfigView  # noqa F401
 from rockon_environment import RockOnEnvironmentView  # noqa F401
 from rockon_device import RockOnDeviceView  # noqa F401
 from rockon_labels import RockOnLabelView  # noqa F401
+from rockon_networks import RockOnNetworkView  # noqa F401
 from disk_smart import DiskSMARTDetailView  # noqa F401
 from config_backup import (
     ConfigBackupListView,

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -23,13 +23,9 @@ import pickle
 import re
 
 import requests
-from django.conf import settings
 from django.db import transaction
-from django_ztask.models import Task
 from rest_framework.response import Response
 
-import rest_framework_custom as rfc
-from rockon_helpers import docker_status, rockon_status
 from smart_manager.models import Service
 from storageadmin.models import (
     RockOn,
@@ -46,6 +42,11 @@ from storageadmin.models import (
 )
 from storageadmin.serializers import RockOnSerializer
 from storageadmin.util import handle_exception
+import rest_framework_custom as rfc
+from rockon_helpers import rockon_status
+from system.docker import docker_status
+from django_ztask.models import Task
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/src/rockstor/storageadmin/views/rockon_networks.py
+++ b/src/rockstor/storageadmin/views/rockon_networks.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from storageadmin.models import RockOn, DContainer, DContainerNetwork
+from storageadmin.serializers import RockOnNetworkSerializer
+import rest_framework_custom as rfc
+from storageadmin.util import handle_exception
+
+
+class RockOnNetworkView(rfc.GenericView):
+    serializer_class = RockOnNetworkSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        try:
+            rockon = RockOn.objects.get(id=self.kwargs["rid"])
+        except:
+            e_msg = "Rock-on ({}) does not exist.".format(self.kwargs["rid"])
+            handle_exception(Exception(e_msg), self.request)
+
+        containers = DContainer.objects.filter(rockon=rockon)
+        return DContainerNetwork.objects.filter(container__in=containers).order_by("id")

--- a/src/rockstor/system/docker.py
+++ b/src/rockstor/system/docker.py
@@ -16,8 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
 import collections
+import json
+import logging
+
+from system.osi import run_command
+from system.services import service_status
 
 Image = collections.namedtuple("Image", "repository tag image_id created virt_size")
 Container = collections.namedtuple(
@@ -25,11 +29,21 @@ Container = collections.namedtuple(
 )
 
 DOCKER = "/usr/bin/docker"
+DNET = [
+    DOCKER,
+    "network",
+]
+
+logger = logging.getLogger(__name__)
 
 
 def image_list():
+    """
+    Appears to be unused currently.
+    :return:
+    """
     images = []
-    o, e, rc = run_command([DOCKER, "images",])
+    o, e, rc = run_command([DOCKER, "images"])
     for l in o[1:-1]:
         cur_image = Image(
             l[0:20].strip(),
@@ -43,8 +57,12 @@ def image_list():
 
 
 def container_list():
+    """
+    Appears to be unused currently.
+    :return:
+    """
     containers = []
-    o, e, rc = run_command([DOCKER, "ps", "-a",])
+    o, e, rc = run_command([DOCKER, "ps", "-a"])
     for l in o[1:-1]:
         cur_con = Container(
             l[0:20].strip(),
@@ -57,3 +75,203 @@ def container_list():
         )
         containers.append(cur_con)
     return containers
+
+
+def docker_status():
+    o, e, rc = service_status("docker")
+    if rc != 0:
+        return False
+    return True
+
+
+def dnets(id=None, type=None):
+    """
+    List the docker names of all docker networks.
+    :param id: string, used to test for network presence.
+    :param type: string, either 'custom' or 'builtin'
+    :return: list
+    """
+    cmd = list(DNET) + [
+        "ls",
+        "--format",
+        "{{.Name}}",
+    ]
+    if id:
+        cmd.extend(["--filter", "id={}".format(id)])
+    if type is not None:
+        if type == "custom":
+            cmd.extend((["--filter", "type=custom"]))
+        elif type == "builtin":
+            cmd.extend((["--filter", "type=builtin"]))
+        else:
+            raise Exception("type must be custom or builtin")
+    o, e, rc = run_command(cmd)
+    return o[:-1]
+
+
+def dnet_inspect(dname):
+    """
+    This function takes the name of a docker network as argument
+    and returns a dict of its configuration.
+    :param dname: docker network name
+    :return: dict
+    """
+    cmd = list(DNET) + ["inspect", dname, "--format", "{{json .}}"]
+    o, _, _ = run_command(cmd)
+    return json.loads(o[0])
+
+
+def probe_running_containers(container=None, network=None, all=False):
+    """
+    List docker containers.
+    :param container: container name
+    :param network:
+    :param all:
+    :return:
+    """
+    cmd = [
+        DOCKER,
+        "ps",
+        "--format",
+        "{{.Names}}",
+    ]
+    running_filters = [
+        "--filter",
+        "status=created",
+        "--filter",
+        "status=restarting",
+        "--filter",
+        "status=running",
+        "--filter",
+        "status=paused",
+    ]
+    if all:
+        cmd.extend((["-a",]))
+    if network:
+        cmd.extend((["--filter", "network={}".format(network),]))
+    if container:
+        cmd.extend((running_filters + ["--filter", "name={}".format(container),]))
+    else:
+        cmd.extend((running_filters))
+    o, e, rc = run_command(cmd)
+    return o
+
+
+def dnet_create(
+    network,
+    aux_address=None,
+    dgateway=None,
+    host_binding=None,
+    icc=None,
+    internal=None,
+    ip_masquerade=None,
+    ip_range=None,
+    mtu=1500,
+    subnet=None,
+):
+    """
+    This method checks for an already existing docker network with the same name.
+    If none is found, it will be created using the different parameters given.
+    If no parameter is specified, the network will be created using docker's defaults.
+    :param network:
+    :param aux_address:
+    :param dgateway:
+    :param host_binding:
+    :param icc:
+    :param internal:
+    :param ip_masquerade:
+    :param ip_range:
+    :param mtu:
+    :param subnet:
+    :return:
+    """
+    o, e, rc = run_command(list(DNET) + ["list", "--format", "{{.Name}}",])
+    if network not in o:
+        logger.debug(
+            "the network {} was NOT detected, so create it now.".format(network)
+        )
+        cmd = list(DNET) + [
+            "create",
+        ]
+        if subnet is not None and len(subnet.strip()) > 0:
+            cmd.extend(
+                ["--subnet={}".format(subnet),]
+            )
+        if dgateway is not None and len(dgateway.strip()) > 0:
+            cmd.extend(
+                ["--gateway={}".format(dgateway),]
+            )
+        if aux_address is not None and len(aux_address.strip()) > 0:
+            for i in aux_address.split(","):
+                cmd.extend(
+                    ['--aux-address="{}"'.format(i.strip()),]
+                )
+        if host_binding is not None and len(host_binding.strip()) > 0:
+            cmd.extend(
+                [
+                    "--opt",
+                    "com.docker.network.bridge.host_binding_ipv4={}".format(
+                        host_binding
+                    ),
+                ]
+            )
+        if icc is True:
+            cmd.extend(
+                ["--opt", "com.docker.network.bridge.enable_icc=true",]
+            )
+        if internal is True:
+            cmd.extend(
+                ["--internal",]
+            )
+        if ip_masquerade is True:
+            cmd.extend(
+                ["--opt", "com.docker.network.bridge.enable_ip_masquerade=true",]
+            )
+        if ip_range is not None and len(ip_range.strip()) > 0:
+            cmd.extend(
+                ["--ip-range={}".format(ip_range),]
+            )
+        if mtu != 1500:
+            cmd.extend(
+                ["--opt", "com.docker.network.driver.mtu={}".format(mtu),]
+            )
+        cmd.extend(
+            [network,]
+        )
+        run_command(cmd, log=True)
+    else:
+        logger.debug(
+            "the network {} was detected, so do NOT create it.".format(network)
+        )
+
+
+def dnet_connect(container, network, all=False):
+    """
+    Simple wrapper around docker connect with prior check for the existence of the container
+    and the lack of current connection to desired network.
+    :param container:
+    :param network:
+    :param all:
+    :return:
+    """
+    if (container in probe_running_containers(container=container, all=all)) and (
+        container not in probe_running_containers(network=network, all=all)
+    ):
+        run_command(list(DNET) + ["connect", network, container,], log=True)
+
+
+def dnet_disconnect(container, network):
+    run_command(list(DNET) + ["disconnect", network, container,], log=True)
+
+
+def dnet_remove(network=None):
+    """
+    This method uses the docker toolset to remove a docker network.
+    As this would throw an error if the network does not exist, we need
+    to first verify its presence.
+    :param network: string of network name as seen by `docker network ls`
+    :return:
+    """
+    # First, verify the network still exists
+    if network in dnets():
+        run_command(list(DNET) + ["rm", network,], log=True)

--- a/src/rockstor/system/network.py
+++ b/src/rockstor/system/network.py
@@ -22,7 +22,7 @@ import re
 
 from .exceptions import CommandException
 from .osi import run_command
-
+from .docker import dnets, docker_status, dnet_inspect
 
 NMCLI = "/usr/bin/nmcli"
 DEFAULT_MTU = 1500
@@ -116,6 +116,19 @@ def get_con_config(con_list):
             return None
         return s
 
+    def parse_aux_addresses(dtmap):
+        """
+        Parses auxilliary addresses of a docker network and
+        returns a flat list.
+        :param dtmap:
+        :return:
+        """
+        aux = dtmap["IPAM"]["Config"][0]["AuxiliaryAddresses"]
+        aux_list = []
+        for k, v in aux.items():
+            aux_list.append("{}={}".format(k, v))
+        return flatten(aux_list)
+
     for uuid in con_list:
         if len(uuid.strip()) == 0:
             continue
@@ -176,6 +189,66 @@ def get_con_config(con_list):
                     }
                 elif tmap["ctype"] in ("team", "bond"):
                     tmap[tmap["ctype"]] = {"config": None}
+                elif tmap["ctype"] == "bridge":
+                    cid = tmap["name"]
+                    tmap[tmap["ctype"]] = {
+                        "docker_name": None,
+                        "aux_address": None,
+                        "dgateway": None,
+                        "host_binding": None,
+                        "icc": False,
+                        "internal": False,
+                        "ip_masquerade": False,
+                        "ip_range": None,
+                        "subnet": None,
+                    }
+                    # Get docker_name
+                    if docker_status():
+                        # if (cid[0].startswith('br-')):  # custom-type docker network
+                        if cid.startswith("br-"):  # custom-type docker network
+                            docker_name = dname = dnets(cid[3:])[0]
+                        else:  # default docker0 bridge network
+                            docker_name = cid
+                            dname = "bridge"
+                        # Fill custom information, if any.
+                        dtmap = dnet_inspect(dname)
+                        tmap[tmap["ctype"]]["docker_name"] = docker_name
+                        if dtmap["IPAM"]["Config"][0].get("AuxiliaryAddresses"):
+                            tmap[tmap["ctype"]]["aux_address"] = parse_aux_addresses(
+                                dtmap
+                            )
+                        # In some case, DNET inspect does NOT return Gateway in Docker version 18.09.5, build e8ff056
+                        # This is likely related to the following bug in which the 'Gateway' is not reported the first
+                        # time the docker daemon is started. Upon reload of docker daemon, it IS correctly reported.
+                        # https://github.com/moby/moby/issues/26799
+                        if dtmap["IPAM"]["Config"][0].get("Gateway"):
+                            tmap[tmap["ctype"]]["dgateway"] = dtmap["IPAM"]["Config"][
+                                0
+                            ]["Gateway"]
+                        if dtmap["Options"].get(
+                            "com.docker.network.bridge.host_binding_ipv4"
+                        ):
+                            tmap[tmap["ctype"]]["host_binding"] = dtmap["Options"][
+                                "com.docker.network.bridge.host_binding_ipv4"
+                            ]
+                        if dtmap["Options"].get("com.docker.network.bridge.enable_icc"):
+                            tmap[tmap["ctype"]]["icc"] = dtmap["Options"][
+                                "com.docker.network.bridge.enable_icc"
+                            ]
+                        tmap[tmap["ctype"]]["internal"] = dtmap["Internal"]
+                        if dtmap["Options"].get(
+                            "com.docker.network.bridge.ip_masquerade"
+                        ):
+                            tmap[tmap["ctype"]]["ip_masquerade"] = dtmap["Options"][
+                                "com.docker.network.bridge.ip_masquerade"
+                            ]
+                        if dtmap["IPAM"]["Config"][0].get("IPRange"):
+                            tmap[tmap["ctype"]]["ip_range"] = dtmap["IPAM"]["Config"][
+                                0
+                            ]["IPRange"]
+                        tmap[tmap["ctype"]]["subnet"] = dtmap["IPAM"]["Config"][0][
+                            "Subnet"
+                        ]
                 else:
                     tmap[tmap["ctype"]] = {}
 


### PR DESCRIPTION
Fixes #1982.
Fixes #2003.
Fixes #2013.
Fixes #2009.

@phillxnet, ready for review.

As detailed in #1982, our current inter-containers communication in multi-containers rock-ons is not functional due to the deprecation of containers links by Docker. As originally proposed by @flukejones, we should switch to using docker networks instead. 
This pull-request thus represents a fix for inter-containers communication by following @flukejones idea and recommendation. It also takes the opportunity to expand upon this and proposes a deeper integration of **Docker networks** into Rockstor.  

*Note:* As this PR includes a substantial amount of features and testing, each main point will be split into separate posts.

Immense thanks to @phillxnet for his critical intervention and restructuration of the corresponding branch in the development of this PR.
 
### Overall aims & logic
The proposed implementation of docker networks (referred to as **rocknets** within Rockstor) can be split into three main parts:

1. re-enable `containers_links` object in rock-ons definitions.
2. create a rocknet from the webUI
3. connect a rock-on container to rocknet(s)

In point 1, this PR follows @flukejones' idea and simply uses the existing `container_links` object in the rock-on json to create a dedicated docker network linking the two containers defined in the `container_link`. Notably, as these docker networks are defined in the rock-on json, they are deemed critical for proper function of the rock-on and thus not editable by the user. They are still surfaced to the webUI for conveniency, however.

While rocknets (created in points 2 and 3 above) are using the same docker networks as those defined in `containers_links`, they differ in that they are **created by the user**. As a result, they are editable by the user and can be used to connect any container(s) the user desires.

