### PR TITLE
Add system-wide subvol exclusion mechanism (#2223)

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -84,6 +84,8 @@ ROOT_SUBVOL_EXCLUDE = [
 ]
 # Note in the above we have a non symmetrical exclusions entry of '@/.snapshots
 # this is to help distinguish our .snapshots from snapper's rollback subvol.
+# System-wide subvolume exclude list.
+SUBVOL_EXCLUDE = [".beeshome", "@/.beeshome"]
 
 # tuple subclass for devices from a btrfs view.
 Dev = collections.namedtuple("Dev", "temp_name is_byid devid size allocated")
@@ -765,6 +767,11 @@ def shares_info(pool):
         if re.match("ID ", l) is None:
             continue
         fields = l.split()
+        if fields[-1] in SUBVOL_EXCLUDE:
+            logger.debug(
+                "Skipping system-wide excluded subvol: name=({}).".format(fields[-1])
+            )
+            continue
         # Exclude root fs (in subvol) to avoid dependence on subvol name to
         # root fs top level dir name collision for normal operation.
         # And to expose root fs components that are themselves a subvol of


### PR DESCRIPTION
Adds an additional hard coded subvolume exclusion list, akin to the existing system drive only one. All subvolume matches, by name, to list members are ignored. List pre-populated by ".beeshome" and it's possible boot-to-snapshot counterpart "@/.beeshome".

Includes a unit test mocking a typical data drive including the target ".beeshome" subvolume to prove the exclusion mechanisms function.

Fixes #2223 
Ready for review.

## Testing

The additional unit test was added to prove this exclusion by subvol name:

### Failure case:
Pre exclusion mechanism.
```
./bin/test --settings=test-settings -v 3 -p test_btrfs*

======================================================================
FAIL: test_shares_info_systemwide_exclusion_datapool (fs.tests.test_btrfs.BTRFSTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/rockstor-dev/src/rockstor/fs/tests/test_btrfs.py", line 1290, in test_shares_info_systemwide_exclusion_datapool
    expected))
AssertionError: Failed data pool subvol exclusion:
returned {'netstat-config': '0/259', 'sftp-test': '0/257', 'rock-ons-root': '0/258', '.beeshome': '0/275'},
expected {'netstat-config': '0/259', 'sftp-test': '0/257', 'rock-ons-root': '0/258'}.


----------------------------------------------------------------------
```

### Success case:
Post exclusion mechanism.
```
test_shares_info_systemwide_exclusion_datapool (fs.tests.test_btrfs.BTRFSTests) ... ok
```

## All-test run was as expected:

> ./bin/test -v 2
> ...
> Ran 213 tests in 35.364s
> 
> OK
