### PR TITLE
Typo in pwreset.py: occured -> occurred

### DIFF
--- a/src/rockstor/scripts/pwreset.py
+++ b/src/rockstor/scripts/pwreset.py
@@ -47,7 +47,7 @@ def change_password(username, password):
         users.smbpasswd(username, password)
     except:
         sys.exit(
-            "Low level error occured while changing password of user: %s" % username
+            "Low level error occurred while changing password of user: %s" % username
         )
 
 


### PR DESCRIPTION
Next shot for: https://github.com/rockstor/rockstor-core/issues/2474
Thanks for your patience and help @phillxnet :)