### PR TITLE
(t) 4.5.4-0 Samba shares fail #2471

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=4.5.4
+jslibs_version=4.5.5
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "4.5.4"
+version = "4.5.5"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -49,7 +49,7 @@ def test_parm(config="/etc/samba/smb.conf"):
 
 
 def rockstor_smb_config(fo, exports):
-    mnt_helper = os.path.join(settings.ROOT_DIR, "bin/mnt-share")
+    mnt_helper = os.path.join(settings.ROOT_DIR, ".venv/bin/mnt-share")
     fo.write("{}\n".format(RS_SHARES_HEADER))
     for e in exports:
         admin_users = ""


### PR DESCRIPTION
Correct samba mnt-share script path to account for new .venv dir location on account of changed build system.

## Includes
- Package version increase as first change after 4.5.4-0 tagged release.

Fixes #2471 