### PR TITLE
Add the fields attribute to RockOnDeviceSerializer #2457

### DIFF
--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -330,6 +330,7 @@ class RockOnEnvironmentSerializer(serializers.ModelSerializer):
 class RockOnDeviceSerializer(serializers.ModelSerializer):
     class Meta:
         model = DContainerDevice
+        fields = "__all__"
 
 
 class RockOnLabelSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Fixes #2457 
@phillxnet, ready for review.

See #2457 for a detailed description of the issue. This pull request simply add the fields attribute to the `RockOnDeviceSerializer` to fix the installation wizard for Rock-Ons using the `DContainerDevice` model.

## Functional testing
With this PR, we can again install the Emby Rock-On, for instance. The Rock-On can be toggled ON/OFF, be uninstalled, and the Rockstor system itself reboots successfully.

## Unit testing
```
rockdev:/opt/rockstor/src/rockstor # poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 236 tests in 30.263s

OK
```