### PR TITLE
Remove neglected/redundant AUTHORS file #2328

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,0 @@
-Suman Chakravartula <schakrava@gmail.com>
-Sujeet Srinivasan <sujeetsr@gmail.com>


### PR DESCRIPTION
This file was last updated 9 years ago when only the 2 project founders were contributors. We have now had around 30 contributors but we still have only 2 listed in this file. As we have also had contributor guidelines indicating for interested parties to contribute to this file for some time there is clear indication that it is redundant. Especially as we primarily use git / GitHub for attribution.

Fixes #2328 