### PR TITLE
Implement SSSD-based enrollment into Active Directory or LDAP domains.

### DIFF
--- a/src/rockstor/smart_manager/views/active_directory.py
+++ b/src/rockstor/smart_manager/views/active_directory.py
@@ -16,15 +16,19 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import re
 import socket
-from tempfile import mkstemp
-import shutil
 from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from django.db import transaction
 from base_service import BaseServiceDetailView
 from smart_manager.models import Service
+from system.directory_services import (
+    update_nss,
+    sssd_update_ad,
+    join_domain,
+    domain_workgroup,
+    leave_domain,
+)
 from system.osi import run_command
 from system.samba import update_global_config
 from system.services import systemctl
@@ -32,7 +36,7 @@ from system.services import systemctl
 import logging
 
 logger = logging.getLogger(__name__)
-NET = "/usr/bin/net"
+REALM = "/usr/sbin/realm"
 
 
 class ActiveDirectoryServiceView(BaseServiceDetailView):
@@ -52,9 +56,9 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
             socket.gethostbyname(domain)
         except Exception as e:
             e_msg = (
-                "Domain/Realm(%s) could not be resolved. Check "
+                "Domain/Realm({}) could not be resolved. Check "
                 "your DNS configuration and try again. "
-                "Lower level error: %s" % (domain, e.__str__())
+                "Lower level error: {}".format(domain, e.__str__())
             )
             handle_exception(Exception(e_msg), request)
 
@@ -70,83 +74,13 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
         if e_msg is not None:
             handle_exception(Exception(e_msg), request)
 
-    @staticmethod
-    def _join_domain(config, method="winbind"):
-        domain = config.get("domain")
-        admin = config.get("username")
-        cmd = [NET, "ads", "join", "-U", admin]
-        if method == "sssd":
-            cmd = ["realm", "join", "-U", admin, domain]
-        return run_command(cmd, input=("%s\n" % config.get("password")))
-
-    @staticmethod
-    def _domain_workgroup(domain=None, method="winbind"):
-        cmd = [NET, "ads", "workgroup"]
-        if method == "sssd":
-            cmd = ["adcli", "info", domain]
-        o, e, rc = run_command(cmd)
-        match_str = "Workgroup:"
-        if method == "sssd":
-            match_str = "domain-short = "
-        for l in o:
-            l = l.strip()
-            if re.match(match_str, l) is not None:
-                return l.split(match_str)[1].strip()
-        raise Exception(
-            "Failed to retrieve Workgroup. out: %s err: %s rc: %d" % (o, e, rc)
-        )
-
-    @staticmethod
-    def _update_sssd(domain):
-        # add enumerate = True in sssd so user/group lists will be
-        # visible on the web-ui.
-        el = "enumerate = True\n"
-        fh, npath = mkstemp()
-        sssd_config = "/etc/sssd/sssd.conf"
-        with open(sssd_config) as sfo, open(npath, "w") as tfo:
-            domain_section = False
-            for line in sfo.readlines():
-                if domain_section is True:
-                    if len(line.strip()) == 0 or line[0] == "[":
-                        # empty line or new section without empty line before
-                        # it.
-                        tfo.write(el)
-                        domain_section = False
-                elif re.match("\[domain/%s]" % domain, line) is not None:
-                    domain_section = True
-                tfo.write(line)
-            if domain_section is True:
-                # reached end of file, also coinciding with end of domain
-                # section
-                tfo.write(el)
-        shutil.move(npath, sssd_config)
-        systemctl("sssd", "restart")
-
-    @staticmethod
-    def _leave_domain(config, method="winbind"):
-        pstr = "%s\n" % config.get("password")
-        cmd = [NET, "ads", "leave", "-U", config.get("username")]
-        if method == "sssd":
-            cmd = ["realm", "leave", config.get("domain")]
-            return run_command(cmd)
-        try:
-            return run_command(cmd, input=pstr)
-        except:
-            status_cmd = [NET, "ads", "status", "-U", config.get("username")]
-            o, e, rc = run_command(status_cmd, input=pstr, throw=False)
-            if rc != 0:
-                return logger.debug(
-                    "Status shows not joined. out: %s err: %s rc: %d" % (o, e, rc)
-                )
-            raise
-
     def _config(self, service, request):
         try:
             return self._get_config(service)
         except Exception as e:
             e_msg = (
                 "Missing configuration. Please configure the "
-                "service and try again. Exception: %s" % e.__str__()
+                "service and try again. Exception: {}".format(e.__str__())
             )
             handle_exception(Exception(e_msg), request)
 
@@ -154,7 +88,7 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
     def post(self, request, command):
 
         with self._handle_exception(request):
-            method = "winbind"
+            method = "sssd"
             service = Service.objects.get(name="active-directory")
             if command == "config":
                 config = request.data.get("config")
@@ -164,58 +98,31 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
                 self._resolve_check(config.get("domain"), request)
 
                 # 2. realm discover check?
-                # @todo: phase our realm and just use net?
                 domain = config.get("domain")
                 try:
-                    cmd = ["realm", "discover", "--name-only", domain]
+                    cmd = [REALM, "discover", "--name-only", domain]
                     o, e, rc = run_command(cmd)
                 except Exception as e:
                     e_msg = (
-                        "Failed to discover the given(%s) AD domain. "
-                        "Error: %s" % (domain, e.__str__())
+                        "Failed to discover the given({}) AD domain. "
+                        "Error: {}".format(domain, e.__str__())
                     )
                     handle_exception(Exception(e_msg), request)
-
-                default_range = "10000 - 999999"
-                idmap_range = config.get("idmap_range", "10000 - 999999")
-                idmap_range = idmap_range.strip()
-                if len(idmap_range) > 0:
-                    rfields = idmap_range.split()
-                    if len(rfields) != 3:
-                        raise Exception(
-                            "Invalid idmap range. valid format is "
-                            "two integers separated by a -. eg: "
-                            "10000 - 999999"
-                        )
-                    try:
-                        rlow = int(rfields[0].strip())
-                        rhigh = int(rfields[2].strip())
-                    except Exception as e:
-                        raise Exception(
-                            "Invalid idmap range. Numbers in the "
-                            "range must be valid integers. "
-                            "Error: %s." % e.__str__()
-                        )
-                    if rlow >= rhigh:
-                        raise Exception(
-                            "Invalid idmap range. Numbers in the "
-                            "range must go from low to high. eg: "
-                            "10000 - 999999"
-                        )
-                else:
-                    config["idmap_range"] = default_range
+                # Would be required only if method == "winbind":
+                # validate_idmap_range(config)
 
                 self._save_config(service, config)
 
             elif command == "start":
                 config = self._config(service, request)
-                smbo = Service.objects.get(name="smb")
-                smb_config = self._get_config(smbo)
                 domain = config.get("domain")
                 # 1. make sure ntpd is running, or else, don't start.
                 self._ntp_check(request)
                 # 2. Name resolution check?
                 self._resolve_check(config.get("domain"), request)
+                # 3. Get current Samba config
+                smbo = Service.objects.get(name="smb")
+                smb_config = self._get_config(smbo)
 
                 if method == "winbind":
                     cmd = [
@@ -253,32 +160,44 @@ class ActiveDirectoryServiceView(BaseServiceDetailView):
                         "--enablelocauthorize",
                     ]
                     run_command(cmd)
-                config["workgroup"] = self._domain_workgroup(domain, method=method)
+                config["workgroup"] = domain_workgroup(domain, method=method)
                 self._save_config(service, config)
                 update_global_config(smb_config, config)
-                self._join_domain(config, method=method)
-                if method == "sssd" and config.get("enumerate") is True:
-                    self._update_sssd(domain)
+                join_domain(config, method=method)
 
-                if method == "winbind":
-                    systemctl("winbind", "enable")
-                    systemctl("winbind", "start")
+                # Customize SSSD config
+                if (
+                    method == "sssd"
+                    and (config.get("enumerate") or config.get("case_sensitive"))
+                    is True
+                ):
+                    sssd_update_ad(domain, config)
+
+                # Update nsswitch.conf
+                update_nss(["passwd", "group"], "sss")
+
                 systemctl("smb", "restart")
                 systemctl("nmb", "restart")
+                # The winbind service is required only for id mapping while
+                # accessing samba shares hosted by Rockstor
+                systemctl("winbind", "enable")
+                systemctl("winbind", "start")
 
             elif command == "stop":
                 config = self._config(service, request)
                 try:
-                    self._leave_domain(config, method=method)
+                    leave_domain(config, method=method)
                     smbo = Service.objects.get(name="smb")
                     smb_config = self._get_config(smbo)
                     update_global_config(smb_config)
                     systemctl("smb", "restart")
                     systemctl("nmb", "restart")
+                    systemctl("winbind", "stop")
+                    systemctl("winbind", "disable")
+                    update_nss(["passwd", "group"], "sss", remove=True)
                 except Exception as e:
-                    e_msg = "Failed to leave AD domain(%s). Error: %s" % (
-                        config.get("domain"),
-                        e.__str__(),
+                    e_msg = "Failed to leave AD domain({}). Error: {}".format(
+                        config.get("domain"), e.__str__(),
                     )
                     handle_exception(Exception(e_msg), request)
 

--- a/src/rockstor/smart_manager/views/ldap_service.py
+++ b/src/rockstor/smart_manager/views/ldap_service.py
@@ -16,19 +16,51 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import socket
+
 from rest_framework.response import Response
+from os.path import dirname
 from storageadmin.util import handle_exception
-from system.services import toggle_auth_service
 from django.db import transaction
 from base_service import BaseServiceDetailView
 from smart_manager.models import Service
 
 import logging
 
+from system.directory_services import (
+    update_nss,
+    sssd_add_ldap,
+    sssd_remove_ldap,
+    validate_tls_cert,
+)
+from system.services import systemctl
+
 logger = logging.getLogger(__name__)
 
 
 class LdapServiceView(BaseServiceDetailView):
+    @staticmethod
+    def _resolve_check(server, request):
+        try:
+            socket.gethostbyname(server)
+        except Exception as e:
+            e_msg = (
+                "The LDAP server({}) could not be resolved. Check "
+                "your DNS configuration and try again. "
+                "Lower level error: {}".format(server, e.__str__())
+            )
+            handle_exception(Exception(e_msg), request)
+
+    def _config(self, service, request):
+        try:
+            return self._get_config(service)
+        except Exception as e:
+            e_msg = (
+                "Missing configuration. Please configure the "
+                "service and try again. Exception: {}".format(e.__str__())
+            )
+            handle_exception(Exception(e_msg), request)
+
     @transaction.atomic
     def post(self, request, command):
         """
@@ -39,20 +71,60 @@ class LdapServiceView(BaseServiceDetailView):
             if command == "config":
                 try:
                     config = request.data["config"]
+
+                    # Name resolution check
+                    self._resolve_check(config.get("server"), request)
+
                     self._save_config(service, config)
                 except Exception as e:
                     logger.exception(e)
-                    e_msg = "Ldap could not be configured. Try again"
+                    e_msg = "LDAP could not be configured. Try again"
                     handle_exception(Exception(e_msg), request)
 
-            else:
+            elif command == "start":
+                # Get config from database
+                config = self._config(service, request)
+                server = config.get("server")
+                cert = config.get("cert")
+
+                # @todo: add NTP check as for active_directory?
+                # Name resolution check
+                self._resolve_check(server, request)
+
+                # TLS certificate check
+                validate_tls_cert(server, cert)
+
+                # Extract and format all info of interest
+                ldap_params = {
+                    "server": server,
+                    "basedn": config.get("basedn"),
+                    "ldap_uri": "".join(["ldap://", server]),
+                    "cacertpath": cert,
+                    "cacert_dir": dirname(cert),
+                    "enumerate": config.get("enumerate"),
+                }
+                # Update SSSD config
                 try:
-                    toggle_auth_service(
-                        "ldap", command, config=self._get_config(service)
-                    )
+                    sssd_add_ldap(ldap_params)
+                    systemctl("sssd", "enable")
                 except Exception as e:
                     logger.exception(e)
-                    e_msg = "Failed to %s ldap service due to system error." % command
+                    e_msg = "Failed to start LDAP service due to system error."
                     handle_exception(Exception(e_msg), request)
+                # Update nsswitch.conf
+                update_nss(["passwd", "group"], "sss")
+
+            elif command == "stop":
+                config = self._config(service, request)
+                try:
+                    sssd_remove_ldap(config.get("server"))
+                    systemctl("sssd", "disable")
+                    systemctl("sssd", "stop")
+                except Exception as e:
+                    logger.exception(e)
+                    e_msg = "Failed to stop LDAP service due to system error."
+                    handle_exception(Exception(e_msg), request)
+                # Remove domain from SSSD config
+                update_nss(["passwd", "group"], "sss", remove=True)
 
             return Response()

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -47,22 +47,31 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label" for="password">Password<span class="required"> *</span></label>
                         <div class="col-sm-4">
-                            <input class="form-control" type="password" id="password" name="password" placeholder="Password">
+                            <input class="form-control" type="password" id="password" name="password" value="{{config.password}}" placeholder="Password">
                         </div>
                     </div>
-
-                    <div class="form-group">
-                        <label class="col-sm-4 control-label" for="idmap_range">Idmap Range</label>
-                        <div class="col-sm-4">
-                            <input class="form-control" type="text" id="idmap_range" name="idmap_range" value="{{config.idmap_range}}" placeholder="10000 - 999999">
-                        </div>
-                    </div>
-
                     <div class="form-group">
                         <div class="col-sm-offset-4 col-sm-8">
                             <label class="checkbox inline">
-          <input type="checkbox" id="rfc2307" name="rfc2307" {{#if config.rfc2307}}checked{{/if}}> Enable RFC2307 and use UIDS and homes/shells AD DC values
-        </label>
+                                <input type="checkbox" id="enumerate" name="enumerate" {{#if config.enumerate}}checked{{/if}}>
+                                Enable enumeration
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-4 col-sm-8">
+                            <label class="checkbox inline">
+                                <input type="checkbox" id="no_ldap_id_mapping" name="no_ldap_id_mapping" {{#if config.no_ldap_id_mapping}}checked{{/if}}>
+                                Disable automatic ID mapping
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-4 col-sm-8">
+                            <label class="checkbox inline">
+                                <input type="checkbox" id="case_sensitive" name="case_sensitive" {{#if config.case_sensitive}}checked{{/if}}>
+                                Treat user and group names as case sensitive
+                            </label>
                         </div>
                     </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -29,7 +29,7 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label" for="server">LDAP Server<span class="required"> *</span></label>
                         <div class="col-sm-4">
-                            <input class="form-control" type="text" id="server" name="server" value="{{config.server}}" placeholder="LDAP Server" title="IP address of LDAP Server">
+                            <input class="form-control" type="text" id="server" name="server" value="{{config.server}}" placeholder="LDAP Server" title="Hostname of LDAP Server (FQDN)">
                         </div>
                     </div>
                     <div class="form-group">
@@ -38,31 +38,27 @@
                             <input class="form-control" type="text" id="basedn" name="basedn" value="{{config.basedn}}" placeholder="Search base DN" title="Distinguished Name ">
                         </div>
                     </div>
-                    <div class="checkbox">
-                        <label class="col-sm-4 control-label" for="enableTLS"></label> {{#if config.enabletls}}
-                        <div class="col-sm-4">
-                            <input type="checkbox" name="enabletls" id="enabletls" checked="true">
-                        </div>
-                        {{else}}
-                        <div class="col-sm-4">
-                            <input type="checkbox" name="enabletls" id="enabletls"> {{/if}} Enable TLS to encrypt connections?</div>
-                    </div>
-                    {{#if config.enabletls}}
                     <div class="form-group" id="cert-ph">
-                        {{else}}
-                        <div class="form-group" id="cert-ph" style="visibility: hidden">
-                            {{/if}}
-                            <label class="col-sm-4 control-label" for="cert-utl">Certificate URL<span class="required"> *</span></label>
-                            <div class="col-sm-4">
-                                <input type="text" class="form-control" id="cert" name="cert" value="{{config.cert}}" placeholder="Certificate URL" title="URL to download Certificate in PEM format">
-                            </div>
+                        <label class="col-sm-4 control-label" for="cert-utl">Certificate URL<span class="required"> *</span></label>
+                        <div class="col-sm-4">
+                            <input type="text" class="form-control" id="cert" name="cert" value="{{config.cert}}"
+                                   placeholder="Path to certificate" title="Absolute path to TLS certificate ">
                         </div>
-                        <div class="form-group">
-                            <div class="col-sm-offset-4 col-sm-8">
-                                <button id="cancel" class="btn btn-default">Cancel</button>
-                                <button type="Submit" id="create-user" class="btn btn-primary">Submit</button>
-                            </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-4 col-sm-8">
+                            <label class="checkbox inline">
+                                <input type="checkbox" id="enumerate" name="enumerate" {{#if config.enumerate}}checked{{/if}}>
+                                Enable enumeration
+                            </label>
                         </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-4 col-sm-8">
+                            <button id="cancel" class="btn btn-default">Cancel</button>
+                            <button type="Submit" id="create-user" class="btn btn-primary">Submit</button>
+                        </div>
+                    </div>
                 </form>
 
                 </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -28,8 +28,6 @@ ConfigureServiceView = RockstorLayoutView.extend({
 
     events: {
         'click #cancel': 'cancel',
-        'click #security': 'toggleFormFields',
-        'click #enabletls': 'toggleCertUrl',
         'click #mode': 'toggleNutFields'
     },
 
@@ -58,15 +56,10 @@ ConfigureServiceView = RockstorLayoutView.extend({
                 rocommunity: 'required'
             },
             ldap: {
+                // @todo: add further validation of server, basedn, and cert
                 server: 'required',
                 basedn: 'required',
-                cert: {
-                    required: {
-                        depends: function(element) {
-                            return _this.$('#enabletls').prop('checked');
-                        }
-                    }
-                }
+                cert: 'required'
             },
             docker: {
                 rootshare: 'required'
@@ -195,7 +188,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
         this.$('#active-directory-form #domain').tooltip({
             html: true,
             placement: 'right',
-            title: 'Windows Active Directory or Domain Controller to connect to.'
+            title: 'Windows Active Directory or Domain Controller to which to connect.'
         });
         this.$('#active-directory-form #username').tooltip({
             html: true,
@@ -206,11 +199,6 @@ ConfigureServiceView = RockstorLayoutView.extend({
             html: true,
             placement: 'right',
             title: 'Password for the above username.'
-        });
-        this.$('#active-directory-form #idmap_range').tooltip({
-            html: true,
-            placement: 'right',
-            title: 'Default should work for most cases. rid idmap backend is the only one supported. The default range is 10000 - 999999.'
         });
         this.$('#smartd-form #smartd_config').tooltip({
             html: true,
@@ -376,21 +364,6 @@ To alert on temperature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
         $('#services_modal').modal('hide');
     },
 
-    toggleFormFields: function() {
-
-        if (this.$('#security').val() == 'ads') {
-            this.$('#realm').removeAttr('disabled');
-        } else {
-            this.$('#realm').attr('disabled', 'true');
-        }
-        if (this.$('#security').val() == 'ads' ||
-            this.$('#security').val() == 'domain') {
-            this.$('#templateshell').removeAttr('disabled');
-        } else {
-            this.$('#templateshell').attr('disabled', 'true');
-        }
-    },
-
     toggleNutFields: function() {
 
         if (this.$('#mode').val() == 'standalone') {
@@ -422,16 +395,6 @@ To alert on temperature changes: <br> <strong>DEVICESCAN -W 4,35,40</strong> <br
             this.$('#ups-port').hide();
             this.$('#port').attr('value', 'auto');
             this.$('#nut-server').show();
-        }
-    },
-
-    toggleCertUrl: function() {
-
-        var cbox = this.$('#enabletls');
-        if (cbox.prop('checked')) {
-            this.$('#cert-ph').css('visibility', 'visible');
-        } else {
-            this.$('#cert-ph').css('visibility', 'hidden');
         }
     },
 

--- a/src/rockstor/system/directory_services.py
+++ b/src/rockstor/system/directory_services.py
@@ -1,0 +1,332 @@
+"""
+Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os
+import stat
+
+import re
+
+from osi import append_to_line, run_command
+from tempfile import mkstemp
+from shutil import move
+import logging
+
+from system.services import systemctl
+
+logger = logging.getLogger(__name__)
+
+NSSWITCH_FILE = "/etc/nsswitch.conf"
+SSSD_FILE = "/etc/sssd/sssd.conf"
+NET = "/usr/bin/net"
+REALM = "/usr/sbin/realm"
+ADCLI = "/usr/sbin/adcli"
+OPENSSL = "/usr/bin/openssl"
+
+
+def validate_tls_cert(server, cert):
+    """
+    Run openssl s_client -connect server:389 -CAfile path-to-cert
+    to verify the provided TLS certificate against the LDAP server.
+    :param server: String - FQDN of the LDAP server
+    :param cert: String - Absolute path to the TLS certificate
+    :return:
+    """
+    cmd = [
+        OPENSSL,
+        "s_client",
+        "-connect",
+        "{}:389".format(server),
+        "-CAfile",
+        cert,
+    ]
+    o, e, rc = run_command(cmd, throw=False)
+    if "Verification: OK" not in o:
+        err_msg = (
+            "Failed to validate the TLS certificate ({}).\n"
+            "out: {} err: {} rc: {}".format(cert, o, e, rc)
+        )
+        if any("fopen:No such file or directory" in err for err in e):
+            err_msg = (
+                "The TLS certificate file could not be found at {}.\n"
+                "out: {} err: {} rc: {}".format(cert, o, e, rc)
+            )
+        raise Exception(err_msg)
+
+
+def update_nss(databases, provider, remove=False):
+    """
+    Update the nss configuration file (NSSWITCH_FILE) to include a
+    given provider ("sss", for instance) to one or more databases.
+    :param databases: List - databases to be updated (e.g. ["passwd", "group"])
+    :param provider: String - provider to be used (e.g. "sss")
+    :param remove: Boolean - Remove provider from databases if True
+    :return:
+    """
+    fo, npath = mkstemp()
+    dbs = [db + ":" for db in databases]
+    append_to_line(NSSWITCH_FILE, npath, dbs, provider, remove)
+    move(npath, NSSWITCH_FILE)
+    # Set file to rw- r-- r-- (644) via stat constants.
+    os.chmod(NSSWITCH_FILE, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+    logger.debug(
+        "The {} provider to the {} databases has been updated in {}".format(
+            provider, databases, NSSWITCH_FILE
+        )
+    )
+
+
+def sssd_update_ad(domain, config):
+    """
+    Add enumerate = True in sssd so user/group lists will be
+    visible on the web-ui.
+    :param domain: String - Domain to which the update should apply
+    :param config: Dict - Active Directory service configuration
+    :return:
+    """
+    el = "enumerate = True\n"
+    csl = "case_sensitive = True\n"
+    opts = []
+    if config.get("enumerate") is True:
+        opts.append(el)
+    if config.get("case_sensitive") is True:
+        opts.append(csl)
+    ol = "".join(opts)
+    fh, npath = mkstemp()
+    with open(SSSD_FILE) as sfo, open(npath, "w") as tfo:
+        domain_section = False
+        for line in sfo.readlines():
+            if domain_section is True:
+                if len(line.strip()) == 0 or line[0] == "[":
+                    # empty line or new section without empty line before it.
+                    tfo.write(ol)
+                    domain_section = False
+            elif re.match("\[domain/%s]" % domain, line) is not None:
+                domain_section = True
+            tfo.write(line)
+        if domain_section is True:
+            # reached end of file, also coinciding with end of domain section
+            tfo.write(ol)
+    move(npath, SSSD_FILE)
+    # Set file to rw- --- --- (600) via stat constants.
+    os.chmod(SSSD_FILE, stat.S_IRUSR | stat.S_IWUSR)
+    logger.debug(
+        "The configuration of the {} domain in {} has been updated".format(
+            domain, SSSD_FILE
+        )
+    )
+    systemctl("sssd", "restart")
+
+
+def sssd_add_ldap(ldap_params):
+    """
+    Write to sssd.conf all parameters required for connecting to an ldap server.
+    :param ldap_params: Dict
+    :return:
+    """
+    # Prepare options to write
+    server = ldap_params["server"]
+    opts = {
+        "ldap_id_use_start_tls": "True",
+        "cache_credentials": "True",
+        "ldap_search_base": "{}".format(ldap_params["basedn"]),
+        "id_provider": "ldap",
+        "auth_provider": "ldap",
+        "chpass_provider": "ldap",
+        "ldap_uri": "{}".format(ldap_params["ldap_uri"]),
+        "ldap_tls_reqcert": "demand",
+        "ldap_tls_cacert": "{}".format(ldap_params["cacertpath"]),
+        "ldap_tls_cacertdir": "{}".format(ldap_params["cacert_dir"]),
+        "enumerate": "{}".format(ldap_params["enumerate"]),
+    }
+    # Write to file
+    fh, npath = mkstemp()
+    with open(SSSD_FILE) as sfo, open(npath, "w") as tfo:
+        sssd_section = False
+        domain_section = False
+        for line in sfo.readlines():
+            if sssd_section is True:
+                if re.match("domains = ", line) is not None:
+                    line = "".join([line.strip(), " {}\n".format(server)])
+                    sssd_section = False
+                elif len(line.strip()) == 0:
+                    tfo.write("domains = {}\n".format(server))
+                    sssd_section = False
+            elif domain_section is True:
+                for k, v in opts.items():
+                    if re.match(k, line) is None:
+                        tfo.write("{} = {}\n".format(k, v))
+            elif re.match("\[sssd]", line) is not None:
+                sssd_section = True
+            elif re.match("\[domain/{}]".format(server), line) is not None:
+                domain_section = True
+            tfo.write(line)
+        if domain_section is False:
+            # reached end of file, also coinciding with end of domain section
+            tfo.write("\n[domain/{}]\n".format(server))
+            for k, v in opts.items():
+                tfo.write("{} = {}\n".format(k, v))
+    move(npath, SSSD_FILE)
+    # Set file to rw- --- --- (600) via stat constants.
+    os.chmod(SSSD_FILE, stat.S_IRUSR | stat.S_IWUSR)
+    logger.debug(
+        "The configuration of the {} domain in {} has been updated".format(
+            server, SSSD_FILE
+        )
+    )
+    systemctl("sssd", "restart")
+
+
+def sssd_remove_ldap(server):
+    """
+    Removes any configuration pertaining to "sever" from sssd.conf
+    thereby unconfiguring the LDAP server. We thus need to remove it
+    from the list of domains in the [sssd] section, and then remove
+    its own section titled [domain/server].
+    :param server: String -
+    :return:
+    """
+    fh, npath = mkstemp()
+    with open(SSSD_FILE) as sfo, open(npath, "w") as tfo:
+        sssd_section = False
+        domain_section = False
+        for line in sfo.readlines():
+            if sssd_section is True:
+                if re.match("domains = ", line) is not None:
+                    tfo.write(line.replace(server, ""))
+                    sssd_section = False
+                    continue
+            elif domain_section is True:
+                continue
+            elif re.match("\[sssd]", line) is not None:
+                sssd_section = True
+            elif re.match("\[domain/{}]".format(server), line) is not None:
+                domain_section = True
+                continue
+            elif len(line.strip()) == 0:
+                # empty line
+                domain_section = False
+            tfo.write(line)
+    move(npath, SSSD_FILE)
+    # Set file to rw- --- --- (600) via stat constants.
+    os.chmod(SSSD_FILE, stat.S_IRUSR | stat.S_IWUSR)
+    logger.debug(
+        "The configuration of the {} domain in {} has been removed".format(
+            server, SSSD_FILE
+        )
+    )
+
+
+def join_domain(config, method="sssd"):
+    """
+    Join an Active Directory domain.
+    :param config: Dict - gathered from the AD service config
+    :param method: String - SSSD or Winbind (default is sssd)
+    :return:
+    """
+    domain = config.get("domain")
+    admin = config.get("username")
+    cmd = [REALM, "join", "-U", admin, domain]
+    cmd_options = [
+        "--membership-software=samba",
+    ]
+    if config.get("no_ldap_id_mapping") is True:
+        cmd_options.append("--automatic-id-mapping=no")
+    cmd[-3:-3] = cmd_options
+    if method == "winbind":
+        cmd = [NET, "ads", "join", "-U", admin]
+    return run_command(cmd, input=("{}\n".format(config.get("password"))), log=True)
+
+
+def leave_domain(config, method="sssd"):
+    """
+    Leave a configured Active Directory domain.
+    :param config: Dict - gathered from the AD service config
+    :param method: String - SSSD or Winbind (default is sssd)
+    :return:
+    """
+    pstr = "{}\n".format(config.get("password"))
+    cmd = [REALM, "leave", config.get("domain")]
+    if method == "winbind":
+        cmd = [NET, "ads", "leave", "-U", config.get("username")]
+        try:
+            return run_command(cmd, input=pstr)
+        except:
+            status_cmd = [NET, "ads", "status", "-U", config.get("username")]
+            o, e, rc = run_command(status_cmd, input=pstr, throw=False)
+            if rc != 0:
+                return logger.debug(
+                    "Status shows not joined. out: %s err: %s rc: %d" % (o, e, rc)
+                )
+            raise
+    else:
+        run_command(cmd, log=True)
+
+
+def domain_workgroup(domain=None, method="sssd"):
+    """
+    Fetches the Workgroup value from an Active Directory domain
+    to be fed to Samba configuration.
+    :param domain: String - Active Directory domain
+    :param method: String - SSSD or Winbind (default is sssd)
+    :return:
+    """
+    cmd = [NET, "ads", "workgroup", "-S", domain]
+    if method == "winbind":
+        cmd = [ADCLI, "info", domain]
+    o, e, rc = run_command(cmd)
+    match_str = "Workgroup:"
+    if method == "winbind":
+        match_str = "domain-short = "
+    for l in o:
+        l = l.strip()
+        if re.match(match_str, l) is not None:
+            return l.split(match_str)[1].strip()
+    raise Exception(
+        "Failed to retrieve Workgroup. out: {} err: {} rc: {}".format(o, e, rc)
+    )
+
+
+def validate_idmap_range(config):
+    default_range = "10000 - 999999"
+    idmap_range = config.get("idmap_range", "10000 - 999999")
+    idmap_range = idmap_range.strip()
+    if len(idmap_range) > 0:
+        rfields = idmap_range.split()
+        if len(rfields) != 3:
+            raise Exception(
+                "Invalid idmap range. valid format is "
+                "two integers separated by a -. eg: "
+                "10000 - 999999"
+            )
+        try:
+            rlow = int(rfields[0].strip())
+            rhigh = int(rfields[2].strip())
+        except Exception as e:
+            raise Exception(
+                "Invalid idmap range. Numbers in the "
+                "range must be valid integers. "
+                "Error: {}.".format(e.__str__())
+            )
+        if rlow >= rhigh:
+            raise Exception(
+                "Invalid idmap range. Numbers in the "
+                "range must go from low to high. eg: "
+                "10000 - 999999"
+            )
+    else:
+        config["idmap_range"] = default_range

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -136,6 +136,28 @@ def replace_line_if_found(Original_file, new_file, regex, replacement_line):
     return found_and_replaced
 
 
+def append_to_line(original_file, new_file, regexes, new_content, remove=False):
+    """
+    Append a new string or remove a string from specific lines in a config file
+    identified by one or more regular expressions.
+    :param original_file: Original file path - usually a system configuration file
+    :param new_file: New file path - usually a secure temporary file setup by caller
+    :param regexes: List - list of regex(ex) used to identify lines to be considered
+    :param new_content: String - string to be appended or removed
+    :param remove: Boolean - remove string from line if set to True
+    :return:
+    """
+    with open(original_file) as ofo, open(new_file, "w") as tfo:
+        for line in ofo.readlines():
+            if any(re.match(regex, line) for regex in regexes):
+                if remove:
+                    tfo.write(line.replace("".join([" ", new_content]), ""))
+                else:
+                    tfo.write("".join([line.strip(), " ", new_content, "\n"]))
+            else:
+                tfo.write(line)
+
+
 def run_command(
     cmd,
     shell=False,
@@ -1795,9 +1817,7 @@ def get_dev_byid_name(device_name, remove_path=False):
                         # save the longest by-id type name so far.
                         byid_name = devname
     if err == ["device node not found", ""]:
-        logger.error(
-            "Device ({}) not found by command ({})".format(device_name, cmd)
-        )
+        logger.error("Device ({}) not found by command ({})".format(device_name, cmd))
     if is_byid:
         # Return the longest by-id name found in the DEVLINKS line
         # or the first if multiple by-id names were of equal length.

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -148,44 +148,14 @@ def update_global_config(smb_config=None, ad_config=None):
         # Next add AD config to smb_config and build AD section
         if ad_config is not None:
             smb_config.update(ad_config)
-
         domain = smb_config.pop("domain", None)
         if domain is not None:
-            idmap_high = int(smb_config["idmap_range"].split()[2])
-            default_range = "{} - {}".format(idmap_high + 1, idmap_high + 1000000)
-            workgroup = ad_config["workgroup"]
             tfo.write("{}\n".format(RS_AD_HEADER))
             tfo.write("    security = ads\n")
             tfo.write("    realm = {}\n".format(domain))
-            tfo.write("    template shell = /bin/sh\n")
             tfo.write("    kerberos method = secrets and keytab\n")
-            tfo.write("    winbind use default domain = false\n")
-            tfo.write("    winbind offline logon = true\n")
-            tfo.write("    winbind enum users = yes\n")
-            tfo.write("    winbind enum groups = yes\n")
-            tfo.write("    idmap config * : backend = tdb\n")
-            tfo.write("    idmap config * : range = {}\n".format(default_range))
-            # enable rfc2307 schema and collect UIDS from AD DC we assume if
-            # rfc2307 then winbind nss info too - collects AD DC home and shell
-            # for each user
-            if smb_config.pop("rfc2307", None):
-                tfo.write("    idmap config {} : backend = ad\n".format(workgroup))
-                tfo.write(
-                    "    idmap config {} : range = {}\n".format(
-                        workgroup, smb_config["idmap_range"]
-                    )
-                )
-                tfo.write(
-                    "    idmap config {} : schema_mode = rfc2307\n".format(workgroup)
-                )
-                tfo.write("    winbind nss info = rfc2307\n")
-            else:
-                tfo.write("    idmap config {} : backend = rid\n".format(workgroup))
-                tfo.write(
-                    "    idmap config {} : range = {}\n".format(
-                        workgroup, smb_config["idmap_range"]
-                    )
-                )
+            tfo.write("    client signing = yes\n")
+            tfo.write("    client use spnego = yes\n")
             tfo.write("{}\n\n".format(RS_AD_FOOTER))
 
         # After default [global], custom [global] and AD writes

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -26,13 +26,14 @@ from django.conf import settings
 
 from osi import run_command
 
-AUTHCONFIG = "/usr/sbin/authconfig"
 SSHD_CONFIG = "/etc/ssh/sshd_config"
 SYSTEMCTL_BIN = "/usr/bin/systemctl"
 SUPERCTL_BIN = "%s/bin/supervisorctl" % settings.ROOT_DIR
 SUPERVISORD_CONF = "%s/etc/supervisord.conf" % settings.ROOT_DIR
+SSSD_FILE = "/etc/sssd/sssd.conf"
 NET = "/usr/bin/net"
 WBINFO = "/usr/bin/wbinfo"
+REALM = "/usr/sbin/realm"
 
 
 def init_service_op(service_name, command, throw=True):
@@ -52,11 +53,11 @@ def init_service_op(service_name, command, throw=True):
         "ypbind",
         "rpcbind",
         "ntpd",
-        "nslcd",
         "snmpd",
         "docker",
         "smartd",
         "shellinaboxd",
+        "sssd",
         "nut-server",
         "rockstor-bootstrap",
         "rockstor",
@@ -134,7 +135,22 @@ def service_status(service_name, config=None):
         else:
             return init_service_op("nfs-server", "status", throw=False)
     elif service_name == "ldap":
-        return init_service_op("nslcd", "status", throw=False)
+        o, e, rc = init_service_op("sssd", "status", throw=False)
+        # initial check on sssd status: 0 = OK 3 = stopped
+        if rc != 0:
+            return o, e, rc
+        # check for service configuration
+        if config is None:
+            return o, e, 1
+        # sssd is also used for the Active Directory service, so we need to
+        # check if the configured LDAP domain is defined in its config file
+        with open(SSSD_FILE) as sfo:
+            for line in sfo.readlines():
+                if (
+                    re.search("domains = ", line) and re.search(config["server"], line)
+                ) is not None:
+                    return o, e, rc
+            return o, e, 1
     elif service_name == "sftp":
         out, err, rc = init_service_op("sshd", "status", throw=False)
         # initial check on sshd status: 0 = OK 3 = stopped
@@ -147,7 +163,7 @@ def service_status(service_name, config=None):
                 if re.match(settings.SFTP_STR, line) is not None:
                     return out, err, rc
             # -1 not appropriate as inconsistent with bash return codes
-            # Returning 1 as Catchall for general errors.  the calling system
+            # Returning 1 as Catchall for general errors. The calling system
             # interprets -1 as enabled, 1 works for disabled.
             return out, err, 1
     elif service_name in ("replication", "data-collector", "ztask-daemon"):
@@ -164,58 +180,15 @@ def service_status(service_name, config=None):
         return run_command([SYSTEMCTL_BIN, "status", "nut-monitor"], throw=False)
     elif service_name == "active-directory":
         if config is not None:
-            # 2 steps Active Directory status check
-            # First checks secret via rpc callable
-            # Second checks via auth for admin username
-            # If both give us 0 rc Active Directory is running
-            wbinfo_trust_cmd = [WBINFO, "-t", "--domain", config.get("domain")]
-            wbinfo_auth_credentials = "{}@{}%{}".format(
-                config.get("username"), config.get("domain"), config.get("password")
-            )
-            wbinfo_auth_cmd = [
-                WBINFO,
-                "-a",
-                wbinfo_auth_credentials,
-                "--domain",
-                config.get("domain"),
-            ]
-            wbinfo_trust = run_command(wbinfo_trust_cmd, throw=False)
-            wbinfo_auth = run_command(wbinfo_auth_cmd, throw=False)
             active_directory_rc = 1
-            if wbinfo_trust[2] == 0 and wbinfo_auth[2] == 0:
+            o, e, rc = run_command([REALM, "list", "--name-only",])
+            if config["domain"] in o:
                 active_directory_rc = 0
-
             return "", "", active_directory_rc
         # bootstrap switch subsystem interprets -1 as ON so returning 1 instead
         return "", "", 1
 
     return init_service_op(service_name, "status", throw=False)
-
-
-def ldap_input(config, command):
-    ac_cmd = []
-    if command == "stop":
-        ac_cmd.extend(["--disableldap", "--disableldapauth"])
-    else:
-        ac_cmd.extend(["--enableldap", "--enableldapauth"])
-        ac_cmd.append("--ldapserver={}".format(config["server"]))
-        ac_cmd.append("--ldapbasedn={}".format(config["basedn"]))
-        if config["enabletls"] is True:
-            ac_cmd.append("--enableldaptls")
-            ac_cmd.append("--ldaploadcacert={}".format(config["cert"]))
-    return ac_cmd
-
-
-def toggle_auth_service(service, command, config=None):
-    ac_cmd = [
-        AUTHCONFIG,
-        "--update",
-    ]
-    if service == "ldap":
-        ac_cmd.extend(ldap_input(config, command))
-    else:
-        return None
-    return run_command(ac_cmd)
 
 
 def update_nginx(ip, port):


### PR DESCRIPTION
Fixes #2232.  
Fixes #567.  
@phillxnet, ready for review.  

This pull request (PR) aims to rework our implementation of Active Directory (AD) and Lightweight Directory Access Protocol (LDAP) currently broken due to our past reliance on CentOS-specific tools (#2232 and #567). This PR thus proposes to instead rely on System Security Services Daemon ([SSSD](https://sssd.io/)) to manage remote identification and authentication through AD and LDAP.
Note that as mechanisms for joining/leaving both AD and LDAP are very similar and based on similar logic, both will be implemented in this PR.

### Aims & Logic
#### Active Directory (AD)
Fortunately, SSSD-based AD was already implemented in past versions of Rockstor, so this PR proposes to follow the same logic that was then implemented and reverted back in #1174.

For leaving and joining an AD, the [realmd](https://www.freedesktop.org/software/realmd/docs/realm.html) tool provides a very easy way to automatically configure most settings in various system config files, so this PR proposes to rely on it to manage such configuration upon joining a domain, as well as upon leaving it. Note that while default realmd settings work very well for establishing id mapping via SSSD on the system, we still require the `winbind` service to take charge of id mapping for samba shares (see https://github.com/rockstor/rockstor-core/issues/2232#issuecomment-733835637 for more details). As access to shares via Samba is probably amongst the most common needs for a NAS machine, we thus enable that by default; @phillxnet, please let me know if you'd like to see this as part of an option that the user would need to check during configuration of the AD service in Rockstor webUI.

The only configuration not done with realmd is the definition of the `sss` module as a provider for `passwd` and `groups` in `/etc/nsswitch.conf`; we thus take care of this manually.

#### Lightweight Directory Access Protocol (LDAP)
Unlike AD, realmd does not work well (yet, at least) for LDAP so we have to manually take care of the following configurations:
- `/etc/sssd/sssd.conf`: enroll the LDAP server and define its settings
- `/etc/nsswitch.conf`: define `sss` as a provider for `passwd` and `groups`


### Demonstration
#### AD
A test AD server was set up on a separate and dedicated xubuntu20.04 virtual machine using Samba as an active directory domain controller, following the [Samba wiki instructions](https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller). This leads to an AD server that can be successfully resolved by realmd on the Rockstor machine:
```
# realm discover samdom.example.com
samdom.example.com
  type: kerberos
  realm-name: SAMDOM.EXAMPLE.COM
  domain-name: samdom.example.com
  configured: no
  server-software: active-directory
  client-software: sssd
  required-package: sssd-tools
  required-package: sssd
  required-package: adcli
  required-package: samba-client
```

1. In Rockstor UI, configure the AD service appropriately (see screenshot below). If the domain can be resolved and then discovered by `realm discover --name-only samdom.example.com`, then the AD service configuration is saved.
![image](https://user-images.githubusercontent.com/30297881/101959303-14522c80-3bd3-11eb-8040-7a5fa4955b99.png)


   
2. Turning the AD service ON will **enroll** the Rockstor machine to the configured AD domain:
```
# cat /etc/sssd/sssd.conf 
[sssd]
(...)
domains = samdom.example.com
(...)
[domain/samdom.example.com]
default_shell = /bin/bash
krb5_store_password_if_offline = True
cache_credentials = True
krb5_realm = SAMDOM.EXAMPLE.COM
realmd_tags = manages-system joined-with-samba 
id_provider = ad
fallback_homedir = /home/%u@%d
ad_domain = samdom.example.com
use_fully_qualified_names = True
ldap_id_mapping = True
access_provider = ad
enumerate = True
```

... and activate the `sss` nss module:
```
# cat /etc/nsswitch.conf
(...)
passwd: compat sss
group:  compat sss
shadow: compat
(...)
```

3. In our demonstration case, we have `enumerate` activated so we can see the AD users listed in Rockstor UI:
![image](https://user-images.githubusercontent.com/30297881/101959326-1ddb9480-3bd3-11eb-8b18-ce7c4be01697.png)

   
4. We can also set an AD user as an `admin_user` for a new samba export (of the `test_share01` share):
![image](https://user-images.githubusercontent.com/30297881/101959344-259b3900-3bd3-11eb-8567-4978b4638c6f.png)

   
5. The samba share above can then be accessed by clients. For instance, a Windows 10 machine joined to the SAMDOM AD and logged in as the SAMDOM\Administrator user account, we can see and write a file to the samba share exported:
![image](https://user-images.githubusercontent.com/30297881/101959358-2c29b080-3bd3-11eb-9812-85f02fc42c63.png)

   
6. Turning OFF the AD service removes all configurations listed above.


#### LDAP
On a separate and dedicated Ubuntu server 20.10 VM, an openLDAP server was set up, with the following configuration:

<details><summary>Full `slapcat` output</summary>

```
# slapcat
dn: dc=example,dc=com
objectClass: top
objectClass: dcObject
objectClass: organization
o: example.com
dc: example
structuralObjectClass: organization
entryUUID: aff6e3d0-c9eb-103a-8d00-bd8a16b45e85
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203194423Z
entryCSN: 20201203194423.090781Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201203194423Z

dn: cn=admin,dc=example,dc=com
objectClass: simpleSecurityObject
objectClass: organizationalRole
cn: admin
description: LDAP administrator
userPassword:: e1NTSEF9MHVQbXIraktaZXgzWmtoSXFuUm81eU1GbDVLMlBiVnA=
structuralObjectClass: organizationalRole
entryUUID: b095e21e-c9eb-103a-8d01-bd8a16b45e85
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203194424Z
entryCSN: 20201203194424.132820Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201203194424Z

dn: ou=people,dc=example,dc=com
objectClass: organizationalUnit
ou: people
structuralObjectClass: organizationalUnit
entryUUID: 32c2bb9a-c9ec-103a-8454-bb126af3a0ed
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203194802Z
entryCSN: 20201203194802.530537Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201203194802Z

dn: ou=groups,dc=example,dc=com
objectClass: organizationalUnit
ou: groups
structuralObjectClass: organizationalUnit
entryUUID: 32e19c04-c9ec-103a-8455-bb126af3a0ed
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203194802Z
entryCSN: 20201203194802.732913Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201203194802Z

dn: cn=testusers,ou=groups,dc=example,dc=com
objectClass: posixGroup
gidNumber: 2000
structuralObjectClass: posixGroup
entryUUID: 810f11c2-c9ec-103a-8457-bb126af3a0ed
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203195013Z
cn: testusers
memberUid: testusers
entryCSN: 20201204125346.352107Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201204125346Z

dn: uid=janedoe,ou=people,dc=example,dc=com
uid: janedoe
objectClass: inetOrgPerson
objectClass: posixAccount
objectClass: shadowAccount
loginShell: /bin/bash
userPassword:: e1NTSEF9YU5pZDVCOTg5U0RRL21HRFV3aTB2M0xjeWlYTlI5YlM=
structuralObjectClass: inetOrgPerson
entryUUID: b6d64da6-c9fc-103a-858d-df8394b1653e
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201203214616Z
uidNumber: 2001
homeDirectory: /home/janedoe
sn: JaneDoe
cn: janedoe
gidNumber: 2000
entryCSN: 20201204125356.490873Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201204125356Z

dn: uid=johndoe,ou=people,dc=example,dc=com
uid: johndoe
uidNumber: 2003
homeDirectory: /home/johndoe
sn: JohnDoe
cn: johndoe
objectClass: inetOrgPerson
objectClass: posixAccount
objectClass: shadowAccount
loginShell: /bin/bash
userPassword:: e1NTSEF9YU5pZDVCOTg5U0RRL21HRFV3aTB2M0xjeWlYTlI5YlM=
structuralObjectClass: inetOrgPerson
entryUUID: 86b92476-ca7a-103a-858e-df8394b1653e
creatorsName: cn=admin,dc=example,dc=com
createTimestamp: 20201204124651Z
gidNumber: 2000
entryCSN: 20201204125405.451942Z#000000#000#000000
modifiersName: cn=admin,dc=example,dc=com
modifyTimestamp: 20201204125405Z
```

</details>

1. Configure the LDAP service appropriately. If the server name can be resolved, the configuration is saved.
![image](https://user-images.githubusercontent.com/30297881/101959374-3481eb80-3bd3-11eb-90f7-b6ebbd966535.png)

   
2. Turning the LDAP server ON will write the appropriate settings to file:
```
# cat /etc/sssd/sssd.conf 
[sssd]
(...)
domains = rockldapserver.example.com
(...)
[domain/rockldapserver.example.com]
ldap_tls_reqcert = demand
ldap_id_use_start_tls = True
cache_credentials = True
auth_provider = ldap
chpass_provider = ldap
enumerate = True
ldap_tls_cacert = /etc/ssl/certs/ldapcacert.crt
ldap_search_base = dc=example,dc=com
id_provider = ldap
ldap_uri = ldap://rockldapserver.example.com
ldap_tls_cacertdir = /etc/ssl/certs
```

```
# cat /etc/nsswitch.conf
(...)
passwd: compat sss
group:  compat sss
(...)
```

3. The LDAP users are now listed in Rockstor UI:
![image](https://user-images.githubusercontent.com/30297881/101959390-3cda2680-3bd3-11eb-8bbe-d584f893e75e.png)

   
4. Turning OFF the LDAP service will revert all configurations above.

### New packages needed
Using SSSD requires the following packages:
- sssd
- sssd-tools
- sssd-ad
- sssd-ldap

@phillxnet, note that some of these are dependencies of each other, but I prefer to specify them all here to make sure all required packages are installed.
```
# zypper in --no-recommends sssd sssd-tools sssd-ad sssd-ldap
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 19 NEW packages are going to be installed:
  adcli cyrus-sasl-gssapi libbasicobjects0 libcares2 libcollection4 libdhash1 libini_config5 libpath_utils1 libref_array1 libsss_certmap0 libsss_idmap0 libsss_nss_idmap0 libsss_simpleifp0 python3-sssd-config sssd sssd-ad sssd-krb5-common sssd-ldap sssd-tools

19 new packages to install.
Overall download size: 2.5 MiB. Already cached: 0 B. After the operation, additional 6.7 MiB will be used.
```

### Caveats & shortcomings
For LDAP, I've tried to keep the configuration of SSSD as barebones as possible to make the LDAP service configuration as easy as possible. These settings are working on my test machine, but as I'm not an LDAP expert, I'm unsure what config would be required by real life/production LDAP servers. To help assess this, I've included the full configuration of the openLDAP server I am using to develop this PR. Of note, I do not seem to need to use a bind user, for instance, but that may be needed for some setups. @phillxnet, I'm hoping this will be part of the community feedback. Note, also, that all these settings are supported by SSSD and can thus be included in the LDAP section manually in `sssd.conf`.

Still related to LDAP, note that I'm forcing here the use of TLS encryption as per SSSD's recommendation:
> LDAP back end supports id, auth, access and chpass providers. If you want to authenticate against an LDAP server either TLS/SSL or LDAPS is required. sssd does not support authentication over an unencrypted channel. If the LDAP server is used only as an identity provider, an encrypted channel is not needed.

source: [https://linux.die.net/man/5/sssd-ldap](https://linux.die.net/man/5/sssd-ldap)

We are thus verifying first that the provided certificate matches with the server's upon turning the LDAP service ON.


### Testing

Testing summary:
```
Ran 205 tests in 62.642s

FAILED (failures=5, errors=1)
```


<details><summary>Full testing output</summary>

```
/opt/build # ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (7.600s)
  Applying contenttypes.0001_initial... OK (0.310s)
  Applying auth.0001_initial... OK (1.218s)
  Applying admin.0001_initial... OK (0.280s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.135s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.108s)
  Applying auth.0003_alter_user_email_max_length... OK (0.144s)
  Applying auth.0004_alter_user_username_opts... OK (0.071s)
  Applying auth.0005_alter_user_last_login_null... OK (0.182s)
  Applying auth.0006_require_contenttypes_0002... OK (0.047s)
  Applying oauth2_provider.0001_initial... OK (2.166s)
  Applying oauth2_provider.0002_08_updates... OK (0.737s)
  Applying sessions.0001_initial... OK (0.347s)
  Applying sites.0001_initial... OK (0.182s)
  Applying smart_manager.0001_initial... OK (0.481s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.053s)
  Applying storageadmin.0001_initial... OK (12.769s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.485s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.954s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.269s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.838s)
  Applying storageadmin.0006_dcontainerargs... OK (0.418s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.409s)
  Applying storageadmin.0008_auto_20190115_1637... OK (5.261s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.526s)
  Applying storageadmin.0010_sambashare_time_machine... OK (1.581s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.616s)
  Applying storageadmin.0012_auto_20200429_1428... OK (2.332s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (7.825s)
  Applying contenttypes.0001_initial... OK (0.070s)
  Applying auth.0001_initial... OK (0.056s)
  Applying admin.0001_initial... OK (0.046s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.084s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.048s)
  Applying auth.0003_alter_user_email_max_length... OK (0.052s)
  Applying auth.0004_alter_user_username_opts... OK (0.051s)
  Applying auth.0005_alter_user_last_login_null... OK (0.048s)
  Applying auth.0006_require_contenttypes_0002... OK (0.031s)
  Applying oauth2_provider.0001_initial... OK (0.127s)
  Applying oauth2_provider.0002_08_updates... OK (0.107s)
  Applying sessions.0001_initial... OK (0.035s)
  Applying sites.0001_initial... OK (0.041s)
  Applying smart_manager.0001_initial... OK (2.936s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.048s)
  Applying storageadmin.0001_initial... OK (5.056s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.505s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.487s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.233s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.778s)
  Applying storageadmin.0006_dcontainerargs... OK (0.211s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.407s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.625s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.238s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.230s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.232s)
  Applying storageadmin.0012_auto_20200429_1428... OK (0.794s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... FAIL
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... FAIL
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... FAIL
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

======================================================================
ERROR: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/build/src/rockstor/storageadmin/tests/test_samba.py", line 421, in test_post_requests_2
    response = self.client.post(self.BASE_URL, data=data)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/test.py", line 168, in post
    path, data=data, format=format, content_type=content_type, **extra)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/test.py", line 90, in post
    return self.generic('POST', path, data, content_type, **extra)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/opt/build/src/rockstor/storageadmin/views/samba.py", line 157, in post
    return Response(SambaShareSerializer(smb_share).data)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 435, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 568, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/fields.py", line 316, in get_attribute
    raise type(exc)(msg)
KeyError: u"Got KeyError when attempting to get a value for field `groupname` on serializer `SUserSerializer`.\nThe serializer field might be named incorrectly and not match any attribute or key on the `User` instance.\nOriginal exception text was: 'getgrgid(): gid not found: 1'."

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_group.GroupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_group.py", line 99, in test_post_requests
    msg=response.data)
AssertionError: {'admin': True, 'groupname': u'ngroup2', 'gid': 1, u'id': 1}

======================================================================
FAIL: test_delete_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 396, in test_delete_requests
    status.HTTP_200_OK, msg=response.data)
AssertionError: ['User (games) does not exist.', 'None\n']

======================================================================
FAIL: test_post_requests (storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_user.py", line 175, in test_post_requests
    msg=response.data)
AssertionError: {'username': u'newUser', 'public_key': None, 'shell': u'/bin/bash', 'group': 3, 'pincard_allowed': 'no', 'admin': True, 'managed_user': True, 'homedir': u'/home/newUser', 'email': None, 'groupname': u'admin', 'gid': 5, 'user': 38, 'uid': 3, 'smb_shares': [], u'id': 2, 'has_pincard': False}

======================================================================
FAIL: test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 152, in test_disable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to disable auto update due to this exception:  ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 392, in post\n    auto_update(enable=False)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 62, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

======================================================================
FAIL: test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/build/src/rockstor/storageadmin/tests/test_commands.py", line 144, in test_enable_auto_update_command
    status.HTTP_200_OK, msg=response.data)
AssertionError: ["Failed to enable auto update due to this exception: ([Errno 2] No such file or directory: '/etc/yum/yum-cron.conf').", 'Traceback (most recent call last):\n  File "/opt/build/src/rockstor/storageadmin/views/command.py", line 382, in post\n    auto_update(enable=True)\n  File "/opt/build/src/rockstor/system/pkg_mgmt.py", line 62, in auto_update\n    with open(YCFILE) as ifo, open(npath, "w") as tfo:\nIOError: [Errno 2] No such file or directory: \'/etc/yum/yum-cron.conf\'\n']

----------------------------------------------------------------------
Ran 205 tests in 62.642s

FAILED (failures=5, errors=1)
```

</details>
