### PR TITLE
Refactor restore_service() logic to assume the service is OFF (#2334)

### DIFF
--- a/src/rockstor/storageadmin/tests/test_config_backup.py
+++ b/src/rockstor/storageadmin/tests/test_config_backup.py
@@ -23,13 +23,12 @@ from storageadmin.views.config_backup import (
     update_rockon_shares,
     validate_install_config,
     validate_update_config,
+    validate_service_status,
 )
 
 
 class ConfigBackupTests(APITestMixin, APITestCase):
-    fixtures = [
-        "fix2.json"
-    ]
+    fixtures = ["fix2.json"]
     BASE_URL = "/api/config-backup"
     sa_ml = [
         {
@@ -874,6 +873,280 @@ class ConfigBackupTests(APITestMixin, APITestCase):
             "pk": 30,
         },
     ]
+    sm_ml = [
+        {
+            "fields": {
+                "display_name": "Replication",
+                "config": None,
+                "name": "replication",
+            },
+            "model": "smart_manager.service",
+            "pk": 1,
+        },
+        {
+            "fields": {"display_name": "Samba", "config": None, "name": "smb"},
+            "model": "smart_manager.service",
+            "pk": 2,
+        },
+        {
+            "fields": {"display_name": "NFS", "config": None, "name": "nfs"},
+            "model": "smart_manager.service",
+            "pk": 3,
+        },
+        {
+            "fields": {"display_name": "NTP", "config": None, "name": "ntpd"},
+            "model": "smart_manager.service",
+            "pk": 5,
+        },
+        {
+            "fields": {"display_name": "NIS", "config": None, "name": "nis"},
+            "model": "smart_manager.service",
+            "pk": 6,
+        },
+        {
+            "fields": {"display_name": "LDAP", "config": None, "name": "ldap"},
+            "model": "smart_manager.service",
+            "pk": 7,
+        },
+        {
+            "fields": {"display_name": "SFTP", "config": None, "name": "sftp"},
+            "model": "smart_manager.service",
+            "pk": 8,
+        },
+        {
+            "fields": {
+                "display_name": "Rockstor",
+                "config": None,
+                "name": "rockstor",
+            },
+            "model": "smart_manager.service",
+            "pk": 9,
+        },
+        {
+            "fields": {
+                "display_name": "S.M.A.R.T",
+                "config": None,
+                "name": "smartd",
+            },
+            "model": "smart_manager.service",
+            "pk": 10,
+        },
+        {
+            "fields": {
+                "display_name": "Active Directory",
+                "config": None,
+                "name": "active-directory",
+            },
+            "model": "smart_manager.service",
+            "pk": 11,
+        },
+        {
+            "fields": {"display_name": "NUT-UPS", "config": None, "name": "nut"},
+            "model": "smart_manager.service",
+            "pk": 12,
+        },
+        {
+            "fields": {"display_name": "SNMP", "config": None, "name": "snmpd"},
+            "model": "smart_manager.service",
+            "pk": 13,
+        },
+        {
+            "fields": {
+                "display_name": "Rock-on",
+                "config": '{"root_share": "rockons-root"}',
+                "name": "docker",
+            },
+            "model": "smart_manager.service",
+            "pk": 14,
+        },
+        {
+            "fields": {
+                "display_name": "Shell In A Box",
+                "config": '{"detach": false, "css": "white-on-black", "shelltype": "LOGIN"}',
+                "name": "shellinaboxd",
+            },
+            "model": "smart_manager.service",
+            "pk": 15,
+        },
+        {
+            "fields": {
+                "display_name": "ZTaskd",
+                "config": None,
+                "name": "ztask-daemon",
+            },
+            "model": "smart_manager.service",
+            "pk": 17,
+        },
+        {
+            "fields": {
+                "display_name": "Bootstrap",
+                "config": None,
+                "name": "rockstor-bootstrap",
+            },
+            "model": "smart_manager.service",
+            "pk": 18,
+        },
+        {
+            "fields": {
+                "status": True,
+                "count": 15,
+                "ts": "2021-12-24T18:49:51.195Z",
+                "service": 14,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 17,
+        },
+        {
+            "fields": {
+                "status": True,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.756Z",
+                "service": 9,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 18,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.783Z",
+                "service": 10,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 19,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.816Z",
+                "service": 2,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 20,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.829Z",
+                "service": 11,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 21,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.858Z",
+                "service": 5,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 22,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.890Z",
+                "service": 12,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 23,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.921Z",
+                "service": 13,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 24,
+        },
+        {
+            "fields": {
+                "status": True,
+                "count": 2,
+                "ts": "2021-12-24T18:47:11.948Z",
+                "service": 8,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 25,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.133Z",
+                "service": 1,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 26,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.169Z",
+                "service": 15,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 27,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.216Z",
+                "service": 3,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 28,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.243Z",
+                "service": 7,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 29,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.283Z",
+                "service": 6,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 30,
+        },
+        {
+            "fields": {
+                "status": True,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.475Z",
+                "service": 17,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 31,
+        },
+        {
+            "fields": {
+                "status": False,
+                "count": 2,
+                "ts": "2021-12-24T18:47:12.513Z",
+                "service": 18,
+            },
+            "model": "smart_manager.servicestatus",
+            "pk": 32,
+        },
+    ]
 
     @classmethod
     def setUpClass(cls):
@@ -1490,4 +1763,41 @@ class ConfigBackupTests(APITestMixin, APITestCase):
                 msg="Un-expected validate_update_config() result:\n "
                 "returned = {}.\n "
                 "expected = {}.".format(rockons, o),
+            )
+
+    def test_validate_service_status(self):
+        """
+        Test correct parsing of sm_ml for two services:
+        - docker service is set as ON below
+        - shellinabox service is set as OFF below
+        """
+        services = {
+            "docker": {"id": 14, "conf": {"config": {"root_share": "rockons-root"}}}
+        }
+        out = [True]
+
+        services.update(
+            {
+                "shellinaboxd": {
+                    "id": 15,
+                    "conf": {
+                        "config": {
+                            "detach": False,
+                            "css": "white-on-black",
+                            "shelltype": "LOGIN",
+                        }
+                    },
+                }
+            }
+        )
+        out.append(False)
+
+        for s, o in zip(services, out):
+            ret = validate_service_status(self.sm_ml, services[s]["id"])
+            self.assertEqual(
+                ret,
+                o,
+                msg="Un-expected validate_service_status() result:\n "
+                "returned = {}.\n "
+                "expected = {}.".format(ret, o),
             )


### PR DESCRIPTION
Fixes #2334 
@phillxnet, ready for review.

As discussed in #2334, our config restore logic currently fails when restoring a config backup on a brand new Rockstor install. This is due to the fact that on an install where the user has not *yet* visited the *System* > *Services* page, the `ServiceStatus` model has no entry. This leads to our current attempt at getting the current status of a given service to be restore to fail with a `DoesNotExist` error.

This pull-request (PR) thus proposes to assume the given service is OFF if it has no entry in the `ServiceStatus` model, and proceeds with the restore procedure to turn it ON (if it was indeed ON in the backup that is currently restored).
This PR also wraps this part of the process into a `try`/`except` to prevent the entire restore procedure to fail in case of an issue with a service.
Finally, this PR adds the detection of a service present in the config backup but no longer defined in Rockstor database so that we can restore old backups in the future (if one or more services has/have been deprecated, for instance). In this event, we simply ignore the service and move along with the restore procedure.

## Demonstration
1. On a Rockstor source build, set the system to create a config backup to be restored later on:
   - attach separate disk
   - create a pool
   - create a share to be used as rockons-root
   - configure the Rock-ons service and turn it ON
   - install the Netdata Rock-ons
2. Create a config backup and download on local disk
3. Edit the config backup to add an entry for a fake service (to test the detection of a deprecated service):
```
{"fields": {"config": "{\"fakekey\": \"fakevalue\"}", "display_name": "Fake service", "name": "fakeservice"}, "model": "smart_manager.service", "pk": 19}
```
4. Restore the VM to a snapshot taken prior to step 1 above.
5. Upload this branch onto it and build Rockstor
6. Verify disk is imported and that the Rock-ons root share is present
7. Verify that the `ServiceStatus` model has no entry
8. Go to *System* > *Config Backup* and upload the file edited in step 3 above
9. Restore the file and watch the logs.
```
[31/Dec/2021 14:00:31] INFO [storageadmin.views.config_backup:140] Started restoring services.
[31/Dec/2021 14:00:31] INFO [storageadmin.views.config_backup:151] Restore the following service: docker
[31/Dec/2021 14:00:32] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/services/docker/config. Payload: {'config': {u'root_share': u'rockons-root'}}
[31/Dec/2021 14:00:32] DEBUG [storageadmin.views.config_backup:165] The docker service has no ServiceStatus entry, so assume OFF
[31/Dec/2021 14:00:32] DEBUG [system.osi:182] Running command: /usr/bin/systemctl enable docker
[31/Dec/2021 14:00:32] DEBUG [system.osi:182] Running command: /usr/bin/systemctl start docker
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/services/docker/start. Payload: {}
```
We can see above that we correctly caught the `DoesNotExist` exception and assumed the service to be OFF, proceeding with its activation.

Next, the `fakeservice`:
```
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:151] Restore the following service: fakeservice
[31/Dec/2021 14:00:33] ERROR [storageadmin.views.config_backup:63] Exception occurred while creating resource: https://localhost/api/sm/services/fakeservice/config. Payload: {'config': {u'fakekey': u'fakevalue'}}. Exception: ['Invalid api end point: https://localhost/api/sm/services/fakeservice/config']. Moving on.
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:162] The service named fakeservice does not exist; skip it.
```
... was correctly skipped.

The ``shellinaboxd` service is in the same situation as the `docker` service:
```
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:151] Restore the following service: shellinaboxd
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/services/shellinaboxd/config. Payload: {'config': {u'detach': False, u'css': u'white-on-black', u'shelltype': u'LOGIN'}}
[31/Dec/2021 14:00:33] DEBUG [storageadmin.views.config_backup:165] The shellinaboxd service has no ServiceStatus entry, so assume OFF
```
... with the `DoesNotExist` exception being correctly caught. This service was OFF in the backup so we do not activate it.

The rest of the restore procedure completes as expected:
```
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:169] Finished restoring services.
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:203] Started restoring scheduled tasks.
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:226] Finished restoring scheduled tasks.
[31/Dec/2021 14:00:33] INFO [storageadmin.tasks:63] Task [restore_config] completed OK
[31/Dec/2021 14:00:33] INFO [storageadmin.tasks:55] Now executing Huey task [restore_rockons], id: 133fd90e-9eb7-41f1-a699-9c9dd1d0d68c.
[31/Dec/2021 14:00:33] INFO [storageadmin.views.config_backup:258] Started restoring rock-ons.
[31/Dec/2021 14:00:33] DEBUG [storageadmin.views.rockon:124] Update Rock-ons info in database
[31/Dec/2021 14:01:12] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/rockons/update. Payload: {}
[31/Dec/2021 14:01:12] INFO [storageadmin.views.config_backup:260] The following rock-ons will be restored: {74: {'rname': u'Netdata (official)', 'new_rid': 74}}.
[31/Dec/2021 14:01:12] DEBUG [storageadmin.views.config_backup:267] index = 0, rid = 74
[31/Dec/2021 14:01:12] INFO [storageadmin.views.config_backup:311] Send install command to the rock-ons api for the following rock-on: Netdata (official)
[31/Dec/2021 14:01:13] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/rockons/74/install. Payload: {'rname': u'Netdata (official)', 'cc': {}, 'devices': {}, 'new_rid': 74, 'environment': {u'PGID': u'476'}, 'shares': {}, 'ports': {19999: 19999}, 'containers': [81]}
[31/Dec/2021 14:01:13] DEBUG [storageadmin.views.config_backup:277] Current rockons[rid] = {'rname': u'Netdata (official)', 'cc': {}, 'labels': {}, 'devices': {}, 'new_rid': 74, 'environment': {u'PGID': u'476'}, 'shares': {}, 'ports': {19999: 19999}, 'containers': [81]}
[31/Dec/2021 14:01:13] INFO [storageadmin.views.config_backup:286] Finished restoring rock-ons.
[31/Dec/2021 14:01:13] INFO [storageadmin.tasks:63] Task [restore_rockons] completed OK
[31/Dec/2021 14:01:13] INFO [storageadmin.tasks:55] Now executing Huey task [install], id: 30ad6086-f609-4495-9cdb-4c3e578e4c48.
[31/Dec/2021 14:01:13] DEBUG [system.osi:182] Running command: /usr/bin/docker stop netdata_official
[31/Dec/2021 14:01:13] ERROR [system.osi:199] non-zero code(1) returned by command: ['/usr/bin/docker', 'stop', 'netdata_official']. output: [''] error: ['Error response from daemon: No such container: netdata_official', '']
[31/Dec/2021 14:01:13] DEBUG [system.osi:182] Running command: /usr/bin/docker rm netdata_official
[31/Dec/2021 14:01:13] ERROR [system.osi:199] non-zero code(1) returned by command: ['/usr/bin/docker', 'rm', 'netdata_official']. output: [''] error: ['Error: No such container: netdata_official', '']
[31/Dec/2021 14:01:13] DEBUG [storageadmin.views.rockon_helpers:69] Attempted to remove a container (netdata_official). Out: [''] Err: ['Error: No such container: netdata_official', ''] rc: 1.
[31/Dec/2021 14:01:13] DEBUG [system.osi:182] Running command: /usr/bin/docker pull netdata/netdata:latest
[31/Dec/2021 14:01:13] DEBUG [system.osi:182] Running command: /usr/bin/docker run -d --restart=unless-stopped --name netdata_official -v /etc/localtime:/etc/localtime:ro -p 19999:19999/tcp -p 19999:19999/udp --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/host/proc:ro -v /sys:/host/sys:ro -v /etc/os-release:/etc/os-release:ro -e PGID=476 netdata/netdata:latest
[31/Dec/2021 14:01:14] DEBUG [storageadmin.views.rockon_helpers:210] Set rock-on 74 state to installed
[31/Dec/2021 14:01:14] INFO [storageadmin.tasks:63] Task [install] completed OK
```

## Unit testing
This PR **adds one unit testing** for the `validate_service_status()` function. Although not changed by this PR, this simple function was not covered before, so I thought I would add a quick and simple test for it.

On the same VM as above (Rockstor-4.0.9 ISO Leap 15.3 base):
```
radmin:/opt/rockstor-dev # ./bin/test -v 2
(...)
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_service_status (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
(...)
Ran 217 tests in 25.000s

FAILED (errors=1)
```
Note that all `ConfigBackupTests` pass, the failed one is the same as in #2327 (see details below).

<details><summary>Full testing output</summary>

```
radmin:/opt/rockstor-dev # ./bin/test -v 2
/opt/rockstor-dev/eggs/psycopg2-2.7.4-py2.7-linux-x86_64.egg/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)

Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, djhuey, messages
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
  Applying storageadmin.0014_rockon_taskid... OK
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, djhuey, messages
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
  Applying storageadmin.0014_rockon_taskid... OK
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_service_status (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_delete (storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (storageadmin.tests.test_network.NetworkTests) ... ok
test_put (storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (storageadmin.tests.test_network.NetworkTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ERROR
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_systemwide_exclusion_datapool (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_domain_workgroup (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_invalid (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_missing (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok

======================================================================
ERROR: test_post_requests_2 (storageadmin.tests.test_samba.SambaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/rockstor-dev/eggs/mock-1.0.1-py2.7.egg/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/opt/rockstor-dev/src/rockstor/storageadmin/tests/test_samba.py", line 436, in test_post_requests_2
    response = self.client.post(self.BASE_URL, data=data)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 168, in post
    path, data=data, format=format, content_type=content_type, **extra)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 90, in post
    return self.generic('POST', path, data, content_type, **extra)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/compat.py", line 222, in generic
    return self.request(**r)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 157, in request
    return super(APIClient, self).request(**kwargs)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/test.py", line 109, in request
    request = super(APIRequestFactory, self).request(**kwargs)
  File "/opt/rockstor-dev/eggs/Django-1.8.16-py2.7.egg/django/test/client.py", line 466, in request
    six.reraise(*exc_info)
  File "/opt/rockstor-dev/eggs/Django-1.8.16-py2.7.egg/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/rockstor-dev/eggs/Django-1.8.16-py2.7.egg/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/rockstor-dev/eggs/Django-1.8.16-py2.7.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 452, in dispatch
    response = self.handle_exception(exc)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/views.py", line 449, in dispatch
    response = handler(request, *args, **kwargs)
  File "/opt/rockstor-dev/eggs/Django-1.8.16-py2.7.egg/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/opt/rockstor-dev/src/rockstor/storageadmin/views/samba.py", line 157, in post
    return Response(SambaShareSerializer(smb_share).data)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 466, in data
    ret = super(Serializer, self).data
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 213, in data
    self._data = self.to_representation(self.instance)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 435, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 568, in to_representation
    self.child.to_representation(item) for item in iterable
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/serializers.py", line 426, in to_representation
    attribute = field.get_attribute(instance)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 299, in get_attribute
    return get_attribute(instance, self.source_attrs)
  File "/opt/rockstor-dev/eggs/djangorestframework-3.1.1-py2.7.egg/rest_framework/fields.py", line 70, in get_attribute
    instance = getattr(instance, attr)
  File "/opt/rockstor-dev/src/rockstor/storageadmin/models/user.py", line 59, in groupname
    return ifp_get_groupname(self.gid)
  File "/opt/rockstor-dev/src/rockstor/system/users.py", line 277, in ifp_get_groupname
    "org.freedesktop.sssd.infopipe", "/org/freedesktop/sssd/infopipe/Groups"
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 243, in get_object
    follow_name_owner_changes=follow_name_owner_changes)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 250, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 182, in activate_name_owner
    self.start_service_by_name(bus_name)
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 280, in start_service_by_name
    'su', (bus_name, flags)))
  File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 653, in call_blocking
    message, timeout)
DBusException: org.freedesktop.DBus.Error.Spawn.ChildExited: Launch helper exited with unknown return code 1

----------------------------------------------------------------------
Ran 217 tests in 25.000s

FAILED (errors=1)
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
``` 

</details>


