### PR TITLE
Web-UI update to start rockstor-bootstrap.service #2488

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -453,10 +453,9 @@ def update_run(subscription=None, update_all_other=False):
     with open(npath, "w") as atfo:
         if not update_all_other:
             atfo.write("sleep 10\n")
-            atfo.write("{} stop rockstor\n".format(SYSTEMCTL))
-            # rockstor-pre stop ensures initrock re-run on next rockstor start
-            atfo.write("{} stop rockstor-pre\n".format(SYSTEMCTL))
-            # Exclude eggs subdir, as these are in rpm so will be deleted
+            # stop rockstor* services: rockstor-bootstrap, via Requires, restarts them.
+            atfo.write("{} stop rockstor*\n".format(SYSTEMCTL))
+            # Exclude eggs subdir (pre-v4.5.4-0), as these are in rpm so will be deleted
             # as otherwise floods YUM log with "No such file or directory"
             atfo.write(
                 '/usr/bin/find {} -name "*.pyc" -not -path "*/eggs/*" -type f -delete\n'.format(
@@ -466,8 +465,8 @@ def update_run(subscription=None, update_all_other=False):
             atfo.write(pkg_refresh_cmd)
             # account for moving from dev/source to package type install:
             atfo.write(pkg_in_up_rockstor)
-            # the following rockstor start invokes rockstor-pre (initrock) also
-            atfo.write("{} start rockstor\n".format(SYSTEMCTL))
+            # rockstor-bootstrap Requires rockstor which Requires rockstor-pre (initrock)
+            atfo.write("{} start rockstor-bootstrap\n".format(SYSTEMCTL))
         else:  # update_all_other True so update all bar the rockstor package.
             logger.info(
                 "Updating all but rockstor package for distro {}".format(distro_id)


### PR DESCRIPTION
Change from starting rockstor.service to rockstor-bootstrap.service after a Web-UI initiated update. This service start is now in-line with that defined by our systemd-presets-branding-rockstor package on OBS, and with our build instructions.

Fixes #2488 

We also now stop all rockstor* services before these updates to have systemd handle the interdependencies/ordering, and account for any additional services of ours in the future.

## Caveat
rockstor-hdparm.service is not accounted for: however its function is primarily during boot and it is of Type=oneshot.