### PR TITLE
initrock via rockstor-pre fails on non-existent /etc/issue #2335

### DIFF
--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -92,7 +92,8 @@ def init_update_issue(logger):
     if ipaddr is None:
         ipaddr_list = inet_addrs()
 
-    with open("/etc/issue", "w") as ifo:
+    # We open w+ in case /etc/issue does not exist
+    with open("/etc/issue", "w+") as ifo:
         if ipaddr is None and len(ipaddr_list) == 0:
             ifo.write("The system does not yet have an ip address.\n")
             ifo.write(
@@ -507,7 +508,6 @@ def main():
     logging.info("firewalld stopped and disabled")
     update_nginx(logging)
 
-    shutil.copyfile("/etc/issue", "/etc/issue.rockstor")
     init_update_issue(logging)
 
     establish_shellinaboxd_service(logging)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -871,15 +871,6 @@ def get_net_config(all=False, name=None):
     return {name: net_config_helper(name)}
 
 
-def update_issue(ipaddr):
-    msg = (
-        "\n\nYou can go to RockStor's Web-UI by pointing your web browser"
-        " to https://{}\n\n".format(ipaddr)
-    )
-    with open("/etc/issue", "w") as ifo:
-        ifo.write(msg)
-
-
 def sethostname(hostname):
     return run_command([HOSTNAMECTL, "set-hostname", hostname])
 


### PR DESCRIPTION
We previously assumed the existence of /etc/issue, avoid rockstor service failures in this case by creating during the open process if required.

Fixes #2335 
Ready for review.

## Includes:
- Remove the now defunct /etc/issue.rockstor copy from /etc/issue.
- Remove dead code previously used to update /etc/issue - osi.py: update_issue()