### PR TITLE
[NG] - Authorized_keys doesn't allow public key ssh login. Fixes #2212

### DIFF
--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -31,6 +31,7 @@ import chardet
 import random
 import string
 import crypt
+import stat
 
 import logging
 
@@ -233,7 +234,8 @@ def add_ssh_key(username, key, old_key=None):
     if not os.path.isdir(SSH_DIR):
         os.mkdir(SSH_DIR)
     run_command([CHOWN, "-R", "%s:%s" % (username, groupname), SSH_DIR])
-    os.chmod(SSH_DIR, 700)
+    # Set directory to rwx --- --- (700) via stat constants.
+    os.chmod(SSH_DIR, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
     fo, npath = mkstemp()
     exists = False
     with open(AUTH_KEYS, openmode) as afo, open(npath, "w") as tfo:
@@ -248,5 +250,6 @@ def add_ssh_key(username, key, old_key=None):
     if exists:
         return os.remove(npath)
     move(npath, AUTH_KEYS)
-    os.chmod(AUTH_KEYS, 600)
+    # Set file to rw- --- --- (600) via stat constants.
+    os.chmod(AUTH_KEYS, stat.S_IRUSR | stat.S_IWUSR)
     run_command([CHOWN, "%s:%s" % (username, groupname), AUTH_KEYS])


### PR DESCRIPTION
Fix incorrect use of os.chmod leading to dir/file permissions based failure of public key based ssh/sftp user access.

Current Rockstor defaults only allow the root user access via ssh, however sftp access can also use public ssh key based authentication. If a non root Rockstor user is also the owner of a Rockstor share, and that share is exported via SFTP, key based authentication can be enabled by supplying a client public key to the Rockstor users profile:

System - Users - Edit user (pen icon)

The resulting sftp access is within a chroot environment wherein the owned sftp exported shares are mapped.

But this public key based authentication method failed due to safeguards in the ssh subsystem when incorrect dir/file permissions were found.

Fixes #2212 

## Security note
Only public keys entered via the Rockstor Web-UI (System - Users edit) method would have been affected by the resulting incorrect file permissions. However if a private key was generated via the command line, and the same user also had a public key entered into their user profile via the Rockstor Web-UI thereafter then the private key would also be affected by this bug.

## Resolving an existing config (via Web-UI)
Removing an existing public key, submitting the change, and then re-adding the key resolves all known directory and file permissions resulting from this bug for the given user. And by virtue of then conforming to the strict dir/file permissions enforced by the ssh subsystem, ssh based key authentication functions as expected.
