### PR TITLE
Account for Tumbleweed sshd config changes #2501

### DIFF
--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -24,11 +24,14 @@ import shutil
 import sys
 from tempfile import mkstemp
 
+import distro
 from django.conf import settings
 
 from system import services
 from system.osi import run_command, md5sum, replace_line_if_found
+from system.ssh import SSHD_CONFIG
 from collections import OrderedDict
+
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +228,7 @@ def bootstrap_sshd_config(log):
     :param log:
     :return:
     """
-    sshd_config = "/etc/ssh/sshd_config"
+    sshd_config = SSHD_CONFIG[distro.id()]
 
     # Comment out default sftp subsystem
     fh, npath = mkstemp()
@@ -242,7 +245,7 @@ def bootstrap_sshd_config(log):
 
     # Set AllowUsers and Subsystem if needed
     with open(sshd_config, "a+") as sfo:
-        log.info("SSHD_CONFIG Customization")
+        log.info("SSHD_CONFIG ({}) Customization".format(sshd_config))
         found = False
         for line in sfo.readlines():
             if (

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -22,11 +22,11 @@ import shutil
 import stat
 from tempfile import mkstemp
 
+import distro
 from django.conf import settings
-
 from osi import run_command
+from system.ssh import SSHD_CONFIG
 
-SSHD_CONFIG = "/etc/ssh/sshd_config"
 SYSTEMCTL_BIN = "/usr/bin/systemctl"
 SUPERCTL_BIN = "{}.venv/bin/supervisorctl".format(settings.ROOT_DIR)
 SUPERVISORD_CONF = "{}etc/supervisord.conf".format(settings.ROOT_DIR)
@@ -192,7 +192,7 @@ def service_status(service_name, config=None):
             return out, err, rc
         # sshd has sftp subsystem so we check for its config line which is
         # inserted or deleted to enable or disable the sftp service.
-        with open(SSHD_CONFIG) as sfo:
+        with open(SSHD_CONFIG[distro.id()]) as sfo:
             for line in sfo.readlines():
                 if re.match(settings.SFTP_STR, line) is not None:
                     return out, err, rc


### PR DESCRIPTION
Newer systems now establish default sshd config in /usr/etc/ssh/sshd_config; and include overrides via drop-in files in /etc/ssh/sshd_config.d/*.conf. Accommodate these changes: initially instantiated in Tumbleweed.
