### PR TITLE
Move Rock-on url default definitions to runtime #2305

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -421,12 +421,6 @@ UPDATE_CHANNELS = {
 		},
 }
 
-ROCKONS = {
-	'remote_metastore': 'https://rockstor.com/rockons',
-	'remote_root': 'root.json',
-	'local_metastore': '{}/rockons-metastore'.format(BASE_DIR),
-}
-
 HUEY = SqliteHuey(filename='{}/rockstor-tasks-huey.db'.format(BASE_DIR))
 
 TASK_SCHEDULER = {

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -49,6 +49,12 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
+ROCKONS = {
+    "remote_metastore": "https://rockstor.com/rockons",
+    "remote_root": "root.json",
+    "local_metastore": "{}/rockons-metastore".format(settings.BASE_DIR),
+}
+
 
 class RockOnView(rfc.GenericView):
     serializer_class = RockOnSerializer
@@ -473,8 +479,8 @@ class RockOnView(rfc.GenericView):
             # don't fetch if service is not configured.
             return {}
 
-        url_root = settings.ROCKONS.get("remote_metastore")
-        remote_root = "{}/{}".format(url_root, settings.ROCKONS.get("remote_root"))
+        url_root = ROCKONS.get("remote_metastore")
+        remote_root = "{}/{}".format(url_root, ROCKONS.get("remote_root"))
         msg = "Error while processing remote metastore at ({}).".format(remote_root)
         with self._handle_exception(self.request, msg=msg):
             response = requests.get(remote_root, timeout=10)
@@ -492,7 +498,7 @@ class RockOnView(rfc.GenericView):
                     cur_res.raise_for_status()
                 meta_cfg.update(cur_res.json())
 
-        local_root = settings.ROCKONS.get("local_metastore")
+        local_root = ROCKONS.get("local_metastore")
         if os.path.isdir(local_root):
             for f in os.listdir(local_root):
                 fp = "{}/{}".format(local_root, f)


### PR DESCRIPTION
Fixes #2305 
@phillxnet, ready for review.

We currently define the location of the remote and local Rock-Ons metastores in a constant placed in settings.py. As a result, any need to modify any of these settings would require the user to rebuild Rockstor.

This pull request (PR) moves the definition of this constant to rockon.py where it is used, enabling the user to only need a restart of the rockstor service after customization.

## Testing
1. The Rock-Ons service was configured and turned ON
2. Rock-Ons list was updated by pressing the Update button on the Rock-Ons page.
3. The `/opt/rockstor/rockons-metastore` dir (default local metastore path) was created and a custom Rock-On was placed inside it.
4. Rock-Ons list was updated by pressing the Update button on the Rock-Ons page. **The custom Rock-On appears.**
5. The custom Rock-On was removed from this dir.
6. Rock-Ons list was updated by pressing the Update button on the Rock-Ons page. The custom Rock-On is no longer listed.
7. A new local metastore was defined in the `ROCKONS` constant at `/opt/my_custom_metastore`.
8. The dir `/opt/my_custom_metastore` was created and a custom Rock-On was placed inside it.
9. Restart the Rockstor service: `systemctl restart rockstor`.
10. Rock-Ons list was updated by pressing the Update button on the Rock-Ons page. **The custom Rock-On appears**


## Unit testing
```
buildvm:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 236 tests in 12.831s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```