### PR TITLE
(t) data-collector (Dashboard backend) fails to start #2368

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -27,7 +27,6 @@ monkey.patch_all()
 
 from fs.btrfs import degraded_pools_found
 
-
 import psutil  # noqa E402
 import re  # noqa E402
 import json  # noqa E402
@@ -41,6 +40,12 @@ from os import path  # noqa E402
 from sys import getsizeof  # noqa E402
 from glob import glob  # noqa E402
 
+# See:
+# https://docs.djangoproject.com/en/1.11/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage
+import django
+from django.conf import settings  # noqa E402
+django.setup()
+
 from system.pinmanager import (
     has_pincard,
     username_to_uid,  # noqa E402
@@ -49,7 +54,6 @@ from system.pinmanager import (
     generate_otp,
 )
 
-from django.conf import settings  # noqa E402
 from system.osi import uptime, kernel_info, get_byid_name_map, run_command  # noqa E402
 from datetime import datetime, timedelta  # noqa E402
 import time  # noqa E402


### PR DESCRIPTION
Add in required as of Django 1.11 django.setup() to our data_collector. It may-well be that we are still doing things wrong here but adding for now to re-establish some more basic functionality.

N.B. django.setup() can only be run once. See included reference.

Fixes #2368 

## Testing
Post patch we successfully start our data-collector via supervisord:
```
2022-04-11 18:44:54,422 CRIT Supervisor running as root (no user in config file)
2022-04-11 18:44:54,429 INFO RPC interface 'supervisor' initialized
2022-04-11 18:44:54,429 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2022-04-11 18:44:54,430 INFO supervisord started with pid 23283
2022-04-11 18:44:55,433 INFO spawned: 'nginx' with pid 23287
2022-04-11 18:44:55,434 INFO spawned: 'gunicorn' with pid 23288
2022-04-11 18:44:55,437 INFO spawned: 'data-collector' with pid 23289
2022-04-11 18:44:55,440 INFO spawned: 'ztask-daemon' with pid 23290
2022-04-11 18:44:58,385 INFO success: data-collector entered RUNNING state, process has stayed up for > than 2 seconds (startsecs)
2022-04-11 18:45:01,389 INFO success: nginx entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2022-04-11 18:45:01,390 INFO success: gunicorn entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2022-04-11 18:45:06,397 INFO success: ztask-daemon entered RUNNING state, process has stayed up for > than 10 seconds (startsecs)
```
Post pr we have no additional failures (for current testing branch) on our tests:
```
Ran 208 tests in 19.124s
FAILED (failures=4, errors=10)
```
And a working dashboard and 'live' Web-UI elements.
