### PR TITLE
2540 migrate hard wired config paths re poetry build

### DIFF
--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 Rockstor, Inc. <https://rockstor.com>
+Copyright (c) 2012-2023 Rockstor, Inc. <https://rockstor.com>
 This file is part of Rockstor.
 
 Rockstor is free software; you can redistribute it and/or modify
@@ -114,19 +114,15 @@ ROCKSTOR_LEGACY_SYSTEMD_SERVICES = [
 LocalFile = namedtuple("LocalFile", "path mask services")
 LOCAL_FILES = {
     "samba_config": LocalFile(
-        path="/etc/samba/smb.conf",
-        mask=None,
-        services=["nmb", "smb"]
+        path="/etc/samba/smb.conf", mask=None, services=["nmb", "smb"]
     ),
     "rockstor_crontab": LocalFile(
-        path="/etc/cron.d/rockstortab",
-        mask=stat.S_IRUSR | stat.S_IWUSR,
-        services=None
+        path="/etc/cron.d/rockstortab", mask=stat.S_IRUSR | stat.S_IWUSR, services=None
     ),
     "replication_crontab": LocalFile(
         path="/etc/cron.d/replicationtab",
         mask=stat.S_IRUSR | stat.S_IWUSR,
-        services=None
+        services=None,
     ),
 }
 
@@ -257,6 +253,7 @@ def bootstrap_sshd_config(log):
     if conf_altered:
         logger.info("SSHD config altered, restarting service")
         run_command([SYSTEMCTL, "restart", "sshd"])
+
 
 def establish_shellinaboxd_service():
     """
@@ -427,22 +424,38 @@ def establish_poetry_paths():
             )
             if altered:
                 if LOCAL_FILES[local_file].mask is not None:
-                    logger.debug("Set {} to mask {}".format(local_file, oct(LOCAL_FILES[local_file].mask)))
+                    logger.debug(
+                        "Set {} to mask {}".format(
+                            local_file, oct(LOCAL_FILES[local_file].mask)
+                        )
+                    )
                     os.chmod(npath, LOCAL_FILES[local_file].mask)
                 else:
                     shutil.copystat(LOCAL_FILES[local_file].path, npath)
                 shutil.move(npath, LOCAL_FILES[local_file].path)
-                logger.info("The path to binaries in {} ({}) has been updated.".format(local_file, LOCAL_FILES[local_file].path))
+                logger.info(
+                    "The path to binaries in {} ({}) has been updated.".format(
+                        local_file, LOCAL_FILES[local_file].path
+                    )
+                )
                 if LOCAL_FILES[local_file].services is not None:
                     for service in LOCAL_FILES[local_file].services:
                         if services.is_systemd_service_active(service):
-                            logger.info("The {} service is currently active... restart it".format(service))
+                            logger.info(
+                                "The {} service is currently active... restart it".format(
+                                    service
+                                )
+                            )
                             run_command([SYSTEMCTL, "restart", service], log=True)
             else:
                 os.remove(npath)
                 logger.info("{} already looks good.".format(local_file))
         else:
-            logger.info("The {} ({}) could not be found".format(local_file, LOCAL_FILES[local_file].path))
+            logger.info(
+                "The {} ({}) could not be found".format(
+                    local_file, LOCAL_FILES[local_file].path
+                )
+            )
     logger.info("### DONE establishing poetry path to binaries in local files.")
 
 

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -21,16 +21,17 @@ import logging
 import os
 import re
 import shutil
+import stat
 import sys
 from tempfile import mkstemp
 
 from django.conf import settings
 
 from system import services
-from system.osi import run_command, md5sum
+from system.osi import run_command, md5sum, replace_pattern_inline
 from system.ssh import remove_sftp_server_subsystem, init_sftp_config
 from system.constants import SYSTEMCTL
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 
 
 logger = logging.getLogger(__name__)
@@ -104,6 +105,30 @@ ROCKSTOR_EXTRA_SYSTEMD_SERVICES = [
 ROCKSTOR_LEGACY_SYSTEMD_SERVICES = [
     "rockstor-ipv6check.service",  # Legacy service from pre v4.1.0-0 development.
 ]
+
+# Local files that need checking
+# path: path to file.
+# mask: use constants from the stat module to apply desired permissions to file.
+#       use None to use the current mask of the target file defined at <path>.
+# services: Python List of service(s) to restart, if any, after modifying the file.
+LocalFile = namedtuple("LocalFile", "path mask services")
+LOCAL_FILES = {
+    "samba_config": LocalFile(
+        path="/etc/samba/smb.conf",
+        mask=None,
+        services=["nmb", "smb"]
+    ),
+    "rockstor_crontab": LocalFile(
+        path="/etc/cron.d/rockstortab",
+        mask=stat.S_IRUSR | stat.S_IWUSR,
+        services=None
+    ),
+    "replication_crontab": LocalFile(
+        path="/etc/cron.d/replicationtab",
+        mask=stat.S_IRUSR | stat.S_IWUSR,
+        services=None
+    ),
+}
 
 
 def inet_addrs(interface=None):
@@ -379,6 +404,48 @@ def install_or_update_systemd_service(
     return False
 
 
+def establish_poetry_paths():
+    """Ensure path to Rockstor's binaries point to Poetry venv
+
+    Before our move to Poetry, our binaries lived in /opt/rockstor/bin.
+    After our move to Poetry, these now reside in /opt/rockstor/.venv/bin.
+    While the generation of new local files using these paths account for these
+    new paths, pre-existing files still use the non-existent old paths.
+    This function checks for these local files and changes them accordingly. If one
+    or more systemd service is associated to these files, it restarts it/them if the
+    given service(s) is/are currently active.
+    The local files in questions are defined in the LOCAL_FILES constant.
+    """
+    logger.info("### BEGIN Establishing poetry path to binaries in local files...")
+    pattern = "/opt/rockstor/bin/"
+    replacement = "/opt/rockstor/.venv/bin/"
+    for local_file in LOCAL_FILES:
+        if os.path.isfile(LOCAL_FILES[local_file].path):
+            fh, npath = mkstemp()
+            altered = replace_pattern_inline(
+                LOCAL_FILES[local_file].path, npath, pattern, replacement
+            )
+            if altered:
+                if LOCAL_FILES[local_file].mask is not None:
+                    logger.debug("Set {} to mask {}".format(local_file, oct(LOCAL_FILES[local_file].mask)))
+                    os.chmod(npath, LOCAL_FILES[local_file].mask)
+                else:
+                    shutil.copystat(LOCAL_FILES[local_file].path, npath)
+                shutil.move(npath, LOCAL_FILES[local_file].path)
+                logger.info("The path to binaries in {} ({}) has been updated.".format(local_file, LOCAL_FILES[local_file].path))
+                if LOCAL_FILES[local_file].services is not None:
+                    for service in LOCAL_FILES[local_file].services:
+                        if services.is_systemd_service_active(service):
+                            logger.info("The {} service is currently active... restart it".format(service))
+                            run_command([SYSTEMCTL, "restart", service], log=True)
+            else:
+                os.remove(npath)
+                logger.info("{} already looks good.".format(local_file))
+        else:
+            logger.info("The {} ({}) could not be found".format(local_file, LOCAL_FILES[local_file].path))
+    logger.info("### DONE establishing poetry path to binaries in local files.")
+
+
 def main():
     loglevel = logging.INFO
     if len(sys.argv) > 1 and sys.argv[1] == "-x":
@@ -558,6 +625,8 @@ def main():
     init_update_issue(logging)
 
     establish_systemd_services()
+
+    establish_poetry_paths()
 
 
 if __name__ == "__main__":

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -182,6 +182,30 @@ def append_to_line(original_file, new_file, regexes, new_content, sep, remove=Fa
                 tfo.write(line)
 
 
+def replace_pattern_inline(source_file, target_file, pattern, replacement):
+    """Replace a regex pattern with a string inline
+
+    Similar to `sed`, this function will search for the presence of the regex
+    pattern (re module) in a given line, and replace it with the `replacement`
+    string.
+
+    @param source_file: path to source file
+    @param target_file: path to target file
+    @param pattern: regex pattern
+    @param replacement: string
+    @return: boolean; True if pattern was found and replaced
+    """
+    altered = False
+    with open(source_file) as sfo, open(target_file, "w") as tfo:
+        for line in sfo.readlines():
+            if re.search(pattern, line) is not None:
+                tfo.write(re.sub(pattern, replacement, line))
+                altered = True
+            else:
+                tfo.write(line)
+    return altered
+
+
 def run_command(
     cmd,
     shell=False,

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -54,6 +54,7 @@ def init_service_op(service_name, command, throw=True):
     #  to be used in for example model properties etc, where we need only a boolean.
     supported_services = (
         "nfs-server",
+        "nmb",
         "smb",
         "sshd",
         "ypbind",


### PR DESCRIPTION
Fixes #2540 
@phillxnet, @Hooverdan96, ready for review.

As detailed in #2540, we have a few local files generated by Rockstor that refer some of our binaries with hard-coded paths. Since our move to Poetry, these binaries have moved to Poetry's local virtual environment.
These new paths have already been corrected for newly-generated "local files" (see #2476), but already existing files still refer to the now-old paths. This would result in users upgrading from a pre-Poetry RPM to a post-Poetry RPM having broken scheduled tasks, replication tasks, and Samba exports.

To fix this, this pull request (PR) proposes to check these local files at Rockstor start time and correct the paths if necessary.
It also proposes to ensure proper files permissions.

We currently have identified 3 different files affected by this issue:
- `/etc/samba/smb.conf`
- `/etc/cron.d/rockstortab`
- `/etc/cron.d/replicationtab`

# Demonstration
1. Manually edit these three files to contain the old path `/opt/rockstor/bin/<...>`
2. Simulate startup after update by triggering initrock: `poetry run initrock`
3. The paths will now show: `/opt/rockstor/.venv/bin/<...>`
If the samba service was on, for instance, it will also be detected and restarted as its configuration has changed. Note that we do not need to manually restart anything after modifying the crontabs as the system automatically detects their modification and reloads the crontabs in question:
```
May 25 14:23:01 rockdev cron[848]: (*system*) RELOAD (/etc/cron.d/rockstortab)
```

In the logs, we can see:
```
rockdev:/opt/rockstor # poetry run initrock
(...)
2023-05-25 14:22:40,779: ### BEGIN Establishing poetry path to binaries in local files...
2023-05-25 14:22:40,779: The replication_crontab (/etc/cron.d/replicationtab) could not be found
2023-05-25 14:22:40,780: The path to binaries in samba_config (/etc/samba/smb.conf) has been updated.
2023-05-25 14:22:40,786: The nmb service is currently active... restart it
2023-05-25 14:22:40,843: The smb service is currently active... restart it
2023-05-25 14:22:40,913: The path to binaries in rockstor_crontab (/etc/cron.d/rockstortab) has been updated.
2023-05-25 14:22:40,913: ### DONE establishing poetry path to binaries in local files.
```

Re-triggering `initrock` to simulate a reboot/rockstor restart and nothing is modified as it no-longer needs to be corrected:
```
rockdev:/opt/rockstor # poetry run initrock
(...)
2023-05-25 14:25:11,995: ### BEGIN Establishing poetry path to binaries in local files...
2023-05-25 14:25:11,995: The replication_crontab (/etc/cron.d/replicationtab) could not be found
2023-05-25 14:25:11,995: samba_config already looks good.
2023-05-25 14:25:11,995: rockstor_crontab already looks good.
2023-05-25 14:25:11,995: ### DONE establishing poetry path to binaries in local files.
```

Note that this was tested in Leap 15.4 only.

# Tests
```
rockdev:/opt/rockstor # cd src/rockstor/ ; poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
.............................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 253 tests in 12.521s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```
