### PR TITLE
Update pyproject.toml and poetry.lock for python 3.6 #2564

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "dbus-python"
 version = "1.2.18"
 description = "Python bindings for libdbus"
@@ -246,8 +257,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = {version = ">=3.0.2,<5", markers = "python_version < \"3\""}
-idna = {version = ">=2.5,<3", markers = "python_version < \"3\""}
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
@@ -296,8 +307,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "~2.7"
-content-hash = "97e749f2edf0ce4751638161258eaf8d34f3cfe050f255eaeb7b91b839b760c6"
+python-versions = "~3.6"
+content-hash = "945d7af6ca64e514e2cdc02a0a92ffb86c06b178cfa0cc0cfe67d7feb4ca0ae2"
 
 [metadata.files]
 certifi = [
@@ -307,6 +318,10 @@ certifi = [
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 dbus-python = [
     {file = "dbus-python-1.2.18.tar.gz", hash = "sha256:92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 2 :: Only", # at least initially
+    "Programming Language :: Python :: 3 :: Only", # at least initially
     # The "license" property should auto-invoke License classifier/classifiers.
 ]
 authors = [
@@ -55,7 +55,7 @@ generate-setup-file = false
 # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
 #
 # https://python-poetry.org/docs/1.1/dependency-specification/
-python = "~2.7"
+python = "~3.6"
 
 # [tool.poetry.group.django.dependencies]
 django = "==1.11.29"


### PR DESCRIPTION
As part of our move to Python 3 we must first establish our new python 3 dependencies via Poetry. And resolve all issues re dependencies from there on.

Deleting poetry.lock and recreating via:
```
cd /opt/rockstor
poetry lock
```
with the changes within this draft PR for discussion.

And then we see our first failure during the subsequent install/build of our stated dependencies:
```
rm -rf .venv/
poetry install

Creating virtualenv rockstor in /opt/rockstor/.venv
Installing dependencies from lock file

Package operations: 30 installs, 0 updates, 0 removals

  • Installing certifi (2021.10.8)
  • Installing charset-normalizer (2.0.12)
  • Installing greenlet (2.0.2)
  • Installing idna (2.10)
  • Installing pytz (2022.6)
  • Installing six (1.16.0)
  • Installing urllib3 (1.26.12)
  • Installing django (1.11.29)
  • Installing gevent (1.1.2): Failed

  EnvCommandError

  Command ['/opt/rockstor/.venv/bin/pip', 'install', '--no-deps', '/root/.cache/pypoetry/artifacts/2b/9a/65/69c2b29d8ba2348465126687493d4827d5553e8e1465e4d3cb94bc1043/gevent-1.1.2.tar.gz'] errored with the following return code 1, and output: 
  Processing /root/.cache/pypoetry/artifacts/2b/9a/65/69c2b29d8ba2348465126687493d4827d5553e8e1465e4d3cb94bc1043/gevent-1.1.2.tar.gz
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Building wheels for collected packages: gevent
    Building wheel for gevent (setup.py): started
    Building wheel for gevent (setup.py): finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /opt/rockstor/.venv/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-utjon_l2
         cwd: /tmp/pip-req-build-2hw6qcwc/
    Complete output (62 lines):
    running bdist_wheel
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.6
    creating build/lib.linux-x86_64-3.6/gevent
    copying gevent/__init__.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_corecffi_build.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_fileobjectcommon.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_fileobjectposix.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_semaphore.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_socket2.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_socket3.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_socketcommon.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_ssl2.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_ssl3.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_sslgte279.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_tblib.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_threading.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/_util_py2.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/backdoor.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/baseserver.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/builtins.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/core.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/corecffi.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/coros.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/event.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/fileobject.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/greenlet.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/hub.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/local.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/lock.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/monkey.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/os.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/pool.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/pywsgi.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/queue.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/resolver_ares.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/resolver_thread.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/select.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/server.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/signal.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/socket.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/ssl.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/subprocess.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/thread.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/threading.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/threadpool.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/timeout.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/util.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/win32util.py -> build/lib.linux-x86_64-3.6/gevent
    copying gevent/wsgi.py -> build/lib.linux-x86_64-3.6/gevent
    running build_ext
    Running '(cd  "/tmp/pip-req-build-2hw6qcwc/libev"  && /bin/sh ./configure   && cp config.h "$OLDPWD" ) > configure-output.txt' in /tmp/pip-req-build-2hw6qcwc/build/temp.linux-x86_64-3.6/libev
    building 'gevent.corecext' extension
    creating build/temp.linux-x86_64-3.6/gevent
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -DOPENSSL_LOAD_CONF -fwrapv -fno-semantic-interposition -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -fPIC -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.linux-x86_64-3.6/libev -Ilibev -I/opt/rockstor/.venv/include -I/usr/include/python3.6m -c gevent/gevent.corecext.c -o build/temp.linux-x86_64-3.6/gevent/gevent.corecext.o
    gevent/gevent.corecext.c:5:10: fatal error: Python.h: No such file or directory
     #include "Python.h"
              ^~~~~~~~~~
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
    ERROR: Failed building wheel for gevent
    Running setup.py clean for gevent
  Failed to build gevent
  Installing collected packages: gevent
      Running setup.py install for gevent: started
      Running setup.py install for gevent: finished with status 'error'
      ERROR: Command errored out with exit status 1:
       command: /opt/rockstor/.venv/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-139zzw30/install-record.txt --single-version-externally-managed --compile --install-headers /opt/rockstor/.venv/include/site/python3.6/gevent
           cwd: /tmp/pip-req-build-2hw6qcwc/
      Complete output (15 lines):
      running install
      /opt/rockstor/.venv/lib/python3.6/site-packages/setuptools/command/install.py:37: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        setuptools.SetuptoolsDeprecationWarning,
      running build
      running build_py
      running build_ext
      Running '(cd  "/tmp/pip-req-build-2hw6qcwc/libev"  && /bin/sh ./configure   && cp config.h "$OLDPWD" ) > configure-output.txt' in /tmp/pip-req-build-2hw6qcwc/build/temp.linux-x86_64-3.6/libev
      building 'gevent.corecext' extension
      creating build/temp.linux-x86_64-3.6/gevent
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -DOPENSSL_LOAD_CONF -fwrapv -fno-semantic-interposition -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -fPIC -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.linux-x86_64-3.6/libev -Ilibev -I/opt/rockstor/.venv/include -I/usr/include/python3.6m -c gevent/gevent.corecext.c -o build/temp.linux-x86_64-3.6/gevent/gevent.corecext.o
      gevent/gevent.corecext.c:5:10: fatal error: Python.h: No such file or directory
       #include "Python.h"
                ^~~~~~~~~~
      compilation terminated.
      error: command 'gcc' failed with exit status 1
      ----------------------------------------
  ERROR: Command errored out with exit status 1: /opt/rockstor/.venv/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-2hw6qcwc/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-139zzw30/install-record.txt --single-version-externally-managed --compile --install-headers /opt/rockstor/.venv/include/site/python3.6/gevent Check the logs for full command output.
  

  at ~/.local/share/pypoetry/venv/lib64/python3.6/site-packages/poetry/utils/env.py:1195 in _run
      1191│                 output = subprocess.check_output(
      1192│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1193│                 )
      1194│         except CalledProcessError as e:
    → 1195│             raise EnvCommandError(e, input=input_)
      1196│ 
      1197│         return decode(output)
      1198│ 
      1199│     def execute(self, bin, *args, **kwargs):

  • Installing oauthlib (3.1.0)
  • Installing python-engineio (2.3.2)
  • Installing requests (2.27.1)
```

As expected and detailed in our ongoing issue #1877 
comment: https://github.com/rockstor/rockstor-core/issues/1877#issuecomment-1097037208

We have a blocker of gevent!