### PR TITLE
Fetch Group management setting and add it to payload (#2294).

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_group.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_group.js
@@ -72,6 +72,7 @@ AddGroupView = RockstorLayoutView.extend({
             submitHandler: function() {
                 var groupname = _this.$('#groupname').val();
                 var gid = _this.$('#gid').val() || null;
+                var admin = _this.$('#admin').prop("checked");
                 var group;
                 if (_this.groupname != null && _this.group != null) {
                     group = new Group({
@@ -92,7 +93,8 @@ AddGroupView = RockstorLayoutView.extend({
                     group = new tmpGroupModel();
                     group.save({
                         groupname: groupname,
-                        gid: gid
+                        gid: gid,
+                        admin: admin
                     }, {
                         success: function(model, response, options) {
                             _this.$('#group-create-form :input').tooltip('hide');


### PR DESCRIPTION
Fixes #2294.
@phillxnet, ready for review.

As mentioned in #2294, all groups created from the webUI end up listed as "managed by Rosktor" regardless of the user choice in the group creation form. This turns out to be due to the fact that we do not actually fetch and send this info as part of the payload on form submission.
This pull request (PR) thus simply proposes to add this information to the payload:
1. We fetch the user's choice by getting the `"checked"` status of the corresponding checkbox (`id="admin"`).
2. We add it to the payload.

As this functionality was implemented before (we seem to have lost it during various changes), we already have all the backend logic in place and working so the changes included in this PR are all we need.

For demonstration, two groups were created from the webUI:
- **ManagedGroup**: the checkbox "Put this group under Rockstor management?" was **checked**
- **UnmanagedGroup**: the checkbox "Put this group under Rockstor management?" was **unchecked**.

Both are listed in their respective table:
![image](https://user-images.githubusercontent.com/30297881/114191904-e67bbb00-991a-11eb-9ddd-1a8572fbe9b1.png)

 