### PR TITLE
Correct license anomalies in newly added pyproject.toml #2447

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=4.5.3
+jslibs_version=4.5.4
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=4.5.2
+jslibs_version=4.5.3
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.
@@ -47,7 +47,7 @@ if [ ! -d "jslibs" ]; then
   echo
   mkdir -p jslibs/js/lib
   # GitHub versioned archives have rockstor-jslibs-{jslibs_version} top directory,
-  # i.e. rockstor-jslibs-4.5.1, we strip this single top directory.
+  # i.e. rockstor-jslibs-#.#.#, we strip this single top directory.
   tar zxvf rockstor-jslibs.tar.gz --directory jslibs/js/lib --strip-components=1
   echo
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "4.5.3"
+version = "4.5.4"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"
@@ -25,7 +25,7 @@ maintainers = [
     "Philip Paul Guyton <support@linuxlines.com>",
 ]
 # Source0: (rockstor-core) is GPL-3.0-or-later, Source1: (rockstor-jslibs) has mixed licensing:
-license = "GPL-3.0-or-later AND (MIT AND GPL-2.0-or-later AND Apache-2.0 AND GPL-2.0-only AND LGPL-3.0-or-later AND BSD-3-Clause AND ISC)"
+license = "GPL-3.0-or-later AND (MIT AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND ISC)"
 include = [
     "COPYING",  # Our GPL 3 file from rockstor-core.
     "rockstor-jslibs.tar.gz",  # https://github.com/rockstor/rockstor-jslibs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "4.5.2"
+version = "4.5.3"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"
@@ -16,7 +16,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 2 :: Only", # at least initially
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    # The "license" property should auto-invoke License classifier/classifiers.
 ]
 authors = [
     "The Rockstor Project <support@linuxlines.com>",
@@ -24,9 +24,10 @@ authors = [
 maintainers = [
     "Philip Paul Guyton <support@linuxlines.com>",
 ]
-license = "GPL-2.0-or-later"
+# Source0: (rockstor-core) is GPL-3.0-or-later, Source1: (rockstor-jslibs) has mixed licensing:
+license = "GPL-3.0-or-later AND (MIT AND GPL-2.0-or-later AND Apache-2.0 AND GPL-2.0-only AND LGPL-3.0-or-later AND BSD-3-Clause AND ISC)"
 include = [
-    "COPYING",  # Our GPL 3 file, but this may be redundant.
+    "COPYING",  # Our GPL 3 file from rockstor-core.
     "rockstor-jslibs.tar.gz",  # https://github.com/rockstor/rockstor-jslibs
     "rockstor-jslibs.tar.gz.sha256sum",  # sha256 of above tar.gz
     "build.sh",  # master build script


### PR DESCRIPTION
Given poetry generates license classifiers we can remove this to focus on keeping our top level "license" property up-to-date. The latter is updated to take account of recent and ongoing licensing improvements across rockstor-core and rockstor-jslibs.

Includes core & jslibs release increase.

Fixes #2447