### PR TITLE
Add mixed raid levels #2520

### DIFF
--- a/src/rockstor/storageadmin/models/pool.py
+++ b/src/rockstor/storageadmin/models/pool.py
@@ -39,6 +39,7 @@ class Pool(models.Model):
     uuid = models.CharField(max_length=100, null=True)
     """size of the pool in KB"""
     size = models.BigIntegerField(default=0)
+    """raid expected values defined in PROFILE dict"""
     raid = models.CharField(max_length=10)
     toc = models.DateTimeField(auto_now=True)
     compression = models.CharField(max_length=256, null=True)
@@ -154,6 +155,22 @@ class Pool(models.Model):
             return are_quotas_enabled(self.mnt_pt_var)
         except:
             return False
+
+    @property
+    def data_raid(self, *args, **kwargs):
+        # Convenience property to return data_raid from self.raid
+        try:
+            return PROFILE[self.raid].data_raid
+        except:
+            return "unknown"
+
+    @property
+    def metadata_raid(self, *args, **kwargs):
+        # Convenience property to return metadata_raid from self.raid
+        try:
+            return PROFILE[self.raid].metadata_raid
+        except:
+            return "unknown"
 
     class Meta:
         app_label = "storageadmin"

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -90,6 +90,9 @@ class PoolInfoSerializer(serializers.ModelSerializer):
     dev_stats_ok = serializers.BooleanField()
     dev_missing_count = serializers.IntegerField()
     redundancy_exceeded = serializers.BooleanField()
+    data_raid = serializers.CharField()
+    metadata_raid = serializers.CharField()
+
 
     class Meta:
         model = Pool

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -37,12 +37,7 @@
                 <label class="col-sm-4 control-label" for="raid_level">Raid configuration<span class="required"> *</span></label>
                 <div class="col-sm-6">
                     <select class="form-control" id="raid_level" name="raid_level">
-                        <option value="single">Single</option>
-                        <option value="raid0">Raid0</option>
-                        <option value="raid1">Raid1</option>
-                        <option value="raid10">Raid10</option>
-                        <option value="raid5">Raid5</option>
-                        <option value="raid6">Raid6</option>
+                        {{display_all_raid_levels}}
                     </select>
                 </div>
             </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_info_module.jst
@@ -23,7 +23,8 @@
 <div class="module-content">
   <h3>Details</h3>
   Created on: <strong>{{getPoolCreationDate model.toc}}</strong><br/>
-  Raid configuration: <strong>{{model.raid}}</strong><br/>
+  Btrfs Raid configuration: <strong>{{model.raid}}</strong>
+  (Data: {{model.data_raid}} - Metadata: {{model.metadata_raid}})<br/>
   Active mount options / Status: <strong>
   {{#if model.is_mounted}}
     {{model.mount_status}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/add_disks.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/add_disks.jst
@@ -8,7 +8,9 @@
     {{#if model.raidChange}}
     <div class="row">
     <div class="form-group col-md-4">
-        <label for="raid-level">Select a new raid level<br>raid5 & raid6 are not production-ready</label>
+        <label for="raid-level">Select a new raid level<br>
+            raid5 & raid6 are not production-ready<br>
+            mixed raid levels are data-metadata</label>
         <select id="raid-level" name="raid-level" class="form-control">
             <option value="">Select a new raid level</option>
             {{display_raid_levels}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/raid_change.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/resize/raid_change.jst
@@ -8,7 +8,9 @@
 <form id="raid-change-form">
   <div class="row">
   <div class="form-group col-md-4">
-     <label for="raid-level">Select a new raid level<br>raid5 & raid6 are not production-ready</label>
+     <label for="raid-level">Select a new raid level<br>
+       raid5 & raid6 are not production-ready<br>
+       mixed raid levels are data-metadata</label>
     <select id="raid-level" name="raid-level" class="form-control">
       <option value="">Select a new raid level</option>
       {{display_raid_levels}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -363,6 +363,20 @@ AddPoolView = Backbone.View.extend({
         Handlebars.registerHelper('humanReadableSize', function (diskSize) {
             return humanize.filesize(diskSize * 1024);
         });
+
+        Handlebars.registerHelper('display_all_raid_levels', function () {
+            var html = '';
+            // Before 6.2.0 kernel
+            // var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            // After 6.2.0 kernel
+            var levels = ['single', 'single-dup', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6',
+                'raid1c3', 'raid1c4', "raid1-1c3", "raid1-1c4", "raid10-1c3",
+                "raid10-1c4", "raid5-1", "raid5-1c3", "raid6-1c3", "raid6-1c4"];
+            _.each(levels, function (level) {
+                html += '<option value="' + level + '">' + level + '</option>';
+            });
+            return new Handlebars.SafeString(html);
+        });
     }
 });
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/add_disks.js
@@ -143,7 +143,10 @@ PoolAddDisks = RockstorWizardPage.extend({
         Handlebars.registerHelper('display_raid_levels', function(){
             var html = '';
             var _this = this;
-            var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            // var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            var levels = ['single', 'single-dup', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6',
+                'raid1c3', 'raid1c4', "raid1-1c3", "raid1-1c4", "raid10-1c3",
+                "raid10-1c4", "raid5-1", "raid5-1c3", "raid6-1c3", "raid6-1c4"];
             _.each(levels, function(level) {
                 if (_this.raidLevel != level) {
                     html += '<option value="' + level + '">' + level + '</option>';

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/raid_change.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool/resize/raid_change.js
@@ -77,7 +77,10 @@ PoolRaidChange = RockstorWizardPage.extend({
         Handlebars.registerHelper('display_raid_levels', function() {
             var html = '';
             var _this = this;
-            var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            // var levels = ['single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6'];
+            var levels = ['single', 'single-dup', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6',
+                'raid1c3', 'raid1c4', "raid1-1c3", "raid1-1c4", "raid10-1c3",
+                "raid10-1c4", "raid5-1", "raid5-1c3", "raid6-1c3", "raid6-1c4"];
             _.each(levels, function(level) {
                 if (_this.raidLevel != level) {
                     html += '<option value="' + level + '">' + level + '</option>';

--- a/src/rockstor/storageadmin/tests/test_commands.py
+++ b/src/rockstor/storageadmin/tests/test_commands.py
@@ -32,7 +32,7 @@ class CommandTests(APITestMixin):
         cls.mock_get_pool_info = cls.patch_get_pool_info.start()
         cls.mock_get_pool_info.return_value = {"disks": [], "label": "pool2"}
 
-        cls.patch_pool_raid = patch("storageadmin.views.command.pool_raid")
+        cls.patch_pool_raid = patch("storageadmin.views.command.get_pool_raid_levels")
         cls.mock_pool_raid = cls.patch_pool_raid.start()
 
         cls.patch_mount_share = patch("storageadmin.views.command.mount_share")

--- a/src/rockstor/storageadmin/tests/test_disks.py
+++ b/src/rockstor/storageadmin/tests/test_disks.py
@@ -46,7 +46,7 @@ class DiskTests(APITestMixin):
         cls.patch_mount_root = patch("storageadmin.views.disk.mount_root")
         cls.mock_mount_root = cls.patch_mount_root.start()
 
-        cls.patch_pool_raid = patch("storageadmin.views.disk.pool_raid")
+        cls.patch_pool_raid = patch("storageadmin.views.disk.get_pool_raid_levels")
         cls.mock_pool_raid = cls.patch_pool_raid.start()
         cls.mock_pool_raid.return_value = {"data": "single", "metadata": "single"}
 

--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -22,6 +22,7 @@ from mock import patch
 import fs.btrfs
 from storageadmin.models import Disk, Pool, PoolBalance
 from storageadmin.tests.test_api import APITestMixin
+from storageadmin.views.pool import SUPPORTED_PROFILES
 
 """
 Fixture creation instructions:
@@ -193,10 +194,7 @@ class PoolTests(APITestMixin):
             "pname": "invalid-raid-level",
             "raid_level": "derp",
         }
-        e_msg = (
-            "Unsupported raid level. Use one of: "
-            "('single', 'raid0', 'raid1', 'raid10', 'raid5', 'raid6')."
-        )
+        e_msg = "Unsupported raid level. Use one of: {}.".format(SUPPORTED_PROFILES)
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
             response.status_code,

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -23,7 +23,8 @@ from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
 from storageadmin.views import DiskMixin
 from system.osi import uptime, kernel_info, get_device_mapper_map
-from fs.btrfs import mount_share, mount_root, get_dev_pool_info, pool_raid, mount_snap
+from fs.btrfs import mount_share, mount_root, get_dev_pool_info, get_pool_raid_levels, mount_snap, \
+    get_pool_raid_profile
 from system.ssh import sftp_mount_map, sftp_mount
 from system.osi import (
     system_shutdown,
@@ -125,7 +126,8 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 p.uuid = pool_info.uuid
                 p.save()
                 mount_root(p)
-                p.raid = pool_raid(p.mnt_pt)["data"]
+                pool_raid_info = get_pool_raid_levels(p.mnt_pt)
+                p.raid = get_pool_raid_profile(pool_raid_info)
                 p.size = p.usage_bound()
                 # Consider using mount_status() parse to update root pool db on
                 # active (fstab initiated) compression setting.

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -24,10 +24,10 @@ from fs.btrfs import (
     enable_quota,
     mount_root,
     get_pool_info,
-    pool_raid,
+    get_pool_raid_levels,
     get_dev_pool_info,
     set_pool_label,
-    get_devid_usage,
+    get_devid_usage, get_pool_raid_profile,
 )
 from storageadmin.serializers import DiskInfoSerializer
 from storageadmin.util import handle_exception
@@ -414,7 +414,8 @@ class DiskMixin(object):
                 if pool_name is not None:
                     logger.debug("++++ Creating special system pool db entry.")
                     root_compression = "no"
-                    root_raid = pool_raid("/")["data"]
+                    pool_raid_info = get_pool_raid_levels("/")
+                    root_raid = get_pool_raid_profile(pool_raid_info)
                     # scan_disks() has already acquired our fs uuid so inherit.
                     # We have already established btrfs as the fs type.
                     p = Pool(
@@ -867,7 +868,8 @@ class DiskDetailView(rfc.GenericView):
                         do.role = '{"redirect": "%s"}' % device.name
                 do.save()
                 mount_root(po)
-            po.raid = pool_raid("%s%s" % (settings.MNT_PT, po.name))["data"]
+            pool_raid_info = get_pool_raid_levels("{}{}".format(settings.MNT_PT, po.name))
+            po.raid = get_pool_raid_profile(pool_raid_info)
             po.size = po.usage_bound()
             po.save()
             enable_quota(po)

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -49,10 +49,31 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Currently supported Rockstor btrfs raid profiles.
+# See fs.btrfs.PROFILE for all definitions.
+SUPPORTED_PROFILES = (
+    "single",
+    "single-dup",
+    "raid0",
+    "raid1",
+    "raid10",
+    "raid5",
+    "raid6",
+    "raid1c3",
+    "raid1c4",
+    "raid1-1c3",
+    "raid1-1c4",
+    "raid10-1c3",
+    "raid10-1c4",
+    "raid5-1",
+    "raid5-1c3",
+    "raid6-1c3",
+    "raid6-1c4",
+)
+
 
 class PoolMixin(object):
     serializer_class = PoolInfoSerializer
-    SUPPORTED_PROFILES = ("single", "raid0", "raid1", "raid10", "raid5", "raid6")
 
     @staticmethod
     def _validate_disk(d, request):
@@ -410,9 +431,9 @@ class PoolListView(PoolMixin, rfc.GenericView):
 
             raid_level = request.data["raid_level"]
             # Reject creation of unsupported raid_level:
-            if raid_level not in self.SUPPORTED_PROFILES:
-                e_msg = ("Unsupported raid level. Use one of: {}.").format(
-                    self.SUPPORTED_PROFILES
+            if raid_level not in SUPPORTED_PROFILES:
+                e_msg = "Unsupported raid level. Use one of: {}.".format(
+                    SUPPORTED_PROFILES
                 )
                 handle_exception(Exception(e_msg), request)
 


### PR DESCRIPTION
Extend our existing raid levels to include:
raid1c3 and raid1c4, introduced in kernel 5.5.
Additionally add mixed raid capability.
We artificially reduce mixed raid profile options to assist with usability.

Fixes #2520 

Adds abstraction, with tests, to generate a profile from our existing pool raid levels mechanism.
Includes:
- Minor rename-refactor from prior TODO.
- Enable distinguishing between single & single-dup.
- Add an "unknown" profile as fail-through catch-all.
- Enable easy Web-UI access to data/metadata via additional Pool object properties as thin PROFILE look-ups.
- Surface data-metadata in pool details Web-UI page.
- Remove now redundant single raid designator for data, if metadata = single. As we now have data-metadata surfaced we no longer need this.
- Refactor supported profiles var for test use. SUPPORTED_PROFILES was a class variable without requirement to be this way. Move to module level and use in test_pool.py unsupported profile test case.