### PR TITLE
(t) request.DATA NotImplementedError #2379

### DIFF
--- a/src/rockstor/smart_manager/views/smartd_service.py
+++ b/src/rockstor/smart_manager/views/smartd_service.py
@@ -46,7 +46,7 @@ class SMARTDServiceView(BaseServiceDetailView):
                 install_pkg("smartmontools")
             if command == "config":
                 service = Service.objects.get(name=self.service_name)
-                config = request.DATA.get("config", {})
+                config = request.data.get("config", {})
                 logger.debug("config = %s" % config)
                 self._save_config(service, config)
                 if "custom_config" in config:


### PR DESCRIPTION
Move to newer and non deprecated/removed request.data. Note that a code base wide search failed to turn up any other instances of this older/defunct capitalised variant.

Fixes #2379 

## Testing
Pre patch we are unable to add custom S.M.A.R.T config as described here:
https://rockstor.com/docs/howtos/smart.html#configure-monitoring
see issue text for details of the resulting error.
Post patch we can successfully enact such configuration, and retrieve it thus:
![post-patch-smart-config-ok](https://user-images.githubusercontent.com/2521585/174448556-e7de1e6b-b049-4585-b017-734721b082c6.png)

