### PR TITLE
Make rockon-delete compatible with duplicate RockOn model entries #2549

### DIFF
--- a/src/rockstor/scripts/rockon_delete.py
+++ b/src/rockstor/scripts/rockon_delete.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -26,34 +26,41 @@ from system.osi import run_command
 DOCKER = "/usr/bin/docker"
 
 
-# Console script to delete containers, images and rockstor-db metadata of a
-# Rock-on.
+# Console script to delete containers, images and rockstor-db metadata of a Rock-on.
 def delete_rockon():
     try:
         name = sys.argv[1]
     except IndexError:
         sys.exit(
-            "Delete metadata, containers and images of a "
-            "Rock-on\n\tUsage: %s <rockon name>" % sys.argv[0]
+            "Delete metadata, containers and images of a Rock-On"
+            "\n\tUsage: {} <Rock-On name>"
+            "\n"
+            "\nNOTE: the Rock-On name is case sensitive; use quotes if it includes spaces."
+            '\nexample: {} "Rock-On Name"'.format(sys.argv[0], sys.argv[0])
         )
 
-    try:
-        ro = RockOn.objects.get(name=name)
-    except RockOn.DoesNotExist:
-        sys.exit("Rock-On(%s) does not exist" % name)
+    ros = RockOn.objects.filter(name=name)
+    if len(ros) > 0:
+        for ro in ros:
+            ro_id = ro.id
+            for c in DContainer.objects.filter(rockon=ro).order_by("-launch_order"):
+                # We don't throw any exceptions because we want to ensure metadata is
+                # deleted for sure. It would be nice to fully delete containers and
+                # images, but that's not a hard requirement.
+                run_command([DOCKER, "stop", c.name], throw=False, log=True)
+                run_command([DOCKER, "rm", c.name], throw=False, log=True)
+                # Get image name with tag information
+                img_plus_tag = "{}:{}".format(c.dimage.name, c.dimage.tag)
+                run_command([DOCKER, "rmi", img_plus_tag], throw=False, log=True)
 
-    for c in DContainer.objects.filter(rockon=ro).order_by("-launch_order"):
-        # We don't throw any exceptions because we want to ensure metadata is
-        # deleted for sure. It would be nice to fully delete containers and
-        # images, but that's not a hard requirement.
-        run_command([DOCKER, "stop", c.name], throw=False, log=True)
-        run_command([DOCKER, "rm", c.name], throw=False, log=True)
-        # Get image name with tag information
-        img_plus_tag = "{}:{}".format(c.dimage.name, c.dimage.tag)
-        run_command([DOCKER, "rmi", img_plus_tag], throw=False, log=True)
-
-    ro.delete()
-    print("Rock-On(%s) metadata in the db is deleted" % name)
+            ro.delete()
+            print(
+                "The metadata for the Rock-On named {} (id: {}) has been deleted from the database".format(
+                    name, ro_id
+                )
+            )
+    else:
+        sys.exit("No Rock-On named {} was found in the database".format(name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2549 
@phillxnet, @Hooverdan96, ready for review.

The rockon-delete currently only supports the "normal" case of a single RockOn model entry. In case one of these entries is duplicated, however, it currently fails.

This Pull Request (PR) thus adapts the current logic to get all entries (0, 1, or more) with a given name.

# Demonstration
The example laid out by @Hooverdan96 in #2549 was followed: create a local Rock-On named *Scrutiny.local* and update the list of available Rock-Ons in the webUI. Then, manually duplicate the `RockOn` model entry. We end up with the following:
```
rockdev:/opt/rockstor # psql -U rocky -d storageadmin -c "SELECT id,name,state,status,taskid FROM storageadmin_rockon WHERE name = 'Scrutiny.local';"
Password for user rocky: 
 id |      name      |   state   | status  | taskid 
----+----------------+-----------+---------+--------
 87 | Scrutiny.local | available | stopped | 
 85 | Scrutiny.local | available | stopped | 
(2 rows)
```

We then run the updated script:
```
rockdev:/opt/rockstor # poetry run delete-rockon Scrutiny.local
The metadata for the Rock-On named Scrutiny.local (id: 82) has been deleted from the database
The metadata for the Rock-On named Scrutiny.local (id: 84) has been deleted from the database
```

Verify it is gone:
```
rockdev:/opt/rockstor # poetry run delete-rockon Scrutiny.local
No Rock-On named Scrutiny.local was found in the database

rockdev:/opt/rockstor # psql -U rocky -d storageadmin -c "SELECT id,name,state,status,taskid FROM storageadmin_rockon WHERE name = 'Scrutiny.local';"
Password for user rocky: 
 id | name | state | status | taskid 
----+------+-------+--------+--------
(0 rows)
```

The script still works for a Rock-On with a single entry (normal case):
```
rockdev:/opt/rockstor # poetry run delete-rockon Jellyfin
The metadata for the Rock-On named Jellyfin (id: 83) has been deleted from the database
```

Note that we also have verification by the two forum users who reported this issue that the updated script resolved their duplicate `RockOn` entries:
- [https://forum.rockstor.com/t/get-returned-more-than-one-rockon-it-returned-2/8790/19](https://forum.rockstor.com/t/get-returned-more-than-one-rockon-it-returned-2/8790/19?u=flox)
- [https://forum.rockstor.com/t/get-returned-more-than-one-rockon-it-returned-2/8790/22](https://forum.rockstor.com/t/get-returned-more-than-one-rockon-it-returned-2/8790/22?u=flox)

# Testing
```
rockdev:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
.............................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 253 tests in 12.550s

OK
```

