### PR TITLE
NGINX SSL directive should be aligned to new format #2275

### DIFF
--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -42,9 +42,8 @@ http {
 	index index.html;
 
 	server {
-		listen 443 default_server;
+		listen 443 ssl default_server;
 		server_name "~^(?<myhost>.+)$";
-		ssl on;
 		ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
 		ssl_certificate /opt/rockstor/certs/rockstor.cert;
  		ssl_certificate_key /opt/rockstor/certs/rockstor.key;

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -225,9 +225,9 @@ def update_nginx(ip, port):
                 not http_server
                 and re.search("listen.*default_server", lines[i]) is not None
             ):
-                substr = "listen {} default_server".format(port)
+                substr = "listen {} ssl default_server".format(port)
                 if ip is not None:
-                    substr = "listen {}:{} default_server".format(ip, port)
+                    substr = "listen {}:{} ssl default_server".format(ip, port)
                 lines[i] = re.sub(r"listen.* default_server", substr, lines[i])
             if not http_server:
                 tfo.write(lines[i])


### PR DESCRIPTION
Remove the now deprecated "ssl" directive and establish the same within our existing "listen" directive, both in our default configuration and our 'rockstor' service (Web-UI) ip:port change parser mechanism. Thanks to @Hooverdan96 for creating the associated issue and researching the changes required.

Fixes #2275 

## Testing:
Before proposed change we have:
```
rleap15-3:~ # systemctl status nginx.service 
● nginx.service - The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf
     Loaded: loaded (/usr/lib/systemd/system/nginx.service; disabled; vendor preset: disabled)
    Drop-In: /etc/systemd/system/nginx.service.d
             └─30-rockstor-nginx-override.conf
     Active: active (running) since Sat 2023-01-14 13:09:57 GMT; 47s ago
    Process: 5170 ExecStartPre=/usr/sbin/nginx -t (code=exited, status=0/SUCCESS)
    Process: 5171 ExecStartPre=/usr/sbin/nginx -t -c /opt/rockstor/etc/nginx/nginx.conf (code=exited, status=0/SUCCESS)
   Main PID: 5172 (nginx)
      Tasks: 3
     CGroup: /system.slice/nginx.service
             ├─5172 nginx: master process /usr/sbin/nginx -c /opt/rockstor/etc/nginx/nginx.conf
             ├─5177 nginx: worker process
             └─5178 nginx: worker process

Jan 14 13:09:57 rleap15-3 systemd[1]: Starting The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf...
Jan 14 13:09:57 rleap15-3 nginx[5170]: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
Jan 14 13:09:57 rleap15-3 nginx[5170]: nginx: configuration file /etc/nginx/nginx.conf test is successful
Jan 14 13:09:57 rleap15-3 nginx[5171]: nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/rockstor/etc/nginx/nginx.conf:47
Jan 14 13:09:57 rleap15-3 nginx[5171]: nginx: the configuration file /opt/rockstor/etc/nginx/nginx.conf syntax is ok
Jan 14 13:09:57 rleap15-3 nginx[5171]: nginx: configuration file /opt/rockstor/etc/nginx/nginx.conf test is successful
Jan 14 13:09:57 rleap15-3 systemd[1]: Started The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf.
Jan 14 13:09:57 rleap15-3 nginx[5172]: nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/rockstor/etc/nginx/nginx.conf:47
```
After the proposed change we have:
```
rleap15-3:~ # systemctl status nginx
● nginx.service - The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf
     Loaded: loaded (/usr/lib/systemd/system/nginx.service; disabled; vendor preset: disabled)
    Drop-In: /etc/systemd/system/nginx.service.d
             └─30-rockstor-nginx-override.conf
     Active: active (running) since Sat 2023-01-14 13:15:22 GMT; 1min 1s ago
    Process: 6873 ExecStartPre=/usr/sbin/nginx -t (code=exited, status=0/SUCCESS)
    Process: 6874 ExecStartPre=/usr/sbin/nginx -t -c /opt/rockstor/etc/nginx/nginx.conf (code=exited, status=0/SUCCESS)
   Main PID: 6875 (nginx)
      Tasks: 3
     CGroup: /system.slice/nginx.service
             ├─6875 nginx: master process /usr/sbin/nginx -c /opt/rockstor/etc/nginx/nginx.conf
             ├─6880 nginx: worker process
             └─6881 nginx: worker process

Jan 14 13:15:22 rleap15-3 systemd[1]: Starting The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf...
Jan 14 13:15:22 rleap15-3 nginx[6873]: nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
Jan 14 13:15:22 rleap15-3 nginx[6873]: nginx: configuration file /etc/nginx/nginx.conf test is successful
Jan 14 13:15:22 rleap15-3 nginx[6874]: nginx: the configuration file /opt/rockstor/etc/nginx/nginx.conf syntax is ok
Jan 14 13:15:22 rleap15-3 nginx[6874]: nginx: configuration file /opt/rockstor/etc/nginx/nginx.conf test is successful
Jan 14 13:15:22 rleap15-3 systemd[1]: Started The nginx HTTP and reverse proxy server - 30-rockstor-nginx-override.conf.
```

There is also no indication of the ssl test warning after changing the Web-UI port (via spanner icon against 'rockstor' service). Indicating that we also update appropriately regarding this newer ssl config placement.