### PR TITLE
Remove coverage library as unused and now requires Python 3 #2325

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     install_requires=[
         'URLObject == 2.1.1',
         'chardet == 2.3.0',
-        'coverage',
         'distribute >= 0.6.35',
         'django == 1.8.16',
         'django-oauth-toolkit == 0.9.0',


### PR DESCRIPTION
Although version 5.5 still has Python 2.7 compatibility we are not currently making use of coverage's facilities as we once did a few years ago. So remove for the time being and consider re-adding post our own Python 2 to 3 migration.

Fixes #2325 

@FroggyFlox Creating for test build purposes. I'll update shortly once I have more info post test builds.