### PR TITLE
Fix forum title encoding re auto support topic creation link (#2150)

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -834,6 +834,15 @@ Handlebars.registerHelper('sidenav', function(condition) {
     }
     return new Handlebars.SafeString(html);
 });
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+// attempt to conform to https://tools.ietf.org/html/rfc3986
+Handlebars.registerHelper('clean_forum_title', function(err_detail) {
+    return encodeURIComponent(err_detail).replace(/[!'()*]/g, function(c) {
+        return '%' + c.charCodeAt(0).toString(16);
+    });
+});
+
 //Initiate the router
 var app_router = new AppRouter;
 //###Render the view###
@@ -1198,5 +1207,6 @@ $(document).ready(function() {
 
         return new Handlebars.SafeString(html);
     });
+
 
 });

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/popuperr.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/popuperr.jst
@@ -29,7 +29,8 @@
         </a>
         to copy the above traceback to your clipboard.
     </li>
-      <li>Create a support topic with information from above two steps <a href="https://forum.rockstor.com/new-topic?title={{detail}}&category=support" target="_blank">here</a>.</li>
+      <li>Create a support topic from the above two steps <a
+          href="https://forum.rockstor.com/new-topic?title={{clean_forum_title detail}}&category=support" target="_blank">here</a>.</li>
   </ol>
 </div> <!-- err-help -->
 {{/unless}}


### PR DESCRIPTION
Add forum title encoding handlebars helper to properly encode the auto generated support forum topic creation link. This avoids the possible prior behaviour of inadvertent forum api activation via url API crossover between quoted Rockstor API error messages, used in the title, and actual forum apis. Resulting in failed forum topic creation.

Fixes #2150
Ready for review.

N.B. Please note that during testing a forum account will be required. Ideally one without elevated privileges due to the nature of the failure state (pre-pr).

## Testing
Please see issue text comment https://github.com/rockstor/rockstor-core/issues/2150#issuecomment-769324695 for the testing method/reproducer and proof of fix.

