### PR TITLE
(t) Services, Replication-Send_Receive, and Tasks pages fail #2370

### DIFF
--- a/conf/django-hack.py
+++ b/conf/django-hack.py
@@ -43,7 +43,7 @@ sys.path[0:0] = [
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.py")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/models/models.js
@@ -316,7 +316,7 @@ var Service = Backbone.Model.extend({
 
 var ServiceCollection = RockStorPaginatedCollection.extend({
     model: Service,
-    baseUrl: '/api/sm/services/'
+    baseUrl: '/api/sm/services'
 });
 
 var Appliance = Backbone.Model.extend({
@@ -458,7 +458,7 @@ var Replica = Backbone.Model.extend({
 });
 var ReplicaCollection = RockStorPaginatedCollection.extend({
     model: Replica,
-    baseUrl: '/api/sm/replicas/'
+    baseUrl: '/api/sm/replicas'
 });
 
 var ReplicaTrail = Backbone.Model.extend({
@@ -511,7 +511,7 @@ var ReceiveTrailCollection = RockStorPaginatedCollection.extend({
 });
 
 var TaskDef = Backbone.Model.extend({
-    urlRoot: '/api/sm/tasks/',
+    urlRoot: '/api/sm/tasks',
     max_count: function() {
         if (this.get('json_meta') != null) {
             return JSON.parse(this.get('json_meta')).max_count;
@@ -607,7 +607,7 @@ var TaskDef = Backbone.Model.extend({
 
 var TaskDefCollection = RockStorPaginatedCollection.extend({
     model: TaskDef,
-    baseUrl: '/api/sm/tasks/'
+    baseUrl: '/api/sm/tasks'
 });
 
 var Task = Backbone.Model.extend({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_replication_task.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_replication_task.js
@@ -118,7 +118,7 @@ AddReplicationTaskView = RockstorLayoutView.extend({
                 var data = _this.$('#replication-task-create-form').getJSON();
                 var url, req_type;
                 if (_this.replicaId == null) {
-                    url = '/api/sm/replicas/';
+                    url = '/api/sm/replicas';
                     req_type = 'POST';
                 } else {
                     url = '/api/sm/replicas/' + _this.replicaId;

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_scheduled_task.js
@@ -228,7 +228,7 @@ AddScheduledTaskView = RockstorLayoutView.extend({
                 var data = _this.$('#scheduled-task-create-form').getJSON();
                 var url, req_type;
                 if (_this.taskDefId == null) {
-                    url = '/api/sm/tasks/';
+                    url = '/api/sm/tasks';
                     req_type = 'POST';
                 } else {
                     url = '/api/sm/tasks/' + _this.taskDefId;


### PR DESCRIPTION
Remove trailing "/" from JS ServiceCollection, ReplicaCollection, TaskDefCollection (and it's parent TaskDef) in order to re-enable Web-UI access, post Django update. Note that this may be an issue instead within our url definitions, but it appears to fix more than it breaks.

Fixes #2370 
Fixes #2377 

Thanks to @FroggyFlox  on GitHub for diagnostic assistance.
Thanks to @Hooverdan96 on GitHub for pointing out tasks also affected.

## Includes
- Unrelated django-hack fix re typo in settings initialisation. Issue #2377 
- Further removed js hard coding of trailing "/" in url for POST operations related to scheduled task add and replication add to be compatible with our new url parsing.

## Testing
- Pre patch Services, Replication, and Scheduled Task pages failed.
- Post patch they worked as expected, with only initial testing to date given the scope of the issue.
- Pre patch we are unable to do /opt/rockstor-dev/bin/buildout -c buildout.cfg install collectstatic
- Post patch we can successfully run the the buildout command, which in turn sources the django-hack.