### PR TITLE
remove legacy kernel version maintenance (#2246)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -43,7 +43,6 @@ parts =
       bootstrap-systemd-conf
 # Note the following systemd links are checked / updated in turn by '.initrock'
       setup-systemd-links
-      def-kernel
       start-rockstor
 
 
@@ -118,7 +117,6 @@ logfile = ${buildout:directory}/var/log/rockstor.log
 taplib = ${django-settings-conf:rootdir}/smart_manager/taplib
 output = ${django-settings-conf:rootdir}/settings.py
 debug = True
-kernel = '4.12.4-1.el7.elrepo.x86_64'
 
 [test-settings-conf]
 recipe = collective.recipe.template
@@ -160,12 +158,6 @@ command = if [[ ! -d ${create-cert:cert_loc} ]]; then
         openssl x509 -in ${create-cert:cert_loc}/rockstor.csr -out ${create-cert:cert_loc}/rockstor.cert -sha256 -req -signkey ${create-cert:cert_loc}/rockstor.key -days 3650
 	fi
 update-command = ${create-cert:command}
-
-
-[def-kernel]
-recipe = plone.recipe.command
-command = grubby --set-default=/boot/vmlinuz-${django-settings-conf:kernel}
-update-command = ${def-kernel:command}
 
 [fixtures]
 recipe = plone.recipe.command

--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -357,8 +357,6 @@ CONFROOT = '${buildout:depdir}/conf'
 CERTDIR = '${buildout:depdir}/certs'
 COMPRESSION_TYPES = ('lzo', 'zlib', 'no',)
 
-SUPPORTED_KERNEL_VERSION = ${django-settings-conf:kernel}
-
 SNAP_TS_FORMAT = '%Y%m%d%H%M'
 
 MODEL_DEFS = {

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -344,8 +344,6 @@ CONFROOT = '${buildout:depdir}/conf'
 CERTDIR = '${buildout:depdir}/certs'
 COMPRESSION_TYPES = ('lzo', 'zlib', 'no',)
 
-SUPPORTED_KERNEL_VERSION = ${django-settings-conf:kernel}
-
 SNAP_TS_FORMAT = '%Y%m%d%H%M'
 ROOT_POOL = 'rockstor_rockstor'
 

--- a/prod-buildout.cfg
+++ b/prod-buildout.cfg
@@ -70,7 +70,6 @@ logfile = ${buildout:depdir}/var/log/rockstor.log
 taplib = ${django-settings-conf:rootdir}/smart_manager/taplib
 output = ${buildout:directory}/src/rockstor/settings.py
 debug = False
-kernel = '4.12.4-1.el7.elrepo.x86_64'
 
 [buildout-source-release]
 recipe = zc.recipe.egg:scripts

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -33,12 +33,12 @@ logger = logging.getLogger(__name__)
 
 SYSCTL = "/usr/bin/systemctl"
 BASE_DIR = settings.ROOT_DIR
-BASE_BIN = "%sbin" % BASE_DIR
-DJANGO = "%s/django" % BASE_BIN
-STAMP = "%s/.initrock" % BASE_DIR
-FLASH_OPTIMIZE = "%s/flash-optimize" % BASE_BIN
-PREP_DB = "%s/prep_db" % BASE_BIN
-SUPERCTL = "%s/supervisorctl" % BASE_BIN
+BASE_BIN = "{}bin".format(BASE_DIR)
+DJANGO = "{}/django".format(BASE_BIN)
+STAMP = "{}/.initrock".format(BASE_DIR)
+FLASH_OPTIMIZE = "{}/flash-optimize".format(BASE_BIN)
+PREP_DB = "{}/prep_db".format(BASE_BIN)
+SUPERCTL = "{}/supervisorctl".format(BASE_BIN)
 OPENSSL = "/usr/bin/openssl"
 RPM = "/usr/bin/rpm"
 YUM = "/usr/bin/yum"
@@ -132,8 +132,8 @@ def update_nginx(logger):
 def update_tz(logging):
     # update timezone variable in settings.py
     zonestr = os.path.realpath("/etc/localtime").split("zoneinfo/")[1]
-    logging.info("system timezone = %s" % zonestr)
-    sfile = "%s/src/rockstor/settings.py" % BASE_DIR
+    logging.info("system timezone = {}".format(zonestr))
+    sfile = "{}/src/rockstor/settings.py".format(BASE_DIR)
     fo, npath = mkstemp()
     updated = False
     with open(sfile) as sfo, open(npath, "w") as tfo:
@@ -143,9 +143,9 @@ def update_tz(logging):
                 if curzone == zonestr:
                     break
                 else:
-                    tfo.write("TIME_ZONE = '%s'\n" % zonestr)
+                    tfo.write("TIME_ZONE = '{}'\n".format(zonestr))
                     updated = True
-                    logging.info("Changed timezone from %s to %s" % (curzone, zonestr))
+                    logging.info("Changed timezone from {} to {}".format(curzone, zonestr))
             else:
                 tfo.write(line)
     if updated:
@@ -206,7 +206,7 @@ def bootstrap_sshd_config(logging):
 
 def require_postgres(logging):
     rs_dest = "/etc/systemd/system/rockstor-pre.service"
-    rs_src = "%s/conf/rockstor-pre.service" % BASE_DIR
+    rs_src = "{}/conf/rockstor-pre.service".format(BASE_DIR)
     logging.info("updating rockstor-pre service..")
     with open(rs_dest, "w") as dfo, open(rs_src) as sfo:
         for l in sfo.readlines():
@@ -244,7 +244,7 @@ def establish_shellinaboxd_service(logging):
 
 def enable_rockstor_service(logging):
     rs_dest = "/etc/systemd/system/rockstor.service"
-    rs_src = "%s/conf/rockstor.service" % BASE_DIR
+    rs_src = "{}/conf/rockstor.service".format(BASE_DIR)
     sum1 = md5sum(rs_dest)
     sum2 = md5sum(rs_src)
     if sum1 != sum2:
@@ -257,8 +257,8 @@ def enable_rockstor_service(logging):
 
 def enable_bootstrap_service(logging):
     name = "rockstor-bootstrap.service"
-    bs_dest = "/etc/systemd/system/%s" % name
-    bs_src = "%s/conf/%s" % (BASE_DIR, name)
+    bs_dest = "/etc/systemd/system/{}".format(name)
+    bs_src = "{}/conf/{}".format(BASE_DIR, name)
     sum1 = "na"
     if os.path.isfile(bs_dest):
         sum1 = md5sum(bs_dest)
@@ -269,23 +269,23 @@ def enable_bootstrap_service(logging):
         run_command([SYSCTL, "enable", name])
         run_command([SYSCTL, "daemon-reload"])
         return logging.info("Done.")
-    return logging.info("%s looks correct. Not updating." % name)
+    return logging.info("{} looks correct. Not updating.".format(name))
 
 
 def update_smb_service(logging):
     name = "smb.service"
-    ss_dest = "/etc/systemd/system/%s" % name
+    ss_dest = "/etc/systemd/system/{}".format(name)
     if not os.path.isfile(ss_dest):
-        return logging.info("%s is not enabled. Not updating.")
-    ss_src = "%s/conf/%s" % (BASE_DIR, name)
+        return logging.info("{} is not enabled. Not updating.".format(name))
+    ss_src = "{}/conf/{}".format(BASE_DIR, name)
     sum1 = md5sum(ss_dest)
     sum2 = md5sum(ss_src)
     if sum1 != sum2:
-        logging.info("Updating %s" % name)
+        logging.info("Updating {}".format(name))
         shutil.copy(ss_src, ss_dest)
         run_command([SYSCTL, "daemon-reload"])
         return logging.info("Done.")
-    return logging.info("%s looks correct. Not updating." % name)
+    return logging.info("{} looks correct. Not updating.".format(name))
 
 
 def main():
@@ -294,10 +294,10 @@ def main():
         loglevel = logging.DEBUG
     logging.basicConfig(format="%(asctime)s: %(message)s", level=loglevel)
 
-    cert_loc = "%s/certs/" % BASE_DIR
+    cert_loc = "{}/certs/".format(BASE_DIR)
     if os.path.isdir(cert_loc):
-        if not os.path.isfile("%s/rockstor.cert" % cert_loc) or not os.path.isfile(
-            "%s/rockstor.key" % cert_loc
+        if not os.path.isfile("{}/rockstor.cert".format(cert_loc)) or not os.path.isfile(
+            "{}/rockstor.key".format(cert_loc)
         ):
             shutil.rmtree(cert_loc)
 
@@ -316,9 +316,9 @@ def main():
                 "-newkey",
                 "rsa:2048",
                 "-keyout",
-                "%s/first.key" % cert_loc,
+                "{}/first.key".format(cert_loc),
                 "-out",
-                "%s/rockstor.csr" % cert_loc,
+                "{}/rockstor.csr".format(cert_loc),
                 "-subj",
                 dn,
             ]
@@ -330,9 +330,9 @@ def main():
                 OPENSSL,
                 "rsa",
                 "-in",
-                "%s/first.key" % cert_loc,
+                "{}/first.key".format(cert_loc),
                 "-out",
-                "%s/rockstor.key" % cert_loc,
+                "{}/rockstor.key".format(cert_loc),
             ]
         )
         logging.debug("rockstor key created")
@@ -342,12 +342,12 @@ def main():
                 OPENSSL,
                 "x509",
                 "-in",
-                "%s/rockstor.csr" % cert_loc,
+                "{}/rockstor.csr".format(cert_loc),
                 "-out",
-                "%s/rockstor.cert" % cert_loc,
+                "{}/rockstor.cert".format(cert_loc),
                 "-req",
                 "-signkey",
-                "%s/rockstor.key" % cert_loc,
+                "{}/rockstor.key".format(cert_loc),
                 "-days",
                 "3650",
             ]
@@ -364,18 +364,18 @@ def main():
         logging.info("Updating the timezone from the system")
         update_tz(logging)
     except Exception as e:
-        logging.error("Exception while updating timezone: %s" % e.__str__())
+        logging.error("Exception while updating timezone: {}".format(e.__str__()))
         logging.exception(e)
 
     try:
         logging.info("Updating sshd_config")
         bootstrap_sshd_config(logging)
     except Exception as e:
-        logging.error("Exception while updating sshd_config: %s" % e.__str__())
+        logging.error("Exception while updating sshd_config: {}".format(e.__str__()))
 
     if not os.path.isfile(STAMP):
         logging.info("Please be patient. This script could take a few minutes")
-        shutil.copyfile("%s/conf/django-hack" % BASE_DIR, "%s/django" % BASE_BIN)
+        shutil.copyfile("{}/conf/django-hack".format(BASE_DIR), "{}/django".format(BASE_BIN))
         run_command([SYSCTL, "enable", "postgresql"])
         logging.debug("Progresql enabled")
         pg_data = "/var/lib/pgsql/data"
@@ -428,7 +428,7 @@ def main():
                 "-",
                 "postgres",
                 "-c",
-                "psql storageadmin -f %s/conf/storageadmin.sql.in" % BASE_DIR,
+                "psql storageadmin -f {}/conf/storageadmin.sql.in".format(BASE_DIR),
             ]
         )  # noqa E501
         logging.debug("storageadmin app database loaded")
@@ -438,17 +438,17 @@ def main():
                 "-",
                 "postgres",
                 "-c",
-                "psql smartdb -f %s/conf/smartdb.sql.in" % BASE_DIR,
+                "psql smartdb -f {}/conf/smartdb.sql.in".format(BASE_DIR),
             ]
         )
         logging.debug("smartdb app database loaded")
         logging.info("Done")
         run_command(
-            ["cp", "-f", "%s/conf/postgresql.conf" % BASE_DIR, "/var/lib/pgsql/data/"]
+            ["cp", "-f", "{}/conf/postgresql.conf".format(BASE_DIR), "/var/lib/pgsql/data/"]
         )
         logging.debug("postgresql.conf copied")
         run_command(
-            ["cp", "-f", "%s/conf/pg_hba.conf" % BASE_DIR, "/var/lib/pgsql/data/"]
+            ["cp", "-f", "{}/conf/pg_hba.conf".format(BASE_DIR), "/var/lib/pgsql/data/"]
         )
         logging.debug("pg_hba.conf copied")
         run_command([SYSCTL, "restart", "postgresql"])
@@ -471,14 +471,14 @@ def main():
         db = "default"
         if app == "smart_manager":
             db = app
-        o, e, rc = run_command([DJANGO, "migrate", "--list", "--database=%s" % db, app])
+        o, e, rc = run_command([DJANGO, "migrate", "--list", "--database={}".format(db), app])
         initial_faked = False
         for l in o:
             if l.strip() == "[X] 0001_initial":
                 initial_faked = True
                 break
         if not initial_faked:
-            db_arg = "--database=%s" % db
+            db_arg = "--database={}".format(db)
             logger.debug(
                 "migrate (--fake) db=({}) app=({}) 0001_initial".format(db, app)
             )

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -145,7 +145,9 @@ def update_tz(logging):
                 else:
                     tfo.write("TIME_ZONE = '{}'\n".format(zonestr))
                     updated = True
-                    logging.info("Changed timezone from {} to {}".format(curzone, zonestr))
+                    logging.info(
+                        "Changed timezone from {} to {}".format(curzone, zonestr)
+                    )
             else:
                 tfo.write(line)
     if updated:
@@ -296,9 +298,9 @@ def main():
 
     cert_loc = "{}/certs/".format(BASE_DIR)
     if os.path.isdir(cert_loc):
-        if not os.path.isfile("{}/rockstor.cert".format(cert_loc)) or not os.path.isfile(
-            "{}/rockstor.key".format(cert_loc)
-        ):
+        if not os.path.isfile(
+            "{}/rockstor.cert".format(cert_loc)
+        ) or not os.path.isfile("{}/rockstor.key".format(cert_loc)):
             shutil.rmtree(cert_loc)
 
     if not os.path.isdir(cert_loc):
@@ -356,9 +358,7 @@ def main():
         logging.info("restarting nginx...")
         run_command([SUPERCTL, "restart", "nginx"])
 
-    logging.info(
-        "Checking for flash and Running flash optimizations if appropriate."
-    )
+    logging.info("Checking for flash and Running flash optimizations if appropriate.")
     run_command([FLASH_OPTIMIZE, "-x"], throw=False)
     try:
         logging.info("Updating the timezone from the system")
@@ -375,7 +375,9 @@ def main():
 
     if not os.path.isfile(STAMP):
         logging.info("Please be patient. This script could take a few minutes")
-        shutil.copyfile("{}/conf/django-hack".format(BASE_DIR), "{}/django".format(BASE_BIN))
+        shutil.copyfile(
+            "{}/conf/django-hack".format(BASE_DIR), "{}/django".format(BASE_BIN)
+        )
         run_command([SYSCTL, "enable", "postgresql"])
         logging.debug("Progresql enabled")
         pg_data = "/var/lib/pgsql/data"
@@ -444,7 +446,12 @@ def main():
         logging.debug("smartdb app database loaded")
         logging.info("Done")
         run_command(
-            ["cp", "-f", "{}/conf/postgresql.conf".format(BASE_DIR), "/var/lib/pgsql/data/"]
+            [
+                "cp",
+                "-f",
+                "{}/conf/postgresql.conf".format(BASE_DIR),
+                "/var/lib/pgsql/data/",
+            ]
         )
         logging.debug("postgresql.conf copied")
         run_command(
@@ -471,7 +478,9 @@ def main():
         db = "default"
         if app == "smart_manager":
             db = app
-        o, e, rc = run_command([DJANGO, "migrate", "--list", "--database={}".format(db), app])
+        o, e, rc = run_command(
+            [DJANGO, "migrate", "--list", "--database={}".format(db), app]
+        )
         initial_faked = False
         for l in o:
             if l.strip() == "[X] 0001_initial":

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -881,7 +881,6 @@ class ServicesNamespace(RockstorIO):
 class SysinfoNamespace(RockstorIO):
 
     start = False
-    supported_kernel = settings.SUPPORTED_KERNEL_VERSION
     os_distro_name = settings.OS_DISTRO_NAME
 
     # This function is run once on every connection
@@ -938,16 +937,11 @@ class SysinfoNamespace(RockstorIO):
                 "kernel_info",
                 {
                     "key": "sysinfo:kernel_info",
-                    "data": kernel_info(self.supported_kernel),
+                    "data": kernel_info(),
                 },
             )
-            # kernel_info() in above raises an Exception if the running
-            # kernel != supported kernel and so:
         except Exception as e:
             logger.error("Exception while gathering kernel info: %s" % e.__str__())
-            # Emit an event to the front end to capture error report
-            self.emit("kernel_error", {"key": "sysinfo:kernel_error", "data": str(e)})
-            self.error("unsupported_kernel", str(e))
 
     def update_rockons(self):
 

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -934,11 +934,7 @@ class SysinfoNamespace(RockstorIO):
 
         try:
             self.emit(
-                "kernel_info",
-                {
-                    "key": "sysinfo:kernel_info",
-                    "data": kernel_info(),
-                },
+                "kernel_info", {"key": "sysinfo:kernel_info", "data": kernel_info()}
             )
         except Exception as e:
             logger.error("Exception while gathering kernel info: %s" % e.__str__())

--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -1140,21 +1140,12 @@ $(document).ready(function() {
         }
     });
 
-    var kernelError = function(data) {
-        // If 'kernel' does not show up in the string, we're ok
-        if (data.indexOf('kernel') !== -1) {
-            // Put an alert at the top of the page
-            $('#browsermsg').html('<div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">&times;</button>' + data + '</div>');
-        }
-    };
-
 
     RockStorSocket.addListener(kernelInfo, this, 'sysinfo:kernel_info');
     RockStorSocket.addListener(distroInfo, this, 'sysinfo:distro_info');
     RockStorSocket.addListener(displayLoadAvg, this, 'sysinfo:uptime');
     RockStorSocket.addListener(displayLocaleTime, this, 'sysinfo:localtime');
     RockStorSocket.addListener(displayYumUpdates, this, 'sysinfo:yum_updates');
-    RockStorSocket.addListener(kernelError, this, 'sysinfo:kernel_error');
     RockStorSocket.addListener(displayUpdate, this, 'sysinfo:software_update');
     RockStorSocket.addListener(displayShutdownStatus, this, 'sysinfo:shutdown_status');
     RockStorSocket.addListener(displayPoolDegradedStatus, this, 'sysinfo:pool_degraded_status');

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -258,7 +258,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "kernel":
             try:
-                return Response(kernel_info(settings.SUPPORTED_KERNEL_VERSION))
+                return Response(kernel_info())
             except Exception as e:
                 handle_exception(e, request)
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -604,22 +604,8 @@ def def_kernel():
     return kernel
 
 
-def kernel_info(supported_version):
+def kernel_info():
     uname = os.uname()
-    if uname[2] != supported_version and os.path.isfile(GRUBBY):
-        e_msg = (
-            "You are running an unsupported kernel({}). Some features "
-            "may not work properly.".format(uname[2])
-        )
-        carg = "--set-default=/boot/vmlinuz-{}".format(supported_version)
-        run_command([GRUBBY, carg])
-        e_msg = (
-            "{} Please reboot and the system will "
-            "automatically boot using the supported kernel({})".format(
-                e_msg, supported_version
-            )
-        )
-        raise Exception(e_msg)
     return uname[2]
 
 

--- a/testing.cfg
+++ b/testing.cfg
@@ -43,7 +43,6 @@ parts =
       rockstor-pre-systemd-conf
       rockstor-systemd-conf
       bootstrap-systemd-conf
-      def-kernel
       start-rockstor
 
 
@@ -110,7 +109,6 @@ logfile = ${buildout:directory}/var/log/rockstor.log
 taplib = ${django-settings-conf:rootdir}/smart_manager/taplib
 output = ${django-settings-conf:rootdir}/settings.py
 debug = True
-kernel = '4.12.4-1.el7.elrepo.x86_64'
 
 [test-settings-conf]
 recipe = collective.recipe.template
@@ -152,12 +150,6 @@ command = if [[ ! -d ${create-cert:cert_loc} ]]; then
         openssl x509 -in ${create-cert:cert_loc}/rockstor.csr -out ${create-cert:cert_loc}/rockstor.cert -sha256 -req -signkey ${create-cert:cert_loc}/rockstor.key -days 3650
 	fi
 update-command = ${create-cert:command}
-
-
-[def-kernel]
-recipe = plone.recipe.command
-command = grubby --set-default=/boot/vmlinuz-${django-settings-conf:kernel}
-update-command = ${def-kernel:command}
 
 [fixtures]
 recipe = plone.recipe.command


### PR DESCRIPTION
Move to only reporting the kernel version and remove all mechanisms of version evaluation or enforcement.

Fixes #2246
Ready for review.

## Summary of changes:
- Initrock: remove legacy kernel version enforcement, remove
delete_old_kernels(), remove grubby command reference.
- Buildout/testing.cfg: remove def-kernel mechanism.
- Settings/test-settings.conf.in: remove SUPPORTED_KERNEL_VERSION.
- Buildout/prod-buildout/testing.cfg: remove kernel settings var.
- Remove version evaluation from kernel_info(). The legacy functionality
of kernel_info(), if grubby executable path found, was to call grubby to
enforce a kernel version and emmit an exception which was used by the
front end, via data_collector, to surface kernel version errors. Remove
this functionality so that kernel_info() reports only kernel version
number for Web-UI use. The associated frontend KernelError
listener/processor was was removed.

The following changes were kept in separate commits to aid review and change history.
- adopt string.format in initrock.py. Includes a minor fix for an omitted smb service name with an exception message.
- re-apply black formatting to modified files in issue

## Testing:
The resulting source tree was re-compiled and the resulting services appeared to function as previously as on our new Leap 15.2 openSUSE base there is no functional change with this patch set.

> Ran 212 tests in 34.960s
> 
> OK

Consequent initrock entries from initial rockstor-pre service start:

<details>

Jan 09 14:53:59 rleap15-2 systemd[1]: Starting Tasks required prior to starting Rockstor...
Jan 09 14:53:59 rleap15-2 initrock[17102]: 2021-01-09 14:53:59,896: Checking for flash and Running flash optimizations if appropriate.
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,548: Updating the timezone from the system
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,549: system timezone = Europe/London
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,551: Updating sshd_config
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,551: SSHD_CONFIG Customization
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,553: sshd_config already has the updates. Leaving it unchanged.
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,553: Please be patient. This script could take a few minutes
Jan 09 14:54:00 rleap15-2 systemd[1]: Reloading.
Jan 09 14:54:00 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:00 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,888: Deleting /var/lib/pgsql/data
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,975: initializing Postgresql...
Jan 09 14:54:00 rleap15-2 initrock[17102]: 2021-01-09 14:54:00,975: running generic initdb on /var/lib/pgsql/data
Jan 09 14:54:00 rleap15-2 su[17138]: (to postgres) root on none
Jan 09 14:54:00 rleap15-2 systemd[1]: Created slice User Slice of UID 26.
Jan 09 14:54:01 rleap15-2 systemd[1]: Starting User Runtime Directory /run/user/26...
Jan 09 14:54:01 rleap15-2 systemd[1]: Started User Runtime Directory /run/user/26.
Jan 09 14:54:01 rleap15-2 systemd[1]: Starting User Manager for UID 26...
Jan 09 14:54:01 rleap15-2 systemd[17146]: pam_unix(systemd-user:session): session opened for user postgres by (uid=0)
Jan 09 14:54:01 rleap15-2 systemd[17146]: Reached target Timers.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Starting D-Bus User Message Bus Socket.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Reached target Paths.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Listening on D-Bus User Message Bus Socket.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Reached target Sockets.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Reached target Basic System.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Reached target Default.
Jan 09 14:54:01 rleap15-2 systemd[1]: Started User Manager for UID 26.
Jan 09 14:54:01 rleap15-2 systemd[17146]: Startup finished in 33ms.
Jan 09 14:54:01 rleap15-2 systemd[1]: Started Session c7 of user postgres.
Jan 09 14:54:01 rleap15-2 su[17138]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:03 rleap15-2 su[17138]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:03 rleap15-2 initrock[17102]: 2021-01-09 14:54:03,465: Done.
Jan 09 14:54:03 rleap15-2 systemd[1]: Stopping PostgreSQL database server...
Jan 09 14:54:03 rleap15-2 postgresql-script[17197]: pg_ctl: PID file "/var/lib/pgsql/data/postmaster.pid" does not exist
Jan 09 14:54:03 rleap15-2 postgresql-script[17197]: Is server running?
Jan 09 14:54:03 rleap15-2 systemd[1]: postgresql.service: Control process exited, code=exited status=1
Jan 09 14:54:03 rleap15-2 systemd[1]: postgresql.service: Main process exited, code=exited, status=1/FAILURE
Jan 09 14:54:03 rleap15-2 systemd[1]: Stopped PostgreSQL database server.
Jan 09 14:54:03 rleap15-2 systemd[1]: postgresql.service: Unit entered failed state.
Jan 09 14:54:03 rleap15-2 systemd[1]: postgresql.service: Failed with result 'exit-code'.
Jan 09 14:54:03 rleap15-2 systemd[1]: Starting PostgreSQL database server...
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.591 GMT   [17220]LOG:  listening on IPv4 address "127.0.0.1", port 5432
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.593 GMT   [17220]LOG:  could not create IPv6 socket for address "::1": Address family not supported by protocol
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.599 GMT   [17220]LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.609 GMT   [17220]LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.622 GMT   [17220]LOG:  redirecting log output to logging collector process
Jan 09 14:54:03 rleap15-2 postgresql-script[17209]: 2021-01-09 14:54:03.622 GMT   [17220]HINT:  Future log output will appear in directory "log".
Jan 09 14:54:03 rleap15-2 systemd[1]: Started PostgreSQL database server.
Jan 09 14:54:03 rleap15-2 initrock[17102]: 2021-01-09 14:54:03,691: Creating app databases...
Jan 09 14:54:03 rleap15-2 su[17233]: (to postgres) root on none
Jan 09 14:54:03 rleap15-2 systemd[1]: Started Session c8 of user postgres.
Jan 09 14:54:03 rleap15-2 su[17233]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:05 rleap15-2 su[17233]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:05 rleap15-2 su[17273]: (to postgres) root on none
Jan 09 14:54:05 rleap15-2 systemd[1]: Started Session c9 of user postgres.
Jan 09 14:54:05 rleap15-2 su[17273]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:07 rleap15-2 su[17273]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:07 rleap15-2 initrock[17102]: 2021-01-09 14:54:07,600: Done
Jan 09 14:54:07 rleap15-2 initrock[17102]: 2021-01-09 14:54:07,600: Initializing app databases...
Jan 09 14:54:07 rleap15-2 su[17313]: (to postgres) root on none
Jan 09 14:54:07 rleap15-2 systemd[1]: Started Session c10 of user postgres.
Jan 09 14:54:07 rleap15-2 su[17313]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:07 rleap15-2 su[17313]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:07 rleap15-2 su[17351]: (to postgres) root on none
Jan 09 14:54:07 rleap15-2 systemd[1]: Started Session c11 of user postgres.
Jan 09 14:54:07 rleap15-2 su[17351]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:14 rleap15-2 su[17351]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:14 rleap15-2 su[17399]: (to postgres) root on none
Jan 09 14:54:14 rleap15-2 systemd[1]: Started Session c12 of user postgres.
Jan 09 14:54:14 rleap15-2 su[17399]: pam_unix(su-l:session): session opened for user postgres by (uid=0)
Jan 09 14:54:16 rleap15-2 su[17399]: pam_unix(su-l:session): session closed for user postgres
Jan 09 14:54:16 rleap15-2 initrock[17102]: 2021-01-09 14:54:16,097: Done
Jan 09 14:54:16 rleap15-2 systemd[1]: Stopping PostgreSQL database server...
Jan 09 14:54:17 rleap15-2 systemd[1]: Stopped PostgreSQL database server.
Jan 09 14:54:17 rleap15-2 systemd[1]: Starting PostgreSQL database server...
Jan 09 14:54:17 rleap15-2 postgresql-script[17453]: 2021-01-09 06:54:17.527 PST [17464] LOG:  listening on IPv4 address "127.0.0.1", port 5432
Jan 09 14:54:17 rleap15-2 postgresql-script[17453]: 2021-01-09 06:54:17.534 PST [17464] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
Jan 09 14:54:17 rleap15-2 postgresql-script[17453]: 2021-01-09 06:54:17.546 PST [17464] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
Jan 09 14:54:17 rleap15-2 postgresql-script[17453]: 2021-01-09 06:54:17.556 PST [17464] LOG:  redirecting log output to logging collector process
Jan 09 14:54:17 rleap15-2 postgresql-script[17453]: 2021-01-09 06:54:17.556 PST [17464] HINT:  Future log output will appear in directory "log".
Jan 09 14:54:17 rleap15-2 systemd[1]: Started PostgreSQL database server.
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,615: Postgresql restarted
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,621: updating rockstor-pre service..
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,622: rockstor-pre now requires postgresql
Jan 09 14:54:17 rleap15-2 systemd[1]: Reloading.
Jan 09 14:54:17 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:17 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,892: systemd daemon reloaded
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,893: Done
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,893: Running app database migrations...
Jan 09 14:54:17 rleap15-2 initrock[17102]: 2021-01-09 14:54:17,893: migrate (--fake-initial) contenttypes
Jan 09 14:54:19 rleap15-2 initrock[17102]: 2021-01-09 14:54:19,687: migrate (--fake) db=(default) app=(storageadmin) 0001_initial
Jan 09 14:54:23 rleap15-2 initrock[17102]: 2021-01-09 14:54:23,862: migrate (--fake) db=(smart_manager) app=(smart_manager) 0001_initial
Jan 09 14:54:26 rleap15-2 systemd[1]: user-runtime-dir@26.service: Unit not needed anymore. Stopping.
Jan 09 14:54:26 rleap15-2 systemd[1]: Stopping User Manager for UID 26...
Jan 09 14:54:26 rleap15-2 systemd[17146]: Stopped target Default.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Stopped target Basic System.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Stopped target Sockets.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Stopped target Paths.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Closed D-Bus User Message Bus Socket.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Reached target Shutdown.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Starting Exit the Session...
Jan 09 14:54:26 rleap15-2 systemd[17146]: Stopped target Timers.
Jan 09 14:54:26 rleap15-2 systemd[17146]: Received SIGRTMIN+24 from PID 17564 (kill).
Jan 09 14:54:26 rleap15-2 systemd[17149]: pam_unix(systemd-user:session): session closed for user postgres
Jan 09 14:54:26 rleap15-2 systemd[1]: user-runtime-dir@26.service: Unit not needed anymore. Stopping.
Jan 09 14:54:26 rleap15-2 systemd[1]: Stopped User Manager for UID 26.
Jan 09 14:54:26 rleap15-2 systemd[1]: user-runtime-dir@26.service: Unit not needed anymore. Stopping.
Jan 09 14:54:26 rleap15-2 systemd[1]: user-26.slice: Unit not needed anymore. Stopping.
Jan 09 14:54:26 rleap15-2 systemd[1]: Stopping User Runtime Directory /run/user/26...
Jan 09 14:54:26 rleap15-2 systemd[1]: Stopped User Runtime Directory /run/user/26.
Jan 09 14:54:26 rleap15-2 systemd[1]: user-26.slice: Unit not needed anymore. Stopping.
Jan 09 14:54:26 rleap15-2 systemd[1]: Removed slice User Slice of UID 26.
Jan 09 14:54:36 rleap15-2 initrock[17102]: 2021-01-09 14:54:36,472: Done
Jan 09 14:54:36 rleap15-2 initrock[17102]: 2021-01-09 14:54:36,472: Running prepdb...
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,255: Done
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,256: stopping firewalld...
Jan 09 14:54:37 rleap15-2 systemd[1]: Reloading.
Jan 09 14:54:37 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:37 rleap15-2 systemd[1]: Binding to IPv6 address not available since kernel does not support IPv6.
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,657: firewalld stopped and disabled
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,860: Normalising on shellinaboxd service file
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,860: - shellinaboxd.service already exists
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,860: rockstor service looks correct. Not updating.
Jan 09 14:54:37 rleap15-2 initrock[17102]: 2021-01-09 14:54:37,861: rockstor-bootstrap.service looks correct. Not updating.
Jan 09 14:54:37 rleap15-2 systemd[1]: Started Tasks required prior to starting Rockstor.
Jan 09 14:54:37 rleap15-2 systemd[1]: Started RockStor startup script.
Jan 09 14:54:38 rleap15-2 supervisord[17635]: 2021-01-09 14:54:38,084 CRIT Supervisor running as root (no user in config file)
Jan 09 14:54:38 rleap15-2 supervisord[17635]: 2021-01-09 14:54:38,093 INFO RPC interface 'supervisor' initialized
Jan 09 14:54:38 rleap15-2 supervisord[17635]: 2021-01-09 14:54:38,093 CRIT Server 'unix_http_server' running without any HTTP authentication checking
Jan 09 14:54:38 rleap15-2 supervisord[17635]: 2021-01-09 14:54:38,093 INFO supervisord started with pid 17635
Jan 09 14:54:39 rleap15-2 supervisord[17635]: 2021-01-09 14:54:39,096 INFO spawned: 'nginx' with pid 17639
Jan 09 14:54:39 rleap15-2 supervisord[17635]: 2021-01-09 14:54:39,099 INFO spawned: 'gunicorn' with pid 17640
Jan 09 14:54:39 rleap15-2 supervisord[17635]: 2021-01-09 14:54:39,100 INFO spawned: 'data-collector' with pid 17641
Jan 09 14:54:39 rleap15-2 supervisord[17635]: 2021-01-09 14:54:39,102 INFO spawned: 'ztask-daemon' with pid 17642
Jan 09 14:54:41 rleap15-2 supervisord[17635]: 2021-01-09 14:54:41,109 INFO success: data-collector entered RUNNING state, process has stayed up for > than 2 seconds (startsecs)
Jan 09 14:54:41 rleap15-2 supervisord[17635]: 2021-01-09 14:54:41,109 INFO success: ztask-daemon entered RUNNING state, process has stayed up for > than 2 seconds (startsecs)
Jan 09 14:54:44 rleap15-2 supervisord[17635]: 2021-01-09 14:54:44,191 INFO success: nginx entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
Jan 09 14:54:44 rleap15-2 supervisord[17635]: 2021-01-09 14:54:44,191 INFO success: gunicorn entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)

</details>