### PR TITLE
Unit test maintenance re legacy disparity. Fixes #2243

### DIFF
--- a/src/rockstor/storageadmin/tests/test_commands.py
+++ b/src/rockstor/storageadmin/tests/test_commands.py
@@ -56,6 +56,12 @@ class CommandTests(APITestMixin, APITestCase):
         cls.mock_update_check = cls.patch_update_check.start()
         cls.mock_update_check.return_value = 1, 1, 1
 
+        # Mock src/rockstor/system/pkg_mgmt.py auto_update() in
+        # src/rockstor/storageadmin/views/command.py
+        cls.patch_auto_update = patch('storageadmin.views.command.auto_update')
+        cls.mock_auto_update = cls.patch_auto_update.start()
+        cls.mock_auto_update.return_value = True
+
         cls.patch_system_shutdown = patch(
             'storageadmin.views.command.system_shutdown')
         cls.mock_system_shutdown = cls.patch_system_shutdown.start()

--- a/src/rockstor/storageadmin/tests/test_group.py
+++ b/src/rockstor/storageadmin/tests/test_group.py
@@ -92,12 +92,12 @@ class GroupTests(APITestMixin, APITestCase):
 
         # invalid gid
         data = {'groupname': 'ngroup2',
-                'gid': 1001, }
+                'gid': 100, }
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(response.status_code,
                          status.HTTP_400_BAD_REQUEST,
                          msg=response.data)
-        err_msg = 'GID (1001) already exists. Choose a different one.'
+        err_msg = 'GID (100) already exists. Choose a different one.'
         self.assertEqual(response.data[0], err_msg)
 
         # happy path

--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -347,12 +347,24 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
         e_msg = "Must provide share names."
         self.assertEqual(response.data[0], e_msg)
 
+    @mock.patch("storageadmin.models.user.grp.getgrgid")
     @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
     @mock.patch("storageadmin.views.samba.User")
-    def test_post_requests_2(self, mock_user, mock_validate_share):
+    def test_post_requests_2(self, mock_user, mock_validate_share, mock_getgrgid):
         """
          . Create a samba export for the share that has already been exported
         """
+        # Nullify exception of getgrgid via:
+        mock_getgrgid.side_effects = None
+
+        # Python2
+        # import grp
+        # >>> groupname = grp.getgrgid("470")
+        # >>> print(groupname)
+        # grp.struct_group(gr_name='ntp', gr_passwd='x', gr_gid=470, gr_mem=[])
+        # return "testgroup" for all gr_name calls:
+        mock_getgrgid.gr_name.return_value = "testgroup"
+
         mock_validate_share.return_value = self.temp_share_smb
 
         # create samba with invalid browsable, guest_ok, read_only choices
@@ -413,6 +425,9 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
         }
         mock_validate_share.return_value = self.temp_share2
         mock_user.objects.get.side_effects = None
+        # The following relies on our mocked return value in grp.getgrgid.gr_name.
+        # Otherwise we error/exception out with grp.getgrgid(1) in models/user.py
+        # 'getgrgid(): gid not found: 1'
         temp_user = User.objects.create(
             username="admin", uid=1, gid=1, admin=False, user=self.user
         )

--- a/src/rockstor/storageadmin/tests/test_user.py
+++ b/src/rockstor/storageadmin/tests/test_user.py
@@ -165,15 +165,15 @@ class UserTests(APITestMixin, APITestCase):
         #          "username.")
         # self.assertEqual(response.data[0], e_msg)
 
-        # create a user with existing uid ('nobody' has a uid 99)
+        # create a user with existing uid ('nobody' has a uid 65534)
         # TODO: We are not limiting user id to >= 1000.
         data = {'username': 'newUser', 'password': 'pwuser2',
-                'group': 'admin', 'uid': '99', 'pubic_key': 'xxx'}
+                'group': 'admin', 'uid': '65534', 'pubic_key': 'xxx'}
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(response.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR,
                          msg=response.data)
-        e_msg = "UID (99) already exists. Please choose a different one."
+        e_msg = "UID (65534) already exists. Please choose a different one."
         self.assertEqual(response.data[0], e_msg)
 
         # create a user that is already a system user(eg: root)
@@ -390,7 +390,10 @@ class UserTests(APITestMixin, APITestCase):
                          status.HTTP_500_INTERNAL_SERVER_ERROR,
                          msg=response.data)
 
-        username = 'games'
+        # Hack fix as lp exists as real system user but is currently, incorrectly, not
+        # included in the exclude_list within src/rockstor/storageadmin/views/user.py
+        # Proper approach would be to setup a User.objects mock
+        username = 'lp'
         response = self.client.delete('{}/{}'.format(self.BASE_URL, username))
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -627,3 +627,11 @@ class SystemPackageTests(unittest.TestCase):
                 "returned = ({}).\n "
                 "expected = ({}).".format(returned, expected),
             )
+
+    # TODO: Add test for zypper auto update functionality post transition from currently
+    #  legacy yum based system which was previously lightly tested to exist only via
+    #  API level unit test src/rockstor/storageadmin/tests/test_commands.py
+    #  Suggested name:
+    #  test_auto_update(self)
+    #  Related additional low level test:
+    #  test_auto_update_status(self)

--- a/src/rockstor/system/tests/test_system_network.py
+++ b/src/rockstor/system/tests/test_system_network.py
@@ -163,8 +163,13 @@ class SystemNetworkTests(unittest.TestCase):
         which should return a dict with detailed config for each network connection detected.
         """
         # Mock and patch docker-specific calls
+        self.patch_docker_status = patch("system.network.docker_status")
+        self.mock_docker_status = self.patch_docker_status.start()
+        self.mock_docker_status.return_value = True
+
         self.patch_dnets = patch("system.network.dnets")
         self.mock_dnets = self.patch_dnets.start()
+
         self.patch_dnet_inspect = patch("system.network.dnet_inspect")
         self.mock_dnet_inspect = self.patch_dnet_inspect.start()
 


### PR DESCRIPTION
Re-establish prior CentOS baseline of all existing tests passing.

Fixes #2243
Ready for review.

The aim here was to re-establish our pre 'Built on openSUSE' endeavour baseline established in our prior CentOS base. This looks to have been achieved and although there is still much work to be done in the tests, mainly failures to mock actual system state effectively, it does look like we have at least returned to our prior 'baseline' by explainable OS differences alone.

## Summary of changes:
- Delete of existing, non excluded user 'games' fails as non existent in openSUSE base. Replace with non excluded 'lp' user that does exist.
- Creation of new user with existing uid test failed as prior uid of 99 for nobody (CentOS) is now available. Change to 65534 which is openSUSE uid for user nobody.
- Auto_update (legacy yum-based) is now defunct: we are now zypper based. Disable/Enable tests failed with "No such file or directory: '/etc/yum/yum-cron.conf'" but are intended as API level tests. Mock low level auto_update() and add TODO to test_pkg_mgmt.py for the appropriate low level test once we migrate this functionality to a zypper equivalent. This way we preserve & test the presence of the existing API.
- Group create with pre-existing group id fails as group id used did not actually exist. Substitute with gid of users (100) which does exist in our new openSUSE base.
- Prior samba test created a temporary user that relied on a real system user gid existing. This same gid does not exist in the new openSUSE base, resulting in a an exception. Fix by mocking a fake group name return via getgrgid.
- Add missing docker_status() mocking that was failing a more recently added low level network test: test_get_con_config(), due to system docker state. Thanks to @FroggyFlox on GitHub for this fix.


### Testing results:
As for git/GitHub tag 4.0.5-0 which equates to Release Candidate 6

#### Pre-pr
> Ran 212 tests in 34.752s
> FAILED (failures=6, errors=1)

#### Post pr:
> Ran 212 tests in 39.875s
> OK