### PR TITLE
remove unused jquery.sparkline.min.js - rockstor-jslibs related #2453

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -88,7 +88,6 @@
     <script src="/static/js/lib/jquery.validate.js"></script>
     <script src="/static/js/lib/jquery.touch-punch.min.js"></script>
     <script src="/static/js/lib/jquery.shapeshift.js"></script>
-    <script src="/static/js/lib/jquery.sparkline.min.js"></script>
     <script src="/static/js/lib/humanize.js"></script>
     <script src="/static/js/lib/moment.min.js"></script>
     <script src="/static/js/lib/simple-slider.min.js"></script>

--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -78,7 +78,6 @@
     <script src="/static/js/lib/jquery.validate.js"></script>
     <script src="/static/js/lib/jquery.touch-punch.min.js"></script>
     <script src="/static/js/lib/jquery.shapeshift.js"></script>
-    <script src="/static/js/lib/jquery.sparkline.min.js"></script>
     <script src="/static/js/lib/humanize.js"></script>
     <script src="/static/js/lib/moment.min.js"></script>
     <script src="/static/js/lib/socket.io.min.js"></script>


### PR DESCRIPTION
This library is no longer use: removing from base.html and setup.html.

Fixes #2453
