### PR TITLE
Remove redundant jquery.flot - rockstor-jslibs related #2448

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -87,14 +87,6 @@
     <script src="/static/js/lib/bootstrap.js"></script>
     <script src="/static/js/lib/jsonform.js"></script>
     <script src="/static/js/lib/jquery.validate.js"></script>
-    <script src="/static/js/lib/jquery.flot.js"></script>
-    <script src="/static/js/lib/jquery.flot.navigate.js"></script>
-    <script src="/static/js/lib/jquery.flot.resize.js"></script>
-    <script src="/static/js/lib/jquery.flot.stack.js"></script>
-    <script src="/static/js/lib/jquery.flot.tooltip_0.5.js"></script>
-    <script src="/static/js/lib/jquery.flot.axislabels.js"></script>
-    <script src="/static/js/lib/jquery.flot.stackpercent.js"></script>
-    <script src="/static/js/lib/jquery.flot.time.js"></script>
     <script src="/static/js/lib/jquery.touch-punch.min.js"></script>
     <script src="/static/js/lib/jquery.shapeshift.js"></script>
     <script src="/static/js/lib/jquery.sparkline.min.js"></script>

--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -77,13 +77,6 @@
     <script src="/static/js/lib/bootstrap.js"></script>
     <script src="/static/js/lib/jsonform.js"></script>
     <script src="/static/js/lib/jquery.validate.js"></script>
-    <script src="/static/js/lib/jquery.flot.js"></script>
-    <script src="/static/js/lib/jquery.flot.navigate.js"></script>
-    <script src="/static/js/lib/jquery.flot.resize.js"></script>
-    <script src="/static/js/lib/jquery.flot.stack.js"></script>
-    <script src="/static/js/lib/jquery.flot.tooltip_0.5.js"></script>
-    <script src="/static/js/lib/jquery.flot.axislabels.js"></script>
-    <script src="/static/js/lib/jquery.flot.stackpercent.js"></script>
     <script src="/static/js/lib/jquery.touch-punch.min.js"></script>
     <script src="/static/js/lib/jquery.shapeshift.js"></script>
     <script src="/static/js/lib/jquery.sparkline.min.js"></script>


### PR DESCRIPTION
Now redundant and no longer used, removing from base.html and setup.html script entries. No known dependencies remain, bar jquery. Removing also the dependant plugin of: jquery.flot.tooltip_0.5.js
Note additional removal of jquery.flot.time.js in base.html.

Fixes #2448 