### PR TITLE
Replace Yum logs with Zypper history in Logs Manager (#2314)

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -248,6 +248,7 @@ class LogManagerNamespace(RockstorIO):
     rockstor_logs = "%svar/log/" % settings.ROOT_DIR
     samba_subd_logs = "%ssamba/" % system_logs
     nginx_subd_logs = "%snginx/" % system_logs
+    zypp_subd_logs = "%szypp/" % system_logs
 
     readers = {
         "cat": {"command": "/usr/bin/cat", "args": "-n"},
@@ -295,7 +296,7 @@ class LogManagerNamespace(RockstorIO):
             "logdir": rockstor_logs,
         },
         "supervisord": {"logfile": "supervisord.log", "logdir": rockstor_logs},
-        "yum": {"logfile": "yum.log", "logdir": system_logs},
+        "zypper": {"logfile": "history", "logdir": zypp_subd_logs},
     }
 
     tar_utility = ["/usr/bin/tar", "czf"]

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/logs.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/logs.js
@@ -267,7 +267,7 @@ LogsView = RockstorLayoutView.extend({
             'gunicorn': 'Gunicorn (WebUI)',
             'gunicorn_stdout': 'Gunicorn stdout (WebUI)',
             'gunicorn_stderr': 'Gunicorn stderr (WebUI)',
-            'yum': 'Yum (System updates)'
+            'zypper': 'Zypper (System updates)'
         };
 
         Handlebars.registerHelper('print_logs_divs', function() {


### PR DESCRIPTION
Fixes #2314 
@phillxnet, ready for review.

@Hooverdan96 found that the Logs Manager still includes mention and reference to `yum` and its logs (see #2314 for details). This pull request (PR) proposes to fix this by simply referring to the Zypper logs instead. While several levels of zypper logs can be fetched, it is proposed to focus on the main zypper history as this includes similar information to what would be displayed in the standard output if one were to run the `zypper` command(s) manually at the command line. 

# Description of changes
As the current implementation of the Logs Manager is rather flexible, it is possible to simply change the current reference/definition of the `yum` logs to point to the `zypper` logs instead.
The `zypper` log chosen for fetching is the zypper **history** that can be found at `/var/logs/zypp/history`.

# Demonstration
In the *Logs Manager* page, one can select the *Zypper (System updates)* logs instead, replacing the current *Yum (System updates)* option. This is true in both the Logs Reader and Logs Downloader boxes.
![image](https://user-images.githubusercontent.com/30297881/134700220-7441f4e6-cc5a-4c06-b274-88d47c5b1b1d.png)

One can also read the Zypper history in the logs reader:
![image](https://user-images.githubusercontent.com/30297881/134700355-509d8f4f-758c-459b-b427-0280a876c835.png)

This demonstration was reproduced without error in both a Leap 15.2 base and a Leap 15.3 base.

# Testing
All currently passing tests were confirmed to be still passing in this branch in both a Leap 15.2 base and Leap 15.3 base.
Full testing outputs coming soon...