### PR TITLE
Improve handling of rock-on-related functions when Rock-ons service is OFF

### DIFF
--- a/src/rockstor/storageadmin/models/rockon.py
+++ b/src/rockstor/storageadmin/models/rockon.py
@@ -71,7 +71,7 @@ class RockOn(models.Model):
         """
         for co in self.dcontainer_set.all():
             res = probe_running_containers(container=co.name, network="host", all=True)
-            if len(res) > 1:
+            if (res is not None) and (len(res) > 1):
                 return True
             else:
                 return False

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/network/network.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/network/network.jst
@@ -51,18 +51,24 @@
                     data-parent="#connections"
                     data-target="#accordion-{{this.id}}"><a> {{this.name}}</a>&nbsp;&nbsp;
                     {{#unless this.docker_name}}
-                    <a href="#network/edit/{{this.id}}"><i
+                    <a href="#network/edit/{{this.id}}" title="Edit connection"><i
                             class="glyphicon glyphicon-pencil"></i></a>
                     <a id="{{this.id}}" data-action="delete" rel="tooltip"
                        title="Delete connection"><i
                             class="glyphicon glyphicon-trash"></i></a></td>
                     {{/unless}}
                     {{#if this.user_dnet}}
-                    <a href="#network/edit/{{this.id}}"><i
+                    {{#if ../docker_running}}
+                    <a href="#network/edit/{{this.id}}" title="Edit connection"><i
                             class="glyphicon glyphicon-pencil"></i></a>
                     <a id="{{this.id}}" data-action="delete" rel="tooltip"
                        title="Delete connection"><i
                             class="glyphicon glyphicon-trash"></i></a></td>
+                    {{else}}
+                    <i class="glyphicon glyphicon-info-sign"
+                       title="Cannot edit/delete rocknet while the Rock-on service is OFF">
+                    </i></td>
+                    {{/if}}
                     {{/if}}
                 <td>{{this.uuid}}</td>
                 <td>{{this.ctype}} {{#if

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/network.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/network.js
@@ -37,11 +37,16 @@ NetworkView = Backbone.View.extend({
         this.collection.on('reset', this.renderNetwork, this);
         this.devices = new NetworkDeviceCollection();
         this.devices.on('reset', this.renderNetwork, this);
+        this.docker_service = new Service({
+            name: 'docker'
+        });
+        this.docker_service.on('reset', this.renderNetwork, this);
         this.initHandlebarHelpers();
     },
 
     render: function() {
         var _this = this;
+        this.docker_service.fetch();
         this.collection.fetch();
         this.devices.fetch();
         return this;
@@ -60,6 +65,11 @@ NetworkView = Backbone.View.extend({
                 this.pc.push(c.toJSON());
             }
         }
+        // Get status of Rock-on service to display edit/delete links accordingly
+        // on docker network connections (rocknets)
+        if (typeof this.current_docker_status == 'undefined') {
+            this.current_docker_status = this.docker_service.get('status');
+        }
 
         $(this.el).empty();
         $(this.el).append(this.template({
@@ -67,7 +77,8 @@ NetworkView = Backbone.View.extend({
             connections: this.collection.toJSON(),
             parent_connections: this.pc,
             child_connections: this.cc,
-            devices: this.devices.toJSON()
+            devices: this.devices.toJSON(),
+            docker_running: this.current_docker_status
         }));
         setApplianceName();
 

--- a/src/rockstor/storageadmin/views/network.py
+++ b/src/rockstor/storageadmin/views/network.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -56,7 +56,6 @@ DEFAULT_MTU = MIN_MTU
 
 
 class NetworkMixin(object):
-    logger.debug("The class NetworkMixin has been initialized")
     # Runners for teams. @todo: support basic defaults + custom configuration.
     # @todo: lacp doesn't seem to be activating
     runners = {
@@ -131,7 +130,7 @@ class NetworkMixin(object):
                 )
 
         else:
-            logger.error("Unknown ctype: {} config: {}".format(ctype, config))
+            logger.debug("Unknown ctype: {} config: {}".format(ctype, config))
 
     @staticmethod
     @transaction.atomic

--- a/src/rockstor/system/docker.py
+++ b/src/rockstor/system/docker.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -145,16 +145,17 @@ def probe_running_containers(container=None, network=None, all=False):
         "--filter",
         "status=paused",
     ]
-    if all:
-        cmd.extend((["-a",]))
-    if network:
-        cmd.extend((["--filter", "network={}".format(network),]))
-    if container:
-        cmd.extend((running_filters + ["--filter", "name={}".format(container),]))
-    else:
-        cmd.extend((running_filters))
-    o, e, rc = run_command(cmd)
-    return o
+    if docker_status():
+        if all:
+            cmd.extend((["-a",]))
+        if network:
+            cmd.extend((["--filter", "network={}".format(network),]))
+        if container:
+            cmd.extend((running_filters + ["--filter", "name={}".format(container),]))
+        else:
+            cmd.extend((running_filters))
+        o, e, rc = run_command(cmd)
+        return o
 
 
 def dnet_create(
@@ -185,6 +186,11 @@ def dnet_create(
     :param subnet:
     :return:
     """
+    if not docker_status():
+        raise Exception(
+            "Cannot create rocknet while docker is not running. "
+            "Turn the Rock-on service ON and try again"
+        )
     o, e, rc = run_command(list(DNET) + ["list", "--format", "{{.Name}}",])
     if network not in o:
         logger.debug(


### PR DESCRIPTION
Fixes #2239
@phillxnet, ready for review

As detailed in https://github.com/rockstor/rockstor-core/issues/2239#issuecomment-754075723, we are facing several known issues throughout the web-UI when the Rock-on service is turned OFF (following #2207). These are:
1. Error when opening the Rock-ons page, due to a failure to fetch docker networking-related information as the docker daemon in not running.
2. Failure to create a new rocknet, due to failure to run the underlying needed docker commands as the docker daemon is not running.
3. Failure to edit an existing rocknet, due to failure to run the underlying needed docker commands as the docker daemon is not running.
4. Visiting the System > Network page throws the old `unknown ctype: bridge` error in the logs even though we know deal with these connections. This is because the logic behind that is expecting the Rock-on service to be ON. 

This pull-request (PR) thus proposes to implement additional verifications that the docker daemon (Rock-on service) is running before initiating procedures leading to docker commands. These are implemented both in the back-end and in the web-UI through new interface elements with explicit information for the user.

The fixes for each point listed above are detailed below in their own section.

## Error while visiting the Rock-ons page
This error occurred during the logic used to determine whether a rock-on is using host-networking. We thus now propose check that the docker daemon is running before running this command and return nothing if not. The `RockOn` model method is adjusted accordingly to deal with such possibility.

## Failure to create a new rocknet
Understandably, one cannot create a docker network if the docker daemon is not running. We thus now check whether the docker service is running before attempting to run the `dnet_create()` function. If not, we surface an explicit error to the user as seen below:
![image](https://user-images.githubusercontent.com/30297881/104104385-bff3a880-5275-11eb-9292-da346b242fe3.png)


## Failure to edit/delete an existing rocknet
While we could follow the same approach as the above point, we can here stop the user from even encountering an error by informing it of the necessity to turn the Rock-on service ON before attempting to edit/delete an existing rocknet. As a result, this PR implement a new fetch for the Rock-on service status on the JS view and replaces the edit/delete icons and links with a new information icon informing the user that edit/delete is not possible when the Rock-on service is OFF.
![image](https://user-images.githubusercontent.com/30297881/104104388-c5e98980-5275-11eb-96c1-643b77e0e1d8.png)


## Misleading log error
While we do account for the `bridge` ctype post #2207, this is only true when the Rock-on service is ON, explaining why we still see this "error" in the logs when the Rock-on service is OFF. While we could add another `if` condition to deal with such case, it seems unnecessary to add yet another conditional that would in the end lead to nothing. It thus chose to simply "increase" the log level to `DEBUG`. We thus avoid spamming the logs with an "error" that isn't really an error.


## Testing
@phillxnet, note that this PR was from a branch created before your work on unit testing. I thus rebased it before running the tests below, but the branch state in this PR is before that (so that I keep a clean commit).

**_Leap 15.2 (ISO install)_**:  

```
Ran 212 tests in 59.982s

OK
```


## Full Testing Outputs

<details><summary>Leap15.2 (ISO install)</summary>

```
# ./bin/test -v 2


Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete (storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (storageadmin.tests.test_network.NetworkTests) ... ok
test_put (storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (storageadmin.tests.test_network.NetworkTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

----------------------------------------------------------------------
Ran 212 tests in 59.982s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```


</details>
