### PR TITLE
configure Dependabot against testing branch #2412

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # Enable version updates for Python
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    target-branch: "testing"


### PR DESCRIPTION
Begin explicit configuration of GitHub Dependabot, adding a target-branch directive of "testing".

Fixes #2412 