### PR TITLE
Bump versions to a 4.5.9 base (RC6) #2541

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=4.5.8
+jslibs_version=4.5.9
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "4.5.8"
+version = "4.5.9"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"


### PR DESCRIPTION
We are keeping our jslibs version in sync, and need to increase our pyproject.toml definition in line with our pending git tag.

Fixes #2541 