### PR TITLE
normalise on underscore.js in setup.html & base.html #2443

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -70,7 +70,7 @@
     <script src="/static/js/lib/jquery.tools.min.js"></script>
     <script src="/static/js/lib/d3.v3.min.js"></script>
     <script src="/static/js/lib/cubism.v1.js"></script>
-    <script src="/static/js/lib/underscore-1.3.2.js"></script>
+    <script src="/static/js/lib/underscore.js"></script>
     <script src="/static/js/lib/backbone-0.9.2.js"></script>
     <script src="/static/js/lib/backbone.routefilter.min.js"></script>
     <script src="/static/js/lib/cocktail.js"></script>


### PR DESCRIPTION
As part of an upgrade we had moved from 1.3.2 to 1.8.3 but setup.html still referenced the older version. Normalise on underscore.js to enable the following pull request:
source rockstor-jslibs directly from GitHub releases #2440 #2441

N.B. this modification is also related to the following rockstor-jslibs effort:
"Resolve differences between website download and GitHub release":
https://github.com/rockstor/rockstor-jslibs/issues/15

Linking to the aformentioned upgrade in our rockstor-jslibs repo:
https://github.com/rockstor/rockstor-jslibs/pull/7
N.B. the commit in that pr indicates upgrading to 1.8.2, but the library eventually used is version 1.8.3 (from it's headers).

Fixes #2443
From this repositories perspective at least.