### PR TITLE
Account for empty meta in reboot_shutdown.py #2514

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
+++ b/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 def validate_reboot_shutdown_meta(meta):
     if type(meta) != dict:
-        raise Exception("meta must be a dictionary, not %s" % type(meta))
+        raise Exception("meta must be a dictionary, not {}".format(type(meta)))
     return meta
 
 
@@ -99,8 +99,8 @@ def main():
         aw = APIWrapper()
         if tdo.task_type not in ["reboot", "shutdown", "suspend"]:
             logger.error(
-                "task_type(%s) is not a system reboot, "
-                "shutdown or suspend." % tdo.task_type
+                "task_type({}) is not a system reboot, "
+                "shutdown or suspend.".format(tdo.task_type)
             )
             return
         meta = json.loads(tdo.json_meta)
@@ -119,7 +119,7 @@ def main():
         try:
             # set default command url before checking if it's a shutdown
             # and if we have an rtc wake up
-            url = "commands/%s" % tdo.task_type
+            url = "commands/{}".format(tdo.task_type)
 
             # if task_type is shutdown and rtc wake up true
             # parse crontab hour & minute vs rtc hour & minute to state
@@ -144,15 +144,15 @@ def main():
                     epoch += timedelta(days=1)
 
                 epoch = epoch.strftime("%s")
-                url = "%s/%s" % (url, epoch)
+                url = "{}/{}".format(url, epoch)
 
             aw.api_call(url, data=None, calltype="post", save_error=False)
-            logger.debug("System %s scheduled" % tdo.task_type)
+            logger.debug("System {} scheduled".format(tdo.task_type))
             t.state = "finished"
 
         except Exception as e:
             t.state = "failed"
-            logger.error("Failed to schedule system %s" % tdo.task_type)
+            logger.error("Failed to schedule system {}".format(tdo.task_type))
             logger.exception(e)
 
         finally:

--- a/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
+++ b/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -32,7 +32,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def validate_shutdown_meta(meta):
+def validate_reboot_shutdown_meta(meta):
     if type(meta) != dict:
         raise Exception("meta must be a dictionary, not %s" % type(meta))
     return meta
@@ -47,7 +47,7 @@ def all_devices_offline(addresses):
 
 
 def run_conditions_met(meta):
-    if meta["ping_scan"]:
+    if meta and meta["ping_scan"]:
         address_parser = csv_reader([meta["ping_scan_addresses"]], delimiter=",")
         addresses = list(address_parser)
 
@@ -104,7 +104,7 @@ def main():
             )
             return
         meta = json.loads(tdo.json_meta)
-        validate_shutdown_meta(meta)
+        validate_reboot_shutdown_meta(meta)
 
         if not run_conditions_met(meta):
             logger.debug(

--- a/src/rockstor/scripts/tests/test_reboot_shutdown.py
+++ b/src/rockstor/scripts/tests/test_reboot_shutdown.py
@@ -1,0 +1,162 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
+This file is part of RockStor.
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+import unittest
+from mock import patch
+
+from scripts.scheduled_tasks.reboot_shutdown import (
+    validate_reboot_shutdown_meta,
+    all_devices_offline,
+    run_conditions_met,
+)
+
+
+class ScriptTests(unittest.TestCase):
+    """
+    The tests in this suite can be run via the following command:
+    cd <root dir of rockstor ie /opt/rockstor>
+    ./bin/test --settings=test-settings -v 3 -p test_system_network*
+    """
+
+    def setUp(self):
+        self.patch_is_network_device_responding = patch(
+            "scripts.scheduled_tasks.reboot_shutdown.is_network_device_responding"
+        )
+        self.mock_is_network_device_responding = (
+            self.patch_is_network_device_responding.start()
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_validate_reboot_shutdown_meta(self):
+        """
+        Test the following scenarios:
+        1. Reboot task valid
+        2. Suspend/Shutdown valid
+        3. Reboot/Suspend/Shutdown task invalid
+        """
+        # 1. Valid meta is a Dict (empty if reboot task)
+        meta = {}
+        expected = meta
+        returned = validate_reboot_shutdown_meta(meta)
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected validate_reboot_shutdown_meta result:\n "
+            "returned = ({}).\n "
+            "expected = ({}).".format(returned, expected),
+        )
+
+        # 2. Valid Shutdown meta
+        meta = {
+            "ping_scan_addresses": "1.1.1.1,8.8.8.8",
+            "ping_scan_interval": "5",
+            "rtc_minute": 0,
+            "ping_scan": True,
+            "wakeup": False,
+            "rtc_hour": 0,
+            "ping_scan_iterations": "3",
+        }
+        expected = meta
+        returned = validate_reboot_shutdown_meta(meta)
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected validate_reboot_shutdown_meta result:\n "
+            "returned = ({}).\n "
+            "expected = ({}).".format(returned, expected),
+        )
+
+        # 3. Invalid meta (not a Dict)
+        meta = []
+        with self.assertRaises(Exception):
+            validate_reboot_shutdown_meta(meta)
+
+    def test_all_devices_offline(self):
+        """
+        Test the following scenarios:
+        1. Target devices are OFFLINE
+        2. Target devices are ONLINE
+        """
+        addresses = ["1.1.1.1", "8.8.8.8"]
+        # 1. Mock target devices as OFFLINE: should return True
+        self.mock_is_network_device_responding.return_value = False
+        returned = all_devices_offline(addresses)
+        self.assertTrue(
+            returned,
+            msg="Un-expected all_devices_offline result:\n "
+            "returned = ({}).\n "
+            "expected = True.".format(returned),
+        )
+
+        # 2. Mock target devices as ONLINE: should return False
+        self.mock_is_network_device_responding.return_value = True
+        returned = all_devices_offline(addresses)
+        self.assertFalse(
+            returned,
+            msg="Un-expected all_devices_offline result:\n "
+            "returned = ({}).\n "
+            "expected = False.".format(returned),
+        )
+
+    def test_run_conditions_met(self):
+        """
+        Test the following scenarios:
+        1. Reboot task: empty meta
+        2. Shutdown/Suspend task, valid meta, ping targets OFFLINE
+        3. Shutdown/Suspend task, valid meta, ping targets ONLINE
+
+        Note that for Shutdown/Suspend tasks, an invalid meta will be caught
+        by validate_reboot_shutdown_meta() before run_conditions_met()
+        so no need to test for an invalid meta here.
+        """
+        # 1. Reboot task, empty meta: should return True
+        meta = {}
+        returned = run_conditions_met(meta)
+        self.assertTrue(
+            returned,
+            msg="Un-expected run_conditions_met result:\n "
+            "returned = ({}).\n "
+            "expected = True.".format(returned),
+        )
+
+        # Shutdown/Suspend task
+        meta = {
+            "ping_scan_addresses": "1.1.1.1,8.8.8.8",
+            "ping_scan_interval": "5",
+            "rtc_minute": 0,
+            "ping_scan": True,
+            "wakeup": False,
+            "rtc_hour": 0,
+            "ping_scan_iterations": "1",
+        }
+        # 2. ping targets OFFLINE: should return True
+        self.mock_is_network_device_responding.return_value = False
+        returned = run_conditions_met(meta)
+        self.assertTrue(
+            returned,
+            msg="Un-expected run_conditions_met result:\n "
+            "returned = ({}).\n "
+            "expected = True.".format(returned),
+        )
+        # 3. ping targets ONLINE: should return False
+        self.mock_is_network_device_responding.return_value = True
+        returned = run_conditions_met(meta)
+        self.assertFalse(
+            returned,
+            msg="Un-expected run_conditions_met result:\n "
+            "returned = ({}).\n "
+            "expected = False.".format(returned),
+        )

--- a/src/rockstor/scripts/tests/test_reboot_shutdown.py
+++ b/src/rockstor/scripts/tests/test_reboot_shutdown.py
@@ -22,11 +22,11 @@ from scripts.scheduled_tasks.reboot_shutdown import (
 )
 
 
-class ScriptTests(unittest.TestCase):
+class RebootShutdownScriptTests(unittest.TestCase):
     """
-    The tests in this suite can be run via the following command:
-    cd <root dir of rockstor ie /opt/rockstor>
-    ./bin/test --settings=test-settings -v 3 -p test_system_network*
+    To run the tests:
+    export DJANGO_SETTINGS_MODULE="settings"
+    cd src/rockstor && poetry run django-admin test -v 2 -p test_reboot_shutdown.py
     """
 
     def setUp(self):


### PR DESCRIPTION
Fixes #2514 
@phillxnet, @Hooverdan96, ready for review.

As detailed in #2514, a scheduled task of type reboot fails due to a omission to account for an empty taskdefinition meta as it is the case for reboot tasks. This pull request thus simply adds a check for an empty meta before trying to extract information from it.

## Demonstration
A scheduled task of type reboot was created. When it was time, the reboot command is indeed issued:
```
Broadcast message from root@rockdev (Sat 2023-03-11 17:45:02 EST):

The system is going down for reboot at Sat 2023-03-11 17:48:02 EST!
```
![image](https://user-images.githubusercontent.com/30297881/224514924-333b9762-955a-4ad8-b17c-4e13eaf9b040.png)

To verify other tasks using the reboot_shutdown.py script are still functional, a task of type shutdown was created. When it was time, the shutdown command is indeed triggered:
```
Broadcast message from root@rockdev (Sat 2023-03-11 17:55:02 EST):

The system is going down for poweroff at Sat 2023-03-11 17:58:02 EST!

[11/Mar/2023 17:55:02] DEBUG [scripts.scheduled_tasks.reboot_shutdown:150] System shutdown scheduled
```
![image](https://user-images.githubusercontent.com/30297881/224515416-21f22efb-89ed-4a26-a2e9-2a5e643a006f.png)


## Unit tests
Three new unit tests are added to cover the reboot_shutdown.py script. Note, however, that the part of `main()` dealing with rtc wake-up time is not covered as I'm not that familiar with working with time data in Python. I'm not sure I want to risk messing users' tasks scheduling as a result.

## Testing
```
rockdev:/opt/rockstor/src/rockstor # poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
..........................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 250 tests in 13.574s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```
