### PR TITLE
Abstract pool balance command construction #2390

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1786,9 +1786,7 @@ def start_resize_pool(cmd):
             )
         raise e
 
-
-@task()
-def start_balance(mnt_pt, force=False, convert=None):
+def balance_pool_cmd(mnt_pt, force=False, convert=None):
     cmd = ["btrfs", "balance", "start", mnt_pt]
     # With no filters we also get a warning that block some balances due to
     # expected long execution time, in this case "--full-balance" is required.
@@ -1807,7 +1805,30 @@ def start_balance(mnt_pt, force=False, convert=None):
         # button tooltip.
         cmd.insert(3, "--full-balance")
     logger.debug("Balance command ({}).".format(cmd))
-    run_command(cmd)
+    return cmd
+
+@task()
+def start_balance(cmd):
+    """
+    Simple named wrapper to run balance command via Huey with logging and possible
+    exception filtering in case we need to improve error messaging.
+    See: start_resize_pool as counterpart wrapper.
+
+    https://www.untangled.dev/2020/07/01/huey-minimal-task-queue-django/
+    "... avoid passing a Django model instance or queryset as parameter."
+    "Instead pass the object id, which is an int..."
+    and retrieve the Django object a-fresh in the task function.
+    :param cmd: btrfs dev add/delete command in run_command() format (ie list).
+    :param cmd:
+    :return:
+    """
+    logger.debug("Balance pool command ({}).".format(cmd))
+    try:
+        run_command(cmd)
+    except CommandException as e:
+        # We may need additional exception filtering/altering here.
+        raise e
+
 
 
 def balance_status(pool):

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -27,6 +27,7 @@ from storageadmin.models import Disk, Pool, Share, PoolBalance
 from fs.btrfs import (
     add_pool,
     resize_pool_cmd,
+    balance_pool_cmd,
     umount_root,
     btrfs_uuid,
     mount_root,
@@ -301,7 +302,8 @@ class PoolMixin(object):
             # pools. Avoid by explicit convert in this instance.
             logger.info("Preserve single data, dup metadata by explicit convert.")
             convert = "single"
-        task_result_handle = start_balance(mnt_pt, force=force, convert=convert)
+        cmd = balance_pool_cmd(mnt_pt, force=force, convert=convert)
+        task_result_handle = start_balance(cmd)
         tid = task_result_handle.id
         logger.debug("balance tid = ({}).".format(tid))
         return tid


### PR DESCRIPTION
Reduces code run under Huey and enables easier testing of balance command construction procedure which will be needed as we expand btrfs-raid support to for example raid1c3 and raid1c4.

Fixes #2390 

Also aligns with format used in pool resize regarding abstracting the command generation and doing only logging and exception handling in btrfs Huey tasks.