### PR TITLE
remove redundant json2.js - rockstor-jslibs related #2451

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -71,7 +71,6 @@
 
     </script>
 
-    <script src="/static/js/lib/json2.js"></script>
     <script src="/static/js/lib/jquery-1.9.1.min.js"></script>
     <script src="/static/js/lib/jquery-migrate-1.2.1.min.js"></script>
     <script src="/static/js/lib/jquery-ui.min.js"></script>

--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -62,7 +62,6 @@
 
     </script>
 
-    <script src="/static/js/lib/json2.js"></script>
     <script src="/static/js/lib/jquery-1.9.1.min.js"></script>
     <script src="/static/js/lib/jquery-migrate-1.2.1.min.js"></script>
     <script src="/static/js/lib/jquery-ui.min.js"></script>


### PR DESCRIPTION
This library helped with now very old browsers, i.e. IE8. Removing reference as it is now no longer needed.

Fixes #2451 