### PR TITLE
(t) avoid recalculating pool free #2386

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -26,7 +26,6 @@ from storageadmin.serializers import PoolInfoSerializer
 from storageadmin.models import Disk, Pool, Share, PoolBalance
 from fs.btrfs import (
     add_pool,
-    pool_usage,
     resize_pool_cmd,
     umount_root,
     btrfs_uuid,
@@ -697,11 +696,10 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                         )
                         handle_exception(Exception(e_msg), request)
 
-                    usage = pool_usage("/{}/{}".format(settings.MNT_PT, pool.name))
                     size_cut = 0
                     for d in disks:  # to be removed
                         size_cut += d.allocated
-                    available_free = pool.size - usage
+                    available_free = pool.free
                     if size_cut >= available_free:
                         e_msg = (
                             "Removing disks ({}) may shrink the pool by "


### PR DESCRIPTION
Remove a redundant re-calculation of pool.free in PUT (remove) pool command when the exact same calculation has already been made via an earlier and current Pool object @Property instantiation.

Fixes #2386 