### PR TITLE
Preliminary python 3.6 port - development #2564

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,12 +7,26 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "chardet"
-version = "4.0.0"
-description = "Universal encoding detector for Python 2 and 3"
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "dbus-python"
@@ -84,18 +98,28 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "gevent"
-version = "1.1.2"
-description = "Coroutine-based network library (python 2.6 - 3.5)"
+version = "22.10.2"
+description = "Coroutine-based network library"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5"
 
 [package.dependencies]
-greenlet = ">=0.4.9"
+cffi = {version = ">=1.12.2", markers = "platform_python_implementation == \"CPython\" and sys_platform == \"win32\""}
+greenlet = {version = ">=2.0.0", markers = "platform_python_implementation == \"CPython\""}
+"zope.event" = "*"
+"zope.interface" = "*"
+
+[package.extras]
+dnspython = ["dnspython (>=1.16.0,<2.0)", "idna"]
+docs = ["repoze.sphinx.autointerface", "sphinxcontrib-programoutput", "zope.schema"]
+monitor = ["psutil (>=5.7.0)"]
+recommended = ["backports.socketpair", "cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "psutil (>=5.7.0)", "selectors2"]
+test = ["backports.socketpair", "cffi (>=1.12.2)", "contextvars (==2.4)", "coverage (>=5.0)", "coveralls (>=1.7.0)", "dnspython (>=1.16.0,<2.0)", "futures", "idna", "mock", "objgraph", "psutil (>=5.7.0)", "requests", "selectors2"]
 
 [[package]]
 name = "gevent-websocket"
-version = "0.9.5"
+version = "0.10.1"
 description = "Websocket handler for the gevent pywsgi server, a Python network library"
 category = "main"
 optional = false
@@ -198,6 +222,14 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "python-engineio"
 version = "2.3.2"
 description = "Engine.IO server"
@@ -246,8 +278,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = {version = ">=3.0.2,<5", markers = "python_version < \"3\""}
-idna = {version = ">=2.5,<3", markers = "python_version < \"3\""}
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
@@ -294,19 +326,110 @@ category = "main"
 optional = false
 python-versions = "*"
 
+[[package]]
+name = "zope.event"
+version = "4.6"
+description = "Very basic event publishing system"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+docs = ["sphinx"]
+test = ["zope.testrunner"]
+
+[[package]]
+name = "zope.interface"
+version = "5.5.2"
+description = "Interfaces for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+docs = ["repoze.sphinx.autointerface", "sphinx"]
+test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
+testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
+
 [metadata]
 lock-version = "1.1"
-python-versions = "~2.7"
-content-hash = "97e749f2edf0ce4751638161258eaf8d34f3cfe050f255eaeb7b91b839b760c6"
+python-versions = "~3.6"
+content-hash = "aa199b53bd2082841064a9f14317b49e81d89578c29e04925462600ff774fcdc"
 
 [metadata.files]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
-chardet = [
-    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
-    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 dbus-python = [
     {file = "dbus-python-1.2.18.tar.gz", hash = "sha256:92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"},
@@ -336,35 +459,62 @@ djangorestframework = [
     {file = "djangorestframework-3.9.3.tar.gz", hash = "sha256:2884763160b997073ff1e937bd820a69d23978902a3ccd0ba53a217e196239f0"},
 ]
 gevent = [
-    {file = "gevent-1.1.2-cp26-cp26m-macosx_10_11_intel.whl", hash = "sha256:ca934dc30f26e84c79e483db4de433702283ff02344d029635730ff9e7c1d416"},
-    {file = "gevent-1.1.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:f42de31de5f29a11f5480f76c05f3afce80e030333295718efd64bfb823e4e82"},
-    {file = "gevent-1.1.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:a24fb153e3c65d025c065b140e39998d483d4df6887b02503ba66debf32b49d6"},
-    {file = "gevent-1.1.2-cp27-cp27m-win32.whl", hash = "sha256:a51f414f22f31a110823ff0365cb088dc3317a06227c85033d8523dd619ada72"},
-    {file = "gevent-1.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:a4ce00048808d3c2ee7e8c83860595b0d2090724770e499056aec1c8947bd2d1"},
-    {file = "gevent-1.1.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d072a29ca28bb84d9433434e2675c44ca29635c0aa0ed51b1eecf216991fd204"},
-    {file = "gevent-1.1.2-cp33-cp33m-manylinux1_x86_64.whl", hash = "sha256:2cb985038826eb353f5759dda2ec7bca581abf4e5c2e90b95ddb5d976dc785e6"},
-    {file = "gevent-1.1.2-cp33-cp33m-win32.whl", hash = "sha256:9ce82526317a1279de2997e5da2744342ff0bd1459a14d75e749350966ae1e17"},
-    {file = "gevent-1.1.2-cp33-cp33m-win_amd64.whl", hash = "sha256:2af2b6eae04ccfa0766a135c31056c92a127ebcb172858880d8309a9e57f52d8"},
-    {file = "gevent-1.1.2-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:bd0c6dcc30ec8014426e61a2cc429c7fcbcc26bd7b682bd590d31fce2d2bd843"},
-    {file = "gevent-1.1.2-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:720574505391b0f0817b092edfcbb97938d6d407ce912444a92267dab763eb8e"},
-    {file = "gevent-1.1.2-cp34-cp34m-win32.whl", hash = "sha256:7188cbec74276e42ea0671ad479e4209f9f12d82bc542d21217a09f759e647e3"},
-    {file = "gevent-1.1.2-cp34-cp34m-win_amd64.whl", hash = "sha256:c7f86e297b8ffff7e101993980062f053ebda92ed8c40ab3a9c53c50ff9ef408"},
-    {file = "gevent-1.1.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:26a622ad8da282b0fea17f3800bfc4eae9be89a53c22ffba5a2b357278b8f8e8"},
-    {file = "gevent-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:4552cc8ffefd4c5301ba75ac2720befb0001bc134e4e8c28475e96992e513300"},
-    {file = "gevent-1.1.2-cp35-cp35m-win32.whl", hash = "sha256:468bc2aea02aa1963bd0c73803f0378530f60af8fc93a576d0ca79285d60e833"},
-    {file = "gevent-1.1.2-cp35-cp35m-win_amd64.whl", hash = "sha256:58bdc8d1ca56e3dab833c2e2098a9afa98d0ff0f738c63e896138289c2a08b5e"},
-    {file = "gevent-1.1.2-pp253-pypy_41-macosx_10_11_x86_64.whl", hash = "sha256:3963faca1c5e175fdcfeec3ee7116f3d8082be2f94e096871e9b08da10fa4c25"},
-    {file = "gevent-1.1.2.tar.gz", hash = "sha256:cb15cf73d69a2eeefed330858f09634e2c50bf46da9f9e7635730fcfb872c02c"},
-    {file = "gevent-1.1.2.win-amd64-py2.7.exe", hash = "sha256:911ebb03dee09e841d0f7ee367b1b8380f8918b3e30c3a822bc41599ae74d2a3"},
-    {file = "gevent-1.1.2.win-amd64-py3.3.exe", hash = "sha256:f403a6b18b3cdb6de4c0140711de690071783433cd0f325c9e46c585497e580c"},
-    {file = "gevent-1.1.2.win-amd64-py3.4.exe", hash = "sha256:3c43de92658eb4723572cd7e543340943e96bf4666f92a819d36f93653c39d15"},
-    {file = "gevent-1.1.2.win-amd64-py3.5.exe", hash = "sha256:2feb3fddc0240373bfc0176d7625cb667132beef18009bf7101216baafd136e9"},
-    {file = "gevent-1.1.2.win32-py2.7.exe", hash = "sha256:2f578b4469cbd2c5a59f353dacb81f8435b54afe4ec706c6155900aff39e8a12"},
-    {file = "gevent-1.1.2.win32-py3.4.exe", hash = "sha256:7d8e8ff35decff1c70fd55959e74e5067505862828d875250a840d8031bf48c2"},
-    {file = "gevent-1.1.2.win32-py3.5.exe", hash = "sha256:192439e55f6f99215ba98f95c53cf990b8380858d195d8c84ad60eb55ef4161b"},
+    {file = "gevent-22.10.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:97cd42382421779f5d82ec5007199e8a84aa288114975429e4fd0a98f2290f10"},
+    {file = "gevent-22.10.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:1e1286a76f15b5e15f1e898731d50529e249529095a032453f2c101af3fde71c"},
+    {file = "gevent-22.10.2-cp27-cp27m-win32.whl", hash = "sha256:59b47e81b399d49a5622f0f503c59f1ce57b7705306ea0196818951dfc2f36c8"},
+    {file = "gevent-22.10.2-cp27-cp27m-win_amd64.whl", hash = "sha256:1d543c9407a1e4bca11a8932916988cfb16de00366de5bf7bc9e7a3f61e60b18"},
+    {file = "gevent-22.10.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4e2f008c82dc54ec94f4de12ca6feea60e419babb48ec145456907ae61625aa4"},
+    {file = "gevent-22.10.2-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:990d7069f14dc40674e0d5cb43c68fd3bad8337048613b9bb94a0c4180ffc176"},
+    {file = "gevent-22.10.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f23d0997149a816a2a9045af29c66f67f405a221745b34cefeac5769ed451db8"},
+    {file = "gevent-22.10.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b43d500d7d3c0e03070dee813335bb5315215aa1cf6a04c61093dfdd718640b3"},
+    {file = "gevent-22.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b68f4c9e20e47ad49fe797f37f91d5bbeace8765ce2707f979a8d4ec197e4d"},
+    {file = "gevent-22.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1f001cac0ba8da76abfeb392a3057f81fab3d67cc916c7df8ea977a44a2cc989"},
+    {file = "gevent-22.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:3b7eae8a0653ba95a224faaddf629a913ace408edb67384d3117acf42d7dcf89"},
+    {file = "gevent-22.10.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8f2477e7b0a903a01485c55bacf2089110e5f767014967ba4b287ff390ae2638"},
+    {file = "gevent-22.10.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ddaa3e310a8f1a45b5c42cf50b54c31003a3028e7d4e085059090ea0e7a5fddd"},
+    {file = "gevent-22.10.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:98bc510e80f45486ef5b806a1c305e0e89f0430688c14984b0dbdec03331f48b"},
+    {file = "gevent-22.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:877abdb3a669576b1d51ce6a49b7260b2a96f6b2424eb93287e779a3219d20ba"},
+    {file = "gevent-22.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d21ad79cca234cdbfa249e727500b0ddcbc7adfff6614a96e6eaa49faca3e4f2"},
+    {file = "gevent-22.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e955238f59b2947631c9782a713280dd75884e40e455313b5b6bbc20b92ff73"},
+    {file = "gevent-22.10.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5aa99e4882a9e909b4756ee799c6fa0f79eb0542779fad4cc60efa23ec1b2aa8"},
+    {file = "gevent-22.10.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:d82081656a5b9a94d37c718c8646c757e1617e389cdc533ea5e6a6f0b8b78545"},
+    {file = "gevent-22.10.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f4bfd74c178351a4a05c5c7df6f8a0a279ff6f392b57608ce0e83c768207f9"},
+    {file = "gevent-22.10.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ff3796692dff50fec2f381b9152438b221335f557c4f9b811f7ded51b7a25a1"},
+    {file = "gevent-22.10.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f01c9adbcb605364694b11dcd0542ec468a29ac7aba2fb5665dc6caf17ba4d7e"},
+    {file = "gevent-22.10.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:9d85574eb729f981fea9a78998725a06292d90a3ed50ddca74530c3148c0be41"},
+    {file = "gevent-22.10.2-cp36-cp36m-win32.whl", hash = "sha256:8c192d2073e558e241f0b592c1e2b34127a4481a5be240cad4796533b88b1a98"},
+    {file = "gevent-22.10.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a2237451c721a0f874ef89dbb4af4fdc172b76a964befaa69deb15b8fff10f49"},
+    {file = "gevent-22.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:53ee7f170ed42c7561fe8aff5d381dc9a4124694e70580d0c02fba6aafc0ea37"},
+    {file = "gevent-22.10.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:96c56c280e3c43cfd075efd10b250350ed5ffd3c1514ec99a080b1b92d7c8374"},
+    {file = "gevent-22.10.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c144e08dfad4106effc043a026e5d0c0eff6ad031904c70bf5090c63f3a6a7"},
+    {file = "gevent-22.10.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:018f93de7d5318d2fb440f846839a4464738468c3476d5c9cf7da45bb71c18bd"},
+    {file = "gevent-22.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7ed2346eb9dc4344f9cb0d7963ce5b74fe16fdd031a2809bb6c2b6eba7ebcd5"},
+    {file = "gevent-22.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:84c517e33ed604fa06b7d756dc0171169cc12f7fdd68eb7b17708a62eebf4516"},
+    {file = "gevent-22.10.2-cp37-cp37m-win32.whl", hash = "sha256:4114f0f439f0b547bb6f1d474fee99ddb46736944ad2207cef3771828f6aa358"},
+    {file = "gevent-22.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:0d581f22a5be6281b11ad6309b38b18f0638cf896931223cbaa5adb904826ef6"},
+    {file = "gevent-22.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2929377c8ebfb6f4d868d161cd8de2ea6b9f6c7a5fcd4f78bcd537319c16190b"},
+    {file = "gevent-22.10.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:efc003b6c1481165af61f0aeac248e0a9ac8d880bb3acbe469b448674b2d5281"},
+    {file = "gevent-22.10.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db562a8519838bddad0c439a2b12246bab539dd50e299ea7ff3644274a33b6a5"},
+    {file = "gevent-22.10.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1472012493ca1fac103f700d309cb6ef7964dcdb9c788d1768266e77712f5e49"},
+    {file = "gevent-22.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c04ee32c11e9fcee47c1b431834878dc987a7a2cc4fe126ddcae3bad723ce89"},
+    {file = "gevent-22.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8729129edef2637a8084258cb9ec4e4d5ca45d97ac77aa7a6ff19ccb530ab731"},
+    {file = "gevent-22.10.2-cp38-cp38-win32.whl", hash = "sha256:ae90226074a6089371a95f20288431cd4b3f6b0b096856afd862e4ac9510cddd"},
+    {file = "gevent-22.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:494c7f29e94df9a1c3157d67bb7edfa32a46eed786e04d9ee68d39f375e30001"},
+    {file = "gevent-22.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:58898dbabb5b11e4d0192aae165ad286dc6742c543e1be9d30dc82753547c508"},
+    {file = "gevent-22.10.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:4197d423e198265eef39a0dea286ef389da9148e070310f34455ecee8172c391"},
+    {file = "gevent-22.10.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da4183f0b9d9a1e25e1758099220d32c51cc2c6340ee0dea3fd236b2b37598e4"},
+    {file = "gevent-22.10.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5488eba6a568b4d23c072113da4fc0feb1b5f5ede7381656dc913e0d82204e2"},
+    {file = "gevent-22.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:319d8b1699b7b8134de66d656cd739b308ab9c45ace14d60ae44de7775b456c9"},
+    {file = "gevent-22.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f3329bedbba4d3146ae58c667e0f9ac1e6f1e1e6340c7593976cdc60aa7d1a47"},
+    {file = "gevent-22.10.2-cp39-cp39-win32.whl", hash = "sha256:172caa66273315f283e90a315921902cb6549762bdcb0587fd60cb712a9d6263"},
+    {file = "gevent-22.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:323b207b281ba0405fea042067fa1a61662e5ac0d574ede4ebbda03efd20c350"},
+    {file = "gevent-22.10.2-pp27-pypy_73-win_amd64.whl", hash = "sha256:ed7f16613eebf892a6a744d7a4a8f345bc6f066a0ff3b413e2479f9c0a180193"},
+    {file = "gevent-22.10.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:a47a4e77e2bc668856aad92a0b8de7ee10768258d93cd03968e6c7ba2e832f76"},
+    {file = "gevent-22.10.2.tar.gz", hash = "sha256:1ca01da176ee37b3527a2702f7d40dbc9ffb8cfc7be5a03bfa4f9eec45e55c46"},
 ]
 gevent-websocket = [
-    {file = "gevent-websocket-0.9.5.tar.gz", hash = "sha256:0091d6e6aa7298510cadcccb8068e1097a50d4e19090d0c055a93068d4530056"},
+    {file = "gevent-websocket-0.10.1.tar.gz", hash = "sha256:7eaef32968290c9121f7c35b973e2cc302ffb076d018c9068d2f5ca8b2d85fb0"},
+    {file = "gevent_websocket-0.10.1-py3-none-any.whl", hash = "sha256:17b67d91282f8f4c973eba0551183fc84f56f1c90c8f6b6b30256f31f66f5242"},
 ]
 greenlet = [
     {file = "greenlet-2.0.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d"},
@@ -483,6 +633,10 @@ psycopg2 = [
     {file = "psycopg2-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:d5062ae50b222da28253059880a871dc87e099c25cb68acf613d9d227413d6f7"},
     {file = "psycopg2-2.8.6.tar.gz", hash = "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"},
 ]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 python-engineio = [
     {file = "python-engineio-2.3.2.tar.gz", hash = "sha256:871f4d022eb9171e380281266ba2aef0759b264ba862350bc94e7a597a98a443"},
     {file = "python_engineio-2.3.2-py2.py3-none-any.whl", hash = "sha256:306a91fda59e3678b34755f475ff6b5b3dc0deb0272a23e213f2f259b5602c4c"},
@@ -546,4 +700,46 @@ urllib3 = [
 ]
 urlobject = [
     {file = "URLObject-2.1.1.tar.gz", hash = "sha256:06462b6ab3968e7be99442a0ecaf20ac90fdf0c50dca49126019b7bf803b1d17"},
+]
+"zope.event" = [
+    {file = "zope.event-4.6-py2.py3-none-any.whl", hash = "sha256:73d9e3ef750cca14816a9c322c7250b0d7c9dbc337df5d1b807ff8d3d0b9e97c"},
+    {file = "zope.event-4.6.tar.gz", hash = "sha256:81d98813046fc86cc4136e3698fee628a3282f9c320db18658c21749235fce80"},
+]
+"zope.interface" = [
+    {file = "zope.interface-5.5.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:a2ad597c8c9e038a5912ac3cf166f82926feff2f6e0dabdab956768de0a258f5"},
+    {file = "zope.interface-5.5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:65c3c06afee96c654e590e046c4a24559e65b0a87dbff256cd4bd6f77e1a33f9"},
+    {file = "zope.interface-5.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d514c269d1f9f5cd05ddfed15298d6c418129f3f064765295659798349c43e6f"},
+    {file = "zope.interface-5.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5334e2ef60d3d9439c08baedaf8b84dc9bb9522d0dacbc10572ef5609ef8db6d"},
+    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc26c8d44472e035d59d6f1177eb712888447f5799743da9c398b0339ed90b1b"},
+    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:17ebf6e0b1d07ed009738016abf0d0a0f80388e009d0ac6e0ead26fc162b3b9c"},
+    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f98d4bd7bbb15ca701d19b93263cc5edfd480c3475d163f137385f49e5b3a3a7"},
+    {file = "zope.interface-5.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:696f3d5493eae7359887da55c2afa05acc3db5fc625c49529e84bd9992313296"},
+    {file = "zope.interface-5.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7579960be23d1fddecb53898035a0d112ac858c3554018ce615cefc03024e46d"},
+    {file = "zope.interface-5.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:765d703096ca47aa5d93044bf701b00bbce4d903a95b41fff7c3796e747b1f1d"},
+    {file = "zope.interface-5.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e945de62917acbf853ab968d8916290548df18dd62c739d862f359ecd25842a6"},
+    {file = "zope.interface-5.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:655796a906fa3ca67273011c9805c1e1baa047781fca80feeb710328cdbed87f"},
+    {file = "zope.interface-5.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:0fb497c6b088818e3395e302e426850f8236d8d9f4ef5b2836feae812a8f699c"},
+    {file = "zope.interface-5.5.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:008b0b65c05993bb08912f644d140530e775cf1c62a072bf9340c2249e613c32"},
+    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:404d1e284eda9e233c90128697c71acffd55e183d70628aa0bbb0e7a3084ed8b"},
+    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3218ab1a7748327e08ef83cca63eea7cf20ea7e2ebcb2522072896e5e2fceedf"},
+    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d169ccd0756c15bbb2f1acc012f5aab279dffc334d733ca0d9362c5beaebe88e"},
+    {file = "zope.interface-5.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:e1574980b48c8c74f83578d1e77e701f8439a5d93f36a5a0af31337467c08fcf"},
+    {file = "zope.interface-5.5.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:0217a9615531c83aeedb12e126611b1b1a3175013bbafe57c702ce40000eb9a0"},
+    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:311196634bb9333aa06f00fc94f59d3a9fddd2305c2c425d86e406ddc6f2260d"},
+    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6373d7eb813a143cb7795d3e42bd8ed857c82a90571567e681e1b3841a390d16"},
+    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:959697ef2757406bff71467a09d940ca364e724c534efbf3786e86eee8591452"},
+    {file = "zope.interface-5.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dbaeb9cf0ea0b3bc4b36fae54a016933d64c6d52a94810a63c00f440ecb37dd7"},
+    {file = "zope.interface-5.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604cdba8f1983d0ab78edc29aa71c8df0ada06fb147cea436dc37093a0100a4e"},
+    {file = "zope.interface-5.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e74a578172525c20d7223eac5f8ad187f10940dac06e40113d62f14f3adb1e8f"},
+    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0980d44b8aded808bec5059018d64692f0127f10510eca71f2f0ace8fb11188"},
+    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6e972493cdfe4ad0411fd9abfab7d4d800a7317a93928217f1a5de2bb0f0d87a"},
+    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9d783213fab61832dbb10d385a319cb0e45451088abd45f95b5bb88ed0acca1a"},
+    {file = "zope.interface-5.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:a16025df73d24795a0bde05504911d306307c24a64187752685ff6ea23897cb0"},
+    {file = "zope.interface-5.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:40f4065745e2c2fa0dff0e7ccd7c166a8ac9748974f960cd39f63d2c19f9231f"},
+    {file = "zope.interface-5.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8a2ffadefd0e7206adc86e492ccc60395f7edb5680adedf17a7ee4205c530df4"},
+    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d692374b578360d36568dd05efb8a5a67ab6d1878c29c582e37ddba80e66c396"},
+    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4087e253bd3bbbc3e615ecd0b6dd03c4e6a1e46d152d3be6d2ad08fbad742dcc"},
+    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fb68d212efd057596dee9e6582daded9f8ef776538afdf5feceb3059df2d2e7b"},
+    {file = "zope.interface-5.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:7e66f60b0067a10dd289b29dceabd3d0e6d68be1504fc9d0bc209cf07f56d189"},
+    {file = "zope.interface-5.5.2.tar.gz", hash = "sha256:bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 2 :: Only", # at least initially
+    "Programming Language :: Python :: 3 :: Only", # at least initially
     # The "license" property should auto-invoke License classifier/classifiers.
 ]
 authors = [
@@ -55,7 +55,7 @@ generate-setup-file = false
 # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
 #
 # https://python-poetry.org/docs/1.1/dependency-specification/
-python = "~2.7"
+python = "~3.6"
 
 # [tool.poetry.group.django.dependencies]
 django = "==1.11.29"
@@ -70,14 +70,13 @@ dbus-python = "==1.2.18"
 # N.B. officially Django >= 2.2.1 is required for psycopg2 >= 2.8
 psycopg2 = "==2.8.6"  # last Python 2.7 version, PostgreSQL 13 errorcodes map?
 psycogreen = "==1.0"
-gevent = "==1.1.2"
-gevent-websocket = "==0.9.5"
+gevent = "*"  # can be an extra dependency to gunicorn.
+gevent-websocket = "*"
 # Python WSGI HTTP Server - 20.0 (2019/10/30) dropped Python 2.7.
 gunicorn = "==19.10.0"  # buildout previously used 19.7.1
 
 # [tool.poetry.group.requests.dependencies]
 requests = "==2.27.1"  # Last Python 2/3 version, requires chardet
-chardet = "==4.0.0"  # 5.0.0 requires Python3.
 idna = "==2.10"  # Requests (2.27.1) requires idna<3,>=2.5
 certifi = "==2021.10.8"  # Requests (2.27.1) requires certifi>=2017.4.17
 urllib3 = "==1.26.12"  # Requests (2.27.1) requires urllib3<1.27,>=1.21.1

--- a/src/rockstor/cli/__init__.py
+++ b/src/rockstor/cli/__init__.py
@@ -1,1 +1,1 @@
-from api_wrapper import APIWrapper  # noqa F401
+from cli.api_wrapper import APIWrapper  # noqa F401

--- a/src/rockstor/cli/rest_util.py
+++ b/src/rockstor/cli/rest_util.py
@@ -23,7 +23,7 @@ import json
 import base64
 from storageadmin.exceptions import RockStorAPIException
 from functools import wraps
-from base_console import BaseConsole
+from cli.base_console import BaseConsole
 from storageadmin.models import OauthApp
 from django.conf import settings
 

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -33,7 +33,7 @@ from system.osi import (
 )
 from system.exceptions import CommandException
 from system.constants import MOUNT, UMOUNT, RMDIR, DEFAULT_MNT_DIR
-from pool_scrub import PoolScrub
+from fs.pool_scrub import PoolScrub
 from huey.contrib.djhuey import task
 from django.conf import settings
 import logging

--- a/src/rockstor/rest_framework_custom/__init__.py
+++ b/src/rockstor/rest_framework_custom/__init__.py
@@ -16,5 +16,5 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from generic_view import GenericView  # noqa F401
-from renderers import IgnoreClient  # noqa F401
+from rest_framework_custom.generic_view import GenericView  # noqa F401
+from rest_framework_custom.renderers import IgnoreClient  # noqa F401

--- a/src/rockstor/rest_framework_custom/generic_view.py
+++ b/src/rockstor/rest_framework_custom/generic_view.py
@@ -21,7 +21,7 @@ from rest_framework.authentication import (BasicAuthentication,
                                            SessionAuthentication,)
 from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
-from oauth_wrapper import RockstorOAuth2Authentication
+from rest_framework_custom.oauth_wrapper import RockstorOAuth2Authentication
 from contextlib import contextmanager
 from storageadmin.util import handle_exception
 from storageadmin.exceptions import RockStorAPIException

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -426,15 +426,6 @@ TASK_SCHEDULER = {
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 
-# Setup OS specific command paths via 'which cmd' calls
-# N.B. this method will not work with an alias, ie in CentOS
-# which ls
-# alias ls='ls --color=auto'
-#         /usr/bin/ls
-# The following have been tested in CentOS, openSUSE Leap15, and Tumbleweed
-UDEVADM = subprocess.check_output(["which", "udevadm"]).rstrip()
-SHUTDOWN = subprocess.check_output(["which", "shutdown"]).rstrip()
-
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.
 # Examples given are for CentOS Rockstor variant, Leap 15, and Tumblweed.

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 # Django settings for Rockstor project.
 import os
-import subprocess, distro
+import distro
 from huey import SqliteHuey
 
 DEBUG = False
@@ -317,7 +317,7 @@ strictly required by btrfs. Similarly the maximum is 2^64 bytes which is more th
 enough for all practical purposes and also is the max allowed in btrfs.
 """
 MIN_SHARE_SIZE = 100
-MAX_SHARE_SIZE = 18014398509481984L
+MAX_SHARE_SIZE = 18014398509481984
 
 START_UID = 5000
 END_UID = 6000

--- a/src/rockstor/smart_manager/models/__init__.py
+++ b/src/rockstor/smart_manager/models/__init__.py
@@ -16,23 +16,23 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from cpu_metric import CPUMetric  # noqa E501
-from disk_stat import DiskStat  # noqa E501
-from load_avg import LoadAvg  # noqa E501
-from mem_info import MemInfo  # noqa E501
-from vm_stat import VmStat  # noqa E501
-from service import Service, ServiceStatus  # noqa E501
-from sprobe import SProbe  # noqa E501
-from nfsd import NFSDCallDistribution, NFSDClientDistribution  # noqa E501  # noqa E501
-from nfsd_share import NFSDShareDistribution  # noqa E501
-from pool_usage import PoolUsage  # noqa E501
-from net_stat import NetStat  # noqa E501
-from nfsd_share_client import NFSDShareClientDistribution  # noqa E501
-from share_usage import ShareUsage  # noqa E501
-from nfsd_uid_gid import NFSDUidGidDistribution  # noqa E501
-from task_def import TaskDefinition  # noqa E501
-from task import Task  # noqa E501
-from share_replication import (
+from smart_manager.models.cpu_metric import CPUMetric  # noqa E501
+from smart_manager.models.disk_stat import DiskStat  # noqa E501
+from smart_manager.models.load_avg import LoadAvg  # noqa E501
+from smart_manager.models.mem_info import MemInfo  # noqa E501
+from smart_manager.models.vm_stat import VmStat  # noqa E501
+from smart_manager.models.service import Service, ServiceStatus  # noqa E501
+from smart_manager.models.sprobe import SProbe  # noqa E501
+from smart_manager.models.nfsd import NFSDCallDistribution, NFSDClientDistribution  # noqa E501  # noqa E501
+from smart_manager.models.nfsd_share import NFSDShareDistribution  # noqa E501
+from smart_manager.models.pool_usage import PoolUsage  # noqa E501
+from smart_manager.models.net_stat import NetStat  # noqa E501
+from smart_manager.models.nfsd_share_client import NFSDShareClientDistribution  # noqa E501
+from smart_manager.models.share_usage import ShareUsage  # noqa E501
+from smart_manager.models.nfsd_uid_gid import NFSDUidGidDistribution  # noqa E501
+from smart_manager.models.task_def import TaskDefinition  # noqa E501
+from smart_manager.models.task import Task  # noqa E501
+from smart_manager.models.share_replication import (
     Replica,
     ReplicaTrail,
     ReplicaShare,  # noqa E501

--- a/src/rockstor/smart_manager/views/__init__.py
+++ b/src/rockstor/smart_manager/views/__init__.py
@@ -15,43 +15,43 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-from sprobes import SProbeView  # noqa E501
-from mem_info import MemInfoView  # noqa E501
-from net_stat import NetStatView  # noqa E501
-from disk_stat import DiskStatView  # noqa E501
-from nfs_distrib import NFSDistribView  # noqa E501
-from nfs_client_distrib import NFSDClientDistribView  # noqa E501
-from nfs_share_distrib import NFSDShareDistribView  # noqa E501
-from nfs_share_client_distrib import NFSDShareClientDistribView  # noqa E501
-from cpu_util import CPUMetricView  # noqa E501
-from nfs_uid_gid import NFSDUidGidDistributionView  # noqa E501
-from load_avg import LoadAvgView  # noqa E501
-from sprobe_metadata import SProbeMetadataView, SProbeMetadataDetailView  # noqa E501
-from base_service import BaseServiceView, BaseServiceDetailView  # noqa E501
-from nis_service import NISServiceView  # noqa E501
-from samba_service import SambaServiceView  # noqa E501
-from nfs_service import NFSServiceView  # noqa E501
-from replication import ReplicaListView, ReplicaDetailView  # noqa E501
-from replica_trail import ReplicaTrailListView, ReplicaTrailDetailView  # noqa E501
-from replication_service import ReplicationServiceView  # noqa E501
-from ntp_service import NTPServiceView  # noqa E501
-from ldap_service import LdapServiceView  # noqa E501
-from sftp_service import SFTPServiceView  # noqa E501
-from tasktypes import TaskTypeView  # noqa E501
-from task_scheduler import TaskSchedulerListView, TaskSchedulerDetailView  # noqa E501
-from task_log import TaskLogView  # noqa E501
-from replica_share import ReplicaShareListView, ReplicaShareDetailView  # noqa E501
-from receive_trail import ReceiveTrailListView, ReceiveTrailDetailView  # noqa E501
-from ts_service import TaskSchedulerServiceView  # noqa E501
-from dc_service import DataCollectorServiceView  # noqa E501
-from sm_service import ServiceMonitorView  # noqa E501
-from snmp_service import SNMPServiceView  # noqa E501
-from docker_service import DockerServiceView  # noqa E501
-from smartd_service import SMARTDServiceView  # noqa E501
-from nut_service import NUTServiceView  # noqa E501
-from active_directory import ActiveDirectoryServiceView  # noqa E501
-from receiver_pools import ReceiverPoolListView  # noqa E501
-from ztaskd_service import ZTaskdServiceView  # noqa E501
-from bootstrap_service import BootstrapServiceView  # noqa E501
-from shellinaboxd_service import ShellInABoxServiceView  # noqa E501
-from rockstor_service import RockstorServiceView  # noqa E501
+from smart_manager.views.sprobes import SProbeView  # noqa E501
+from smart_manager.views.mem_info import MemInfoView  # noqa E501
+from smart_manager.views.net_stat import NetStatView  # noqa E501
+from smart_manager.views.disk_stat import DiskStatView  # noqa E501
+from smart_manager.views.nfs_distrib import NFSDistribView  # noqa E501
+from smart_manager.views.nfs_client_distrib import NFSDClientDistribView  # noqa E501
+from smart_manager.views.nfs_share_distrib import NFSDShareDistribView  # noqa E501
+from smart_manager.views.nfs_share_client_distrib import NFSDShareClientDistribView  # noqa E501
+from smart_manager.views.cpu_util import CPUMetricView  # noqa E501
+from smart_manager.views.nfs_uid_gid import NFSDUidGidDistributionView  # noqa E501
+from smart_manager.views.load_avg import LoadAvgView  # noqa E501
+from smart_manager.views.sprobe_metadata import SProbeMetadataView, SProbeMetadataDetailView  # noqa E501
+from smart_manager.views.base_service import BaseServiceView, BaseServiceDetailView  # noqa E501
+from smart_manager.views.nis_service import NISServiceView  # noqa E501
+from smart_manager.views.samba_service import SambaServiceView  # noqa E501
+from smart_manager.views.nfs_service import NFSServiceView  # noqa E501
+from smart_manager.views.replication import ReplicaListView, ReplicaDetailView  # noqa E501
+from smart_manager.views.replica_trail import ReplicaTrailListView, ReplicaTrailDetailView  # noqa E501
+from smart_manager.views.replication_service import ReplicationServiceView  # noqa E501
+from smart_manager.views.ntp_service import NTPServiceView  # noqa E501
+from smart_manager.views.ldap_service import LdapServiceView  # noqa E501
+from smart_manager.views.sftp_service import SFTPServiceView  # noqa E501
+from smart_manager.views.tasktypes import TaskTypeView  # noqa E501
+from smart_manager.views.task_scheduler import TaskSchedulerListView, TaskSchedulerDetailView  # noqa E501
+from smart_manager.views.task_log import TaskLogView  # noqa E501
+from smart_manager.views.replica_share import ReplicaShareListView, ReplicaShareDetailView  # noqa E501
+from smart_manager.views.receive_trail import ReceiveTrailListView, ReceiveTrailDetailView  # noqa E501
+from smart_manager.views.ts_service import TaskSchedulerServiceView  # noqa E501
+from smart_manager.views.dc_service import DataCollectorServiceView  # noqa E501
+from smart_manager.views.sm_service import ServiceMonitorView  # noqa E501
+from smart_manager.views.snmp_service import SNMPServiceView  # noqa E501
+from smart_manager.views.docker_service import DockerServiceView  # noqa E501
+from smart_manager.views.smartd_service import SMARTDServiceView  # noqa E501
+from smart_manager.views.nut_service import NUTServiceView  # noqa E501
+from smart_manager.views.active_directory import ActiveDirectoryServiceView  # noqa E501
+from smart_manager.views.receiver_pools import ReceiverPoolListView  # noqa E501
+from smart_manager.views.ztaskd_service import ZTaskdServiceView  # noqa E501
+from smart_manager.views.bootstrap_service import BootstrapServiceView  # noqa E501
+from smart_manager.views.shellinaboxd_service import ShellInABoxServiceView  # noqa E501
+from smart_manager.views.rockstor_service import RockstorServiceView  # noqa E501

--- a/src/rockstor/smart_manager/views/active_directory.py
+++ b/src/rockstor/smart_manager/views/active_directory.py
@@ -22,7 +22,7 @@ import socket
 from django.db import transaction
 from rest_framework.response import Response
 
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from storageadmin.util import handle_exception
 from system.directory_services import (

--- a/src/rockstor/smart_manager/views/base_service.py
+++ b/src/rockstor/smart_manager/views/base_service.py
@@ -90,9 +90,8 @@ class BaseServiceView(ServiceMixin, rfc.GenericView):
                 sos = []
                 for s in Service.objects.all():
                     sos.append(self._get_or_create_sso(s))
-                return sorted(
-                    sos, cmp=lambda x, y: cmp(x.display_name, y.display_name)
-                )  # noqa
+                # https://docs.python.org/3.6/howto/sorting.html#key-functions
+                return sorted(sos, key=lambda each: each.display_name)
 
 
 class BaseServiceDetailView(ServiceMixin, rfc.GenericView):

--- a/src/rockstor/smart_manager/views/bootstrap_service.py
+++ b/src/rockstor/smart_manager/views/bootstrap_service.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework.response import Response
 from system.services import systemctl
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 import logging
 

--- a/src/rockstor/smart_manager/views/cpu_util.py
+++ b/src/rockstor/smart_manager/views/cpu_util.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from smart_manager.models import CPUMetric
 from smart_manager.serializers import CPUMetricSerializer
-from generic_sprobe import GenericSProbeView
+from smart_manager.views.generic_sprobe import GenericSProbeView
 
 
 class CPUMetricView(GenericSProbeView):

--- a/src/rockstor/smart_manager/views/dc_service.py
+++ b/src/rockstor/smart_manager/views/dc_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import superctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 
 

--- a/src/rockstor/smart_manager/views/disk_stat.py
+++ b/src/rockstor/smart_manager/views/disk_stat.py
@@ -20,7 +20,7 @@ from operator import attrgetter
 from smart_manager.models import DiskStat
 from storageadmin.models import Disk
 from smart_manager.serializers import DiskStatSerializer
-from generic_sprobe import GenericSProbeView
+from smart_manager.views.generic_sprobe import GenericSProbeView
 
 
 class DiskStatView(GenericSProbeView):

--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -25,7 +25,7 @@ from django.conf import settings
 from django.db import transaction
 from rest_framework.response import Response
 
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from fs.btrfs import mount_share
 from smart_manager.models import Service
 from storageadmin.models import Share

--- a/src/rockstor/smart_manager/views/ldap_service.py
+++ b/src/rockstor/smart_manager/views/ldap_service.py
@@ -23,7 +23,7 @@ from os.path import dirname
 from django.db import transaction
 from rest_framework.response import Response
 
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from storageadmin.util import handle_exception
 from system.directory_services import (

--- a/src/rockstor/smart_manager/views/mem_info.py
+++ b/src/rockstor/smart_manager/views/mem_info.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from smart_manager.models import MemInfo
 from smart_manager.serializers import MemInfoSerializer
-from generic_sprobe import GenericSProbeView
+from smart_manager.views.generic_sprobe import GenericSProbeView
 
 
 class MemInfoView(GenericSProbeView):

--- a/src/rockstor/smart_manager/views/net_stat.py
+++ b/src/rockstor/smart_manager/views/net_stat.py
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from smart_manager.models import NetStat
 from smart_manager.serializers import NetStatSerializer
-from generic_sprobe import GenericSProbeView
+from smart_manager.views.generic_sprobe import GenericSProbeView
 
 
 class NetStatView(GenericSProbeView):

--- a/src/rockstor/smart_manager/views/nfs_client_distrib.py
+++ b/src/rockstor/smart_manager/views/nfs_client_distrib.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 from smart_manager.models import NFSDClientDistribution
 from smart_manager.serializers import NFSDClientDistributionSerializer
 

--- a/src/rockstor/smart_manager/views/nfs_distrib.py
+++ b/src/rockstor/smart_manager/views/nfs_distrib.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 from smart_manager.models import NFSDCallDistribution
 from smart_manager.serializers import NFSDCallDistributionSerializer
 

--- a/src/rockstor/smart_manager/views/nfs_service.py
+++ b/src/rockstor/smart_manager/views/nfs_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import systemctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 
 import logging

--- a/src/rockstor/smart_manager/views/nfs_share_client_distrib.py
+++ b/src/rockstor/smart_manager/views/nfs_share_client_distrib.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 from smart_manager.models import NFSDShareClientDistribution
 from smart_manager.serializers import NFSDShareClientDistributionSerializer
 

--- a/src/rockstor/smart_manager/views/nfs_share_distrib.py
+++ b/src/rockstor/smart_manager/views/nfs_share_distrib.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 from smart_manager.models import NFSDShareDistribution
 from smart_manager.serializers import NFSDShareDistributionSerializer
 

--- a/src/rockstor/smart_manager/views/nfs_uid_gid.py
+++ b/src/rockstor/smart_manager/views/nfs_uid_gid.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 from smart_manager.models import NFSDUidGidDistribution
 from smart_manager.serializers import NFSDUidGidDistributionSerializer
 

--- a/src/rockstor/smart_manager/views/nis_service.py
+++ b/src/rockstor/smart_manager/views/nis_service.py
@@ -22,7 +22,7 @@ from system.osi import run_command
 from system.services import systemctl
 from system.nis import configure_nis
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 
 import logging

--- a/src/rockstor/smart_manager/views/ntp_service.py
+++ b/src/rockstor/smart_manager/views/ntp_service.py
@@ -21,7 +21,7 @@ from storageadmin.util import handle_exception
 from system.services import systemctl
 from system.osi import run_command
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from django.conf import settings
 import re

--- a/src/rockstor/smart_manager/views/replication_service.py
+++ b/src/rockstor/smart_manager/views/replication_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import superctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from storageadmin.models import NetworkConnection
 

--- a/src/rockstor/smart_manager/views/rockstor_service.py
+++ b/src/rockstor/smart_manager/views/rockstor_service.py
@@ -19,10 +19,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from storageadmin.models import NetworkConnection
-import ztask_helpers
+from smart_manager.views import ztask_helpers
 
 
 import logging

--- a/src/rockstor/smart_manager/views/samba_service.py
+++ b/src/rockstor/smart_manager/views/samba_service.py
@@ -25,7 +25,7 @@ from django.conf import settings
 from django.db import transaction
 from rest_framework.response import Response
 
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from smart_manager.serializers import ServiceStatusSerializer
 from storageadmin.util import handle_exception

--- a/src/rockstor/smart_manager/views/sftp_service.py
+++ b/src/rockstor/smart_manager/views/sftp_service.py
@@ -21,7 +21,7 @@ import logging
 from django.db import transaction
 from rest_framework.response import Response
 
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from storageadmin.util import handle_exception
 from system.ssh import toggle_sftp_service

--- a/src/rockstor/smart_manager/views/shellinaboxd_service.py
+++ b/src/rockstor/smart_manager/views/shellinaboxd_service.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 from rest_framework.response import Response
 from system.services import systemctl
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 from system.shell import update_shell_config, restart_shell
 import json

--- a/src/rockstor/smart_manager/views/sm_service.py
+++ b/src/rockstor/smart_manager/views/sm_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import superctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 import logging
 

--- a/src/rockstor/smart_manager/views/smartd_service.py
+++ b/src/rockstor/smart_manager/views/smartd_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from system.services import systemctl
 from system.pkg_mgmt import install_pkg
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 import os
 from system import smart
 from smart_manager.models import Service

--- a/src/rockstor/smart_manager/views/snmp_service.py
+++ b/src/rockstor/smart_manager/views/snmp_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import systemctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from system.snmp import configure_snmp
 from smart_manager.models import Service
 

--- a/src/rockstor/smart_manager/views/sprobe_metadata.py
+++ b/src/rockstor/smart_manager/views/sprobe_metadata.py
@@ -20,7 +20,7 @@ from smart_manager.models import SProbe
 from smart_manager.serializers import SProbeSerializer
 from rest_framework.response import Response
 from django.conf import settings
-from advanced_sprobe import AdvancedSProbeView
+from smart_manager.views.advanced_sprobe import AdvancedSProbeView
 
 
 class SProbeMetadataView(AdvancedSProbeView):

--- a/src/rockstor/smart_manager/views/ts_service.py
+++ b/src/rockstor/smart_manager/views/ts_service.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import superctl
 from django.db import transaction
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 import logging
 

--- a/src/rockstor/smart_manager/views/ztaskd_service.py
+++ b/src/rockstor/smart_manager/views/ztaskd_service.py
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from rest_framework.response import Response
 from storageadmin.util import handle_exception
 from system.services import superctl
-from base_service import BaseServiceDetailView
+from smart_manager.views.base_service import BaseServiceDetailView
 from smart_manager.models import Service
 
 import logging

--- a/src/rockstor/storageadmin/models/__init__.py
+++ b/src/rockstor/storageadmin/models/__init__.py
@@ -16,42 +16,42 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from pool import Pool  # noqa E501
-from disk import Disk  # noqa E501
-from snapshot import Snapshot  # noqa E501
-from share import Share  # noqa E501
-from nfs_export_group import NFSExportGroup  # noqa E501
-from nfs_export import NFSExport  # noqa E501
-from iscsi_target import IscsiTarget  # noqa E501
-from api_keys import APIKeys  # noqa E501
-from network_interface import (NetworkConnection, NetworkDevice,  # noqa E501
+from storageadmin.models.pool import Pool  # noqa E501
+from storageadmin.models.disk import Disk  # noqa E501
+from storageadmin.models.snapshot import Snapshot  # noqa E501
+from storageadmin.models.share import Share  # noqa E501
+from storageadmin.models.nfs_export_group import NFSExportGroup  # noqa E501
+from storageadmin.models.nfs_export import NFSExport  # noqa E501
+from storageadmin.models.iscsi_target import IscsiTarget  # noqa E501
+from storageadmin.models.api_keys import APIKeys  # noqa E501
+from storageadmin.models.network_interface import (NetworkConnection, NetworkDevice,  # noqa E501
                                EthernetConnection, TeamConnection, BondConnection,
                                BridgeConnection)  # noqa E501
-from appliance import Appliance  # noqa E501
-from support_case import SupportCase  # noqa E501
-from dashboard_config import DashboardConfig  # noqa E501
-from group import Group  # noqa E501
-from user import User  # noqa E501
-from samba_share import SambaShare  # noqa E501
-from samba_custom import SambaCustomConfig  # noqa E501
-from posix_acls import PosixACLs  # noqa E501
-from scrub import PoolScrub  # noqa E501
-from setup import Setup  # noqa E501
-from sftp import SFTP  # noqa E501
-from plugin import Plugin  # noqa E501
-from adv_nfs_exports import AdvancedNFSExport  # noqa E501
-from oauth_app import OauthApp  # noqa E501
-from pool_balance import PoolBalance  # noqa E501
-from tls_certificate import TLSCertificate  # noqa E501
-from rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
+from storageadmin.models.appliance import Appliance  # noqa E501
+from storageadmin.models.support_case import SupportCase  # noqa E501
+from storageadmin.models.dashboard_config import DashboardConfig  # noqa E501
+from storageadmin.models.group import Group  # noqa E501
+from storageadmin.models.user import User  # noqa E501
+from storageadmin.models.samba_share import SambaShare  # noqa E501
+from storageadmin.models.samba_custom import SambaCustomConfig  # noqa E501
+from storageadmin.models.posix_acls import PosixACLs  # noqa E501
+from storageadmin.models.scrub import PoolScrub  # noqa E501
+from storageadmin.models.setup import Setup  # noqa E501
+from storageadmin.models.sftp import SFTP  # noqa E501
+from storageadmin.models.plugin import Plugin  # noqa E501
+from storageadmin.models.adv_nfs_exports import AdvancedNFSExport  # noqa E501
+from storageadmin.models.oauth_app import OauthApp  # noqa E501
+from storageadmin.models.pool_balance import PoolBalance  # noqa E501
+from storageadmin.models.tls_certificate import TLSCertificate  # noqa E501
+from storageadmin.models.rockon import (RockOn, DImage, DContainer, DPort, DVolume,  # noqa E501
                     ContainerOption, DCustomConfig, DContainerLink,  # noqa E501
                     DContainerEnv, DContainerDevice, DContainerArgs,
                     DContainerLabel, DContainerNetwork)  # noqa E501
-from smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
+from storageadmin.models.smart import (SMARTAttribute, SMARTCapability, SMARTErrorLog,  # noqa E501
                    SMARTErrorLogSummary, SMARTTestLog, SMARTTestLogDetail,  # noqa E501
                    SMARTIdentity, SMARTInfo)  # noqa E501
-from config_backup import ConfigBackup  # noqa E501
-from email import EmailClient  # noqa E501
-from update_subscription import UpdateSubscription  # noqa E501
-from pincard import Pincard  # noqa E501
-from installed_plugin import InstalledPlugin  # noqa E501
+from storageadmin.models.config_backup import ConfigBackup  # noqa E501
+from storageadmin.models.email import EmailClient  # noqa E501
+from storageadmin.models.update_subscription import UpdateSubscription  # noqa E501
+from storageadmin.models.pincard import Pincard  # noqa E501
+from storageadmin.models.installed_plugin import InstalledPlugin  # noqa E501

--- a/src/rockstor/storageadmin/models/nfs_export_group.py
+++ b/src/rockstor/storageadmin/models/nfs_export_group.py
@@ -17,11 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.db import models
-from validators import (
-    validate_nfs_host_str,
-    validate_nfs_modify_str,
-    validate_nfs_sync_choice,
-)
+from storageadmin.models import validators
 
 
 class NFSExportGroup(models.Model):
@@ -33,7 +29,7 @@ class NFSExportGroup(models.Model):
     INSECURE = "insecure"
 
     """hostname string in /etc/exports"""
-    host_str = models.CharField(max_length=4096, validators=[validate_nfs_host_str])
+    host_str = models.CharField(max_length=4096, validators=[validators.validate_nfs_host_str])
     """mount options"""
     """mount read only by default"""
     MODIFY_CHOICES = (
@@ -44,7 +40,7 @@ class NFSExportGroup(models.Model):
         max_length=2,
         choices=MODIFY_CHOICES,
         default=READ_WRITE,
-        validators=[validate_nfs_modify_str],
+        validators=[validators.validate_nfs_modify_str],
     )
     """mount async by default"""
     SYNC_CHOICES = (
@@ -55,7 +51,7 @@ class NFSExportGroup(models.Model):
         max_length=5,
         choices=SYNC_CHOICES,
         default=ASYNC,
-        validators=[validate_nfs_sync_choice],
+        validators=[validators.validate_nfs_sync_choice],
     )
     """allow mounting from a >1024 port by default"""
     MSECURITY_CHOICES = (

--- a/src/rockstor/storageadmin/models/samba_share.py
+++ b/src/rockstor/storageadmin/models/samba_share.py
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from django.db import models
-from user import User
+from storageadmin.models.user import User
 
 
 class SambaShare(models.Model):

--- a/src/rockstor/storageadmin/models/user.py
+++ b/src/rockstor/storageadmin/models/user.py
@@ -18,7 +18,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import grp
 
-import chardet
 from django.conf import settings
 from django.contrib.auth.models import User as DjangoUser
 from django.core.validators import validate_email
@@ -58,8 +57,6 @@ class User(models.Model):
         if self.gid is not None:
             try:
                 groupname = grp.getgrgid(self.gid).gr_name
-                charset = chardet.detect(groupname)
-                groupname = groupname.decode(charset["encoding"])
                 return groupname
             except KeyError:
                 # Failed to fetch user using grp, so let's try with InfoPipe

--- a/src/rockstor/storageadmin/views/__init__.py
+++ b/src/rockstor/storageadmin/views/__init__.py
@@ -17,56 +17,56 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 
-from home import login_page, login_submit, logout_user, home  # noqa F401
-from snapshot import SnapshotView  # noqa F401
-from share import ShareListView, ShareDetailView, PoolShareListView  # noqa F401
-from disk import DiskMixin, DiskListView, DiskDetailView  # noqa F401
-from pool import PoolListView, PoolDetailView, get_usage_bound  # noqa F401
-from command import CommandView  # noqa F401
-from appliances import ApplianceListView, ApplianceDetailView  # noqa F401
-from login import LoginView  # noqa F401
-from user import UserListView, UserDetailView  # noqa F401
-from dashboardconfig import DashboardConfigView  # noqa F401
+from storageadmin.views.home import login_page, login_submit, logout_user, home  # noqa F401
+from storageadmin.views.snapshot import SnapshotView  # noqa F401
+from storageadmin.views.share import ShareListView, ShareDetailView, PoolShareListView  # noqa F401
+from storageadmin.views.disk import DiskMixin, DiskListView, DiskDetailView  # noqa F401
+from storageadmin.views.pool import PoolListView, PoolDetailView, get_usage_bound  # noqa F401
+from storageadmin.views.command import CommandView  # noqa F401
+from storageadmin.views.appliances import ApplianceListView, ApplianceDetailView  # noqa F401
+from storageadmin.views.login import LoginView  # noqa F401
+from storageadmin.views.user import UserListView, UserDetailView  # noqa F401
+from storageadmin.views.dashboardconfig import DashboardConfigView  # noqa F401
 from storageadmin.views.network import (
     NetworkDeviceListView,
     NetworkConnectionListView,
     NetworkStateView,
     NetworkConnectionDetailView,
 )
-from pool_scrub import PoolScrubView  # noqa F401
-from setup_user import SetupUserView  # noqa F401
-from share_acl import ShareACLView  # noqa F401
-from nfs_exports import (
+from storageadmin.views.pool_scrub import PoolScrubView  # noqa F401
+from storageadmin.views.setup_user import SetupUserView  # noqa F401
+from storageadmin.views.share_acl import ShareACLView  # noqa F401
+from storageadmin.views.nfs_exports import (
     NFSExportGroupListView,
     NFSExportGroupDetailView,  # noqa F401
     AdvancedNFSExportView,
 )  # noqa F401
-from share_command import ShareCommandView  # noqa F401
-from samba import SambaListView, SambaDetailView  # noqa F401
-from sftp import SFTPListView, SFTPDetailView  # noqa F401
-from oauth_app import OauthAppView  # noqa F401
-from group import GroupListView, GroupDetailView  # noqa F401
-from pool_balance import PoolBalanceView  # noqa F401
-from tls_certificate import TLSCertificateView  # noqa F401
-from rockon import RockOnView  # noqa F401
-from rockon_id import RockOnIdView  # noqa F401
-from rockon_container import RockOnContainerView  # noqa F401
-from rockon_volume import RockOnVolumeView  # noqa F401
-from rockon_port import RockOnPortView  # noqa F401
-from rockon_custom_config import RockOnCustomConfigView  # noqa F401
-from rockon_environment import RockOnEnvironmentView  # noqa F401
-from rockon_device import RockOnDeviceView  # noqa F401
-from rockon_labels import RockOnLabelView  # noqa F401
-from rockon_networks import RockOnNetworkView  # noqa F401
-from disk_smart import DiskSMARTDetailView  # noqa F401
-from config_backup import (
+from storageadmin.views.share_command import ShareCommandView  # noqa F401
+from storageadmin.views.samba import SambaListView, SambaDetailView  # noqa F401
+from storageadmin.views.sftp import SFTPListView, SFTPDetailView  # noqa F401
+from storageadmin.views.oauth_app import OauthAppView  # noqa F401
+from storageadmin.views.group import GroupListView, GroupDetailView  # noqa F401
+from storageadmin.views.pool_balance import PoolBalanceView  # noqa F401
+from storageadmin.views.tls_certificate import TLSCertificateView  # noqa F401
+from storageadmin.views.rockon import RockOnView  # noqa F401
+from storageadmin.views.rockon_id import RockOnIdView  # noqa F401
+from storageadmin.views.rockon_container import RockOnContainerView  # noqa F401
+from storageadmin.views.rockon_volume import RockOnVolumeView  # noqa F401
+from storageadmin.views.rockon_port import RockOnPortView  # noqa F401
+from storageadmin.views.rockon_custom_config import RockOnCustomConfigView  # noqa F401
+from storageadmin.views.rockon_environment import RockOnEnvironmentView  # noqa F401
+from storageadmin.views.rockon_device import RockOnDeviceView  # noqa F401
+from storageadmin.views.rockon_labels import RockOnLabelView  # noqa F401
+from storageadmin.views.rockon_networks import RockOnNetworkView  # noqa F401
+from storageadmin.views.disk_smart import DiskSMARTDetailView  # noqa F401
+from storageadmin.views.config_backup import (
     ConfigBackupListView,
     ConfigBackupDetailView,  # noqa F401
     ConfigBackupUpload,
 )  # noqa F401
-from email_client import EmailClientView  # noqa F401
-from update_subscription import (
+from storageadmin.views.email_client import EmailClientView  # noqa F401
+from storageadmin.views.update_subscription import (
     UpdateSubscriptionListView,  # noqa F401
     UpdateSubscriptionDetailView,
 )  # noqa F401
-from pincard import PincardView  # noqa F401
+from storageadmin.views.pincard import PincardView  # noqa F401

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -46,7 +46,7 @@ from datetime import datetime
 from django.utils.timezone import utc
 from django.conf import settings
 from django.db import transaction
-from share_helpers import sftp_snap_toggle, import_shares, import_snapshots
+from storageadmin.views.share_helpers import sftp_snap_toggle, import_shares, import_snapshots
 from rest_framework_custom.oauth_wrapper import RockstorOAuth2Authentication
 from system.pkg_mgmt import (
     auto_update,
@@ -55,7 +55,7 @@ from system.pkg_mgmt import (
     update_run,
     auto_update_status,
 )
-from nfs_exports import NFSExportMixin
+from storageadmin.views.nfs_exports import NFSExportMixin
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/rockstor/storageadmin/views/disk.py
+++ b/src/rockstor/storageadmin/views/disk.py
@@ -32,7 +32,7 @@ from fs.btrfs import (
 )
 from storageadmin.serializers import DiskInfoSerializer
 from storageadmin.util import handle_exception
-from share_helpers import import_shares, import_snapshots
+from storageadmin.views.share_helpers import import_shares, import_snapshots
 from django.conf import settings
 import rest_framework_custom as rfc
 from system import smart
@@ -369,7 +369,7 @@ class DiskMixin(object):
                 dev_name = d.name
                 if d.partitions != {}:  # could have btrfs fs from a partition?
                     # d.partitions={'/dev/vdc1': 'vfat', '/dev/vdc2': 'btrfs'}
-                    for partition, fs in d.partitions.iteritems():
+                    for partition, fs in iter(d.partitions.items()):
                         if fs == "btrfs":  # We only allow one btrfs part / dev
                             dev_name = partition
                             break

--- a/src/rockstor/storageadmin/views/group.py
+++ b/src/rockstor/storageadmin/views/group.py
@@ -25,7 +25,7 @@ from storageadmin.models import Group
 import rest_framework_custom as rfc
 from system.users import groupadd, groupdel
 import grp
-from ug_helpers import combined_groups
+from storageadmin.views.ug_helpers import combined_groups
 import logging
 from django.conf import settings
 

--- a/src/rockstor/storageadmin/views/nfs_exports.py
+++ b/src/rockstor/storageadmin/views/nfs_exports.py
@@ -27,7 +27,7 @@ from storageadmin.serializers import (
 )
 from fs.btrfs import mount_share
 from system.osi import refresh_nfs_exports, nfs4_mount_teardown
-from share_helpers import validate_share
+from storageadmin.views.share_helpers import validate_share
 import rest_framework_custom as rfc
 from rest_framework.exceptions import NotFound
 import logging

--- a/src/rockstor/storageadmin/views/pool_balance.py
+++ b/src/rockstor/storageadmin/views/pool_balance.py
@@ -26,7 +26,7 @@ from storageadmin.serializers import PoolBalanceSerializer
 from storageadmin.models import Pool, PoolBalance
 import rest_framework_custom as rfc
 from fs.btrfs import balance_status_all
-from pool import PoolMixin
+from storageadmin.views.pool import PoolMixin
 from huey.contrib.djhuey import db_task
 
 import logging

--- a/src/rockstor/storageadmin/views/rockon.py
+++ b/src/rockstor/storageadmin/views/rockon.py
@@ -43,7 +43,7 @@ from storageadmin.models import (
 from storageadmin.serializers import RockOnSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
-from rockon_helpers import rockon_status
+from storageadmin.views.rockon_helpers import rockon_status
 from system.docker import docker_status
 from huey.contrib.djhuey import HUEY
 from django.conf import settings
@@ -432,7 +432,7 @@ class RockOnView(rfc.GenericView):
         return sorted_keys
 
     def _update_model(self, modelinst, ad):
-        for k, v in ad.iteritems():
+        for k, v in iter(ad.items()):
             setattr(modelinst, k, v)
         modelinst.save()
 

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -41,7 +41,7 @@ from storageadmin.models import (
 from system.docker import dnet_create, dnet_connect
 from system.osi import run_command
 from fs.btrfs import mount_share
-from rockon_utils import container_status
+from storageadmin.views.rockon_utils import container_status
 
 DOCKER = "/usr/bin/docker"
 ROCKON_URL = "https://localhost/api/rockons"

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -38,7 +38,7 @@ from storageadmin.models import (
 from storageadmin.serializers import RockOnSerializer
 import rest_framework_custom as rfc
 from storageadmin.util import handle_exception
-from rockon_helpers import start, stop, install, uninstall, update
+from storageadmin.views.rockon_helpers import start, stop, install, uninstall, update
 from system.services import superctl
 from system.docker import docker_status, dnet_create, dnet_disconnect, dnet_remove
 from storageadmin.views.network import NetworkMixin

--- a/src/rockstor/storageadmin/views/samba.py
+++ b/src/rockstor/storageadmin/views/samba.py
@@ -25,7 +25,7 @@ from rest_framework.response import Response
 
 import rest_framework_custom as rfc
 from fs.btrfs import mount_share
-from share import ShareMixin
+from storageadmin.views.share import ShareMixin
 from storageadmin.models import SambaShare, User, SambaCustomConfig
 from storageadmin.serializers import SambaShareSerializer
 from storageadmin.util import handle_exception

--- a/src/rockstor/storageadmin/views/sftp.py
+++ b/src/rockstor/storageadmin/views/sftp.py
@@ -26,7 +26,7 @@ from rest_framework.response import Response
 
 import rest_framework_custom as rfc
 from fs.btrfs import is_share_mounted, umount_root
-from share_helpers import helper_mount_share, validate_share, sftp_snap_toggle
+from storageadmin.views.share_helpers import helper_mount_share, validate_share, sftp_snap_toggle
 from storageadmin.models import SFTP
 from storageadmin.serializers import SFTPSerializer
 from storageadmin.util import handle_exception

--- a/src/rockstor/storageadmin/views/share_command.py
+++ b/src/rockstor/storageadmin/views/share_command.py
@@ -21,8 +21,8 @@ from storageadmin.models import Share, Snapshot, NFSExport, SambaShare
 from storageadmin.serializers import ShareSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
-from clone_helpers import create_clone, create_repclone
-from share import ShareMixin
+from storageadmin.views.clone_helpers import create_clone, create_repclone
+from storageadmin.views.share import ShareMixin
 from django.core.exceptions import ObjectDoesNotExist
 import logging
 

--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -39,9 +39,9 @@ from system.osi import refresh_nfs_exports
 from storageadmin.serializers import SnapshotSerializer
 from storageadmin.util import handle_exception
 import rest_framework_custom as rfc
-from share_helpers import toggle_sftp_visibility
-from clone_helpers import create_clone, create_repclone
-from nfs_exports import NFSExportMixin
+from storageadmin.views.share_helpers import toggle_sftp_visibility
+from storageadmin.views.clone_helpers import create_clone, create_repclone
+from storageadmin.views.nfs_exports import NFSExportMixin
 
 import logging
 

--- a/src/rockstor/storageadmin/views/ug_helpers.py
+++ b/src/rockstor/storageadmin/views/ug_helpers.py
@@ -34,7 +34,7 @@ def combined_users():
             uo.uid = sys_users[u][0]
             uo.gid = sys_users[u][1]
             uo.shell = sys_users[u][2]
-            gname = get_groups(uo.gid).keys()[0]
+            gname = list(get_groups(uo.gid).keys())[0]
             create = True
             if uo.group is not None:
                 if uo.group.gid == uo.gid or uo.group.groupname == gname:
@@ -77,9 +77,7 @@ def combined_users():
     for u in User.objects.all():
         if u.username not in uname_list:
             users.append(u)
-    return sorted(
-        users, cmp=lambda x, y: cmp(x.username.lower(), y.username.lower())  # noqa F821
-    )
+    return sorted(users, key=lambda each: each.username.lower())
 
 
 def combined_groups():
@@ -97,7 +95,4 @@ def combined_groups():
     for g in Group.objects.all():
         if g.groupname not in gname_list:
             groups.append(g)
-    return sorted(
-        groups,
-        cmp=lambda x, y: cmp(x.groupname.lower(), y.groupname.lower()),  # noqa F821
-    )
+    return sorted(groups, key=lambda each: each.groupname.lower())

--- a/src/rockstor/storageadmin/views/user.py
+++ b/src/rockstor/storageadmin/views/user.py
@@ -29,7 +29,7 @@ from system.users import useradd, usermod, userdel, smbpasswd, add_ssh_key, upda
 import pwd
 from system.pinmanager import username_to_uid, flush_pincard
 from system.ssh import is_pub_key
-from ug_helpers import combined_users, combined_groups
+from storageadmin.views.ug_helpers import combined_users, combined_groups
 import logging
 import re
 

--- a/src/rockstor/system/acl.py
+++ b/src/rockstor/system/acl.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
+from system.osi import run_command
 
 CHOWN = "/usr/bin/chown"
 CHMOD = "/usr/bin/chmod"

--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -30,3 +30,7 @@ UMOUNT = "/usr/bin/umount"
 USERMOD = "/usr/sbin/usermod"
 
 SYSTEMCTL = "/usr/bin/systemctl"
+
+# Works in Leap 15.4 (systemd-249.16-150400.8.28.3) and Tumbleweed (systemd-253.4-2.1)
+UDEVADM = "/usr/bin/udevadm"
+SHUTDOWN = "/sbin/shutdown"

--- a/src/rockstor/system/directory_services.py
+++ b/src/rockstor/system/directory_services.py
@@ -21,7 +21,7 @@ import stat
 
 import re
 
-from osi import append_to_line, run_command
+from system.osi import append_to_line, run_command
 from tempfile import mkstemp
 from shutil import move
 import logging

--- a/src/rockstor/system/email_util.py
+++ b/src/rockstor/system/email_util.py
@@ -19,9 +19,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 # to be moved to views/email_client.py after an update or so.
 
 import smtplib
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEText import MIMEText
-from email.Utils import formatdate
+# https://docs.python.org/3.6/library/email.mime.html
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
 from system.osi import gethostname
 
 

--- a/src/rockstor/system/iscsi.py
+++ b/src/rockstor/system/iscsi.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
+from system.osi import run_command
 
 TGTADM_BIN = "/usr/sbin/tgtadm"
 DD_BIN = "/usr/bin/dd"

--- a/src/rockstor/system/nis.py
+++ b/src/rockstor/system/nis.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import inplace_replace
+from system.osi import inplace_replace
 from tempfile import mkstemp
 from shutil import move
 import logging

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -34,7 +34,7 @@ from distutils.util import strtobool
 
 from django.conf import settings
 
-from exceptions import CommandException, NonBTRFSRootException
+from system.exceptions import CommandException, NonBTRFSRootException
 from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR
 
 logger = logging.getLogger(__name__)
@@ -208,7 +208,7 @@ def replace_pattern_inline(source_file, target_file, pattern, replacement):
 
 def run_command(
     cmd,
-    shell=False,
+    shell=False,  ## Default
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
     stdin=subprocess.PIPE,
@@ -220,13 +220,20 @@ def run_command(
         # We force run_command to always use en_US
         # to avoid issues on date and number formats
         # on not Anglo-Saxon systems (ex. it, es, fr, de, etc)
-        fake_env = dict(os.environ)
-        fake_env["LANG"] = "en_US.UTF-8"
-        cmd = map(str, cmd)
+        # fake_env = dict(os.environ)
+        # fake_env["LANG"] = "en_US.UTF-8"
+        # cmd = map(str, cmd)
         if log:
             logger.debug("Running command: {}".format(" ".join(cmd)))
         p = subprocess.Popen(
-            cmd, shell=shell, stdout=stdout, stderr=stderr, stdin=stdin, env=fake_env
+            cmd,
+            shell=shell,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            encoding="utf-8",
+            # env=fake_env,
+            universal_newlines=True,  # 3.7 adds text parameter universal_newlines alias
         )
         out, err = p.communicate(input=input)
         out = out.split("\n")
@@ -244,7 +251,7 @@ def run_command(
             logger.error(e_msg)
         if throw:
             raise CommandException(cmd, out, err, rc)
-    return (out, err, rc)
+    return out, err, rc
 
 
 def scan_disks(min_size, test_mode=False):
@@ -1437,7 +1444,7 @@ def md5sum(fpath):
     md5 = hashlib.md5()
     with open(fpath) as tfo:
         for l in tfo.readlines():
-            md5.update(l)
+            md5.update(l.encode())
     return md5.hexdigest()
 
 
@@ -1567,7 +1574,7 @@ def is_rotational(device_name, test=None):
     both often report usb sticks as 1 = rotational.  N.B. we use
     --query=property and so have only 2 fields rather than 3 and no spaces,
     only '=' this simplifies the parsing required.
-    :param device: string containing device name eg sda or /dev/sda, ie any
+    :param device_name: string containing device name eg sda or /dev/sda, ie any
     legal udevadm --name parameter. N.B. in the case of by-id type names they
     must contain a full path, by-id alone does not work.
     :return: True if rotational, false if error or unknown.

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -35,7 +35,7 @@ from distutils.util import strtobool
 from django.conf import settings
 
 from system.exceptions import CommandException, NonBTRFSRootException
-from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR
+from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR, UDEVADM, SHUTDOWN
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +52,8 @@ HOSTNAMECTL = "/usr/bin/hostnamectl"
 LS = "/usr/bin/ls"
 LSBLK = "/usr/bin/lsblk"
 NMCLI = "/usr/bin/nmcli"
-SHUTDOWN = settings.SHUTDOWN
 SYSTEMD_ESCAPE = "/usr/bin/systemd-escape"
 SYSTEMD_DIR = "/usr/lib/systemd/system"
-UDEVADM = settings.UDEVADM
 WIPEFS = "/usr/sbin/wipefs"
 RTC_WAKE_FILE = "/sys/class/rtc/rtc0/wakealarm"
 PING = "/usr/bin/ping"

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -21,8 +21,8 @@ import platform
 import re
 import stat
 from tempfile import mkstemp
-from osi import run_command
-from services import systemctl
+from system.osi import run_command
+from system.services import systemctl
 import shutil
 import time
 from datetime import datetime, timedelta

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -23,8 +23,8 @@ from tempfile import mkstemp
 
 from django.conf import settings
 
-from osi import run_command
-from services import service_status, define_avahi_service
+from system.osi import run_command
+from system.services import service_status, define_avahi_service
 from storageadmin.models import SambaCustomConfig
 
 TESTPARM = "/usr/bin/testparm"
@@ -129,7 +129,7 @@ def update_global_config(smb_config=None, ad_config=None):
             "printcap name": "/dev/null",
             "map to guest": "Bad User",
         }
-        for key, value in smb_default_options.iteritems():
+        for key, value in iter(smb_default_options.items()):
             if key not in smb_config:
                 tfo.write("    {} = {}\n".format(key, value))
 

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -23,7 +23,7 @@ import stat
 from tempfile import mkstemp
 
 from django.conf import settings
-from osi import run_command
+from system.osi import run_command
 from system.constants import SYSTEMCTL
 from system.ssh import is_sftp_running
 

--- a/src/rockstor/system/shell.py
+++ b/src/rockstor/system/shell.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
+from system.osi import run_command
 import shutil
 from tempfile import mkstemp
 from django.conf import settings

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -23,8 +23,8 @@ from tempfile import mkstemp
 
 import distro
 
-from exceptions import CommandException
-from osi import run_command, get_base_device_byid, get_device_path
+from system.exceptions import CommandException
+from system.osi import run_command, get_base_device_byid, get_device_path
 from system.email_util import email_root
 
 logger = logging.getLogger(__name__)
@@ -97,7 +97,7 @@ def extended_info(device, custom_options="", test_mode=TESTMODE):
     Attribute name.
 
     :param device: disk device name
-    :param testmode: Not True causes cat from file rather than smartctl command
+    :param test_mode: Not True causes cat from file rather than smartctl command
     :return: dictionary of smart attributes extracted from device or test file
 
     """
@@ -440,16 +440,15 @@ def get_dev_options(dev_byid, custom_options=""):
         dev_options = [get_device_path(get_base_device_byid(dev_byid, TESTMODE))]
     else:
         # Convert string of custom options into a list ready for run_command
-        # TODO: think this ascii should be utf-8 as that's kernel standard
-        # TODO: or just use str(custom_options).split()
-        dev_options = custom_options.encode("ascii").split()
+        dev_options = custom_options.encode("utf-8").split()
         # Remove Rockstor native 'autodev' custom smart option raid dev target.
         # As we automatically add the full path by-id if a raid controller
         # target dev is not found, we can simply remove this option.
         # N.B. here we assume there is either 'autodev' or a specified target:
         # input validation was tested to reject both being entered.
+        # TODO: Needs validation post Preliminary python 3.6 port
         if "autodev" in dev_options:
-            dev_options.remove("autodev")
+            dev_options.remove(b"autodev")
         # If our custom options don't contain a raid controller target then add
         # the full path to our base device as our last device specific option.
         if re.search("/dev/tw|/dev/cciss/c|/dev/sg|/dev/sd", custom_options) is None:

--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -164,24 +164,27 @@ def usermod(username, passwd):
     # TODO: 'salt = crypt.mksalt()' # Python 3.3 onwards provides system best.
     # Salt starting "$6$" & of 19 chars signifies SHA-512 current system best.
     # Salt must contain only [./a-zA-Z0-9] chars (bar first 3 if len > 2)
-    salt_header = "$6$"  # SHA-512
-    rnd = random.SystemRandom()
-    salt = "".join(
-        [rnd.choice(string.ascii_letters + string.digits + "./") for _ in range(16)]
-    )
-    crypted_passwd = crypt.crypt(passwd.encode("utf8"), salt_header + salt)
+    # salt_header = "$6$"  # SHA-512
+    # rnd = random.SystemRandom()
+    # salt = "".join(
+    #     [rnd.choice(string.ascii_letters + string.digits + "./") for _ in range(16)]
+    # )
+    # crypted_passwd = crypt.crypt(passwd.encode("utf8"), salt_header + salt)
+    salt = crypt.mksalt()
+    crypted_passwd = crypt.crypt(passwd, salt)
     cmd = [USERMOD, "-p", crypted_passwd, username]
-    p = subprocess.Popen(
-        cmd,
-        shell=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-    )
-    out, err = p.communicate(input=None)
-    rc = p.returncode
-    if rc != 0:
-        raise CommandException(cmd, out, err, rc)
+    out, err, rc = run_command(cmd, log=True)
+    # p = subprocess.Popen(
+    #     cmd,
+    #     shell=False,
+    #     stdout=subprocess.PIPE,
+    #     stderr=subprocess.PIPE,
+    #     stdin=subprocess.PIPE,
+    # )
+    # out, err = p.communicate(input=None)
+    # rc = p.returncode
+    # if rc != 0:
+    #     raise CommandException(cmd, out, err, rc)
     return out, err, rc
 
 

--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -16,26 +16,21 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 import crypt
-import fcntl
 import grp
 import logging
 import os
 import pwd
-import random
 import re
 import stat
-import string
-import subprocess
-import time
+from subprocess import run, Popen, PIPE
 from shutil import move
 from tempfile import mkstemp
 
-import chardet
 import dbus
 from dbus import DBusException
 
-from exceptions import CommandException
-from osi import run_command
+from system.exceptions import CommandException
+from system.osi import run_command
 from system.services import is_systemd_service_active
 
 logger = logging.getLogger(__name__)
@@ -62,46 +57,34 @@ IFP_CONSTANTS = {
 }
 
 
-# this is a hack for AD to get as many users as possible within 90 seconds.  If
+# this is a hack for AD to get as many users as possible within 60 seconds.  If
 # there are several thousands of domain users and AD isn't that fast, winbind
 # takes a long time to enumerate the users for getent. Subsequent queries
 # finish faster because of caching. But this prevents timing out.
-def get_users(max_wait=90):
-    t0 = time.time()
+def get_users(max_wait=60):
     users = {}
-    p = subprocess.Popen(
+    # TODO: In Python 3.7 we have a capture_output option.
+    result = run(
         ["/usr/bin/getent", "passwd"],
         shell=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        encoding="utf-8",
+        # stdout and stderr as string
+        universal_newlines=True,  # 3.7 adds text parameter universal_newlines alias
+        timeout=max_wait,
     )
-    fcntl.fcntl(p.stdout.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
-    alive = True
-    user_data = ""
-    while alive:
-        try:
-            if p.poll() is not None:
-                alive = False
-            user_data += p.stdout.read()
-        except IOError:
-            if time.time() - t0 < max_wait:
-                continue
-        except Exception as e:
-            logger.exception(e)
-            p.terminate()
-        uf = user_data.split("\n")
-        # If the feed ends in \n, the last element will be '', if not, it will
-        # be a partial line to be processed next time around.
-        user_data = uf[-1]
-        for u in uf[:-1]:
-            ufields = u.split(":")
-            if len(ufields) > 3:
-                charset = chardet.detect(ufields[0])
-                uname = ufields[0].decode(charset["encoding"])
-                users[uname] = (int(ufields[2]), int(ufields[3]), str(ufields[6]))
-            if time.time() - t0 > max_wait:
-                p.terminate()
-                break
+    out = result.stdout
+    # TODO: Report & handle exception reported via CompletedProcess (result)
+    out_list = out.split("\n")
+    # out_list looks like;
+    # ['root:x:0:0:root:/root:/bin/bash', ...
+    # 'radmin:x:1000:100::/home/radmin:/bin/bash', '']
+    for line in out_list[:-1]:  # skip empty last line.
+        fields = line.split(":")
+        if len(fields) > 3:
+            uname = fields[0]
+            users[uname] = (int(fields[2]), int(fields[3]), str(fields[6]))
     return users
 
 
@@ -111,8 +94,8 @@ def get_groups(*gids):
         for g in gids:
             try:
                 entry = grp.getgrgid(g)
-                charset = chardet.detect(entry.gr_name)
-                gr_name = entry.gr_name.decode(charset["encoding"])
+                # Assume utf-8 encoded gr_name str
+                gr_name = entry.gr_name
                 groups[gr_name] = entry.gr_gid
             except KeyError:
                 # The block above can sometimes fail for domain users (AD/LDAP)
@@ -130,8 +113,8 @@ def get_groups(*gids):
                 )
     else:
         for g in grp.getgrall():
-            charset = chardet.detect(g.gr_name)
-            gr_name = g.gr_name.decode(charset["encoding"])
+            # Assume utf-8 encoded gr_name str
+            gr_name = g.gr_name
             groups[gr_name] = g.gr_gid
 
         # If sssd.service is running:
@@ -204,19 +187,19 @@ def usermod(username, passwd):
 
 def smbpasswd(username, passwd):
     cmd = [SMBPASSWD, "-s", "-a", username]
-    p = subprocess.Popen(
+    p = Popen(
         cmd,
         shell=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        stdin=PIPE,
     )
     pstr = "%s\n%s\n" % (passwd, passwd)
     out, err = p.communicate(input=pstr.encode("utf8"))
     rc = p.returncode
     if rc != 0:
         raise CommandException(cmd, out, err, rc)
-    return (out, err, rc)
+    return out, err, rc
 
 
 def update_shell(username, shell):
@@ -247,7 +230,7 @@ def useradd(username, shell, uid=None, gid=None):
                 "User({0}) already exists, but her shell({1}) is "
                 "different from the input({2}).".format(username, pw_entry.shell, shell)
             )
-        return ([""], [""], 0)
+        return [""], [""], 0
 
     cmd = [USERADD, "-s", shell, "-m", username]
     if uid is not None:

--- a/src/rockstor/system/util.py
+++ b/src/rockstor/system/util.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from osi import run_command
+from system.osi import run_command
 
 TAR = "/usr/bin/tar"
 


### PR DESCRIPTION
As part of our move to Python 3 we must first establish our
initial python 3 dependencies via Poetry.

Fixes #2564 

## Includes:
- Update pyproject.toml and poetry.lock for python 3.6.
- Remove int long designator from settings.py: Python 3
no longer uses the "L" suffix.
- Use full path in initial import conversions. Python 3
has more stringent import path requirements.
- Update imports for 3.6 email module. These differ in Python 3.
- Encode unicode line for system.osi.md5sum.
TypeError: Unicode-objects must be encoded before hashing
- Tidy/update init_sftp_config() re Python 3.
There was a subtle file pointer behaviour change
between 2.7 and 3.6 which broke this mechanism.
- Address TODO re custom opener re Python 3.
- Services page & Users page - Python 3 style sorted():
"cmp" sorted parameter and buildin function dropped
in Python 3.
- init fix of groups page by adaptation to str type.
- Replace chardet dependency with charset-normalizer:
also used by requests.
- Removes redundant encoding on already encoded groupname.
- Init dashboard fix via gevent/websocket update.
Thanks to @FroggyFlox for investigations here.
- Init fix of get_users() - non admin users did not show.
Move to more modern - time limited subprocess.run().
- fix samba, disk partition, rockon, re iteritems()
In Python 3 we use iter(d.items()) instead:
https://peps.python.org/pep-0469/
- Address TODO re ascii to utf-8 on SMART custom options.
- Untested bytecast in smart.py:
custom options autodev related byte assertion.

# Independent commits for attribution from @FroggyFlox 
- Move UDEVADM and SHUTDOWN definitions to runtime constants.
Removes now redundant and incompatible mechanism.
- Move passwd to str and use crypt.mksalt() to generate salt.
Updates this mechanism re Python 3 capabilities.