### PR TITLE
Refactor scrub status parsing to enhance/enable testing #2342

### DIFF
--- a/src/rockstor/storageadmin/views/pool_scrub.py
+++ b/src/rockstor/storageadmin/views/pool_scrub.py
@@ -22,7 +22,7 @@ from storageadmin.util import handle_exception
 from storageadmin.serializers import PoolScrubSerializer
 from storageadmin.models import Pool, PoolScrub
 import rest_framework_custom as rfc
-from fs.btrfs import scrub_start, scrub_status
+from fs.btrfs import scrub_start, scrub_status, btrfsprogs_legacy
 from datetime import timedelta
 
 import logging
@@ -56,7 +56,7 @@ class PoolScrubView(rfc.GenericView):
         except:
             return Response()
         if ps.status == "started" or ps.status == "running":
-            cur_status = scrub_status(pool)
+            cur_status = scrub_status(pool, btrfsprogs_legacy())
             if (
                 cur_status["status"] == "finished"
                 or cur_status["status"] == "halted"


### PR DESCRIPTION
Previous scrub status enhancements lacked test coverage. By refactoring our scrub status parsing mechanisms we can return almost full test coverage to this capability.

Replaces all-in-one scrub_status() with a wrapper that invokes:
1. scrub_status_raw() 'btrfs scrub status -R' parser.
2. scrub_status_extra() non '-R' variant of 1. Combining the results there-after.

## Includes
- Replacing pkg_resources (setuptools) 'parse_version' with custom btrfsprogs_legacy() function.
- Tests for btrfsprogs_legacy() and previously missing scrub status parsing extensions now refactored into (1.) and (2.) above.

Fixes #2342 
N.B. the stated issue is primarily functionally addressed by the referenced pull requests in that issue:
"BTRFS SCRUB status enhancements for rockstor #2157
However there remained, there-after, important test deficits indicated by @FroggyFlox 's review comment here:
https://github.com/rockstor/rockstor-core/pull/2157#pullrequestreview-404667948

This pull request addresses the following code review comments intended for follow-up work; such as this pr:

> ## Caveats
> 
> ... I did notice, however, a few points that could improved in further PRs. These do not break the current system, however, so I believe they shouldn't necessarily be blocking this current PR.
> 
> 1. in scrub_status(), we now have a total of three calls to run_command(). While these work well as it, having several calls to the same command within a given function will prevent us (I believe) from properly covering these with our units tests. I would thus suggest to keep in mind the possibility for separating them from the scrub_status() function. The first one, for instance, simply fetches the btrfs-progs version, which could thus be separated and thus easily re-used as necessary.
> 2. Following-up on the previous point, we should think of updating our relevant unit tests (test_btrfs_*) to cover the newly-parsed metrics.

And my own forum comments here: https://forum.rockstor.com/t/integer-out-of-range/8183/12

> ...that we don’t have test coverage of the most recent additions to that rather critical function. So I’ll leave the associated issue open where we can also add test data from the latest kernel.

regarding the same initial issue.

