### PR TITLE
Allow delete of un-mounted/un-mountable pool #2395

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -805,7 +805,7 @@ def umount_root(root_pool_mnt):
         if ce.rc == 32:
             for l in ce.err:
                 l = l.strip()
-                if re.search("not mounted$", l) is not None:
+                if re.search("not mounted\.$", l) is not None:
                     return
             raise ce
     for i in range(20):
@@ -1149,8 +1149,8 @@ def share_id(pool, share_name):
 
 def remove_share(pool, share_name, pqgroup, force=False):
     """
-    umount share if its mounted.
-    unsures given pool is mounted.
+    umount share if it's mounted.
+    ensures given pool is mounted.
     if force flag set then first delete all share's subvolumes.
     btrfs subvolume delete root_mnt/vol_name.
     destroy shares qgroup and associated pqgroup.

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pool_details_layout.jst
@@ -119,7 +119,9 @@
       </div>
       <div class="modal-body">
         <div class="messages"></div>
-        <h4>{{poolName}} will be deleted including it's Shares listed below and their Snapshots, NFS exports, Samba and SFTP config and Replicas. Are you sure?</h4>
+        <h4>Pool and all associated Shares, Snapshots, NFS/Samba/SFTP exports, and Replicas, will be deleted.</h4>
+        <div class="alert alert-danger">Are you sure? DATA WILL BE LOST!</div>
+        Rockstor managed Shares:
         <ul>
         {{#each share}}
         <li>{{this.name}} ({{this.size_gb}} GB)</li>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -136,7 +136,9 @@
            </div>
            <div class="modal-body">
             <div class="messages"></div>
-            <h4>{{this.name}} will be deleted including it's Shares listed below and their Snapshots, NFS exports, Samba and SFTP config and Replics. Are you sure?</h4>
+            <h4>Pool and all associated Shares, Snapshots, NFS/Samba/SFTP exports, and Replicas, will be deleted.</h4>
+            <div class="alert alert-danger">Are you sure? DATA WILL BE LOST!</div>
+            Rockstor managed Shares:
             <ul id="pool-shares"></ul>
            </div>
            <div class="modal-footer">


### PR DESCRIPTION
Fix CommandException handling to ignore report of already unmounted pool when attempting an unmount command.

Fixes #2395 

## Includes:
- Improved user facing warning re Pool Delete dialog.
- Minor comment typo.
- Avoid filesystem interaction during pool delete when:
-- pool is unmounted.
-- pool has exceeded its raid level redundancy.
- remove tangentially related exception handler on long
   removed code.

## Delete Dialog improvements:
Before:
![Delete_Pool_dialog_before_pr](https://github.com/rockstor/rockstor-core/assets/2521585/79004ccd-801b-4fcb-aa36-ecc43fa937fb)

After:
![Delete_Pool_dialog_after_pr](https://github.com/rockstor/rockstor-core/assets/2521585/b1f27758-9eb6-4ef2-855a-a663f8b154e2)

