### PR TITLE
Sender issues re notification emails #2339

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/email/email.jst
@@ -100,7 +100,7 @@
     </div>
   </form>
   <div class="alert alert-success auth-results" id="auth_success" style="display: none;">
-  <strong>SMTP Authentication was successful</strong> Save your settings
+  <strong>SMTP Authentication was successful</strong> Submit your settings
   </div>
   <div class="alert alert-danger auth-results" id="auth_failed" style="display: none;">
   <strong>SMTP Authentication failed!</strong> Please update your settings before saving.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -882,7 +882,12 @@ def gethostname():
 
 
 def getdnsdomain():
-    o, e, rc = run_command([DNSDOMAIN])
+    o, e, rc = run_command([DNSDOMAIN], throw=False, log=True)
+    if rc != 0:
+        logger.info(
+            "Check your network domain configuration. See above error for details."
+        )
+        return ""
     return o[0]
 
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -41,6 +41,7 @@ CAT = "/usr/bin/cat"
 CHATTR = "/usr/bin/chattr"
 DD = "/usr/bin/dd"
 DEFAULT_MNT_DIR = "/mnt2/"
+DNSDOMAIN = "/usr/bin/dnsdomainname"
 EXPORTFS = "/usr/sbin/exportfs"
 GRUBBY = "/usr/sbin/grubby"
 HDPARM = "/usr/sbin/hdparm"
@@ -877,6 +878,11 @@ def sethostname(hostname):
 
 def gethostname():
     o, e, rc = run_command([HOSTNAMECTL, "--static"])
+    return o[0]
+
+
+def getdnsdomain():
+    o, e, rc = run_command([DNSDOMAIN])
     return o[0]
 
 


### PR DESCRIPTION
Adds 3 additional entries to /etc/postfix/generic of the form:

@hostname.dnsdomain sender
@localhost sender
@localhost.localdomain sender

In order that the receiving email server is able to validate the from and sender against real emails addresses. Avoiding the problematic 'from' of root@localhost.

Fixes #2339 
Fixes #2165 
@FroggyFlox Ready for review

## Includes:
- Adding a trivial dnsdomainname wrapper - system/osi.py:getdnsdomain().
- Cosmetic text fix on form settings test. I.e. 'Submit' not 'Save'.
- Additional log entry on master.cf new config entry.
- New TODO: for reverting ipv4 enforcement in our postfix config.
- Comment typo.


## Testing.

The functional change enacted by this pr is the addition of 3 lines into /etc/postfix/generic:

### Before pr
rleap15-3:~ # cat /etc/postfix/generic
@rleap15-3 sending-email
@rleap15-3.localdomain sending-email

### After pr
rleap15-3:~ # cat /etc/postfix/generic
@rleap15-3  sending-email
@rleap15-3.localdomain  sending-email
**@rleap15-3.lan  sending-email**
**@localhost  sending-email**
**@localhost.localdomain  sending-email**


Using fastmail as the email provider:
"Email - of the dedicated Rockstor sending account" from: https://rockstor.com/docs/interface/system/email_setup.html#initial-email-setup

Two different email recipient addresses, one of them a gmail, successfully received email from the Rockstor Web-UI test feature. From and To were as per the Rockstor Web-UI indicators.

Testing root forwarding, which is how the system notification emails are 'routed' to the recipient, from the command line via:
```
echo "test email body text post pr" | mail -s "Test root forwarding - Email Alert" root
```
Also resulted in successful email delivery with two different clients showing sane from and to entries.

A Rockstor Web-UI initiated update was also performed to do end-to-end system notification testing. The result with a gmail recipient was:

> Subject: Output from your job 3
> from:	root \<sending-email\>
> to:	sending-email

Details:

> <20220104170306.4541663391@localhost>
> Delivered-To: target@gmail-address.com
> Return-Path: \<sending-email\>

With the expected contents from such a job:

> The following item is locked and will not be changed by any action:
>  Available:
>   rockstor
> ...
> (4/5) Installing: libxcb1-1.13-3.7.1.x86_64 [.........done]
> (5/5) Installing: libtiff5-4.0.9-45.2.1.x86_64 [................done]
>  
> 1 lock has been successfully removed.

## Caveat

The last example, although functional, was less optimal than desired but no issues were expressed by the client or within the details of the message. Also note that an email sent to a dynamic address generated by the following website:

https://www.mail-tester.com/

via for example:

> echo "email body text for mail-tester" | mail -s "mail-tester.com test" test-<random-letters>@srv1.mail-tester.com

Received a perfect 10/10. With only 'no html' and 'unsubscribe' notes to improve the message content itself.
From : root \<sending-email\>

### Empty/No domain or Error return from dnsdomainname
In this situation we simply skip the relevant line entry in /etc/postfix/generic thus:
If for example we have on temp-installer KVM machine with no domain defined:
```
temp-installer:~ # dnsdomainname 
dnsdomainname: No address associated with hostname
temp-installer:~ # echo $?
1
```
we write the following to postfix's generic file for hostname domainname mapping:
```
temp-installer:~ # cat /etc/postfix/generic
@temp-installer sending-email
@temp-installer.localdomain sending-email
@localhost sending-email
@localhost.localdomain sending-email
```
I.e. no domain specific hostname.\<domain\> as we don't have one to enter, or dnsdomainname can't tell us what it is.