### PR TITLE
Correct typo in field label (#2244)

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
@@ -39,7 +39,7 @@
                         </div>
                     </div>
                     <div class="form-group" id="cert-ph">
-                        <label class="col-sm-4 control-label" for="cert-utl">Certificate URL<span class="required"> *</span></label>
+                        <label class="col-sm-4 control-label" for="cert">Certificate path<span class="required"> *</span></label>
                         <div class="col-sm-4">
                             <input type="text" class="form-control" id="cert" name="cert" value="{{config.cert}}"
                                    placeholder="Path to certificate" title="Absolute path to TLS certificate ">


### PR DESCRIPTION
Fixes #2244.
@phillxnet, ready for review.

Very simple commit to fix a typo in field label for the "Certificate path" in the LDAP service configuration form.