### PR TITLE
alt arch causing false positive update available #2468

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -321,7 +321,7 @@ def rockstor_pkg_update_check(subscription=None):
     machine_arch = platform.machine()
     if subscription is not None:
         switch_repo(subscription)
-    pkg = "rockstor"
+    pkg = "rockstor*{}".format(machine_arch)
     version, date = rpm_build_info(pkg)
     if date is None:
         # None date signifies no rpm installed so list all changelog entries.

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -635,3 +635,4 @@ class SystemPackageTests(unittest.TestCase):
     #  test_auto_update(self)
     #  Related additional low level test:
     #  test_auto_update_status(self)
+    #  Add test for rockstor_pkg_update_check()


### PR DESCRIPTION
As we are now multi arch we need to specify the arch of the package we are interested in as the dnf-yum changelog facility we use to retrieve this info seems to return changelogs for all architectures.
Fix by adding "*arch" where arch = host architecture to our "rockstor" package search term.

Add TODO to associated tests as we don't yet have this procedure covered.

Fixes #2468