### PR TITLE
Retrieve remote groups information using SSSD InfoPipe (#2240)

### DIFF
--- a/src/rockstor/smart_manager/views/ldap_service.py
+++ b/src/rockstor/smart_manager/views/ldap_service.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,22 +16,22 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+import logging
 import socket
-
-from rest_framework.response import Response
 from os.path import dirname
-from storageadmin.util import handle_exception
+
 from django.db import transaction
+from rest_framework.response import Response
+
 from base_service import BaseServiceDetailView
 from smart_manager.models import Service
-
-import logging
-
+from storageadmin.util import handle_exception
 from system.directory_services import (
     update_nss,
     sssd_add_ldap,
     sssd_remove_ldap,
     validate_tls_cert,
+    sssd_update_services,
 )
 from system.services import systemctl
 
@@ -106,6 +106,8 @@ class LdapServiceView(BaseServiceDetailView):
                 # Update SSSD config
                 try:
                     sssd_add_ldap(ldap_params)
+                    # Ensure ifp service is activated
+                    sssd_update_services(service="ifp")
                     systemctl("sssd", "enable")
                 except Exception as e:
                     logger.exception(e)

--- a/src/rockstor/storageadmin/models/user.py
+++ b/src/rockstor/storageadmin/models/user.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,13 +16,16 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from django.db import models
+import grp
+
+import chardet
+from django.conf import settings
 from django.contrib.auth.models import User as DjangoUser
 from django.core.validators import validate_email
-from django.conf import settings
+from django.db import models
+
 from storageadmin.models import Group
-import grp
-import chardet
+from system.users import ifp_get_groupname
 
 
 class User(models.Model):
@@ -46,10 +49,14 @@ class User(models.Model):
         if self.group is not None:
             return self.group.groupname
         if self.gid is not None:
-            groupname = grp.getgrgid(self.gid).gr_name
-            charset = chardet.detect(groupname)
-            groupname = groupname.decode(charset["encoding"])
-            return groupname
+            try:
+                groupname = grp.getgrgid(self.gid).gr_name
+                charset = chardet.detect(groupname)
+                groupname = groupname.decode(charset["encoding"])
+                return groupname
+            except Exception:
+                # Failed to fetch user using grp, so let's try with infofipe
+                return ifp_get_groupname(self.gid)
         return None
 
     @property

--- a/src/rockstor/storageadmin/views/ug_helpers.py
+++ b/src/rockstor/storageadmin/views/ug_helpers.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -20,11 +20,8 @@ from storageadmin.models import (
     User,
     Group,
 )
-from system.users import get_users, get_groups
 from system.pinmanager import pincard_states
-import logging
-
-logger = logging.getLogger(__name__)
+from system.users import get_users, get_groups
 
 
 def combined_users():
@@ -74,9 +71,7 @@ def combined_users():
                 admin=False,
             )
             temp_uo.managed_user = False
-            temp_uo.pincard_allowed, temp_uo.has_pincard = pincard_states(
-                temp_uo
-            )  # noqa E501
+            temp_uo.pincard_allowed, temp_uo.has_pincard = pincard_states(temp_uo)
             users.append(temp_uo)
 
     for u in User.objects.all():

--- a/src/rockstor/storageadmin/views/user.py
+++ b/src/rockstor/storageadmin/views/user.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify

--- a/src/rockstor/system/directory_services.py
+++ b/src/rockstor/system/directory_services.py
@@ -78,8 +78,9 @@ def update_nss(databases, provider, remove=False):
     :return:
     """
     fo, npath = mkstemp()
+    sep = " "
     dbs = [db + ":" for db in databases]
-    append_to_line(NSSWITCH_FILE, npath, dbs, provider, remove)
+    append_to_line(NSSWITCH_FILE, npath, dbs, provider, sep, remove)
     move(npath, NSSWITCH_FILE)
     # Set file to rw- r-- r-- (644) via stat constants.
     os.chmod(NSSWITCH_FILE, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
@@ -193,7 +194,7 @@ def sssd_add_ldap(ldap_params):
 
 def sssd_remove_ldap(server):
     """
-    Removes any configuration pertaining to "sever" from sssd.conf
+    Removes any configuration pertaining to "server" from sssd.conf
     thereby unconfiguring the LDAP server. We thus need to remove it
     from the list of domains in the [sssd] section, and then remove
     its own section titled [domain/server].
@@ -229,6 +230,23 @@ def sssd_remove_ldap(server):
             server, SSSD_FILE
         )
     )
+
+
+def sssd_update_services(service, remove=False):
+    """
+    Update the list of sssd services.
+    :param service: String - name of the service to be updated
+    :param remove: Boolean - Remove from list of services if True
+    """
+    fo, npath = mkstemp()
+    sep = ", "
+    pattern = ["services = "]
+    append_to_line(SSSD_FILE, npath, pattern, service, sep, remove)
+    move(npath, SSSD_FILE)
+    # Set file to rw- --- --- (600) via stat constants.
+    os.chmod(SSSD_FILE, stat.S_IRUSR | stat.S_IWUSR)
+    logger.debug("The {} service has been added to {}".format(service, SSSD_FILE))
+    systemctl("sssd", "restart")
 
 
 def join_domain(config, method="sssd"):

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -16,9 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from socket import inet_ntoa
-from struct import pack
-from tempfile import mkstemp
 import collections
 import hashlib
 import logging
@@ -30,6 +27,9 @@ import stat
 import subprocess  # TODO: consider drop in replacement of subprocess32 module
 import time
 import uuid
+from socket import inet_ntoa
+from struct import pack
+from tempfile import mkstemp
 
 from django.conf import settings
 
@@ -136,10 +136,11 @@ def replace_line_if_found(Original_file, new_file, regex, replacement_line):
     return found_and_replaced
 
 
-def append_to_line(original_file, new_file, regexes, new_content, remove=False):
+def append_to_line(original_file, new_file, regexes, new_content, sep, remove=False):
     """
     Append a new string or remove a string from specific lines in a config file
     identified by one or more regular expressions.
+    :param sep: String - separator (" " or ", ", for instance)
     :param original_file: Original file path - usually a system configuration file
     :param new_file: New file path - usually a secure temporary file setup by caller
     :param regexes: List - list of regex(ex) used to identify lines to be considered
@@ -151,9 +152,11 @@ def append_to_line(original_file, new_file, regexes, new_content, remove=False):
         for line in ofo.readlines():
             if any(re.match(regex, line) for regex in regexes):
                 if remove:
-                    tfo.write(line.replace("".join([" ", new_content]), ""))
+                    tfo.write(line.replace("".join([sep, new_content]), ""))
+                elif re.search(new_content, line) is None:
+                    tfo.write("".join([line.strip(), sep, new_content, "\n"]))
                 else:
-                    tfo.write("".join([line.strip(), " ", new_content, "\n"]))
+                    tfo.write(line)
             else:
                 tfo.write(line)
 


### PR DESCRIPTION
Fixes #2240
Fixes #1580 

@phillxnet, ready for review

As detailed in #2240, we currently fail to fetch and list groups information after joining and AD or LDAP server, until a machine or rockstor service restart. This has been tracked down to some issue with `grp` not being able to fetch the groups information of such remote users until after a `gunicorn` or rockstor service restart. This pull request (PR) thus proposes to implement a fail-over mechanism to fetch this groups information in such cases based on the D-Bus API of SSSD: InfoPipe.

## Logic and implementation
### Overall description
The error described in #2240 occurs when trying to fetch the *groups* information of a remote user. This ultimately boils down the fact that we are using two different approaches to fetch *users* and *groups*. While users are fetched from the system database using `getent passwd`, the *groups* information is based on the python `grp` module. As the former sees remote users (in these conditions) but the latter does not, we end up in a situation where we ask `grp` to retrieve information on a group it doesn't know, thereby causing the error.
As a result, this PR proposes to implement a new way to fetch the *groups* information based on the D-Bus API built in SSSD: InfoPipe. Instead of completely replacing the existing way we fetch *groups*, this PR proposes to use the InfoPipe-based mechanisms as a fail-over if `grp` fails to fetch this information.

### Implementation details
#### New packages needed
This PR requires **2** additional packages:
- `sssd-dbus`: the D-Bus responder of SSSD
- `python-dbus-python`: dbus python module

```shell
# zypper in --no-recommends python-dbus-python sssd-dbus
Loading repository data...
Reading installed packages...
'python-dbus-python' not found in package names. Trying capabilities.
Resolving package dependencies...

The following 3 NEW packages are going to be installed:
  python2-dbus-python python2-gobject sssd-dbus

3 new packages to install.
Overall download size: 729.6 KiB. Already cached: 0 B. After the operation, additional 2.4 MiB will be used.
Continue? [y/n/v/...? shows all options] (y):
Retrieving package python2-gobject-3.34.0-lp152.2.3.x86_64                                      (1/3), 396.2 KiB (  1.3 MiB unpacked)
Retrieving: python2-gobject-3.34.0-lp152.2.3.x86_64.rpm ..........................................................[done (80.8 KiB/s)]
Retrieving package sssd-dbus-1.16.1-lp152.15.2.x86_64                                           (2/3), 138.5 KiB (295.3 KiB unpacked)
Retrieving: sssd-dbus-1.16.1-lp152.15.2.x86_64.rpm ............................................................................[done]
Retrieving package python2-dbus-python-1.2.4-lp152.6.7.x86_64                                   (3/3), 194.9 KiB (792.4 KiB unpacked)
Retrieving: python2-dbus-python-1.2.4-lp152.6.7.x86_64.rpm ....................................................................[done]

Checking for file conflicts: ..................................................................................................[done]
(1/3) Installing: python2-gobject-3.34.0-lp152.2.3.x86_64 .....................................................................[done]
(2/3) Installing: sssd-dbus-1.16.1-lp152.15.2.x86_64 ..........................................................................[done]
(3/3) Installing: python2-dbus-python-1.2.4-lp152.6.7.x86_64 ..................................................................[done]
```


#### New functions
Two new functions based on InfoPipe are added:
- `ifp_get_groupname(gid)`: given a *gid*, retrieve the groupname from InfoPipe
- `ifp_get_groups()`: use InfoPipe to list all remote groups

As we also need to activate the `ifp` service in SSSD config, this PR includes a new function to customize the services declared in `/etc/sssd/sssd.conf`. We also improve the existing `append_to_line()` helper function to make it slightly more smart by verifying the desired customization is not already present before writing it.

As mentioned above, the `ifp`-based logic is implemented only as fail-over mechanism in case `grp` fails to retrieve the required information. This is particularly important as `ifp` seems to only see remote (AD/LDAP) *groups*, and requires the `sssd` service to be up and running (and therefore the Rockstor machine to have already joined an AD/LDAP server). We thus cannot use `ifp` as the default mechanism to fetch *users*/*groups* information. This PR thus proposes to include these in a `try`/`except` block:
1. Fetch users from `getent passwd`, including its primary `gid`.
2. `try` to retrieve groupname using `grp` (pre-PR mechanism).
3. if it fails, use `ifp`

Similarly, we now retrieve and list all groups (triggered when visiting the *Groups* page):
1. list all groups from `grp`
2. `try` to fetch groups from `ifp`
3. Add any group fetched by `ifp` in step 2 to the list of step 1 if not already present

## Demonstration
1. Configure the AD service
2. Turn on the AD service. We can verify that the `ifp` service is indeed defined in sssd.conf:
```shell
# head /etc/sssd/sssd.conf 
[sssd]
config_file_version = 2
services = nss, pam, ifp
domains = samdom.example.com
(...)
```
   

3. Visit the *Groups* page and see the AD groups being listed:
![image](https://user-images.githubusercontent.com/30297881/107883627-01532580-6ebe-11eb-98ec-0a323ecc8935.png)

   
4. Visit the *Users* page and see all AD users being listed:
![image](https://user-images.githubusercontent.com/30297881/107883633-06b07000-6ebe-11eb-96fe-a2d5d915ce4e.png)

   
The same has been verified after joining an LDAP server.

**Important**: the `ifp`-based methods have been verified to be triggered only right after joining an AD/LDAP server'; upon restarting the rockstor service, all *user* and *group* information was retrieved by the primary mechanisms.

## Miscellaneous
Although this issue fixes #2240 and #1580, it doesn't fix #1817 as the current PR represents more a workaround than a true fix for the root cause of these issues, which seems to relate to some caching and/or env issue related to `gunicorn` (explaining why a `gunicorn` restart "fixes" all the problem.


## Testing
The full suite of tests yields:

**_Leap 15.2 (ISO install)_**:  

```
----------------------------------------------------------------------
Ran 216 tests in 56.769s

OK
```


## Full Testing Outputs

<details><summary>Leap15.2 (ISO install)</summary>

```
# ./bin/test -v 2
Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Creating table django_ztask_task
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, messages, django_ztask
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete (storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (storageadmin.tests.test_network.NetworkTests) ... ok
test_put (storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (storageadmin.tests.test_network.NetworkTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_systemwide_exclusion_datapool (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_domain_workgroup (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_invalid (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_missing (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok

----------------------------------------------------------------------
Ran 216 tests in 56.769s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```


</details>
