### PR TITLE
Remove donate menu item and update legacy paypal mechanism (#2260)

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -957,19 +957,6 @@ $(document).ready(function() {
             $(target).removeClass('in');
             $(target).css('height', '0');
         }
-    });
-
-    // donate menu item handler
-    $('#donate_nav').click(function(event) {
-        if (event) {
-            event.preventDefault();
-        }
-        $('#donate-modal').modal('show');
-    });
-
-    // donate modal paypal donate button handler
-    $('#donate-modal #paypal_donate_button').click(function(event) {
-        $('#donate-modal').modal('hide');
     });
 
     /********** Websockets **************/

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -56,7 +56,6 @@
       <li><a href="mailto:support@rockstor.com" target="_blank">Team email</a></li>
     </ul>
   </li>
-  <li><a id="donate_nav" href="#"></i> Donate</a></li>
   <li><a href="http://shop.rockstor.com" target="_blank"><i class="fa fa-shopping-cart fa-lg" style="color:#E76545"></i> Shop</a></li>
 
 </ul>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -29,7 +29,8 @@ $(document).ready(function(){
         Rockstor package
         <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank"> update channels. </a>
         Please activate appropriately for your needs.
-        <br>- <strong>Stable updates</strong>: recommended for production use (paid).
+        <br>- <strong>Stable updates</strong>: recommended for production use (paid) -
+        <a href="http://rockstor.com/commercial_support.html" target="_blank"><i>Commercial Support</i></a> eligible.
         <br>- <strong>Testing updates</strong>: for development / actively testing latest code (free).
         <br>See our <a href="https://forum.rockstor.com/" target="_blank">friendly forum</a> for advise.
       </p>
@@ -82,6 +83,11 @@ $(document).ready(function(){
           <td><i class="fa fa-check"></i></td>
           <td><i class="fa fa-times"></i></td>
 	</tr>
+  <tr>
+          <td>Commercial Support available</td>
+          <td><i class="fa fa-check"></i></td>
+          <td><i class="fa fa-times"></i></td>
+  </tr>
 	<tr>
           <td></td>
           <td><a id="stable-modal" class="btn btn-success" title="Activate Stable subscription">Activate</a></td>
@@ -127,8 +133,15 @@ $(document).ready(function(){
 <div class="col-md-offset-2 col-md-8 col-md-offset-2" id="supportBox">
   {{#is_sub_active defaultSub}}
   <div class="alert alert-success" id="contrib-alert">
-    <h4>We are happy to make this update available to you. Please support us by
-      <a id="showDonateModal" href="#">Donating</a> or making a <a href="http://shop.rockstor.com" target="_blank"> Purchase</a></h4>
+    <h4>Our Open Source development is dependant upon active
+      <a href="http://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates </a>
+      participation,
+      <a href="https://www.paypal.me/rockstor" target="_blank"> donations (paypal.me)</a>
+      , and
+      <a href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates </a>
+      subscriptions with their associated
+      <a href="http://rockstor.com/commercial_support.html" target="_blank"><i>Commercial Support</i></a> options.
+    </h4>
   </div>
   {{/is_sub_active}}
   <a id="update" class="btn btn-primary" title="start update">Start Update</a>
@@ -155,8 +168,10 @@ $(document).ready(function(){
     <p></p>
     <p>
       <a href="http://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
-      are <strong>activated</strong>. While it's not recommended, if you are
-      absolutely sure,
+      are <strong>activated</strong> - install eligible for
+      <a href="http://rockstor.com/commercial_support.html" target="_blank"><i>Commercial Support.</i></a>
+      <br><br>
+      While it's not recommended, if you are absolutely sure,
       <a href="http://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
       can be activated by clicking <a id="testing-modal"> here.</a>
     </p>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -27,7 +27,6 @@
 VersionView = RockstorLayoutView.extend({
     events: {
         'click #update': 'update',
-        'click #showDonateModal': 'showDonateModal',
         'click #autoUpdateSwitch': 'autoUpdateSwitch',
         'click #enableAuto': 'enableAutoUpdate',
         'click #disableAuto': 'disableAutoUpdate',
@@ -118,10 +117,6 @@ VersionView = RockstorLayoutView.extend({
             backdrop: 'static',
             show: false
         });
-    },
-
-    showDonateModal: function() {
-        $('#donate-modal').modal('show');
     },
 
     update: function() {

--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -4,7 +4,7 @@
   <head>
     <!--
     /**
-    * Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+    * Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
     * This file is part of RockStor.
     *
     * RockStor is free software; you can redistribute it and/or modify
@@ -249,41 +249,6 @@
   <div id="appliance-select-popup" class="modal hide fade">
       <div id="appliance-select-content"></div>
   </div>
-
-  <div class="modal fade" id="donate-modal">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal"
-                  aria-label="Close"><span aria-hidden="true">&times;</span>
-          </button>
-          <h2 id="donate-modal-label">Please consider donating to help support
-            Rockstor's development</h2>
-        </div>
-        <div class="modal-body">
-          <h5 id="donate-modal-subtitle">Our Open Source development is
-            dependant upon update channel subscriptions and donations.</h5>
-          <form id="inner-contrib-form"
-                action="https://www.paypal.com/cgi-bin/webscr" method="post"
-                target="_blank" style="text-align: center;">
-            <input type="hidden" name="cmd" value="_s-xclick"/>
-            <input type="hidden" name="hosted_button_id"
-                   value="P72VDTYULUZTC"/>
-            <input type="image"
-                   src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_SM.gif"
-                   border="0" name="paypal_donate_button"
-                   id="paypal_donate_button"
-                   title="PayPal - The safer, easier way to pay online!"
-                   alt="Donate with PayPal button"/>
-            <!--      <img alt="" border="0" src="https://www.paypal.com/en_GB/i/scr/pixel.gif"-->
-            <!--           width="1" height="1"/>-->
-          </form>
-              <em>Upon clicking the above button, you will be redirected to our donation handler PayPal.</em>
-        </div><!-- /.model-body -->
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
-
 
   <form name="dummy-form" action="/login" method="post">
       {% csrf_token %}


### PR DESCRIPTION
See referenced issue for context. The paypal button we have used for our donation link is now regarded as legacy. This pr moves our donate Web-UI elements to the newer paypal.me mechanism and centres our donate related text on the update page while simultaneously removing the main Donate menu item and it's associated dedicated dialog.

Fixes #2260 
Ready for review.

Summary of changes:
- Remove Donate menu entry.
- Remove Donate dialog.
- Move prior Donate dialog main text re donations etc to update page.
- Add commercial support links to subscription dependant update page text.
- Move remaining donate links from legacy paypal button to paypal.me.
- Updated relevant copy write notices date element.

## Testing post pr:
### Top menu (no Donate entry)
![rhs-menu-post-pr](https://user-images.githubusercontent.com/2521585/105640381-9e99db80-5e75-11eb-8ce7-db13bd387e79.png)
### No subscription activated
![no-subscription-top-banner](https://user-images.githubusercontent.com/2521585/105640646-0ac90f00-5e77-11eb-99f1-1a035d869de1.png)
and
![commercial-support-options-in-table](https://user-images.githubusercontent.com/2521585/105640385-a3f72600-5e75-11eb-9a28-c59765154152.png)
### Stable updates enabled
![stable-enabled-post-pr](https://user-images.githubusercontent.com/2521585/105640388-a9ed0700-5e75-11eb-8298-6de2c3874520.png)
### Testing updates enabled
![testing-enabled-post-pr](https://user-images.githubusercontent.com/2521585/105640389-aeb1bb00-5e75-11eb-94f5-793e5be71299.png)


