### PR TITLE
change rockons default url to https #2304

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -415,7 +415,7 @@ UPDATE_CHANNELS = {
 }
 
 ROCKONS = {
-	'remote_metastore': 'http://rockstor.com/rockons',
+	'remote_metastore': 'https://rockstor.com/rockons',
 	'remote_root': 'root.json',
 	'local_metastore': '${buildout:depdir}/rockons-metastore',
 }


### PR DESCRIPTION
As rockstor.com is now https only, changed the config setting for remote_metastore to https to save redirects

Fixes #2304 