### PR TITLE
Prevent duplicate localdomain entry in generic map #2373

### DIFF
--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -164,7 +164,7 @@ def update_generic(sender, revert=False):
             fo.write("@{} {}\n".format(hostname, sender))
             fo.write("@{}.localdomain {}\n".format(hostname, sender))
             # add @<hostname>.<domain> if we can get a dnsdomain:
-            if dnsdomain != "":
+            if dnsdomain not in ("", "localdomain"):
                 fo.write("@{}.{} {}\n".format(hostname, dnsdomain, sender))
             # Add fall through entries for when the sending agent uses localhost.
             # This avoids some bounce scenarios when sender/from is root@localhost


### PR DESCRIPTION
Prevent creation of a duplicate entry if the local network domain is localdomain in the /etc/postfix/generic lookup table when configuring email alerts

[Maintainer edit]
Fixes #2373