### PR TITLE
Improve README.md re package licensing, project goals etc #2489

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,50 @@
 # The Rockstor Project
 
-An open source (GPLv3 core / AGPLv3 Rock-ons) community endeavour to sustainably develop, maintain, and
-distribute an easy to use, flexible, Linux & BTRFS based DIY storage appliance.
+An Open Source (Licensed: FSF Free/Libre & OSI approved) community endeavour
+to sustainably develop, maintain, and distribute an easy to use, flexible,
+Linux & BTRFS based DIY Network Attached Storage (NAS) software appliance.
 
-[About Us](http://rockstor.com/about-us.html)
+[About Us](https://rockstor.com/about-us.html)
 
-Donations welcome: 
+# License:
 
-[www.paypal.me/rockstor](https://www.paypal.me/rockstor)
+The Rockstor package code, as distributed, is developed under two main repositories:
+
+* Source0: [rockstor-core](https://github.com/rockstor/rockstor-core) is
+  [GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0-standalone.html) licensed.
+
+* Source1: [rockstor-jslibs](https://github.com/rockstor/rockstor-jslibs) is
+  ([MIT](https://opensource.org/license/mit-0) AND
+  [Apache-2.0](https://opensource.org/license/apache2.0) AND
+  [GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0-standalone.html) AND
+  [LGPL-3.0-or-later](https://www.gnu.org/licenses/lgpl-3.0-standalone.html) AND
+  [ISC](https://spdx.org/licenses/ISC.html)) licensed.
+  Indicating the combined works in this jslibs repository.
+
+Making the package license, as per the **Fedora Project Wiki**
+[Packaging:LicensingGuidelines](https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#Mixed_Source_Licensing_Scenario):
+
+* **"GPL-3.0-or-later AND (MIT AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND ISC)"**
+
+The optional [Rock-ons (Docker Plugins)](https://rockstor.com/docs/interface/overview.html)
+sub-system uses definitions developed in the 
+[rockon-registry](https://github.com/rockstor/rockon-registry) which are
+licensed [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html).
+These definitions are not included within our distributed package,
+but retrieved via the internet (from production servers) upon this sub-systems setup.
+
+*Note: All additional software installed via the optional Rock-on sub-system
+is subject to the individual projects licensing terms.
+As indicated by their respective websites: linked within Rockstors Rock-ons Web-UI.*
+
+See the [SPDX License List](https://spdx.org/licenses) for details on the above assertions.
+
+# Documentation
+
+[Our Documentation](https://rockstor.com/docs) is developed in the open in the
+[rockstor-doc](https://github.com/rockstor/rockstor-doc) repository and
+licensed [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0).
+As with all our code, contributions and corrections are always welcome.
 
 # What is Rockstor?
 
@@ -16,59 +53,53 @@ Filesystem (BTRFS). It is written in Python and Javascript and is made
 available as a complete Linux distribution for convenience. Rockstor takes NAS
 to a new level with advanced features, ease of use, and management. It goes
 beyond traditional NAS by supporting Docker based apps, RESTful APIs; and serves as a
-powerful cloud storage platform out-of-the-box.
+private cloud storage platform out-of-the-box.
 
 # What are the project goals?
 
-The main goal is to develop an easy to deploy and use open source NAS solution for
-for commodity hardware. For more information, see:
-[Our Endeavour](http://rockstor.com/about-us.html).
+The main goal is to establish sustainable Open Source development
+of an easy to deploy and use NAS solution for commodity hardware.
+For more information, see:
+[Our Endeavour](https://rockstor.com/about-us.html).
 
 # Who should use it?
 
-Rockstor aims to aid individuals and organisations alike. As a DIY setup some
-familiarity with PC/Pi4 operating system install is required; but not much beyond
-the basics. For more information please see our main web site:
-[rockstor.com](http://rockstor.com)
+The Rockstor Project aims to aid individuals and organisations alike.
+As a DIY appliance some familiarity with PC/Pi4/ARM64 operating system install is required;
+but not much beyond the basics.
+For more information see our main website:
+[rockstor.com](https://rockstor.com)
 
 # Getting started and questions
 
 The best way to get started is by following the [quickstart
-guide](http://rockstor.com/docs/quickstart.html).
+guide](https://rockstor.com/docs/quickstart.html).
 
 To get in touch with developers, users, and contributors join our
-[community forum](http://forum.rockstor.com) and ask away.
+[community forum](https://forum.rockstor.com) and ask away.
 
-# Documentation
-
-[Our Documentation](http://rockstor.com/docs) is also a community endeavour with its
-own GitHub repo: [rockstor-doc](https://github.com/rockstor/rockstor-doc): contributions
-and corrections are always welcome.
 
 # Troubleshooting
 
-The [community forum](http://forum.rockstor.com) is the ideal location for help and 
+The [community forum](https://forum.rockstor.com) is the ideal location for help and 
 support; all current developers are also active forum members.
 
 # Issue tracking
 
-We use GitHub's issue system, although a forum post/discussion is advised prior to
-opening a GitHub issue as this often helps in identifying exactly what should be added
-to an new issue.
-[Rocksor issues](https://github.com/rockstor/rockstor-core/issues).
-
-# License
-
-Please see the file [COPYING](https://github.com/rockstor/rockstor-core/blob/master/COPYING).
+We use GitHubs issues, although a forum post/discussion is advised beforehand.
+This often helps with clarifying exactly what any new issue should contain;
+or in establishing if any existing issue is relevant.
+It is also important to correctly identify the relevant
+[rockstor](https://github.com/rockstor) repository.
 
 # Contributing
 
 Development environment setup and contribution guidelines are available in our docs:
-[Contributing to Rockstor - Overview](http://rockstor.com/docs/contribute.html)
+[Contributing to Rockstor - Overview](https://rockstor.com/docs/contribute/contribute.html)
 
 There is no Contributor License Agreement (CLA).
 
 Pull requests are welcome. Pick an issue that interests you or create a new one.
-Please also reference our [friendly community forum ](http://forum.rockstor.com)
+Reference our [friendly community forum ](https://forum.rockstor.com)
 for open questions and our ever-growing wiki entries that serve as our
 community facing developer notes.  


### PR DESCRIPTION
Improve licensing details re clarifications from the distributed package point-of-view. This file can then be referenced, within the packaging system itself, as an overview, given its central location in our rockstor-core repository. Includes some section re-ordering to collect license and repo information. SPDX references were adopted through-out.

Fixes #2489 