### PR TITLE
(t) rpm update fails 'command not found' in poetry-install.txt #2463

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ PATH="$HOME/.local/bin:$PATH"
 # https://github.com/python-poetry/poetry/issues/3078
 export LANG=C.UTF-8
 export PYTHONIOENCODING=utf8
-poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
+/root/.local/bin/poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
 echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ fi
 # Additional collectstatic options --clear --dry-run
 export DJANGO_SETTINGS_MODULE=settings
 # must be run in project root:
-poetry run django-admin collectstatic --no-input --verbosity 2
+/root/.local/bin/poetry run django-admin collectstatic --no-input --verbosity 2
 echo
 
 echo "ROCKSTOR BUILD SCRIPT COMPLETED"


### PR DESCRIPTION
Hard-wire the root's install of poetry, although we already add this to the PATH environmental variable, we may be limited by our environment when run from the Web-UI. I.e. as per a similar path hard-wire in rockstor-pre.service.
Fixes #2463 
Or at least fixes the initial poetry not found (during rpm update) element of these failures.