### PR TITLE
Convert pool ID in backup file to the one in the database #2508

### DIFF
--- a/src/rockstor/storageadmin/fixtures/test_config_backup.json
+++ b/src/rockstor/storageadmin/fixtures/test_config_backup.json
@@ -14,6 +14,20 @@
     }
 },
 {
+    "model": "storageadmin.pool",
+    "pk": 4,
+    "fields": {
+        "name": "rock-pool2",
+        "uuid": "3176aa98-a939-4f7b-aa6c-70c18570fc8e",
+        "size": 5242880,
+        "raid": "single",
+        "toc": "2023-03-03T21:21:14.952Z",
+        "compression": "no",
+        "mnt_options": "",
+        "role": null
+    }
+},
+{
     "model": "storageadmin.share",
     "pk": 3,
     "fields": {

--- a/src/rockstor/storageadmin/views/config_backup.py
+++ b/src/rockstor/storageadmin/views/config_backup.py
@@ -33,7 +33,7 @@ from rest_framework.response import Response
 import rest_framework_custom as rfc
 from cli.rest_util import api_call
 from smart_manager.models.service import Service, ServiceStatus
-from storageadmin.models import ConfigBackup, RockOn, Share
+from storageadmin.models import ConfigBackup, RockOn, Pool, Share
 from storageadmin.serializers import ConfigBackupSerializer
 from storageadmin.util import handle_exception
 from storageadmin.views.rockon_helpers import rockon_tasks_pending
@@ -214,6 +214,12 @@ def validate_taskdef_meta(sa_ml, taskdef_meta, task_type):
         target_share_id = get_target_share_id(source_name)
         # Update taskdef_meta (needs to be a unicode object)
         taskdef_meta["share"] = unicode(target_share_id)
+    if task_type == "scrub":
+        # get ID of pool name in the target system
+        target_pool_id = get_target_pool_id(taskdef_meta["pool_name"])
+        # Update taskdef_meta (needs to be a unicode object)
+        taskdef_meta["pool"] = unicode(target_pool_id)
+
     return taskdef_meta
 
 
@@ -556,6 +562,14 @@ def get_target_share_id(source_name):
     """
     so = Share.objects.get(name=source_name)
     return so.id
+
+
+def get_target_pool_id(source_name):
+    """
+    Takes a pool name and returns its ID from the database.
+    """
+    po = Pool.objects.get(name=source_name)
+    return po.id
 
 
 @db_task()


### PR DESCRIPTION
Fixes #2508.
@phillxnet, @Hooverdan96, ready for review.

We currently use the pool ID for a scrub scheduled task in a config backup file as is. If this pool now has a different ID in the target system (the one where the config backup file is being restored), this will lead to a failure in restoring the pool scrub task.

This pull request (PR) thus implements a simple conversion logic in which we fetch the pool ID for the given pool name from the target system's database.

## Demonstration
1. Create a VM with 1 OS disk + 2 data disks (Data1 and Data2).
2. Create the following pools:
  - `rock-pool` on Data1
  - `rock-pool2` on Data2
3. Create two scheduled tasks:
  - pool scrub on `rock-pool`: rockpool_scrub
  - pool scrub on `rockpool2`: rockpool2_scrub
4. Create a config backup
5. Delete the `rock-pool2` Pool and wipe the disk
6. Create a new pool named `rock-pool2` using disk Data2. The pool named `rock-pool2` thus now has a different pool ID than before.
7. Restore config backup taken in step 4

The Rockstor log now shows:
```
[06/Mar/2023 19:32:35] INFO [storageadmin.views.config_backup:234] Started restoring scheduled tasks.
[06/Mar/2023 19:32:36] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/tasks. Payload: {'task_type': u'scrub', 'name': u'rockpool_scrub', 'crontabwindow': u'*-*-*-*-*-*', 'enabled': False, 'crontab': u'42 3 * * 5', 'meta': {u'pool_name': u'rock-pool', u'pool': u'2'}}
[06/Mar/2023 19:32:36] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/tasks. Payload: {'task_type': u'scrub', 'name': u'rockpool2_scrub', 'crontabwindow': u'*-*-*-*-*-*', 'enabled': False, 'crontab': u'42 3 * * 5', 'meta': {u'pool_name': u'rock-pool2', u'pool': u'4'}}
[06/Mar/2023 19:32:36] INFO [storageadmin.views.config_backup:238] Finished restoring scheduled tasks.
```
In the above log excerpt, we can see that for the second task named `rockpool2_scrub`, the pool ID was successfully converted from `3` to `4`.
To confirm the tasks were restored, we can look at the scheduled tasks page:
![image](https://user-images.githubusercontent.com/30297881/223213997-55061127-1cd5-47d7-944d-8f44c96e7c76.png)


## Unit tests
Note that unit tests were updated accordingly.
```
radmin:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
.......................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 247 tests in 13.272s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```