### PR TITLE
Replace orphaned django-ztask with Huey (#2276)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -101,9 +101,10 @@ gunicorn_cmd = ${buildout:directory}/bin/gunicorn --bind=${init-gunicorn:bind}:$
 smart_manager_cmd = ${buildout:directory}/bin/sm
 replicad_cmd = ${buildout:directory}/bin/replicad
 dc_cmd = ${buildout:directory}/bin/data-collector
-sm_cmd = ${buildout:directory}/bin/service-monitor
-jd_cmd = ${buildout:directory}/bin/job-dispatcher
-ztask_cmd = ${buildout:directory}/bin/django ztaskd --noreload -l DEBUG -f ${supervisord-conf:logdir}/ztask.log
+# Huey ommandline options take precedence over those in settings.py.
+# https://huey.readthedocs.io/en/latest/django.html#running-the-consumer
+# "... Worker type, must be “thread”, “process” or “greenlet”. The default is thread, ..."
+huey_cmd = ${buildout:directory}/bin/django run_huey --workers 2 --worker-type thread --logfile ${supervisord-conf:logdir}/huey.log
 
 [django-settings-conf]
 rootdir = ${buildout:directory}/src/rockstor

--- a/conf/django-hack
+++ b/conf/django-hack
@@ -16,7 +16,7 @@ sys.path[0:0] = [
     join(base, 'eggs/django_braces-1.8.0-py2.7.egg'),
     join(base, 'eggs/django_oauth_toolkit-0.9.0-py2.7.egg'),
     join(base, 'eggs/django_pipeline-1.6.9-py2.7.egg'),
-    join(base, 'eggs/django_ztask-0.1.5-py2.7.egg'),
+    join(base, 'eggs/huey-2.3.0-py2.7.egg'),
     join(base, 'eggs/djangorecipe-1.9-py2.7.egg'),
     join(base, 'eggs/djangorestframework-3.1.1-py2.7.egg'),
     join(base, 'eggs/gevent-1.1.2-py2.7-linux-x86_64.egg'),

--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 # Django settings for Rockstor project.
 import os
 import subprocess, distro
+from huey import SqliteHuey
 
 DEBUG = ${django-settings-conf:debug}
 TEMPLATE_DEBUG = DEBUG
@@ -158,7 +159,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'smart_manager',
     'oauth2_provider',
-    'django_ztask',
+    'huey.contrib.djhuey',
 )
 
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
@@ -419,7 +420,7 @@ ROCKONS = {
 	'local_metastore': '${buildout:depdir}/rockons-metastore',
 }
 
-ZTASKD_URL = 'ipc:///var/run/rockon-ztaskd'
+HUEY = SqliteHuey(filename='${buildout:depdir}/rockstor-tasks-huey.db')
 
 TASK_SCHEDULER = {
 	       'max_log': 100 #max number of task log entries to keep

--- a/conf/start_huey.bash.in
+++ b/conf/start_huey.bash.in
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# incomplete shell wrapper for potential suture invocation of huey:
+# https://github.com/coleifer/huey/issues/88
+
+echo "Starting Rockstor-huey as `whoami`"
+
+# Start Huey
+exec python2 ${buildout:directory}/manage.py run_huey

--- a/conf/supervisord-prod.conf.in
+++ b/conf/supervisord-prod.conf.in
@@ -122,16 +122,17 @@ stderr_logfile=${supervisord-conf:logdir}/supervisord_%(program_name)s_stderr.lo
 stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
 
-; ztask daemon
+; huey daemon - program name maintained as legacy to match existing service name
 [program:ztask-daemon]
 environment=DJANGO_SETTINGS_MODULE=settings
-command=${supervisord-conf:ztask_cmd} ; the program (relative uses PATH, can take args)
+command=${supervisord-conf:huey_cmd} ; the program (relative uses PATH, can take args)
 process_name=%(program_name)s ; process_name expr (default %(program_name)s)
 numprocs=1                    ; number of processes copies to start (def 1)
 priority=200
 autostart=true                ; start at supervisord start (default: true)
-autorestart=unexpected        ; whether/when to restart (default: unexpected)
-startsecs=2                   ; number of secs prog must stay running (def. 1)
+; autorestart=unexpected        ; whether/when to restart (default: unexpected)
+autorestart=true
+startsecs=10                   ; number of secs prog must stay running (def. 1)
 startretries=3                ; max # of serial start failures (default 3)
 exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
 stopsignal=TERM               ; signal used to kill process (default TERM)
@@ -142,3 +143,5 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 stderr_logfile=${supervisord-conf:logdir}/supervisord_%(program_name)s_stderr.log        ; stderr log path, NONE for none; default AUTO
 stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
+;stopasgroup=true

--- a/conf/supervisord.conf.in
+++ b/conf/supervisord.conf.in
@@ -121,16 +121,17 @@ stderr_logfile=${supervisord-conf:logdir}/supervisord_%(program_name)s_stderr.lo
 stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
 
-; ztask daemon
+; huey daemon - program name maintained as legacy to match existing service name
 [program:ztask-daemon]
 environment=DJANGO_SETTINGS_MODULE=settings
-command=${supervisord-conf:ztask_cmd} ; the program (relative uses PATH, can take args)
+command=${supervisord-conf:huey_cmd} ; the program (relative uses PATH, can take args)
 process_name=%(program_name)s ; process_name expr (default %(program_name)s)
 numprocs=1                    ; number of processes copies to start (def 1)
 priority=200
 autostart=true                ; start at supervisord start (default: true)
-autorestart=unexpected        ; whether/when to restart (default: unexpected)
-startsecs=2                   ; number of secs prog must stay running (def. 1)
+; autorestart=unexpected        ; whether/when to restart (default: unexpected)
+autorestart=true
+startsecs=10                   ; number of secs prog must stay running (def. 1)
 startretries=3                ; max # of serial start failures (default 3)
 exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
 stopsignal=TERM               ; signal used to kill process (default TERM)
@@ -141,3 +142,5 @@ stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 stderr_logfile=${supervisord-conf:logdir}/supervisord_%(program_name)s_stderr.log        ; stderr log path, NONE for none; default AUTO
 stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
+;stopasgroup=true

--- a/prod-buildout.cfg
+++ b/prod-buildout.cfg
@@ -55,8 +55,10 @@ gunicorn_cmd = ${buildout:depdir}/bin/gunicorn --bind=${init-gunicorn:bind}:${in
 smart_manager_cmd = ${buildout:depdir}/bin/sm
 replicad_cmd = ${buildout:depdir}/bin/replicad
 dc_cmd = ${buildout:depdir}/bin/data-collector
-sm_cmd = ${buildout:depdir}/bin/service-monitor
-ztask_cmd = ${buildout:depdir}/bin/django ztaskd --noreload --replayfailed -f ${supervisord-conf:logdir}/ztask.log
+# Huey ommandline options take precedence over those in settings.py.
+# https://huey.readthedocs.io/en/latest/django.html#running-the-consumer
+# "... Worker type, must be “thread”, “process” or “greenlet”. The default is thread, ..."
+huey_cmd = ${buildout:directory}/bin/django run_huey --workers 2 --worker-type thread --logfile ${supervisord-conf:logdir}/huey.log
 input = ${buildout:directory}/conf/supervisord-prod.conf.in
 
 [django-settings-conf]

--- a/prod-buildout.cfg
+++ b/prod-buildout.cfg
@@ -58,7 +58,7 @@ dc_cmd = ${buildout:depdir}/bin/data-collector
 # Huey ommandline options take precedence over those in settings.py.
 # https://huey.readthedocs.io/en/latest/django.html#running-the-consumer
 # "... Worker type, must be “thread”, “process” or “greenlet”. The default is thread, ..."
-huey_cmd = ${buildout:directory}/bin/django run_huey --workers 2 --worker-type thread --logfile ${supervisord-conf:logdir}/huey.log
+huey_cmd = ${buildout:depdir}/bin/django run_huey --workers 2 --worker-type thread --logfile ${supervisord-conf:logdir}/huey.log
 input = ${buildout:directory}/conf/supervisord-prod.conf.in
 
 [django-settings-conf]

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'django == 1.8.16',
         'django-oauth-toolkit == 0.9.0',
         'django-pipeline == 1.6.9',
-        'django-ztask == 0.1.5',
+        'huey == 2.3.0',
         'djangorestframework == 3.1.1',
         'python-engineio == 2.3.2',  # Revisit version post 3.0.0
         'gevent == 1.1.2',

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -496,7 +496,6 @@ def main():
     run_command(migration_cmd + ["auth"])
     run_command(migration_cmd + ["storageadmin"])
     run_command(migration_cmd + smartdb_opts)
-    run_command(migration_cmd + ["django_ztask"])
     logging.info("Done")
     logging.info("Running prepdb...")
     run_command([PREP_DB])

--- a/src/rockstor/scripts/prep_db.py
+++ b/src/rockstor/scripts/prep_db.py
@@ -34,6 +34,7 @@ def register_services():
         "Rock-on": "docker",
         "S.M.A.R.T": "smartd",
         "NUT-UPS": "nut",
+        # ZTaskd display/service names maintained: but are now huey pseudonyms.
         "ZTaskd": "ztask-daemon",
         "Bootstrap": "rockstor-bootstrap",
         "Shell In A Box": "shellinaboxd",

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -16,13 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-# @todo: Let's deprecate gevent in favor of django channels and we won't need
+# TODO: Let's deprecate gevent in favor of django channels and we won't need
 # monkey patching and flake8 exceptions.
 from gevent import monkey
+monkey.patch_all()
 
 from fs.btrfs import degraded_pools_found
 
-monkey.patch_all()
 
 import psutil  # noqa E402
 import re  # noqa E402

--- a/src/rockstor/smart_manager/views/rockstor_service.py
+++ b/src/rockstor/smart_manager/views/rockstor_service.py
@@ -53,14 +53,14 @@ class RockstorServiceView(BaseServiceDetailView):
                     raise Exception("Invalid listener port(%d)" % listener_port)
                 ni = config["network_interface"]
                 if len(ni.strip()) == 0:  # empty string
-                    ztask_helpers.restart_rockstor.async(None, listener_port)
+                    ztask_helpers.restart_rockstor(None, listener_port)
                 else:
                     try:
                         nco = NetworkConnection.objects.get(name=ni)
                     except NetworkConnection.DoesNotExist:
                         raise Exception("Network Connection(%s) does not exist." % ni)
                     # @todo: we should make restart transparent to the user.
-                    ztask_helpers.restart_rockstor.async(nco.ipaddr, listener_port)
+                    ztask_helpers.restart_rockstor(nco.ipaddr, listener_port)
                 self._save_config(service, config)
                 return Response()
             except Exception as e:

--- a/src/rockstor/smart_manager/views/ztask_helpers.py
+++ b/src/rockstor/smart_manager/views/ztask_helpers.py
@@ -1,7 +1,7 @@
-from django_ztask.decorators import task
+from huey.contrib.djhuey import task
 from system import services
 
 
-@task()
+@task(name="ztask_helpers.restart_rockstor")
 def restart_rockstor(ip, port):
     services.update_nginx(ip, port)

--- a/src/rockstor/smart_manager/views/ztaskd_service.py
+++ b/src/rockstor/smart_manager/views/ztaskd_service.py
@@ -37,5 +37,5 @@ class ZTaskdServiceView(BaseServiceDetailView):
             superctl(service.name, command)
             return Response()
         except Exception as e:
-            e_msg = "Failed to %s ZTaskd due to an error: %s" % (command, e.__str__())
+            e_msg = "Failed to %s run_huey due to an error: %s" % (command, e.__str__())
             handle_exception(Exception(e_msg), request)

--- a/src/rockstor/storageadmin/migrations/0014_rockon_taskid.py
+++ b/src/rockstor/storageadmin/migrations/0014_rockon_taskid.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storageadmin', '0013_auto_20200815_2004'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rockon',
+            name='taskid',
+            field=models.CharField(max_length=36, null=True),
+        ),
+    ]

--- a/src/rockstor/storageadmin/models/pool_balance.py
+++ b/src/rockstor/storageadmin/models/pool_balance.py
@@ -24,7 +24,7 @@ class PoolBalance(models.Model):
 
     pool = models.ForeignKey(Pool)
     status = models.CharField(max_length=10, default="started")
-    # django ztask uuid
+    # huey uuid
     tid = models.CharField(max_length=36, null=True)
     message = models.CharField(max_length=1024, null=True)
     start_time = models.DateTimeField(auto_now=True)

--- a/src/rockstor/storageadmin/models/rockon.py
+++ b/src/rockstor/storageadmin/models/rockon.py
@@ -26,8 +26,15 @@ class RockOn(models.Model):
     name = models.CharField(max_length=1024)
     description = models.CharField(max_length=2048)
     version = models.CharField(max_length=2048)
+    # available, pending_install, installed, install_failed
+    # pending_uninstall, pending_update
     state = models.CharField(max_length=2048)
+    # started, pending_start, start_failed
+    # stopped, pending_stop, stop_failed
     status = models.CharField(max_length=2048)
+    # We stash our Huey task id to ease sanity checks
+    # Taskid=None means no associated tasks.
+    taskid = models.CharField(max_length=36, null=True)
     link = models.CharField(max_length=1024, null=True)
     website = models.CharField(max_length=2048, null=True)
     https = models.BooleanField(default=False)

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/poolrebalance_table_template.jst
@@ -29,7 +29,7 @@
         <th scope="col" abbr="Status">Status <i class="fa fa-info-circle" title="Both balance types: unknown, running, finished, failed.&#013Regular only: cancelling, cancelled, pausing, paused." /> </th>
         <th scope="col" abbr="Type">Type <i class="fa fa-info-circle" title="Regular or Disk Removal" /></th>
         <th scope="col" abbr="STime">Start Time</th>
-        <!-- <th scope="col" abbr="ETime">End Time</th> -->
+        <th scope="col" abbr="ETime">End Time</th>
         <th scope="col" abbr="Updates">Percent finished <i class="fa fa-info-circle" title="Progress unavailable for Disk Removal." /></th>
         <th scope="col" abbr="Infos">Errors or Notes</th>
       </tr>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_rebalance_table.js
@@ -128,11 +128,11 @@ PoolRebalanceTableModule = RockstorModuleView.extend({
                     html += moment(poolrebalance.get('start_time')).format(RS_DATE_FORMAT);
                 }
                 html += '</td>';
-                // html += '<td>';
-                // if (poolrebalance.get('end_time')) {
-                //     html += moment(poolrebalance.get('end_time')).format(RS_DATE_FORMAT);
-                // }
-                // html += '</td>';
+                html += '<td>';
+                if (poolrebalance.get('end_time')) {
+                    html += moment(poolrebalance.get('end_time')).format(RS_DATE_FORMAT);
+                }
+                html += '</td>';
                 html += '<td>';
                 if (percent_done != 100 && internal_balance) {
                     html += 'unavailable';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/services.js
@@ -43,6 +43,7 @@ ServicesView = Backbone.View.extend({
         };
         this.smTs = null; // current timestamp of sm service
         this.configurable_services = ['nis', 'ntpd', 'active-directory', 'ldap', 'snmpd', 'docker', 'smartd', 'smb', 'nut', 'replication', 'shellinaboxd', 'rockstor'];
+        // N.B. in the following we maintain the ztask-daaemon name which is now Huey based.
         this.tooltipMap = {
             'active-directory': 'By turning this service on, the system will attempt to join the Active Directory domain using the credentials provided during configuration.',
             'rockstor-bootstrap': 'Service responsible for bootstrapping Rockstor when the system starts.',

--- a/src/rockstor/storageadmin/tasks.py
+++ b/src/rockstor/storageadmin/tasks.py
@@ -1,0 +1,86 @@
+"""
+Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+# This file enables auto-discovery of Huey tasks.
+# https://huey.readthedocs.io/en/latest/django.html?highlight=auto#django
+# All Huey decorated functions should either be in this file or included by this file.
+from huey.contrib.djhuey import HUEY
+from django.utils import timezone
+from huey.signals import (
+    SIGNAL_EXECUTING,
+    SIGNAL_COMPLETE,
+    SIGNAL_ERROR,
+    SIGNAL_REVOKED,
+    SIGNAL_LOCKED,
+)
+from storageadmin.models import PoolBalance
+
+# An alternative import method:
+# from huey.contrib import djhuey as huey
+
+# N.B. these imports are required for task auto-discovery, even if not used here-in.
+from fs.btrfs import start_resize_pool, start_balance
+from smart_manager.views.ztask_helpers import restart_rockstor
+from storageadmin.views.rockon_helpers import start, stop, update, install, uninstall
+from storageadmin.views.config_backup import restore_config, restore_rockons
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# HUEY SIGNAL CALLBACKS
+# Executed upon the indicated signal.
+# See: https://huey.readthedocs.io/en/latest/signals.html#signals
+
+
+@HUEY.signal(SIGNAL_EXECUTING)
+def task_signal_executing(signal, task):
+    # global huey
+    # HUEY.storage.put_data("executing-{}".format(task.name), 1)
+    logger.info("Now executing Huey task [{}], id: {}.".format(task.name, task.id))
+
+
+@HUEY.signal(SIGNAL_COMPLETE)
+def task_completed(signal, task):
+    # Task completed OK.
+    # Could do clean if task name begins with rockon_helper:
+    # removing all key,value pairs where value = task.id
+    logger.info("Task [{}] completed OK".format(task.name))
+    if task.name == "start_balance" or task.name == "start_resize_pool":
+        logger.info("Updating end_time accordingly")
+        PoolBalance.objects.filter(tid=task.id).update(end_time=timezone.now())
+
+
+@HUEY.signal(SIGNAL_ERROR, SIGNAL_LOCKED)
+def task_failed(signal, task, exc=None):
+    # FROM: https://huey.readthedocs.io/en/latest/api.html#Huey.signal
+    # Do something in response to the "ERROR" OR "SIGNAL_LOCKED" signals.
+    # Note that the "ERROR" signal includes a third parameter,
+    # which is the unhandled exception that was raised by the task.
+    # Since this parameter is not sent with the "LOCKED" signal, we
+    # provide a default of ``exc=None``.
+    #
+    # Possibly stash error message if it exists.
+    # Only log the final failure, once all retries are exhausted.
+    if task.retries > 0:
+        return
+    message = "Task [{}] failed, Task ID: {} Args: {}, Kwargs: {}, Exception{}".format(
+        task.name, task.id, task.args, task.kwargs, exc
+    )
+    logger.error(message)
+    # mail_admins(subject, message)

--- a/src/rockstor/storageadmin/tests/test_config_backup.py
+++ b/src/rockstor/storageadmin/tests/test_config_backup.py
@@ -1283,7 +1283,7 @@ class ConfigBackupTests(APITestMixin, APITestCase):
                     "containers": [79, 80],
                 },
             }
-            update_rockon_shares(c, self.sa_ml, r, rockons)
+            rockons = update_rockon_shares(c, self.sa_ml, r, rockons)
             self.assertEqual(
                 rockons,
                 out,
@@ -1381,7 +1381,7 @@ class ConfigBackupTests(APITestMixin, APITestCase):
                 75: {"rname": "Alpine With AddStorage Single", "new_rid": 75},
                 74: {"rname": "Alpine With AddStorage 2Ports", "new_rid": 74},
             }
-            validate_install_config(self.sa_ml, r, rockons)
+            rockons = validate_install_config(self.sa_ml, r, rockons)
             self.assertEqual(
                 rockons,
                 o,
@@ -1482,8 +1482,8 @@ class ConfigBackupTests(APITestMixin, APITestCase):
                 75: {"rname": "Alpine With AddStorage Single", "new_rid": 75},
                 74: {"rname": "Alpine With AddStorage 2Ports", "new_rid": 74},
             }
-            validate_install_config(self.sa_ml, r, rockons)
-            validate_update_config(self.sa_ml, r, rockons)
+            rockons = validate_install_config(self.sa_ml, r, rockons)
+            rockons = validate_update_config(self.sa_ml, r, rockons)
             self.assertEqual(
                 rockons,
                 o,

--- a/src/rockstor/storageadmin/tests/test_pool_balance.py
+++ b/src/rockstor/storageadmin/tests/test_pool_balance.py
@@ -24,6 +24,9 @@ from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import Pool
 
 
+class MockTask(object):
+    id = 0
+
 class PoolBalanceTests(APITestMixin, APITestCase):
     # fixture assumed to have:
     # 1 non sys pool (id=2, name='rock-pool', raid='raid1')
@@ -46,7 +49,8 @@ class PoolBalanceTests(APITestMixin, APITestCase):
         cls.patch_start_balance = patch('storageadmin.views.pool.'
                                         'start_balance')
         cls.mock_start_balance = cls.patch_start_balance.start()
-        cls.mock_start_balance.return_value = None
+        # start_balance normally returns a Huey task_result_handle.
+        cls.mock_start_balance.return_value = MockTask()
 
         cls.patch_balance_status = patch('storageadmin.views.pool_balance.'
                                          'balance_status')

--- a/src/rockstor/storageadmin/views/pool_balance.py
+++ b/src/rockstor/storageadmin/views/pool_balance.py
@@ -15,10 +15,10 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-
+from huey.exceptions import TaskException
 from rest_framework.response import Response
 from django.db import transaction
-from django_ztask.models import Task
+from huey.contrib.djhuey import HUEY
 from storageadmin.util import handle_exception
 from storageadmin.serializers import PoolBalanceSerializer
 from storageadmin.models import Pool, PoolBalance
@@ -57,40 +57,83 @@ class PoolBalanceView(PoolMixin, rfc.GenericView):
         except:
             # return empty handed if we have no 'last entry' to update
             return Response()
-        # Check if we have a running task which matches our last pool status
-        # tid
-        if Task.objects.filter(uuid=ps.tid).exists():
-            to = Task.objects.get(uuid=ps.tid)
-            if to.failed is not None:
-                ps.status = "failed"
-                ps.message = to.last_exception
-                ps.end_time = to.failed
-                ps.save()
-                to.delete()
-                return ps
+        # Check if we have a pending task which matches our tid.
+        logger.debug("POOLS BALANCE MODEL PS.TID = {}".format(ps.tid))
+        hi = HUEY
+        logger.debug("HUEY.pending() {}".format(hi.pending()))
+        # Pending balance tasks. N.B. Executing tasks are no longer pending.
+        # There is a 1 to 3 second 'pending" status for Huey tasks.
+        pending_task_ids = [
+            task.id
+            for task in hi.pending()
+            if task.name in ["start_balance", "start_resize_pool"]
+        ]
+        logger.debug("Pending balance task.ids = {}".format(pending_task_ids))
+        try:
+            # https://huey.readthedocs.io/en/latest/api.html#Huey.get
+            # The following does a destructive read unless preserve=True.
+            # This read will also throw the TaskException which is our interest here.
+            # https://huey.readthedocs.io/en/latest/api.html#Huey.result
+            # https://github.com/coleifer/huey/issues/449#issuecomment-535028271
+            # Syntax requires huey 2.1.3
+            hi.result(ps.tid)
+        except TaskException as e:
+            ps.status = "failed"
+            # N.B. metadata indexes: retries, traceback, task_id, error
+            ps.message = e.metadata.get("traceback", "missing 'traceback' key")
+            # TODO: Consider a huey signal to triggered the addition of end time
+            #  currently no SIGNAL_ERROR is seen to be active (see task.py)
+            # ps.end_time = to.failed  # defaults to Null in model.
+            # https://docs.djangoproject.com/en/1.8/ref/models/instances
+            #  /#specifying-which-fields-to-save
+            ps.save(update_fields=["status", "message"])
+            return ps
+        if ps.status == u"started" and ps.tid in pending_task_ids:
+            # Model default (i.e. a new balance) defaults to status "started".
+            # Preserve this state while we await our pending task (1 to 3 seconds).
+            logger.debug("WE CAN LEAVE OUR MODEL AS IS SO RETURN WITH IT")
+            return ps
         # Get the current status of balance on this pool, irrespective of
         # a running balance task, ie command line intervention.
         if ps.internal:
             cur_status = balance_status_internal(pool)
         else:
             cur_status = balance_status(pool)
-        previous_status = ps.status
+        previous_status = {"status": ps.status, "percent_done": ps.percent_done}
+        logger.debug("PREVIOUS_STATUS = {}".format(previous_status))
+        logger.debug("CURRENT STATUS = {}".format(cur_status))
         # TODO: future "Balance Cancel" button should call us to have these
-        # TODO: values updated in the db table ready for display later.
-        if previous_status == "cancelling" and cur_status["status"] == "finished":
+        #  values updated in the db table ready for display later.
+        # Update cur_state to become preferred proposed state.
+        if (
+            previous_status["status"] == u"cancelling"
+            and cur_status["status"] == u"finished"
+        ):
             # override current status as 'cancelled'
-            cur_status["status"] = "cancelled"
-            cur_status["message"] = "cancelled at %s%% complete" % ps.percent_done
+            cur_status["status"] = u"cancelled"
+            cur_status["message"] = u"cancelled at {}% complete".format(ps.percent_done)
             # and retain prior percent finished value
             cur_status["percent_done"] = ps.percent_done
-        if previous_status == "failed" and cur_status["status"] == "finished":
+        elif (
+            previous_status["status"] == u"failed"
+            and cur_status["status"] == u"finished"
+        ):
             # override current status as 'failed'
-            cur_status["status"] = "failed"
+            cur_status["status"] = u"failed"
             # and retain prior percent finished value
             cur_status["percent_done"] = ps.percent_done
-
-        if previous_status != "finished" and previous_status != "cancelled":
+        logger.debug("PROPOSED STATUS = {}".format(cur_status))
+        if cur_status == previous_status:
+            logger.debug("PROPOSED STATUS = MODEL STATUS: NO UPDATE REQUIRED")
+            return ps
+        if (
+            previous_status["status"] != u"finished"
+            and previous_status["status"] != u"cancelled"
+        ):
             # update the last pool balance status with current status info.
+            logger.debug(
+                "UPDATING BALANCE STATUS ID {} WITH {}".format(ps.id, cur_status)
+            )
             PoolBalance.objects.filter(id=ps.id).update(**cur_status)
         return ps
 
@@ -114,7 +157,7 @@ class PoolBalanceView(PoolMixin, rfc.GenericView):
                         pool=pool, status__regex=r"(started|running)"
                     ).order_by("-id")[0]
                     p.status = "terminated"
-                    p.save()
+                    p.save(update_fields=["status"])
                 else:
                     e_msg = (
                         "A Balance process is already running for pool ({})."

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -184,7 +184,8 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                         ceo = DContainerEnv.objects.get(container=co, key=e)
                         ceo.val = env_map[e]
                         ceo.save()
-                install.async(rockon.id)
+                task_result_handle = install(rockon.id)
+                rockon.taskid = task_result_handle.id
                 rockon.state = "pending_install"
                 rockon.save()
             elif command == "uninstall":
@@ -202,7 +203,8 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                         "try again."
                     ).format(rockon.name)
                     handle_exception(Exception(e_msg), request)
-                uninstall.async(rockon.id)
+                task_result_handle = uninstall(rockon.id)
+                rockon.taskid = task_result_handle.id
                 rockon.state = "pending_uninstall"
                 rockon.save()
                 for co in DContainer.objects.filter(rockon=rockon):
@@ -308,13 +310,17 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                                 cno.save()
                 rockon.state = "pending_update"
                 rockon.save()
-                update.async(rockon.id, live=live)
+                task_result_handle = update(rockon.id, live=live)
+                rockon.taskid = task_result_handle.id
+                rockon.save()
             elif command == "stop":
-                stop.async(rockon.id)
+                task_result_handle = stop(rockon.id)
+                rockon.taskid = task_result_handle.id
                 rockon.status = "pending_stop"
                 rockon.save()
             elif command == "start":
-                start.async(rockon.id)
+                task_result_handle = start(rockon.id)
+                rockon.taskid = task_result_handle.id
                 rockon.status = "pending_start"
                 rockon.save()
             elif command == "state_update":

--- a/testing.cfg
+++ b/testing.cfg
@@ -93,9 +93,10 @@ gunicorn_cmd = ${buildout:directory}/bin/gunicorn --bind=${init-gunicorn:bind}:$
 smart_manager_cmd = ${buildout:directory}/bin/sm
 replicad_cmd = ${buildout:directory}/bin/replicad
 dc_cmd = ${buildout:directory}/bin/data-collector
-sm_cmd = ${buildout:directory}/bin/service-monitor
-jd_cmd = ${buildout:directory}/bin/job-dispatcher
-ztask_cmd = ${buildout:directory}/bin/django ztaskd --noreload -l DEBUG -f ${supervisord-conf:logdir}/ztask.log
+# Huey ommandline options take precedence over those in settings.py.
+# https://huey.readthedocs.io/en/latest/django.html#running-the-consumer
+# "... Worker type, must be “thread”, “process” or “greenlet”. The default is thread, ..."
+huey_cmd = ${buildout:directory}/bin/django run_huey --workers 2 --worker-type thread --logfile ${supervisord-conf:logdir}/huey.log
 
 [django-settings-conf]
 rootdir = ${buildout:directory}/src/rockstor


### PR DESCRIPTION
As django-ztask is now orphaned and no longer compatible with newer Django or Python, this commit proposes replacing django-ztask, project wide, with Huey tasks which is both python 2 and 3 compatible as well as apparently functional with our django version and far newer variants.

Fixes #2276 

Ready for review.

As a rather large, but required, change set it is appreciated that a full review is non trivial. However a quick functional double-check of pool balance/add/remove/re-raid and basic rock-on functionality would be appreciated as bar the added balance end time there is no functional change within this pr. Note the new /opt/rockstor/var/log/huey.log file which give live details of Huey task start/end/name/worker.

## Includes:
- Initial Huey instantiation and configuration within Django.
- Maintain existing 'program'/service name within supervisord config and within smart-manager db: to minimise required changes.
- Use rockon task callers result handler to set rockon.taskid.
- Remove storageadmin django_ztasks model migration.
- Transition task() decorators & invocation to Huey's task/db_task.
- Added Huey task signals/logging.
- Includes some black and string.format() improvements.
- Add comments re future Huey pipeline use within config restore.
- Remove defunct service-manager and job-dispatcher cmd vars. In commit 36eeee8514dfe32cc002d71dc3101bcc61d1674d service-manager was removed. And in a9c36db2971f48c33df0652fe90060122b3d5e6a job-dispatcher was added unused when django-ztask was introduced.
- Explicitly specify worker-type for run_huey to aid future re-config.
- Development debug logging
- Update unit tests for Huey task result handler related changes.

### Pool Balance specific:
- Move pool balance and resize from django_ztask to huey task.
- Move to Python 2 & 3 compatible unicode - pool_balance status. When we save byte code strings (Python 2 default) to Django db filed, they are stored and retrieved as unicode strings. Move to explicit unicode to ease Python 3 transition where string literals are unicode by default.
- Minor refactor to ease state change requirement to help reduced redundant db access in pool_balance status update.
- Add clause to not update state if proposed and current are identical.
- Refactor pool balance status processing - reduces db writes.
- Reduce db access - pool_balance status update via update_fields.
- Add/re-enable previously dis-functional balance end time via django timezone.now() and Huey task signals.
- Skip costly pool balance model update if it is not required.
- Includes additional debug logging for balance status processing.

### Rock-on specific:
- In task calls we were calling apis just to update status, these calls would in turn invoke db calls/locks that we already had. This could lead to un-resolvable circular locking issues so use our existing task rockon db handles where every possible first.
- Move to huey task invocation syntax in rockon_id.py in turn removing the Python 3.7 reserved keyword of 'async'.
- Do rock-on config updates within a single huey task.
- Add comments to RockOn model to clarify use of state/status.
- Clarify via comments our slightly obscure use of global() re fail over for generic within rockons.
- Avoid redundant rockon db object retrieval in rockon_status().
- We previously retrieved a rock-on name from a current rockon db object then used this to re-lookup the rock-on db object. Given rockon_status is not run within it's own task we can pass the original object and save on db work.
- Add Huey taskid field to RockOn model to ease sanity checks. Previously our django_ztask uuid index db field was set to it's associated rockon db id. As Huey tasks assign their own uuid we add a field to our RockOn model to aid sanity checks re state/status/task and centralise these three indicators in the same model. Add associated db migration file.
- Manage new Huey taskid field by setting & nulling/assigning None in all existing 'finally' clauses in @db_task decorated rockon functions to aid in this fields management.
- Pass parent huey.task to rockon call_local() instances to have consistent and meaningful Huey logging via signals etc. By passing our parent task through we ensure the task association to the child functions which would otherwise label their associated rockon db objects with a None task: miss-representing the parent tasks invocation as local within the related rockon model.
- Preserve and log rockon.taskid - non live rockon config update. We currently call uninstall install via call_local when doing a rockon non live config update. For consistency / predictability, do not remove the taskid from the rockon model when it is in pending_update. This way we can tell that the rockon is mid update task.
- Add single instant task lock/limiter to restore_config(). As this can be a long running task, especially when re-installing / restoring rock-ons, we ensure that only a single instance of the overall controlling task is active at any one time.
- Fix bug re rockon_transition_checker() only waiting for 2 secs.
- Make rockon_transition_checker aware of pending rockon tasks.
- Increase rock-on restore per instance timeout from 30 to 46 seconds. In many instance with common download and cpu speeds this wait time is more appropriate as the prior 30 seconds timeout would not infrequently abandon early otherwise successful rock-on restores.

#### Minor refactor re rock-ons restore.
Move away from dict parameter modification to explicit returns with intergrated shallow copies of the associated rockons dict within helper functions to aid in isolating their actions. Also note an attempt to remove modifications to the base of iterations in for loops involving this dict. Precautionary moves to help improve data integrity and clarify operations in this complex area of the code. It may be that we need deep copies in some instance where we as yet only have shallow copies.

We also move our rock-on restore tasks 'up-one' to the caller, avoiding the use of Huey pipelines/chains and hopefully simplifying overall. This also helps to accommodate the explicit return values now employed in our rock-on restore sub-processes.

## General notes:
Given Huey non scheduled tasks are still subject to a minor delays of around a second or so within the runner it is best we take the earliest opportunity to stamp our rockon model with it's taskid. This may make the later task code update of this taskid element redundant but it is believed that updating this property at both opportunities should make for a more robust approach: i.e. task fails before scheduled task code is executed. We still have evidence of the prior event. But that info will in turn be overwritten upon any future task code execution, thus self repairing. This may come into play as we move towards automated
task retry capability within Huey.

If we only change a subset of model fields, explicitly update only those fields via model.save()'s update_fields parameter. This helps to reduce db contention as we more more towards proper multi-threaded functioning.

Post the introduction of Huey the data-collector, also run via supervisord, failed all Django model access due to threading constrains.

> "DatabaseError: DatabaseWrapper objects created in a thread can only be used in that same thread. ... "

in supervisord_data-collector_stderr.log. The fix was to apply the greenlet required monkey patching prior to the existing, and previously functional, fs.btrfs import. It is hypothesized that the newer wrapping of the @task Huey decorator within fs.btrfs
invoked this otherwise potential incompatibility.

Traceback was used from Huey TaskException in balances Errors column because initially the 'error' key was chosen and worked well for some issues but for the more common 'real' btrfs errors 'error' simply surfaces: "CommandException()" Where was a full traceback, although messy, does report the actual cause of the CommandException(), i.e. as part of our sterr element:

> "stderr = ["ERROR: error removing device '/dev/disk/by-id/ata-QEMU_HARDDISK_QM00003': No space left on device", '']"

Along with a full traceback, involving the huey egg version, this looks to serve our needs better given we are on new turf here with Huey.

A pending Huey task, once execution begins, is no longer pending. So this does not necessarily mean we have a failed state. Use info to help with user diagnosis.

## Testing
All task related functions re pool balance and rock-ons were tested to behave comparably or better than with our prior django-ztask implementation. Note that the rockstor restart facility within services was not tested as is not considered a show-stopper.

Config restore was tested with the inclusion of 3 typical rock-ons, Plex, Duplicati - by Linuxserver.io, and Gollum. A freshly build source rockstor instal system had this config uploaded post pool import with docker in a disabled state. Post config play-back the rock-on system was re-enabled and configured and all 3 rock-ons were installed and enabled. N.B. under some circumstances an existing issue was observed where docker would report unknown subvolumes. The resolution was to force delete the imported rock-ons-root and re-create a subvol by the same name and re-play the config-backup. Note also that with our current 2 Huey workers there is a practical limit of 2 concurrent docker tasks and attempting a 3rd results in an explanatory Web-UI error message to try again later. This is by design and moving to say 3 concurrent Huey workers was considered overkill. Also note that a single Huey worker is not sufficient for a restore as we depend upon a certain amount of concurrency with our current config restore setup: i.e. the restore process is a task that initiates the rock-on restore as it's last element. As Huey tasks return immediately this is not a problem, however during rock-on restore (itself a Huey task) we in turn require another Huey worker to execute each rock-on install. Hence the minimum requirement of 2 Huey workers.

Unit tests were also trivially modified and thereafter gave the expected result of:

```
./bin/test -v 2 -p test_*

Ran 216 tests in 16.376s

OK
```

## Caveats

This like-for-like replacement of django-ztask by Huey only involved minor modifications to our Web-UI update mechanism; mainly concerned with db optimisations and robustness. And so shares some of the prior hick-ups. However given we intend to move to Django Streams 2, which will involve significant changes to our Web-UI update nature, trivial bug issues remaining in Web-UI update for pool balance and rock-on functionality are also not considered show stoppers here. The main aim is to free our task requirement from the technical dept of django-ztask and allow us to proceed with dependant issues such as are detailed in the referenced above. Allowing us to kick-off our 4 stable variant with more maintainable task technologies.
