### PR TITLE
Improve disk removal error message formatting re pool free space #2388

### DIFF
--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -702,11 +702,11 @@ class PoolDetailView(PoolMixin, rfc.GenericView):
                     available_free = pool.free
                     if size_cut >= available_free:
                         e_msg = (
-                            "Removing disks ({}) may shrink the pool by "
+                            "Removing disk/s ({}) may shrink the pool by "
                             "{} KB, which is greater than available free "
                             "space {} KB. This is "
                             "not supported."
-                        ).format(dnames, size_cut, available_free)
+                        ).format(" ".join(dnames), size_cut, available_free)
                         handle_exception(Exception(e_msg), request)
 
                     # Unlike resize_pool_start() with add=True a remove has an


### PR DESCRIPTION
Avoid literal dumping of the Python list type containing one or more disk names to-be-removed into user facing error message.

Fixes #2388 

## Testing
There are, in issue branch associated with #2384, multiple tests in development to confirm this error messages intended function; for both single and multiple disk removals, post the changes proposed here.