### PR TITLE
Mock ifp_get_groupname() instead of grp.getgrid() (#2327)

### DIFF
--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -347,23 +347,17 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
         e_msg = "Must provide share names."
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch("storageadmin.models.user.grp.getgrgid")
+    @mock.patch("storageadmin.models.user.ifp_get_groupname")
     @mock.patch("storageadmin.views.samba.ShareMixin._validate_share")
     @mock.patch("storageadmin.views.samba.User")
-    def test_post_requests_2(self, mock_user, mock_validate_share, mock_getgrgid):
+    def test_post_requests_2(
+        self, mock_user, mock_validate_share, mock_ifp_get_groupname
+    ):
         """
-         . Create a samba export for the share that has already been exported
+        . Create a samba export for the share that has already been exported
         """
-        # Nullify exception of getgrgid via:
-        mock_getgrgid.side_effects = None
-
-        # Python2
-        # import grp
-        # >>> groupname = grp.getgrgid("470")
-        # >>> print(groupname)
-        # grp.struct_group(gr_name='ntp', gr_passwd='x', gr_gid=470, gr_mem=[])
-        # return "testgroup" for all gr_name calls:
-        mock_getgrgid.gr_name.return_value = "testgroup"
+        # Return "testgroup" for ifp_get_groupname() call
+        mock_ifp_get_groupname.return_value = "testgroup"
 
         mock_validate_share.return_value = self.temp_share_smb
 
@@ -425,9 +419,8 @@ class SambaTests(APITestMixin, APITestCase, SambaListView):
         }
         mock_validate_share.return_value = self.temp_share2
         mock_user.objects.get.side_effects = None
-        # The following relies on our mocked return value in grp.getgrgid.gr_name.
-        # Otherwise we error/exception out with grp.getgrgid(1) in models/user.py
-        # 'getgrgid(): gid not found: 1'
+        # The following relies on our mocked return value in ipf_get_groupname().
+        # Otherwise we error/exception out with ipf_get_groupname() in models/user.py
         temp_user = User.objects.create(
             username="admin", uid=1, gid=1, admin=False, user=self.user
         )


### PR DESCRIPTION
Fixes #2327 
@phillxnet, ready for review

As explained in #2327, we currently have one test failing in our tests covering Samba: `test_post_requests_2()`. This pull request simply proposes to fix that correcting a previous that was no longer working.
This pull request removes the current mock of `grp.getgrgid()` and instead mocks our now fallback mechanism relying on InfoPipe (`ifp_get_groupname()`) when trying to fetch user information when creating a Samba export.

On a Rockstor source build of this branch, all unit tests now PASS:

```
radmin:/opt/rockstor-dev # ./bin/test -v 2
/opt/rockstor-dev/eggs/psycopg2-2.7.4-py2.7-linux-x86_64.egg/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)

Creating test database for alias 'default' ('test_storageadmin')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, djhuey, messages
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
  Applying storageadmin.0014_rockon_taskid... OK
Creating test database for alias 'smart_manager' ('test_smartdb')...
Operations to perform:
  Synchronize unmigrated apps: staticfiles, rest_framework, pipeline, djhuey, messages
  Apply all migrations: oauth2_provider, sessions, admin, sites, auth, contenttypes, smart_manager, storageadmin
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying oauth2_provider.0001_initial... OK
  Applying oauth2_provider.0002_08_updates... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying smart_manager.0001_initial... OK
  Applying smart_manager.0002_auto_20170216_1212... OK
  Applying storageadmin.0001_initial... OK
  Applying storageadmin.0002_auto_20161125_0051... OK
  Applying storageadmin.0003_auto_20170114_1332... OK
  Applying storageadmin.0004_auto_20170523_1140... OK
  Applying storageadmin.0005_auto_20180913_0923... OK
  Applying storageadmin.0006_dcontainerargs... OK
  Applying storageadmin.0007_auto_20181210_0740... OK
  Applying storageadmin.0008_auto_20190115_1637... OK
  Applying storageadmin.0009_auto_20200210_1948... OK
  Applying storageadmin.0010_sambashare_time_machine... OK
  Applying storageadmin.0011_auto_20200314_1207... OK
  Applying storageadmin.0012_auto_20200429_1428... OK
  Applying storageadmin.0013_auto_20200815_2004... OK
  Applying storageadmin.0014_rockon_taskid... OK
test_delete_requests (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_auto_update_status_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (storageadmin.tests.test_commands.CommandTests) ... ok
test_get_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_delete_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (storageadmin.tests.test_group.GroupTests) ... ok
test_delete_requests (storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (storageadmin.tests.test_email_client.EmailTests) ... ok
test_blink_drive (storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (storageadmin.tests.test_disks.DiskTests) ... ok
test_post_requests (storageadmin.tests.test_login.LoginTests) ... ok
test_delete (storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (storageadmin.tests.test_network.NetworkTests) ... ok
test_put (storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (storageadmin.tests.test_network.NetworkTests) ... ok
test_adv_nfs_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_get (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_1 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_requests_2 (storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_compression (storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (storageadmin.tests.test_pools.PoolTests) ... ok
test_get (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_1 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_2 (storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (storageadmin.tests.test_pools.PoolTests) ... ok
test_create_samba_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (storageadmin.tests.test_shares.ShareTests) ... ok
test_create (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete2 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete3 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_set1 (storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_share_with_snapshot (storageadmin.tests.test_shares.ShareTests) ... ok
test_get (storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (storageadmin.tests.test_user.UserTests) ... ok
test_get (storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (storageadmin.tests.test_user.UserTests) ... ok
test_get_sname (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_install_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_update_config (storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_delete_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_snmp_0 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (smart_manager.tests.test_snmp.SNMPTests) ... ok
test_balance_status_cancel_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_cancelled (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_conn_reset (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_finished (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_halted (fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_running (fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_systemwide_exclusion_datapool (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (fs.tests.test_btrfs.BTRFSTests) ... ok
test_pkg_changelog (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_domain_workgroup (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_invalid (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_missing (system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_get_byid_name_map (system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (system.tests.test_osi.OSITests) ... ok
test_get_con_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (system.tests.test_system_network.SystemNetworkTests) ... ok

----------------------------------------------------------------------
Ran 216 tests in 25.610s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```