### PR TITLE
Py3.6 update test_btrfs.py and use built-in mock #2571

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -174,14 +174,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "mock"
-version = "1.0.1"
-description = "A Python Mocking and Patching Library for Testing"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "oauthlib"
 version = "3.1.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -354,7 +346,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.6"
-content-hash = "aa199b53bd2082841064a9f14317b49e81d89578c29e04925462600ff774fcdc"
+content-hash = "bdde4a0b353ef4526f82d73b824193ea5e19d4d728f380f31047eac5be39e333"
 
 [metadata.files]
 certifi = [
@@ -588,10 +580,6 @@ huey = [
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
-]
-mock = [
-    {file = "mock-1.0.1.tar.gz", hash = "sha256:b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f"},
-    {file = "mock-1.0.1.zip", hash = "sha256:8f83080daa249d036cbccfb8ae5cc6ff007b88d6d937521371afabe7b19badbc"},
 ]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ pytz = "==2022.6"
 six = "==1.16.0"  # 1.14.0 (15 Jan 2020) Python 2/3 compat lib
 huey = "==2.3.0"
 psutil = "==5.9.4"
-mock = "==1.0.1"
+# mock = "==1.0.1" now part of std lib in Python 3.3 onwards as unittest.mock
 # pyzmq requires libzmq5 on system unless in wheel form.
 pyzmq = "==19.0.2"  # Last specifying Python 2 on PyPi page.
 distro = "==1.6.0"  # Last Python 2/3 version that works as we expect.

--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -2235,7 +2235,7 @@ def balance_status_internal(pool):
             if unallocated < 0:
                 stats["status"] = "running"
                 break
-    if unallocated >= 0:
+    if unallocated is not None and unallocated >= 0:
         # We have no 'tell' so report a finished balance as there is no
         # evidence of one happening.
         stats["status"] = "finished"

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2017 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2017 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,12 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import json
 import unittest
+from unittest import mock
+from unittest.mock import patch
 from datetime import datetime
 from fs.btrfs import (
     get_pool_raid_levels,
@@ -41,7 +43,14 @@ from fs.btrfs import (
     scrub_status_extra,
     get_pool_raid_profile,
 )
-from mock import patch
+
+
+"""
+The tests in this suite can be run via the following commands:
+
+cd /opt/rockstor/src/rockstor/fs
+poetry run django-admin test --settings=settings -v 3 -p test_btrfs*
+"""
 
 
 class Pool(object):
@@ -52,13 +61,6 @@ class Pool(object):
 
 
 class BTRFSTests(unittest.TestCase):
-    """
-    The tests in this suite can be run via the following commands:
-    N.B. 'root' dir of rockstor is normally /opt/rockstor
-    cd /opt/rockstor/src/rockstor/fs
-    poetry run django-admin test --settings=settings -v 3 -p test_btrfs*
-    """
-
     def setUp(self):
         self.patch_run_command = patch("fs.btrfs.run_command")
         self.mock_run_command = self.patch_run_command.start()
@@ -73,7 +75,7 @@ class BTRFSTests(unittest.TestCase):
         self.mock_os_path_exists = self.patch_os_path_exists.start()
 
     def tearDown(self):
-        patch.stopall()
+        mock.patch.stopall()
 
     # # sample test
     # def test_add_pool_mkfs_fail(self):
@@ -293,8 +295,8 @@ class BTRFSTests(unittest.TestCase):
             raid6_1c4_return,
         ]
         # simple iteration over above example inputs to expected outputs.
-        for raid_level, fi_df, expected_result in map(
-            None, raid_levels_tested, btrfs_fi_di, return_dict
+        for raid_level, fi_df, expected_result in zip(
+            raid_levels_tested, btrfs_fi_di, return_dict
         ):
             # mock example command output with no error and rc=0
             self.mock_run_command.return_value = (fi_df, cmd_e, cmd_rc)

--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2017 RockStor, Inc. <https://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published


### PR DESCRIPTION
As of Python 3.3 mock is available via Python standard library as unittest.mock:
https://docs.python.org/3.6/library/unittest.mock.html https://pypi.org/project/mock/
Includes
- "btrfs.py" fix re Python 3.6 and None type comparison.
- Drop mock dependency.

Fixes #2571 

This patch break a large number of other tests that we also need to transition to the built-in mock/patch in unittest.
A spin-off issue will be created and linked.

## Testing
```
cd src/rockstor/fs/
poetry run django-admin test --settings=settings -v 3 -p test_btrfs*
...
----------------------------------------------------------------------
Ran 58 tests in 0.078s

OK
...
```