### PR TITLE
Account for Tumbleweed sshd config changes #2501

### DIFF
--- a/conf/PermitRootLogin
+++ b/conf/PermitRootLogin
@@ -1,0 +1,3 @@
+# Allow root login on ssh - Delete this file to disable root ssh login.
+# "PermitRootLogin yes" is overridden by "AllowUsers ..." which Rockstor uses.
+# This is a 'Flag file'. Its existence enables root ssh login via AllowUsers.

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -32,6 +32,7 @@ from system.osi import (
     dev_mount_point,
 )
 from system.exceptions import CommandException
+from system.constants import MOUNT, UMOUNT, RMDIR, DEFAULT_MNT_DIR
 from pool_scrub import PoolScrub
 from huey.contrib.djhuey import task
 from django.conf import settings
@@ -46,10 +47,6 @@ logger = logging.getLogger(__name__)
 
 MKFS_BTRFS = "/usr/sbin/mkfs.btrfs"
 BTRFS = "/usr/sbin/btrfs"
-MOUNT = "/usr/bin/mount"
-UMOUNT = "/usr/bin/umount"
-DEFAULT_MNT_DIR = "/mnt2/"
-RMDIR = "/usr/bin/rmdir"
 QID = "2015"
 # The following model/db default setting is also used when quotas are disabled.
 PQGROUP_DEFAULT = settings.MODEL_DEFS["pqgroup"]

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -371,9 +371,6 @@ MODEL_DEFS = {
 	   'pqgroup': '-1/-1',
 }
 
-# Begin SFTP-related variables
-SSHD_HEADER = '###BEGIN: Rockstor SFTP CONFIG. DO NOT EDIT BELOW THIS LINE###'
-SFTP_STR = 'Subsystem\tsftp\tinternal-sftp'
 
 OAUTH_INTERNAL_APP = 'cliapp'
 
@@ -441,7 +438,7 @@ SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.
 # Examples given are for CentOS Rockstor variant, Leap 15, and Tumblweed.
-OS_DISTRO_ID = distro.id()  # rockstor, opensuse-leap, opensuse-tumbleweed
+OS_DISTRO_ID = distro.id()  # rockstor, opensuse-leap/opensuse, opensuse-tumbleweed
 OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed
 # Note that the following will capture the build os version.
 # For live updates (running system) we call distro.version() directly in code.

--- a/src/rockstor/storageadmin/fixtures/test_sftp.json
+++ b/src/rockstor/storageadmin/fixtures/test_sftp.json
@@ -1,0 +1,121 @@
+[
+{
+    "model": "storageadmin.pool",
+    "pk": 3,
+    "fields": {
+        "name": "rock-pool",
+        "uuid": "203ce52b-e73e-4faa-a27b-553fb3501529",
+        "size": 5242880,
+        "raid": "single",
+        "toc": "2023-05-21T15:50:01.365Z",
+        "compression": "no",
+        "mnt_options": "",
+        "role": null
+    }
+},
+{
+    "model": "storageadmin.share",
+    "pk": 3,
+    "fields": {
+        "pool": 3,
+        "qgroup": "0/256",
+        "pqgroup": "2015/1",
+        "name": "share_root_owned",
+        "uuid": null,
+        "size": 1048576,
+        "owner": "root",
+        "group": "root",
+        "perms": "755",
+        "toc": "2023-05-21T15:50:01.615Z",
+        "subvol_name": "share_root_owned",
+        "replica": false,
+        "compression_algo": "no",
+        "rusage": 16,
+        "eusage": 16,
+        "pqgroup_rusage": 16,
+        "pqgroup_eusage": 16
+    }
+},
+{
+    "model": "storageadmin.share",
+    "pk": 4,
+    "fields": {
+        "pool": 3,
+        "qgroup": "0/257",
+        "pqgroup": "2015/2",
+        "name": "share_user_owned",
+        "uuid": null,
+        "size": 1048576,
+        "owner": "admin",
+        "group": "admin",
+        "perms": "755",
+        "toc": "2023-05-21T15:50:01.519Z",
+        "subvol_name": "share_user_owned",
+        "replica": false,
+        "compression_algo": "no",
+        "rusage": 16,
+        "eusage": 16,
+        "pqgroup_rusage": 16,
+        "pqgroup_eusage": 16
+    }
+},
+{
+    "model": "storageadmin.share",
+    "pk": 5,
+    "fields": {
+        "pool": 3,
+        "qgroup": "0/258",
+        "pqgroup": "2015/3",
+        "name": "share_sftp",
+        "uuid": null,
+        "size": 1048576,
+        "owner": "admin",
+        "group": "admin",
+        "perms": "755",
+        "toc": "2023-05-21T15:50:01.567Z",
+        "subvol_name": "share_sftp",
+        "replica": false,
+        "compression_algo": "no",
+        "rusage": 16,
+        "eusage": 16,
+        "pqgroup_rusage": 16,
+        "pqgroup_eusage": 16
+    }
+},
+{
+    "model": "storageadmin.sftp",
+    "pk": 2,
+    "fields": {
+        "share": 5,
+        "editable": "rw"
+    }
+},
+{
+    "model": "storageadmin.user",
+    "pk": 1,
+    "fields": {
+        "user": [
+            "admin"
+        ],
+        "username": "admin",
+        "uid": 1000,
+        "gid": 1000,
+        "public_key": null,
+        "shell": "/bin/bash",
+        "homedir": "/home/admin",
+        "email": null,
+        "admin": true,
+        "group": 1,
+        "smb_shares": []
+    }
+},
+{
+    "model": "storageadmin.group",
+    "pk": 1,
+    "fields": {
+        "gid": 1000,
+        "groupname": "admin",
+        "admin": true
+    }
+}
+]

--- a/src/rockstor/storageadmin/tests/test_sftp.py
+++ b/src/rockstor/storageadmin/tests/test_sftp.py
@@ -12,22 +12,46 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-import mock
 from rest_framework import status
 from mock import patch
 
-from storageadmin.models import Pool, Share, SFTP
+from storageadmin.models import Share, SFTP
 from storageadmin.tests.test_api import APITestMixin
+
+"""
+Fixture creation instructions:
+
+System needs 1 virtio data disk (min 5 GB). System pool not required in fixture.
+
+- Virtio disk serial '1' - we do not required storageadmin.disk in fixture.
+
+- Create  pool 'rock-pool' using btrfs-raid 'single' with virtio disk serial '1'.
+- Create share 'share_root_owned' ('rock-pool') owner.group 'root.root': no SFTP export.
+- Create share 'share_user_owned' ('rock-pool') owner.group 'admin.admin': no SFTP export.
+- Create share 'share_sftp' ('rock-pool') owner.group 'admin.admin' - SFTP exported.
+
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE=settings
+poetry run django-admin dumpdata storageadmin.pool storageadmin.share \
+storageadmin.SFTP storageadmin.user storageadmin.group \
+--natural-foreign --indent 4 > \
+./storageadmin/fixtures/test_sftp.json
+
+(strip out root pool and home share from test_sftp.json as not used)
+
+
+Running this test:
+
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE=settings
+poetry run django-admin test -p test_sftp.py -v 2
+"""
 
 
 class SFTPTests(APITestMixin):
-    # fixture with:
-    # share-sftp (admin:admin) exported by SFTP
-    # share-root-owned (root:root) - no SFTP export
-    # share-user-owned (admin:admin) - no SFTP export.
-    # proposed fixture = "test_sftp.json"
-    fixtures = ["test_api.json"]
-    BASE_URL = '/api/sftp'
+
+    fixtures = ["test_api.json", "test_sftp.json"]
+    BASE_URL = "/api/sftp"
 
     @classmethod
     def setUpClass(cls):
@@ -35,34 +59,32 @@ class SFTPTests(APITestMixin):
 
         # post mocks
 
-        cls.patch_is_share_mounted = patch('storageadmin.views.sftp.'
-                                           'is_share_mounted')
+        cls.patch_is_share_mounted = patch("storageadmin.views.sftp.is_share_mounted")
         cls.mock_is_share_mounted = cls.patch_is_share_mounted.start()
         cls.mock_is_share_mounted.return_value = True
 
-        cls.patch_helper_mount_share = patch('storageadmin.views.sftp.'
-                                             'helper_mount_share')
+        cls.patch_helper_mount_share = patch(
+            "storageadmin.views.sftp.helper_mount_share"
+        )
         cls.mock_helper_mount_share = cls.patch_helper_mount_share.start()
         cls.mock_helper_mount_share.return_value = True
 
-        cls.patch_sftp_mount = patch('storageadmin.views.sftp.sftp_mount')
+        cls.patch_sftp_mount = patch("storageadmin.views.sftp.sftp_mount")
         cls.mock_sftp_mount = cls.patch_sftp_mount.start()
         cls.mock_sftp_mount.return_value = True
 
-        # all values as per fixture
-        cls.temp_pool = Pool(id=10, name='rock-pool', size=5242880)
-        # the following line fails with: "Share matching query does not exist."
-        # cls.temp_share_sftp = Share.objects.get(pk=18)
-        cls.temp_share_sftp = Share(id=18, name='share-sftp',
-                                    pool=cls.temp_pool, owner='admin',
-                                    group='admin')
-        cls.temp_share_root_owned = Share(id=19, name='share-root-owned',
-                                          pool=cls.temp_pool)
-        cls.temp_share_user_owned = Share(id=20, name='share-user-owned',
-                                          pool=cls.temp_pool, owner='admin',
-                                          group='admin')
+        # Avoid low-level chmod/rsync/sftp_user filesystem/sshd prep by mocking.
+        cls.patch_rsync_for_sftp = patch("storageadmin.views.sftp.rsync_for_sftp")
+        cls.mock_rsync_for_sftp = cls.patch_rsync_for_sftp.start()
+        cls.mock_rsync_for_sftp.return_value = True
 
-        cls.temp_sftp = SFTP(id=1, share=cls.temp_share_sftp)
+        cls.patch_update_sftp_user_share_config = patch(
+            "storageadmin.views.sftp.update_sftp_user_share_config"
+        )
+        cls.mock_update_sftp_user_share_config = (
+            cls.patch_update_sftp_user_share_config.start()
+        )
+        cls.mock_update_sftp_user_share_config.return_value = True
 
     @classmethod
     def tearDownClass(cls):
@@ -78,9 +100,8 @@ class SFTPTests(APITestMixin):
         self.get_base(self.BASE_URL)
 
         # get sftp with id
-        response = self.client.get('{}/1'.format(self.BASE_URL))
-        self.assertEqual(response.status_code, status.HTTP_200_OK,
-                         msg=response)
+        response = self.client.get("{}/1".format(self.BASE_URL))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response)
 
     def test_post_requests_1(self):
         """
@@ -89,61 +110,58 @@ class SFTPTests(APITestMixin):
         """
 
         # create sftp with no share names
-        data = {'read_only': 'true', }
+        data = {
+            "read_only": "true",
+        }
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'Must provide share names.'
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Must provide share names."
         self.assertEqual(response.data[0], e_msg)
 
     # TODO: FAIL repair needed.
-    @mock.patch('storageadmin.views.share_helpers.Share')
-    def test_post_requests_2(self, mock_share):
+    def test_post_requests_2(self):
         """
-        . Create sftp for root-owned share
-        . Create sftp for the share that is already exported
+        . Create sftp for root-owned share - should fail as not supported.
+        . Create sftp for the share that is already sftp exported
         . Create sftp for user-owned share
         """
 
-        mock_share.objects.get.return_value = self.temp_share_root_owned
-
-        # create sftp with share owned by root
-        data = {'shares': ('share-root-owned',)}
+        # Create sftp for root-owned share - should fail as not supported.
+        data = {"shares": ("share_root_owned",)}
         response = self.client.post(self.BASE_URL, data=data)
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = ('Share (share-root-owned) is owned by root. It cannot be '
-                 'exported via SFTP with root ownership.')
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = (
+            "Share (share_root_owned) is owned by root. It cannot be "
+            "exported via SFTP with root ownership."
+        )
         self.assertEqual(response.data[0], e_msg)
 
-        # TODO: the rest of this test fails with
-        # 'Share matching query does not exist.'
-        # and later:
-        # AssertionError: "[Errno 2] No such file or directory:
-        # '/lib64/libpopt.so.0'" != 'Share (share-sftp) is already exported via SFTP.'
+        # Create sftp for the share that is already sftp exported
+        data = {"shares": ("share_sftp",)}
+        response = self.client.post(self.BASE_URL, data=data)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "Share (share_sftp) is already exported via SFTP."
+        self.assertEqual(response.data[0], e_msg)
 
-        # mock_share.objects.get.return_value = self.temp_share_sftp
-        #
-        # # create sftp with already existing and sftp exported share.
-        # data = {'shares': ('share-sftp',)}
-        # response = self.client.post(self.BASE_URL, data=data)
-        # self.assertEqual(response.status_code,
-        #                  status.HTTP_500_INTERNAL_SERVER_ERROR,
-        #                  msg=response.data)
-        # e_msg = 'Share (share-sftp) is already exported via SFTP.'
-        # self.assertEqual(response.data[0], e_msg)
-
-        # # TODO: FAIL:
-        # #  stderr = ["usermod: user \'admin\' does not exist", \'\']\n']
-        # mock_share.objects.get.return_value = self.temp_share_user_owned
-        #
-        # # happy path
-        # data = {'shares': ('share-user-owned',), 'read_only': 'true', }
-        # response = self.client.post(self.BASE_URL, data=data)
-        # self.assertEqual(response.status_code,
-        #                  status.HTTP_200_OK, msg=response.data)
+        # Create sftp for user-owned share - happy path
+        data = {
+            "shares": ("share_user_owned",),
+            "read_only": "true",
+        }
+        response = self.client.post(self.BASE_URL, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
     def test_delete_requests_1(self):
         """
@@ -152,23 +170,25 @@ class SFTPTests(APITestMixin):
 
         # Delete sftp that does not exists
         sftp_id = 99999
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, sftp_id))
-        self.assertEqual(response.status_code,
-                         status.HTTP_500_INTERNAL_SERVER_ERROR,
-                         msg=response.data)
-        e_msg = 'SFTP config for the id ({}) does not exist.'.format(sftp_id)
+        response = self.client.delete("{}/{}".format(self.BASE_URL, sftp_id))
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            msg=response.data,
+        )
+        e_msg = "SFTP config for the id ({}) does not exist.".format(sftp_id)
         self.assertEqual(response.data[0], e_msg)
 
-    @mock.patch('storageadmin.views.sftp.SFTP')
-    def test_delete_requests_2(self, mock_sftp):
+    def test_delete_requests_2(self):
         """
         1. Delete sftp export
         """
 
-        mock_sftp.objects.get.return_value = self.temp_sftp
-
         # happy path
-        sftp_id = self.temp_sftp.id
-        response = self.client.delete('{}/{}'.format(self.BASE_URL, sftp_id))
-        self.assertEqual(response.status_code,
-                         status.HTTP_200_OK, msg=response.data)
+        # our fixture's existing sftp export
+        sftp_share = Share.objects.get(name="share_sftp")
+        sftp_export = SFTP.objects.get(share=sftp_share.id)
+        sftp_id = sftp_export.id
+
+        response = self.client.delete("{}/{}".format(self.BASE_URL, sftp_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)

--- a/src/rockstor/storageadmin/views/sftp.py
+++ b/src/rockstor/storageadmin/views/sftp.py
@@ -30,7 +30,7 @@ from share_helpers import helper_mount_share, validate_share, sftp_snap_toggle
 from storageadmin.models import SFTP
 from storageadmin.serializers import SFTPSerializer
 from storageadmin.util import handle_exception
-from system.ssh import update_sftp_config, sftp_mount_map, sftp_mount, rsync_for_sftp
+from system.ssh import update_sftp_user_share_config, sftp_mount_map, sftp_mount, rsync_for_sftp
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class SFTPListView(rfc.GenericView):
                     input_map[sftpo.share.owner] = "{}{}".format(
                         settings.SFTP_MNT_ROOT, sftpo.share.owner,
                     )
-            update_sftp_config(input_map)
+            update_sftp_user_share_config(input_map)
             return Response()
 
 
@@ -123,5 +123,5 @@ class SFTPDetailView(rfc.GenericView):
                     input_map[so.share.owner] = "{}{}".format(
                         settings.SFTP_MNT_ROOT, so.share.owner,
                     )
-            update_sftp_config(input_map)
+            update_sftp_user_share_config(input_map)
             return Response()

--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -1,0 +1,32 @@
+"""
+Copyright (c) 2012-2023 Rockstor, Inc. <https://rockstor.com>
+This file is part of Rockstor.
+
+Rockstor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Rockstor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+# constants.py
+
+"""This module defines system-level constants."""
+"""Take care to minimise import in this module, to guard against circular dependency."""
+
+MKDIR = "/usr/bin/mkdir"
+RMDIR = "/usr/bin/rmdir"
+DEFAULT_MNT_DIR = "/mnt2/"
+MOUNT = "/usr/bin/mount"
+UMOUNT = "/usr/bin/umount"
+
+USERMOD = "/usr/sbin/usermod"
+
+SYSTEMCTL = "/usr/bin/systemctl"

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -35,13 +35,13 @@ from distutils.util import strtobool
 from django.conf import settings
 
 from exceptions import CommandException, NonBTRFSRootException
+from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR
 
 logger = logging.getLogger(__name__)
 
 CAT = "/usr/bin/cat"
 CHATTR = "/usr/bin/chattr"
 DD = "/usr/bin/dd"
-DEFAULT_MNT_DIR = "/mnt2/"
 DNSDOMAIN = "/usr/bin/dnsdomainname"
 EXPORTFS = "/usr/sbin/exportfs"
 GRUBBY = "/usr/sbin/grubby"
@@ -51,16 +51,11 @@ HOSTID = "/usr/bin/hostid"
 HOSTNAMECTL = "/usr/bin/hostnamectl"
 LS = "/usr/bin/ls"
 LSBLK = "/usr/bin/lsblk"
-MKDIR = "/usr/bin/mkdir"
-MOUNT = "/usr/bin/mount"
 NMCLI = "/usr/bin/nmcli"
-RMDIR = "/usr/bin/rmdir"
 SHUTDOWN = settings.SHUTDOWN
-SYSTEMCTL_BIN = "/usr/bin/systemctl"
 SYSTEMD_ESCAPE = "/usr/bin/systemd-escape"
 SYSTEMD_DIR = "/usr/lib/systemd/system"
 UDEVADM = settings.UDEVADM
-UMOUNT = "/usr/bin/umount"
 WIPEFS = "/usr/sbin/wipefs"
 RTC_WAKE_FILE = "/sys/class/rtc/rtc0/wakealarm"
 PING = "/usr/bin/ping"
@@ -1363,7 +1358,7 @@ def system_suspend():
     # This function perform system suspend to RAM via systemctl
     # while reboot and shutdown, both via shutdown command, can be delayed
     # systemctl suspend miss this option
-    return run_command([SYSTEMCTL_BIN, "suspend"])
+    return run_command([SYSTEMCTL, "suspend"])
 
 
 def clean_system_rtc_wake():
@@ -2208,7 +2203,7 @@ def update_hdparm_service(hdparm_command_list, comment):
         # our proposed systemd file is the same length as our template and so
         # contains no ExecStart lines so we disable the rockstor-hdparm
         # service.
-        out, err, rc = run_command([SYSTEMCTL_BIN, "disable", HDPARM_SERVICE_NAME])
+        out, err, rc = run_command([SYSTEMCTL, "disable", HDPARM_SERVICE_NAME])
         if rc != 0:
             return False
         # and remove our HDPARM_SERVICE_NAME file as it's absence indicates
@@ -2231,7 +2226,7 @@ def update_hdparm_service(hdparm_command_list, comment):
         # count (ie entries) is greater than the template file's line count.
         # N.B. can't use systemctl wrapper as then circular dependency ie:-
         # return systemctl('rockstor-hdparm', 'enable')
-        out, err, rc = run_command([SYSTEMCTL_BIN, "enable", HDPARM_SERVICE_NAME])
+        out, err, rc = run_command([SYSTEMCTL, "enable", HDPARM_SERVICE_NAME])
         if rc != 0:
             return False
     return True
@@ -2361,7 +2356,7 @@ def trigger_systemd_update():
     updated to freshly represent the new state of the associated config files.
     :return: o, e, rc as returned by run_command
     """
-    return run_command([SYSTEMCTL_BIN, "daemon-reload"])
+    return run_command([SYSTEMCTL, "daemon-reload"])
 
 
 def systemd_name_escape(original_sting, template=""):

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -23,11 +23,10 @@ import stat
 from tempfile import mkstemp
 
 from django.conf import settings
-
 from osi import run_command
+from system.constants import SYSTEMCTL
+from system.ssh import is_sftp_running
 
-SSHD_CONFIG = "/etc/ssh/sshd_config"
-SYSTEMCTL_BIN = "/usr/bin/systemctl"
 SUPERCTL_BIN = "{}.venv/bin/supervisorctl".format(settings.ROOT_DIR)
 SUPERVISORD_CONF = "{}etc/supervisord.conf".format(settings.ROOT_DIR)
 SSSD_FILE = "/etc/sssd/sssd.conf"
@@ -73,7 +72,7 @@ def init_service_op(service_name, command, throw=True):
     if service_name not in supported_services:
         raise Exception("unknown service: {}".format(service_name))
 
-    arg_list = [SYSTEMCTL_BIN, command, service_name]
+    arg_list = [SYSTEMCTL, command, service_name]
     if command == "status":
         arg_list.append("--lines=0")
 
@@ -97,7 +96,7 @@ def is_systemd_service_active(service_name):
 
 
 def systemctl(service_name, switch):
-    arg_list = [SYSTEMCTL_BIN, switch, service_name]
+    arg_list = [SYSTEMCTL, switch, service_name]
     if switch == "status":
         arg_list.append("--lines=0")
 
@@ -186,35 +185,23 @@ def service_status(service_name, config=None):
                     return o, e, rc
             return o, e, 1
     elif service_name == "sftp":
-        out, err, rc = init_service_op("sshd", "status", throw=False)
-        # initial check on sshd status: 0 = OK 3 = stopped
-        if rc != 0:
-            return out, err, rc
-        # sshd has sftp subsystem so we check for its config line which is
-        # inserted or deleted to enable or disable the sftp service.
-        with open(SSHD_CONFIG) as sfo:
-            for line in sfo.readlines():
-                if re.match(settings.SFTP_STR, line) is not None:
-                    return out, err, rc
-            # -1 not appropriate as inconsistent with bash return codes
-            # Returning 1 as Catchall for general errors. The calling system
-            # interprets -1 as enabled, 1 works for disabled.
-            return out, err, 1
+        # Delegate sshd's sftp subsystem status check to system.ssh.py call.
+        return is_sftp_running(return_boolean=False)
     elif service_name in ("replication", "data-collector", "ztask-daemon"):
         return superctl(service_name, "status")
     elif service_name == "smb":
         out, err, rc = run_command(
-            [SYSTEMCTL_BIN, "--lines=0", "status", "smb"], throw=False
+            [SYSTEMCTL, "--lines=0", "status", "smb"], throw=False
         )
         if rc != 0:
             return out, err, rc
-        return run_command([SYSTEMCTL_BIN, "--lines=0", "status", "nmb"], throw=False)
+        return run_command([SYSTEMCTL, "--lines=0", "status", "nmb"], throw=False)
     elif service_name == "nut":
         # Establish if nut is running by lowest common denominator nut-monitor
         # In netclient mode it is all that is required, however we don't then
         # reflect the state of the other services of nut-server and nut-driver.
         return run_command(
-            [SYSTEMCTL_BIN, "--lines=0", "status", "nut-monitor"], throw=False
+            [SYSTEMCTL, "--lines=0", "status", "nut-monitor"], throw=False
         )
     elif service_name == "active-directory":
         if config is not None:
@@ -262,7 +249,7 @@ def update_nginx(ip, port):
             if http_server is True and lines[i].strip() == "}":
                 http_server = False
     shutil.move(npath, conf)
-    run_command([SYSTEMCTL_BIN, "restart", "nginx"])
+    run_command([SYSTEMCTL, "restart", "nginx"])
 
 
 def define_avahi_service(service_name, share_names=None):

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -21,6 +21,7 @@ import os
 import re
 import platform
 import shutil
+import stat
 from shutil import move, copy
 from tempfile import mkstemp
 
@@ -88,7 +89,10 @@ def init_sftp_config(sshd_config=None):
         logger.info("SSHD - Creating new configuration file ({}).".format(sshd_config))
     # Set AllowUsers and Subsystem sftp-internal if not already in-place.
     # N.B. opening mode "a+" creates this file if it doesn't exist - rw either way.
-    with open(sshd_config, "a+") as sfo:
+    # Post Python 3, consider build-in open with custom opener.
+    with os.fdopen(
+        os.open(sshd_config, os.O_RDWR | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR), "a+"
+    ) as sfo:
         found = False
         for line in sfo.readlines():
             if (


### PR DESCRIPTION
Newer systems now establish default sshd config in /usr/etc/ssh/sshd_config; and include overrides via drop-in files in /etc/ssh/sshd_config.d/*.conf.
Accommodate these changes: initially instantiated in Tumbleweed.

Fixes #2501 

## Includes
- Establish dict of named tuple to abstract distro aware sshd config files and their paths.
- Account for distro 1.7.0 onwards re sshd config.
- Add PermitRootLogin mechanism by way of flag file. We use AllowUsers from initrock onwards. Enable the exclusion of the 'root' user via a flag file deletion mechanism.
- Establish system constants.py file. Helps to avoid circular dependencies and normalises our system variables.
- Re-factor sshd code to be centralised in ssh.py. Removes sshd knowledge requirements from services.py and initrock.py.
- Improve readability via minor renaming refactoring.
- Fix bug blocking creation of non existent sshd config files. Required as for Tumbleweed, on first build, we establish drop-in files rather than just edit the default os sshd files.
- Abstract Subsystem sftp /path/sftp-server disablement.
- Add TODO re abstraction of AllowRootLogin configuration.
- Transition existing test_sftp.py to properly use fixtures.
- Provide standardised instructions to create new fixtures, and run tests (test_sftp.py).
- Black formatted.
- Add additional mocks to avoid fs/sshd interaction. The prior sftp API tests had insufficient mocking casing unintended sshd config interactions. Fix by adding missing mocks. Facilitates the re-enablement of previously remarked out API test entries.