### PR TITLE
Increase minimum disk size to 5 GiB and define at run-time #2308

### DIFF
--- a/conf/settings.conf.in
+++ b/conf/settings.conf.in
@@ -293,12 +293,6 @@ SUPPORT = {
 }
 
 """
-Minimum disk size allowed is 1GB. Anything less is not really usable. Reduce
-this to 100MB if you really need to, but any less would just break things.
-"""
-MIN_DISK_SIZE = 1024 * 1024
-
-"""
 Maximum number of seconds to keep data collected by smart probes. The logic
 behind this needs to evolve quite a bit.
 """

--- a/conf/test-settings.conf.in
+++ b/conf/test-settings.conf.in
@@ -279,12 +279,6 @@ SUPPORT = {
 }
 
 """
-Minimum disk size allowed is 1GB. Anything less is not really usable. Reduce
-this to 100MB if you really need to, but any less would just break things.
-"""
-MIN_DISK_SIZE = 1024 * 1024
-
-"""
 Maximum number of seconds to keep data collected by smart probes. The logic
 behind this needs to evolve quite a bit.
 """

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -64,6 +64,16 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Minimum disk size. Smaller disks will be ignored. Recommended minimum = 16 GiB.
+# Btrfs works in chunks (units) of 1 GiB for data, and 256 MiB for metadata.
+# Using very small disks requires mixed data/metadata chunks of 256 MiB.
+# If a device is less than 16 GiB, the mixed (--mixed) mode is recommended.
+# https://btrfs.wiki.kernel.org/index.php/FAQ
+# https://btrfs.wiki.kernel.org/index.php/Glossary
+# Rockstor does not enforce --mixed for any drive size.
+# 5 GiB = (5 * 1024 * 1024) = 5242880 KiB
+MIN_DISK_SIZE = 5242880
+
 # A list of scan_disks() assigned roles: ie those that can be identified from
 # the output of lsblk with the following switches:
 # -P -o NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID
@@ -102,7 +112,7 @@ class DiskMixin(object):
         :return: serialized models of attached and missing disks via serial num
         """
         # Acquire a list (namedtupil collection) of attached drives > min size
-        disks = scan_disks(settings.MIN_DISK_SIZE)
+        disks = scan_disks(MIN_DISK_SIZE)
         # Acquire a list of uuid's for currently unlocked LUKS containers.
         # Although we could tally these as we go by noting fstype crypt_LUKS
         # and then loop through our db Disks again updating all matching


### PR DESCRIPTION
In a number of trials with btrfs, especially during raid changes, it was found that a practical minimum to allow for basic experimentation was 5GiB. Currently we ignore all devices below 1 GiB.

Fixes #2308 
@FroggyFlox I'm applying this one to testing as a proof of concept to kick off our new testing branch and to help test modification required to our production back-end.

This change increases our 'ignore devices below size' to 5 GiB.

Includes:
- Moving this definition away from build-time Django settings to plain run-time: allowing for user modification if need be.
- Explanatory code comments and upstream btrfs wiki references.
- Note/reference on recommended non mixed mode minimum size as 16 GiB+.