### PR TITLE
NIS regression re Rockstor 4 release candidates. Fixes #2216

### DIFF
--- a/src/rockstor/system/nis.py
+++ b/src/rockstor/system/nis.py
@@ -23,37 +23,61 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-NETWORK_FILE = "/etc/sysconfig/network"
-AUTH_FILE = "/etc/sysconfig/authconfig"
+NETWORK_FILE = "/etc/sysconfig/network/config"
+# AUTH_FILE = "/etc/sysconfig/authconfig"
 YP_FILE = "/etc/yp.conf"
 NSSWITCH_FILE = "/etc/nsswitch.conf"
 
 
 def configure_nis(nis_domain, server):
+    """
+    In NETWORK_FILE:
+    Adds/edits NETCONFIG_NIS_STATIC_DOMAIN to equal nis_domain.
+    Adds/edits NETCONFIG_NIS_STATIC_SERVERS to equal server.
+    In YP_FILE:
+    Adds/edits domain entry to equal "domain $nis_domain server $server"
+    In NSSWITCH_FILE:
+    Adds/edits passwd,shadow,group entries to equal "files nis"
+    Adds/edits hosts entries to equal  "files mdns_minimal [NOTFOUND=return] dns nis"
+    https://doc.opensuse.org/documentation/leap/security/html/book-security/cha-nis.html
+    :param nis_domain: User input NIS domain e.g. "example.com", or "lan".
+    :param server: User input NIS server e.g. "192.168.1.159"
+    """
 
     fo, npath = mkstemp()
-    nl = "NISDOMAIN=%s\n" % nis_domain
-    inplace_replace(NETWORK_FILE, npath, ("NISDOMAIN",), (nl,))
-    fo, apath = mkstemp()
-    inplace_replace(AUTH_FILE, apath, ("USENIS",), ("USENIS=yes\n",))
+    # post yast nis client setup
+    # In /etc/sysconfig/network/config
+    # NETCONFIG_NIS_SETDOMAINNAME="yes" (default "netconfig sets the domainname")
+    # Defines whether to set the default NIS domain. When enabled and no domain
+    # is provided dynamically or in static settings, /etc/defaultdomain is used.
+    # Typically, a Rockstor install will have an empty /etc/defaultdomain.
+    # NETCONFIG_NIS_STATIC_DOMAIN="" (default)
+    # NETCONFIG_NIS_STATIC_SERVERS="" (default)
+    regex = ("NETCONFIG_NIS_STATIC_DOMAIN", "NETCONFIG_NIS_STATIC_SERVERS")
+    nl = (
+        'NETCONFIG_NIS_STATIC_DOMAIN="{}"\n'.format(nis_domain),
+        'NETCONFIG_NIS_STATIC_SERVERS="{}"\n'.format(server),
+    )
+    inplace_replace(NETWORK_FILE, npath, regex, nl)
+    # Legacy CentOS section:
+    # fo, apath = mkstemp()
+    # authconfig is RH Fedora tool, authselect is partial counterpart in Tumbleweed only.
+    # inplace_replace(AUTH_FILE, apath, ("USENIS",), ("USENIS=yes\n",))
     fo, ypath = mkstemp()
-    nl = "domain %s server %s\n" % (nis_domain, server)
+    nl = "domain {} server {}\n".format(nis_domain, server)
     inplace_replace(YP_FILE, ypath, ("domain",), (nl,))
     fo, nspath = mkstemp()
-    regex = (
-        "passwd:",
-        "shadow:",
-        "group:",
-        "hosts:",
-    )
+    regex = ("passwd:", "shadow:", "group:", "hosts:")
+    # We mimic yast2-nis-client plugin behaviour with the following multiple entries.
     nl = (
         "passwd:    files nis\n",
         "shadow:    files nis\n",
         "group:     files nis\n",
-        "hosts:     files dns nis\n",
+        # mdns_minimal [NOTFOUND=return] is added by nss-mdns: an avahi dependency
+        "hosts:     files mdns_minimal [NOTFOUND=return] dns nis\n",
     )
     inplace_replace(NSSWITCH_FILE, nspath, regex, nl)
     move(npath, NETWORK_FILE)
-    move(apath, AUTH_FILE)
+    # move(apath, AUTH_FILE)
     move(ypath, YP_FILE)
     move(nspath, NSSWITCH_FILE)


### PR DESCRIPTION
Modify NIS config file paths and nature of edits appropriate for the current 'Build on openSUSE' endeavour and move the use of chkconfig to systemd which chkconfig was more recently an aliased for anyway. N.B. we no longer release CentOS variants so backward compatibility was not addressed.

Includes:
- Added remarks to explain config_nis().
- Remarking out CentOS'ism (authconfig).
- Addition of executing "netconfig update -f" to instantiate yp.conf edits.

Fixes #2216 

## Testing
An NIS server was setup with around 30,000 users as detailed in the referenced issue. Post pr patch an otherwise 4.0.2-0 Rockstor instance was able to successfully register with the NIS server via Web-UI config means only. Successful NIS client config was then established via:
```
pro8:~ # ypcat passwd | wc -l
30026
```
Demonstrating yellow pages's registration of the addition 30,000 users on top of the client machines default users.

Turning off the NIS service was also observed to in turn remove the additional users. Rockstor's user related Web-UI components were also observed to reflect these consequent users changes.