### PR TITLE
Re-enable IPv6 at kernel level #2309

### DIFF
--- a/conf/rockstor-ipv6check.service
+++ b/conf/rockstor-ipv6check.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Rockstor IPv6 Check
+ConditionKernelCommandLine=ipv6.disable=1
+# Not required - helps to prevent a reboot interrupting our other services.
+After=rockstor-bootstrap.service
+
+
+[Service]
+Type=oneshot
+# N.B. Type oneshot can have multiple ExecStart - executed sequentially.
+ExecStart=/usr/bin/sed -i -e 's/ipv6\\.disable=1[ ]*//g' /etc/default/grub
+ExecStart=/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+# We indicate the requirement to reboot in an unusualy colour.
+ExecStartPost=/usr/bin/sh -c "/usr/bin/echo -e \"\\e[1;45m Reboot required to re-enable IPv6 & Rock-ons \\e[0m\""
+
+
+TimeoutSec=0
+RemainAfterExit=yes
+# Mirror output to console as well.
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd rockstor-ipv6check.service file to conf directory, making it available for the "%post" section of our rpm to install, enable, and unlike our other service, start. We then have an rpm update mechanism for existing installs to receive this re-configuration. A consequent reboot is then required but we are still in the testing channel so this is acceptable. But the late release candidate nature of our current testing channel means we need at least this level of automated re-config to account for our less technical testers. Source installs are not addressed as they are deemed for development only where the system's
setup is the responsibility of the developer. Our installer has this fix pre-installed which would negate this secondary install/update mechanism via the included conditional: i.e. this service will only execute if the running kernel has the "ipv6.disable=1" option active.

Fixes #2309 
@FroggyFlox Ready for review

Service summary:
- Conditionally run only if the kernel command line contains "ipv6.disable=1"
- Remove via stream edit "ipv6.disable=1" with or without trailing space from /etc/default/grub
- Invoke a grub re-config to instantiate the new setup.
- Echo to console and regular log the following message:
" Reboot required to re-enable IPv6 & Rock-ons "
with a magenta background effective in a standard console.

## Testing
See issue text for related systemctl messages post hand install. Automated rpm install/update initiated  installation and execution results to follow.