### PR TITLE
Deprecate update_rockons routine from data_collector.py (#2255)

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -892,7 +892,6 @@ class SysinfoNamespace(RockstorIO):
         self.spawn(self.update_storage_state, sid)
         self.spawn(self.update_check, sid)
         self.spawn(self.yum_updates, sid)
-        self.spawn(self.update_rockons, sid)
         self.spawn(self.send_kernel_info, sid)
         self.spawn(self.prune_logs, sid)
         self.spawn(self.send_localtime, sid)
@@ -938,18 +937,6 @@ class SysinfoNamespace(RockstorIO):
             )
         except Exception as e:
             logger.error("Exception while gathering kernel info: %s" % e.__str__())
-
-    def update_rockons(self):
-
-        try:
-            self.aw.api_call(
-                "rockons/update", data=None, calltype="post", save_error=False
-            )
-        except Exception as e:
-            logger.error(
-                "failed to update Rock-on metadata. low-level "
-                "exception: %s" % e.__str__()
-            )
 
     def update_storage_state(self):
         # update storage state once a minute as long as


### PR DESCRIPTION
Fixes #2255 
@phillxnet, ready for review

This pull request (PR) proposes to remove the update_rockons procedure from the `data_collector` routine in order to prevent unnecessary and repeated outbound calls to the rock-ons server (see #2255).

## Description of changes
As the API call triggered by `data_collector` is identical to the one triggered by the user upon clicking the "Update" button on the Rock-ons page, the former is entirely redundant and can be safely removed. This PR thus simply proposes to remove it.

## Demonstration
1. To verify that no function is lost, a new clean source build was made from this branch.
2. Visit webUI at `https://<rockstor-ip>`
3. Set hostname and create admin user (normal first login procedure) and click "Submit"
4. At this point, the Rock-ons update procedure used to be triggered (prior to this PR); it no longer is the case, as seen in the logs below:
```
<Click Submit on step 3>
[17/Jan/2021 13:02:04] DEBUG [storageadmin.views.network:83] The function _update_or_create_ctype has been called
[17/Jan/2021 13:02:04] DEBUG [storageadmin.views.network:83] The function _update_or_create_ctype has been called
[17/Jan/2021 13:02:04] DEBUG [system.osi:466] --- Inheriting base_root_disk info ---
[17/Jan/2021 13:02:04] DEBUG [storageadmin.views.network:83] The function _update_or_create_ctype has been called
[17/Jan/2021 13:02:04] DEBUG [storageadmin.views.network:83] The function _update_or_create_ctype has been called
[17/Jan/2021 13:02:04] DEBUG [storageadmin.views.disk:397] ++++ Creating special system pool db entry.
[17/Jan/2021 13:02:04] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs quota enable /mnt2/ROOT
[17/Jan/2021 13:02:05] DEBUG [system.osi:466] --- Inheriting base_root_disk info ---
[17/Jan/2021 13:02:08] DEBUG [system.osi:466] --- Inheriting base_root_disk info ---
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(@).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(.snapshots).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(.snapshots/1/snapshot).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(opt).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(root).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(srv).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(tmp).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(var).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(usr/local).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(boot/grub2/i386-pc).
[17/Jan/2021 13:02:10] DEBUG [fs.btrfs:779] Skipping excluded subvol: name=(boot/grub2/x86_64-efi).
[17/Jan/2021 13:02:10] DEBUG [storageadmin.views.share_helpers:111] ---- Share name = home.
[17/Jan/2021 13:02:10] DEBUG [storageadmin.views.share_helpers:165] No prior entries in scanned pool trying all pools.
[17/Jan/2021 13:02:10] DEBUG [storageadmin.views.share_helpers:201] Db share entry does not exist - creating.
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup show /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup create 2015/3 /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup limit none 2015/3 /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup show -pc /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup assign 0/259 2015/3 /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs subvolume list /mnt2/ROOT
[17/Jan/2021 13:02:10] DEBUG [system.osi:179] Running command: /usr/sbin/btrfs qgroup show /mnt2/ROOT/home
```

5. Set up a data pool, rockons_root share, configure and turn ON the rock-ons service.
6. Visit the Rock-ons page... all OK:
![image](https://user-images.githubusercontent.com/30297881/104851957-ffe60b80-58c5-11eb-9dab-f9d50732eda8.png)

7. Click the "Update" button and witness the rock-ons update procedure complete without error in the logs, resulting in the list of all available rock-ons:
![image](https://user-images.githubusercontent.com/30297881/104852007-49365b00-58c6-11eb-93f1-f54fd63b3e0c.png)


## Testing

```
Ran 212 tests in 60.133s

OK
```


<details><summary>Full testing output</summary>

```
# ./bin/test -v 3
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (8.039s)
  Applying contenttypes.0001_initial... OK (0.410s)
  Applying auth.0001_initial... OK (2.617s)
  Applying admin.0001_initial... OK (0.586s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.217s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.183s)
  Applying auth.0003_alter_user_email_max_length... OK (0.175s)
  Applying auth.0004_alter_user_username_opts... OK (0.132s)
  Applying auth.0005_alter_user_last_login_null... OK (0.173s)
  Applying auth.0006_require_contenttypes_0002... OK (0.158s)
  Applying oauth2_provider.0001_initial... OK (3.009s)
  Applying oauth2_provider.0002_08_updates... OK (1.253s)
  Applying sessions.0001_initial... OK (0.725s)
  Applying sites.0001_initial... OK (0.250s)
  Applying smart_manager.0001_initial... OK (0.430s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.100s)
  Applying storageadmin.0001_initial... OK (29.513s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.594s)
  Applying storageadmin.0003_auto_20170114_1332... OK (1.730s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.333s)
  Applying storageadmin.0005_auto_20180913_0923... OK (1.411s)
  Applying storageadmin.0006_dcontainerargs... OK (0.760s)
  Applying storageadmin.0007_auto_20181210_0740... OK (1.031s)
  Applying storageadmin.0008_auto_20190115_1637... OK (2.139s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.422s)
  Applying storageadmin.0010_sambashare_time_machine... OK (1.027s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.401s)
  Applying storageadmin.0012_auto_20200429_1428... OK (1.417s)
  Applying storageadmin.0013_auto_20200815_2004... OK (2.995s)
Running post-migrate handlers for application auth
Adding permission 'auth | permission | Can add permission'
Adding permission 'auth | permission | Can change permission'
Adding permission 'auth | permission | Can delete permission'
Adding permission 'auth | group | Can add group'
Adding permission 'auth | group | Can change group'
Adding permission 'auth | group | Can delete group'
Adding permission 'auth | user | Can add user'
Adding permission 'auth | user | Can change user'
Adding permission 'auth | user | Can delete user'
Running post-migrate handlers for application contenttypes
Adding permission 'contenttypes | content type | Can add content type'
Adding permission 'contenttypes | content type | Can change content type'
Adding permission 'contenttypes | content type | Can delete content type'
Running post-migrate handlers for application sessions
Adding permission 'sessions | session | Can add session'
Adding permission 'sessions | session | Can change session'
Adding permission 'sessions | session | Can delete session'
Running post-migrate handlers for application sites
Adding permission 'sites | site | Can add site'
Adding permission 'sites | site | Can change site'
Adding permission 'sites | site | Can delete site'
Creating example.com Site object
Resetting sequence
Running post-migrate handlers for application admin
Adding permission 'admin | log entry | Can add log entry'
Adding permission 'admin | log entry | Can change log entry'
Adding permission 'admin | log entry | Can delete log entry'
Running post-migrate handlers for application storageadmin
Adding permission 'storageadmin | pool | Can add pool'
Adding permission 'storageadmin | pool | Can change pool'
Adding permission 'storageadmin | pool | Can delete pool'
Adding permission 'storageadmin | disk | Can add disk'
Adding permission 'storageadmin | disk | Can change disk'
Adding permission 'storageadmin | disk | Can delete disk'
Adding permission 'storageadmin | snapshot | Can add snapshot'
Adding permission 'storageadmin | snapshot | Can change snapshot'
Adding permission 'storageadmin | snapshot | Can delete snapshot'
Adding permission 'storageadmin | share | Can add share'
Adding permission 'storageadmin | share | Can change share'
Adding permission 'storageadmin | share | Can delete share'
Adding permission 'storageadmin | nfs export group | Can add nfs export group'
Adding permission 'storageadmin | nfs export group | Can change nfs export group'
Adding permission 'storageadmin | nfs export group | Can delete nfs export group'
Adding permission 'storageadmin | nfs export | Can add nfs export'
Adding permission 'storageadmin | nfs export | Can change nfs export'
Adding permission 'storageadmin | nfs export | Can delete nfs export'
Adding permission 'storageadmin | iscsi target | Can add iscsi target'
Adding permission 'storageadmin | iscsi target | Can change iscsi target'
Adding permission 'storageadmin | iscsi target | Can delete iscsi target'
Adding permission 'storageadmin | api keys | Can add api keys'
Adding permission 'storageadmin | api keys | Can change api keys'
Adding permission 'storageadmin | api keys | Can delete api keys'
Adding permission 'storageadmin | network connection | Can add network connection'
Adding permission 'storageadmin | network connection | Can change network connection'
Adding permission 'storageadmin | network connection | Can delete network connection'
Adding permission 'storageadmin | network device | Can add network device'
Adding permission 'storageadmin | network device | Can change network device'
Adding permission 'storageadmin | network device | Can delete network device'
Adding permission 'storageadmin | ethernet connection | Can add ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can change ethernet connection'
Adding permission 'storageadmin | ethernet connection | Can delete ethernet connection'
Adding permission 'storageadmin | team connection | Can add team connection'
Adding permission 'storageadmin | team connection | Can change team connection'
Adding permission 'storageadmin | team connection | Can delete team connection'
Adding permission 'storageadmin | bond connection | Can add bond connection'
Adding permission 'storageadmin | bond connection | Can change bond connection'
Adding permission 'storageadmin | bond connection | Can delete bond connection'
Adding permission 'storageadmin | bridge connection | Can add bridge connection'
Adding permission 'storageadmin | bridge connection | Can change bridge connection'
Adding permission 'storageadmin | bridge connection | Can delete bridge connection'
Adding permission 'storageadmin | appliance | Can add appliance'
Adding permission 'storageadmin | appliance | Can change appliance'
Adding permission 'storageadmin | appliance | Can delete appliance'
Adding permission 'storageadmin | support case | Can add support case'
Adding permission 'storageadmin | support case | Can change support case'
Adding permission 'storageadmin | support case | Can delete support case'
Adding permission 'storageadmin | dashboard config | Can add dashboard config'
Adding permission 'storageadmin | dashboard config | Can change dashboard config'
Adding permission 'storageadmin | dashboard config | Can delete dashboard config'
Adding permission 'storageadmin | group | Can add group'
Adding permission 'storageadmin | group | Can change group'
Adding permission 'storageadmin | group | Can delete group'
Adding permission 'storageadmin | user | Can add user'
Adding permission 'storageadmin | user | Can change user'
Adding permission 'storageadmin | user | Can delete user'
Adding permission 'storageadmin | samba share | Can add samba share'
Adding permission 'storageadmin | samba share | Can change samba share'
Adding permission 'storageadmin | samba share | Can delete samba share'
Adding permission 'storageadmin | samba custom config | Can add samba custom config'
Adding permission 'storageadmin | samba custom config | Can change samba custom config'
Adding permission 'storageadmin | samba custom config | Can delete samba custom config'
Adding permission 'storageadmin | posix ac ls | Can add posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can change posix ac ls'
Adding permission 'storageadmin | posix ac ls | Can delete posix ac ls'
Adding permission 'storageadmin | pool scrub | Can add pool scrub'
Adding permission 'storageadmin | pool scrub | Can change pool scrub'
Adding permission 'storageadmin | pool scrub | Can delete pool scrub'
Adding permission 'storageadmin | setup | Can add setup'
Adding permission 'storageadmin | setup | Can change setup'
Adding permission 'storageadmin | setup | Can delete setup'
Adding permission 'storageadmin | sftp | Can add sftp'
Adding permission 'storageadmin | sftp | Can change sftp'
Adding permission 'storageadmin | sftp | Can delete sftp'
Adding permission 'storageadmin | plugin | Can add plugin'
Adding permission 'storageadmin | plugin | Can change plugin'
Adding permission 'storageadmin | plugin | Can delete plugin'
Adding permission 'storageadmin | advanced nfs export | Can add advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can change advanced nfs export'
Adding permission 'storageadmin | advanced nfs export | Can delete advanced nfs export'
Adding permission 'storageadmin | oauth app | Can add oauth app'
Adding permission 'storageadmin | oauth app | Can change oauth app'
Adding permission 'storageadmin | oauth app | Can delete oauth app'
Adding permission 'storageadmin | pool balance | Can add pool balance'
Adding permission 'storageadmin | pool balance | Can change pool balance'
Adding permission 'storageadmin | pool balance | Can delete pool balance'
Adding permission 'storageadmin | tls certificate | Can add tls certificate'
Adding permission 'storageadmin | tls certificate | Can change tls certificate'
Adding permission 'storageadmin | tls certificate | Can delete tls certificate'
Adding permission 'storageadmin | rock on | Can add rock on'
Adding permission 'storageadmin | rock on | Can change rock on'
Adding permission 'storageadmin | rock on | Can delete rock on'
Adding permission 'storageadmin | d image | Can add d image'
Adding permission 'storageadmin | d image | Can change d image'
Adding permission 'storageadmin | d image | Can delete d image'
Adding permission 'storageadmin | d container | Can add d container'
Adding permission 'storageadmin | d container | Can change d container'
Adding permission 'storageadmin | d container | Can delete d container'
Adding permission 'storageadmin | d container link | Can add d container link'
Adding permission 'storageadmin | d container link | Can change d container link'
Adding permission 'storageadmin | d container link | Can delete d container link'
Adding permission 'storageadmin | d container network | Can add d container network'
Adding permission 'storageadmin | d container network | Can change d container network'
Adding permission 'storageadmin | d container network | Can delete d container network'
Adding permission 'storageadmin | d port | Can add d port'
Adding permission 'storageadmin | d port | Can change d port'
Adding permission 'storageadmin | d port | Can delete d port'
Adding permission 'storageadmin | d volume | Can add d volume'
Adding permission 'storageadmin | d volume | Can change d volume'
Adding permission 'storageadmin | d volume | Can delete d volume'
Adding permission 'storageadmin | container option | Can add container option'
Adding permission 'storageadmin | container option | Can change container option'
Adding permission 'storageadmin | container option | Can delete container option'
Adding permission 'storageadmin | d container args | Can add d container args'
Adding permission 'storageadmin | d container args | Can change d container args'
Adding permission 'storageadmin | d container args | Can delete d container args'
Adding permission 'storageadmin | d custom config | Can add d custom config'
Adding permission 'storageadmin | d custom config | Can change d custom config'
Adding permission 'storageadmin | d custom config | Can delete d custom config'
Adding permission 'storageadmin | d container env | Can add d container env'
Adding permission 'storageadmin | d container env | Can change d container env'
Adding permission 'storageadmin | d container env | Can delete d container env'
Adding permission 'storageadmin | d container device | Can add d container device'
Adding permission 'storageadmin | d container device | Can change d container device'
Adding permission 'storageadmin | d container device | Can delete d container device'
Adding permission 'storageadmin | d container label | Can add d container label'
Adding permission 'storageadmin | d container label | Can change d container label'
Adding permission 'storageadmin | d container label | Can delete d container label'
Adding permission 'storageadmin | smart capability | Can add smart capability'
Adding permission 'storageadmin | smart capability | Can change smart capability'
Adding permission 'storageadmin | smart capability | Can delete smart capability'
Adding permission 'storageadmin | smart attribute | Can add smart attribute'
Adding permission 'storageadmin | smart attribute | Can change smart attribute'
Adding permission 'storageadmin | smart attribute | Can delete smart attribute'
Adding permission 'storageadmin | smart error log | Can add smart error log'
Adding permission 'storageadmin | smart error log | Can change smart error log'
Adding permission 'storageadmin | smart error log | Can delete smart error log'
Adding permission 'storageadmin | smart error log summary | Can add smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can change smart error log summary'
Adding permission 'storageadmin | smart error log summary | Can delete smart error log summary'
Adding permission 'storageadmin | smart test log | Can add smart test log'
Adding permission 'storageadmin | smart test log | Can change smart test log'
Adding permission 'storageadmin | smart test log | Can delete smart test log'
Adding permission 'storageadmin | smart test log detail | Can add smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can change smart test log detail'
Adding permission 'storageadmin | smart test log detail | Can delete smart test log detail'
Adding permission 'storageadmin | smart identity | Can add smart identity'
Adding permission 'storageadmin | smart identity | Can change smart identity'
Adding permission 'storageadmin | smart identity | Can delete smart identity'
Adding permission 'storageadmin | smart info | Can add smart info'
Adding permission 'storageadmin | smart info | Can change smart info'
Adding permission 'storageadmin | smart info | Can delete smart info'
Adding permission 'storageadmin | config backup | Can add config backup'
Adding permission 'storageadmin | config backup | Can change config backup'
Adding permission 'storageadmin | config backup | Can delete config backup'
Adding permission 'storageadmin | email client | Can add email client'
Adding permission 'storageadmin | email client | Can change email client'
Adding permission 'storageadmin | email client | Can delete email client'
Adding permission 'storageadmin | update subscription | Can add update subscription'
Adding permission 'storageadmin | update subscription | Can change update subscription'
Adding permission 'storageadmin | update subscription | Can delete update subscription'
Adding permission 'storageadmin | pincard | Can add pincard'
Adding permission 'storageadmin | pincard | Can change pincard'
Adding permission 'storageadmin | pincard | Can delete pincard'
Adding permission 'storageadmin | installed plugin | Can add installed plugin'
Adding permission 'storageadmin | installed plugin | Can change installed plugin'
Adding permission 'storageadmin | installed plugin | Can delete installed plugin'
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Adding permission 'smart_manager | cpu metric | Can add cpu metric'
Adding permission 'smart_manager | cpu metric | Can change cpu metric'
Adding permission 'smart_manager | cpu metric | Can delete cpu metric'
Adding permission 'smart_manager | disk stat | Can add disk stat'
Adding permission 'smart_manager | disk stat | Can change disk stat'
Adding permission 'smart_manager | disk stat | Can delete disk stat'
Adding permission 'smart_manager | load avg | Can add load avg'
Adding permission 'smart_manager | load avg | Can change load avg'
Adding permission 'smart_manager | load avg | Can delete load avg'
Adding permission 'smart_manager | mem info | Can add mem info'
Adding permission 'smart_manager | mem info | Can change mem info'
Adding permission 'smart_manager | mem info | Can delete mem info'
Adding permission 'smart_manager | vm stat | Can add vm stat'
Adding permission 'smart_manager | vm stat | Can change vm stat'
Adding permission 'smart_manager | vm stat | Can delete vm stat'
Adding permission 'smart_manager | service | Can add service'
Adding permission 'smart_manager | service | Can change service'
Adding permission 'smart_manager | service | Can delete service'
Adding permission 'smart_manager | service status | Can add service status'
Adding permission 'smart_manager | service status | Can change service status'
Adding permission 'smart_manager | service status | Can delete service status'
Adding permission 'smart_manager | s probe | Can add s probe'
Adding permission 'smart_manager | s probe | Can change s probe'
Adding permission 'smart_manager | s probe | Can delete s probe'
Adding permission 'smart_manager | nfsd call distribution | Can add nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can change nfsd call distribution'
Adding permission 'smart_manager | nfsd call distribution | Can delete nfsd call distribution'
Adding permission 'smart_manager | nfsd client distribution | Can add nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can change nfsd client distribution'
Adding permission 'smart_manager | nfsd client distribution | Can delete nfsd client distribution'
Adding permission 'smart_manager | nfsd share distribution | Can add nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can change nfsd share distribution'
Adding permission 'smart_manager | nfsd share distribution | Can delete nfsd share distribution'
Adding permission 'smart_manager | pool usage | Can add pool usage'
Adding permission 'smart_manager | pool usage | Can change pool usage'
Adding permission 'smart_manager | pool usage | Can delete pool usage'
Adding permission 'smart_manager | net stat | Can add net stat'
Adding permission 'smart_manager | net stat | Can change net stat'
Adding permission 'smart_manager | net stat | Can delete net stat'
Adding permission 'smart_manager | nfsd share client distribution | Can add nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can change nfsd share client distribution'
Adding permission 'smart_manager | nfsd share client distribution | Can delete nfsd share client distribution'
Adding permission 'smart_manager | share usage | Can add share usage'
Adding permission 'smart_manager | share usage | Can change share usage'
Adding permission 'smart_manager | share usage | Can delete share usage'
Adding permission 'smart_manager | nfsd uid gid distribution | Can add nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can change nfsd uid gid distribution'
Adding permission 'smart_manager | nfsd uid gid distribution | Can delete nfsd uid gid distribution'
Adding permission 'smart_manager | task definition | Can add task definition'
Adding permission 'smart_manager | task definition | Can change task definition'
Adding permission 'smart_manager | task definition | Can delete task definition'
Adding permission 'smart_manager | task | Can add task'
Adding permission 'smart_manager | task | Can change task'
Adding permission 'smart_manager | task | Can delete task'
Adding permission 'smart_manager | replica | Can add replica'
Adding permission 'smart_manager | replica | Can change replica'
Adding permission 'smart_manager | replica | Can delete replica'
Adding permission 'smart_manager | replica trail | Can add replica trail'
Adding permission 'smart_manager | replica trail | Can change replica trail'
Adding permission 'smart_manager | replica trail | Can delete replica trail'
Adding permission 'smart_manager | replica share | Can add replica share'
Adding permission 'smart_manager | replica share | Can change replica share'
Adding permission 'smart_manager | replica share | Can delete replica share'
Adding permission 'smart_manager | receive trail | Can add receive trail'
Adding permission 'smart_manager | receive trail | Can change receive trail'
Adding permission 'smart_manager | receive trail | Can delete receive trail'
Running post-migrate handlers for application oauth2_provider
Adding permission 'oauth2_provider | application | Can add application'
Adding permission 'oauth2_provider | application | Can change application'
Adding permission 'oauth2_provider | application | Can delete application'
Adding permission 'oauth2_provider | grant | Can add grant'
Adding permission 'oauth2_provider | grant | Can change grant'
Adding permission 'oauth2_provider | grant | Can delete grant'
Adding permission 'oauth2_provider | access token | Can add access token'
Adding permission 'oauth2_provider | access token | Can change access token'
Adding permission 'oauth2_provider | access token | Can delete access token'
Adding permission 'oauth2_provider | refresh token | Can add refresh token'
Adding permission 'oauth2_provider | refresh token | Can change refresh token'
Adding permission 'oauth2_provider | refresh token | Can delete refresh token'
Running post-migrate handlers for application django_ztask
Adding permission 'django_ztask | task | Can add task'
Adding permission 'django_ztask | task | Can change task'
Adding permission 'django_ztask | task | Can delete task'
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
Running pre-migrate handlers for application auth
Running pre-migrate handlers for application contenttypes
Running pre-migrate handlers for application sessions
Running pre-migrate handlers for application sites
Running pre-migrate handlers for application admin
Running pre-migrate handlers for application storageadmin
Running pre-migrate handlers for application rest_framework
Running pre-migrate handlers for application smart_manager
Running pre-migrate handlers for application oauth2_provider
Running pre-migrate handlers for application django_ztask
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Loading 'initial_data' fixtures...
Checking '/opt/build' for fixtures...
No fixture 'initial_data' in '/opt/build'.
Running migrations:
  Rendering model states... DONE (8.247s)
  Applying contenttypes.0001_initial... OK (0.087s)
  Applying auth.0001_initial... OK (0.100s)
  Applying admin.0001_initial... OK (0.091s)
  Applying contenttypes.0002_remove_content_type_name... OK (0.125s)
  Applying auth.0002_alter_permission_name_max_length... OK (0.116s)
  Applying auth.0003_alter_user_email_max_length... OK (0.159s)
  Applying auth.0004_alter_user_username_opts... OK (0.091s)
  Applying auth.0005_alter_user_last_login_null... OK (0.091s)
  Applying auth.0006_require_contenttypes_0002... OK (0.075s)
  Applying oauth2_provider.0001_initial... OK (0.166s)
  Applying oauth2_provider.0002_08_updates... OK (0.158s)
  Applying sessions.0001_initial... OK (0.075s)
  Applying sites.0001_initial... OK (0.083s)
  Applying smart_manager.0001_initial... OK (8.935s)
  Applying smart_manager.0002_auto_20170216_1212... OK (0.108s)
  Applying storageadmin.0001_initial... OK (4.401s)
  Applying storageadmin.0002_auto_20161125_0051... OK (0.455s)
  Applying storageadmin.0003_auto_20170114_1332... OK (0.446s)
  Applying storageadmin.0004_auto_20170523_1140... OK (0.251s)
  Applying storageadmin.0005_auto_20180913_0923... OK (0.801s)
  Applying storageadmin.0006_dcontainerargs... OK (0.290s)
  Applying storageadmin.0007_auto_20181210_0740... OK (0.475s)
  Applying storageadmin.0008_auto_20190115_1637... OK (0.614s)
  Applying storageadmin.0009_auto_20200210_1948... OK (0.250s)
  Applying storageadmin.0010_sambashare_time_machine... OK (0.242s)
  Applying storageadmin.0011_auto_20200314_1207... OK (0.492s)
  Applying storageadmin.0012_auto_20200429_1428... OK (0.633s)
  Applying storageadmin.0013_auto_20200815_2004... OK (0.867s)
Running post-migrate handlers for application auth
Running post-migrate handlers for application contenttypes
Running post-migrate handlers for application sessions
Running post-migrate handlers for application sites
Running post-migrate handlers for application admin
Running post-migrate handlers for application storageadmin
Running post-migrate handlers for application rest_framework
Running post-migrate handlers for application smart_manager
Running post-migrate handlers for application oauth2_provider
Running post-migrate handlers for application django_ztask
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete (storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (storageadmin.tests.test_network.NetworkTests) ... ok
test_put (storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (storageadmin.tests.test_network.NetworkTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

----------------------------------------------------------------------
Ran 212 tests in 60.133s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```

</details>



