### PR TITLE
Reject null serial disk entries from database #2344

### DIFF
--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -131,8 +131,10 @@ class DiskMixin(object):
             # It makes no sense to save fake serial number drives between scans
             # as on each scan the serial number is re-generated (fake) anyway.
             # Serial numbers beginning with 'fake-serial-' are from scan_disks.
-            if (do.serial in serial_numbers_seen) or (
-                re.match("fake-serial-", do.serial) is not None
+            if (
+                (do.serial in serial_numbers_seen)
+                or (do.serial is None)
+                or (re.match("fake-serial-", do.serial) is not None)
             ):
                 logger.info(
                     "Deleting duplicate or fake (by serial) disk db "


### PR DESCRIPTION
Improve disk tracking robustness and avoid blocking db updates in the currently theoretical scenario of a null serial device database entry. Extend the existing 'pre-wash' mechanism that drops db device entries with repeating or otherwise already flagged serials, to include all null serial device entries as well.

Fixes #2344 

## Testing:
See issue text for before and after patch scenario logs. Db entries were fabricated by-hand to test this additional device entry rejection. The proposed blocking db scenario, re-created by the above db edit, was consequently resolved post patch; proving the self correction mechanism.