### PR TITLE
remove redundant chkconfig use. Fixes #1986

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -437,7 +437,6 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 # The following have been tested in CentOS, openSUSE Leap15, and Tumbleweed
 UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
 SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
-CHKCONFIG_BIN = subprocess.check_output(["which", "chkconfig"]).rstrip()
 
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -395,7 +395,6 @@ UPDATE_CHANNELS = {
 # The following have been tested in CentOS, openSUSE Leap15, and Tumbleweed
 UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
 SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
-CHKCONFIG_BIN = subprocess.check_output(["which", "chkconfig"]).rstrip()
 
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -26,7 +26,6 @@ from django.conf import settings
 
 from osi import run_command
 
-CHKCONFIG_BIN = settings.CHKCONFIG_BIN
 AUTHCONFIG = "/usr/sbin/authconfig"
 SSHD_CONFIG = "/etc/ssh/sshd_config"
 SYSTEMCTL_BIN = "/usr/bin/systemctl"
@@ -67,10 +66,6 @@ def init_service_op(service_name, command, throw=True):
         raise Exception("unknown service: {}".format(service_name))
 
     return run_command([SYSTEMCTL_BIN, command, service_name], throw=throw)
-
-
-def chkconfig(service_name, switch):
-    return run_command([CHKCONFIG_BIN, service_name, switch])
 
 
 def systemctl(service_name, switch):


### PR DESCRIPTION
Post removal of our last remaining use of chkconfig, see commit: 508e883

"NIS regression re Rockstor 4 release candidates. Fixes #2216"

this patch removes it's binary path definition within both production and test settings files and it's associated system/services.py wrapper.

Fixes #1986

## Caveats
This pr is proposed as a follow-up to the indicated, and pending:
"NIS regression re Rockstor 4 release candidates. Fixes #2216" #2221
As such it should be merged after #2221 as it removes elements that are still dependants pre #2221 
