### PR TITLE
(t) legacy binary path in some scripts/functions #2470

### DIFF
--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -48,9 +48,10 @@ class Pool(object):
 
 class BTRFSTests(unittest.TestCase):
     """
-    The tests in this suite can be run via the following command:
-    cd <root dir of rockstor ie /opt/rockstor>
-    ./bin/test --settings=test-settings -v 3 -p test_btrfs*
+    The tests in this suite can be run via the following commands:
+    N.B. 'root' dir of rockstor is normally /opt/rockstor
+    cd /opt/rockstor/src/rockstor/fs
+    poetry run django-admin test --settings=settings -v 3 -p test_btrfs*
     """
 
     def setUp(self):

--- a/src/rockstor/scripts/debugmode.py
+++ b/src/rockstor/scripts/debugmode.py
@@ -29,7 +29,7 @@ from system.osi import run_command
 
 
 SETTINGS_FILE = path.join(settings.ROOT_DIR, "src/rockstor/settings.py")
-SUPERCTL_BIN = path.join(settings.ROOT_DIR, "bin/supervisorctl")
+SUPERCTL_BIN = path.join(settings.ROOT_DIR, ".venv/bin/supervisorctl")
 
 
 def update_settings(debug_flag):

--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -139,7 +139,7 @@ class DockerServiceView(BaseServiceDetailView):
             handle_exception(IOError(e_msg), request)
 
     def _write_docker_service(self, distro_id, mnt_pt, conf_file):
-        docker_wrapper = "{}bin/docker-wrapper".format(settings.ROOT_DIR)
+        docker_wrapper = "{}.venv/bin/docker-wrapper".format(settings.ROOT_DIR)
         # If openSUSE, source conf file from docker package itself
         if re.match("opensuse", distro_id) is not None:
             inf = "/usr/lib/systemd/system/docker.service"

--- a/src/rockstor/smart_manager/views/replication.py
+++ b/src/rockstor/smart_manager/views/replication.py
@@ -52,7 +52,7 @@ class ReplicaMixin(object):
             for replica in Replica.objects.filter(enabled=True):
                 if replica.crontab is not None:
                     cfo.write(
-                        "%s root %sbin/send-replica %d\n"
+                        "%s root %s.venv/bin/send-replica %d\n"
                         % (replica.crontab, settings.ROOT_DIR, replica.id)
                     )
 

--- a/src/rockstor/smart_manager/views/task_scheduler.py
+++ b/src/rockstor/smart_manager/views/task_scheduler.py
@@ -101,19 +101,19 @@ class TaskSchedulerMixin(object):
                 if td.crontab is not None:
                     tab = "%s root" % td.crontab
                     if td.task_type == "snapshot":
-                        tab = "%s %sbin/st-snapshot %d" % (
+                        tab = "%s %s.venv/bin/st-snapshot %d" % (
                             tab,
                             settings.ROOT_DIR,
                             td.id,
                         )
                     elif td.task_type == "scrub":
-                        tab = "%s %s/bin/st-pool-scrub %d" % (
+                        tab = "%s %s.venv/bin/st-pool-scrub %d" % (
                             tab,
                             settings.ROOT_DIR,
                             td.id,
                         )
                     elif td.task_type in ["reboot", "shutdown", "suspend"]:
-                        tab = "%s %s/bin/st-system-power %d" % (
+                        tab = "%s %s.venv/bin/st-system-power %d" % (
                             tab,
                             settings.ROOT_DIR,
                             td.id,

--- a/src/rockstor/storageadmin/templates/storageadmin/login.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/login.html
@@ -138,7 +138,7 @@
             the root user in a console on your Rockstor appliance:<br/>
             (The "root" user is the one created during the initial install
             when a password was requested twice.)<br/><br/>
-            /opt/rockstor/bin/pwreset<br/><br/>
+            /opt/rockstor/.venv/bin/pwreset<br/><br/>
             If you have forgotten the root user's password please see:
             <a href="http://rockstor.com/docs/reset-root-password.html"
                target="_blank"> Resetting root password.</a><br/><br/>

--- a/src/rockstor/storageadmin/views/oauth_app.py
+++ b/src/rockstor/storageadmin/views/oauth_app.py
@@ -84,7 +84,7 @@ class OauthAppView(rfc.GenericView):
                     "it is "
                     "used internally by Rockstor. If you really need to "
                     "delete it, login as root and use "
-                    "{}bin/delete-api-key command. If you do delete it, "
+                    "{}.venv/bin/delete-api-key command. If you do delete it, "
                     "please create another one with the same name as it "
                     "is required by Rockstor "
                     "internally."


### PR DESCRIPTION
Replace all currently identified, previously missed, live legacy binary paths. Thanks to @FroggyFlox on GitHub for greatly assisting with these changes.
Affects:
- debugmode selection script
- docker wrapper functions (dead/legacy code)
- replication
- task scheduling

## Includes
- an example of a change required to our various test comments concerning a similar change required that will be addressed in a follow-up patch (test_btrfs.py)
- user facing text changes pertaining to related path changes: (login.html, oauth_app.py)

Follow-up to #2472 with the following issue opened along the same lines #2475 

Fixes #2470 