### PR TITLE
improve behaviour on missing /dev/disk/by-id dir #2401

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1871,6 +1871,11 @@ def get_byid_name_map():
     was encountered by run_command or no by-id type names were encountered.
     """
     byid_name_map = {}
+    if not os.path.isdir("/dev/disk/by-id"):
+        logger.info(
+            "-- /dev/disk/by-id missing. See 'Minimum system requirements' in docs. --"
+        )
+        return byid_name_map
     out, err, rc = run_command([LS, "-lr", "/dev/disk/by-id"], throw=True)
     if rc == 0:
         for each_line in out:

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -43,6 +43,11 @@ class OSITests(unittest.TestCase):
         self.patch_os_path_isfile = patch('os.path.isfile')
         self.mock_os_path_isfile = self.patch_os_path_isfile.start()
 
+        # some procedures use os.path.isdir so setup mock
+        self.patch_os_path_isdir = patch('os.path.isdir')
+        self.mock_os_path_isdir = self.patch_os_path_isdir.start()
+        self.mock_os_path_isdir.return_value = True
+
         # root_disk() default mock - return /dev/sda for /dev/sda3 '/'
         self.patch_root_disk = patch('system.osi.root_disk')
         self.mock_root_disk = self.patch_root_disk.start()
@@ -1789,6 +1794,13 @@ class OSITests(unittest.TestCase):
             returned = get_byid_name_map()
             self.maxDiff = None
             self.assertDictEqual(returned, expected)
+
+    def test_get_byid_name_map_no_byid_dir(self):
+        """
+        Test get_byid_name_map() for non-existent by-id dir behaviour.
+        """
+        self.mock_os_path_isdir.return_value = False
+        self.assertEqual(get_byid_name_map(), {}, msg="no by-id dir should return {}")
 
 #     def test_mount_status(self):
 #         """


### PR DESCRIPTION
By catching the instance of no by-id directory we avoid an inadvertent 'general' error and enable our existing Web-UI info on missing device serial numbers with its embedded link to our 'Minimum system requirements' docs section. An info log is also added when this directory is nonexistent, again with a pointer to the same doc section.

Fixes #2401 

## Testing
See issue comments from https://github.com/rockstor/rockstor-core/issues/2401#issuecomment-1478321138

In brief pre patch we produce the issue stated error. Post patch we have our usual no-serial indicator but against all disks. We also have an uninterrupted entry into the main Web-UI after the initial setup screen. Where-as before we were blocked from this access by the rouge 'general' error message. But by-hand url manipulation could be used to by-pass this error.