### PR TITLE
Add form validation for share selected multiple times #2064

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
  * This file is part of RockStor.
  *
  * RockStor is free software; you can redistribute it and/or modify
@@ -580,15 +580,36 @@ RockonShareChoice = RockstorWizardPage.extend({
         }));
         //form validation
         this.volForm = this.$('#vol-select-form');
+
+        // Check for duplicate shares selected (one share selected multiple times)
+        $.validator.addMethod('isDuplicate', function (value, element) {
+            var selector = jQuery.validator.format("select[name!='{0}']", element.name);
+            var matches = [];
+            $(selector).each(function (index, item) {
+                if (value === $(item).val()) {
+                    matches.push(item);
+                }
+            });
+            return matches.length === 0;
+        });
+
         var rules = {};
         var messages = {};
         this.volumes.each(function(volume) {
             rules[volume.id] = {
-                required: true
+                required: true,
+                isDuplicate: true
             };
-            messages[volume.id] = 'Please read the tooltip and make the right selection';
+            messages[volume.id] = {
+                required: "Required. Please read the tooltip and make your selection.",
+                isDuplicate: "This share is already selected for another volume. This isn't supported yet."
+            };
         });
         this.validator = this.volForm.validate({
+            focusCleanup: false,
+            onclick: false,
+            onfocusout: false,
+            onkeyup: false,
             rules: rules,
             messages: messages
         });


### PR DESCRIPTION
Fixes #2064 
@phillxnet, ready for review.

During the Rock-On install wizard, selecting the same share to be bound to multiple volumes of the same container is not yet supported by Rockstor. While adding such support is planned, we currently do not prevent the user for doing so, which would thus result in a broken configuration. This has unfortunately already hit several users who expected to be able to do select the same share multiple times.

This PR proposes to add a new form validation rule (`isDuplicate`) to detect such instances of a share being selected as the option for more than one volume and return a specific error message accordingly. The error message is as follows:
**This share is already selected for another volume. This isn't supported yet.**.

Note that this form validation is occurring **only** upon clicking the "Next" button.
See https://github.com/rockstor/rockstor-core/issues/2064#issuecomment-1397674233 for a demonstration (note that the error message displayed in https://github.com/rockstor/rockstor-core/issues/2064#issuecomment-1397674233 is slightly out of date).

This has been tested on Rockstor Testing branch, on Leap 15.3.
@phillxnet , note that this PR only touches JS code, I have not run any unit test for it.