### PR TITLE
9000 user limit within NIS breaks Web-UI for larger user sets. Fixes #2211

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/rockstor.js
@@ -426,7 +426,7 @@ RockStorGlobals = {
     navbarLoaded: false,
     applianceNameSet: false,
     currentAppliance: null,
-    maxPageSize: 9000,
+    maxPageSize: 32000,
     browserChecked: false,
     kernel: null
 };


### PR DESCRIPTION
Increase maxPageSize from 9000 to 32000 predominantly to deal with larger installs, i.e. > 9000 users / groups. System wide change so should also accommodate all other datatable displays and background functions within the Web-UI.

The observed failure in the associated issue, with an NIS user count of greater than 30,000, was triggered via:

Click ‘Storage’–>‘File Sharing’–>Samba’–>‘Add Samba Export’

Resulting in:
```
“Unknown internal error doing a GET to /api/users?page=1&format=json&page_size=9000&count=”
```

This patch is an attempt to narrow down the possible causes of this error by at least raising our known limitation of 9000 items per call. Thus:

Fixes #2211

Hopefully. But it is not unlikely that we have another issue at play here, i.e. time-out related.
