### PR TITLE
Spelling typo in password reset text

### DIFF
--- a/src/rockstor/scripts/pwreset.py
+++ b/src/rockstor/scripts/pwreset.py
@@ -47,7 +47,7 @@ def change_password(username, password):
         users.smbpasswd(username, password)
     except:
         sys.exit(
-            "Low level error occured while changing password of user: %s" % username
+            "Low level error occurred while changing password of user: %s" % username
         )
 
 


### PR DESCRIPTION
Follow-up to [2477](https://github.com/rockstor/rockstor-core/pull/2477) on testing branch