### PR TITLE
NUT timed shutdown has file path bug #2331

### DIFF
--- a/conf/upssched.conf
+++ b/conf/upssched.conf
@@ -42,7 +42,7 @@ CMDSCRIPT /usr/bin/upssched-cmd
 # about how your system works before potentially opening a hole.
 #
 
-PIPEFN /var/run/nut/upssched.pipe
+PIPEFN /var/lib/ups/upssched.pipe
 
 # ============================================================================
 #
@@ -58,7 +58,7 @@ PIPEFN /var/run/nut/upssched.pipe
 # You should put this in the same directory as PIPEFN.
 #
 
-LOCKFN /var/run/nut/upssched.lock
+LOCKFN /var/lib/ups/upssched.lock
 
 # ============================================================================
 #


### PR DESCRIPTION
Fix file path bug introduced in our base OS move from Rockstor v3 (CentOS based) to v4 "Built on openSUSE". This in turn fixes the consequent failure to execute a timed shutdown.

Fixes #2331 

Associated file path changes:
PIPEFN /var/run/nut/upssched.pipe to /var/lib/ups/upssched.pipe
LOCKFN /var/run/nut/upssched.lock to /var/lib/ups/upssched.lock