### PR TITLE
source rockstor-jslibs directly from GitHub releases #2440

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=4.5.1
+jslibs_version=4.5.2
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.

--- a/build.sh
+++ b/build.sh
@@ -18,28 +18,31 @@ poetry install
 echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
-## Production jslibs
-jslibs_url=https://rockstor.com/downloads/jslibs/rockstor-jslibs.tar.gz
-## Development jslibs
-# jslibs_url=https://rockstor.com/downloads/jslibs-dev/rockstor-jslibs.tar.gz
+# Set jslibs_version of GitHub release:
+jslibs_version=4.5.1
+jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
+#  Check for rpm embedded, or previously downloaded jslibs.
 if [ ! -f  "rockstor-jslibs.tar.gz.sha256sum" ]; then
-    echo "Getting latest rockstor-jslibs and checksum files"
-    wget -O rockstor-jslibs.tar.gz.sha256sum "${jslibs_url}.sha256sum"
+    echo "Getting rockstor-jslibs version ${jslibs_version}"
     wget -O rockstor-jslibs.tar.gz "${jslibs_url}"
+    sha256sum rockstor-jslibs.tar.gz > rockstor-jslibs.tar.gz.sha256sum
     echo
-fi
-
-if ! sha256sum --check --status rockstor-jslibs.tar.gz.sha256sum; then
-    echo "rockstor-jslibs checksum failed. Exiting"
-    exit
+else  # Check rpm embedded, or previously downloaded jslibs are unchanged.
+    if ! sha256sum --check --status rockstor-jslibs.tar.gz.sha256sum; then
+      echo "rockstor-jslibs checksum failed. Exiting"
+      exit
+    fi
 fi
 
 if [ ! -d "jslibs" ]; then
   # See: STATICFILES_DIRS in settings.py
-  echo "Creating jslibs/js & populating 'lib' subdir from rockstor-jslibs.tar.gz"
-  mkdir -p jslibs/js
-  tar zxvf rockstor-jslibs.tar.gz --directory jslibs/js  #archive has /lib dir.
+  echo "Creating jslibs/js/lib & populating from rockstor-jslibs.tar.gz"
+  echo
+  mkdir -p jslibs/js/lib
+  # GitHub versioned archives have rockstor-jslibs-{jslibs_version} top directory,
+  # i.e. rockstor-jslibs-4.5.1, we strip this single top directory.
+  tar zxvf rockstor-jslibs.tar.gz --directory jslibs/js/lib --strip-components=1
   echo
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "4.5.1"
+version = "4.5.2"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"


### PR DESCRIPTION
It is more transparent, and removes a single points of failure, to source directly from the GitHub repo concerned
https://github.com/rockstor/rockstor-jslibs via the GitHub releases mechanism. Rather than source our jslibs, post processed, from our main downloads page.

Fixes #2440 