### PR TITLE
Py3.6 ModuleNotFoundError: No module named 'mock' - tests #2575

### DIFF
--- a/src/rockstor/fs/tests/test_btrfs.py
+++ b/src/rockstor/fs/tests/test_btrfs.py
@@ -14,7 +14,6 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import json
 import unittest
-from unittest import mock
 from unittest.mock import patch
 from datetime import datetime
 from fs.btrfs import (
@@ -75,7 +74,7 @@ class BTRFSTests(unittest.TestCase):
         self.mock_os_path_exists = self.patch_os_path_exists.start()
 
     def tearDown(self):
-        mock.patch.stopall()
+        patch.stopall()
 
     # # sample test
     # def test_add_pool_mkfs_fail(self):

--- a/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
+++ b/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import sys
 import json

--- a/src/rockstor/scripts/tests/test_reboot_shutdown.py
+++ b/src/rockstor/scripts/tests/test_reboot_shutdown.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from scripts.scheduled_tasks.reboot_shutdown import (
     validate_reboot_shutdown_meta,

--- a/src/rockstor/smart_manager/tests/test_snmp.py
+++ b/src/rockstor/smart_manager/tests/test_snmp.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status

--- a/src/rockstor/smart_manager/tests/test_task_scheduler.py
+++ b/src/rockstor/smart_manager/tests/test_task_scheduler.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status

--- a/src/rockstor/storageadmin/tests/test_api.py
+++ b/src/rockstor/storageadmin/tests/test_api.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,12 +13,12 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from unittest.mock import patch
 from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
-from mock import patch
 
 
 # functionality for all API tests.

--- a/src/rockstor/storageadmin/tests/test_appliances.py
+++ b/src/rockstor/storageadmin/tests/test_appliances.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,12 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
+from unittest.mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
-from mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_commands.py
+++ b/src/rockstor/storageadmin/tests/test_commands.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,12 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-
-
+from unittest.mock import patch
 from rest_framework import status
-from mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_config_backup.py
+++ b/src/rockstor/storageadmin/tests/test_config_backup.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,9 +10,9 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
+from unittest import mock
 from rest_framework import status
 
 from storageadmin.models import ConfigBackup

--- a/src/rockstor/storageadmin/tests/test_dashboardconfig.py
+++ b/src/rockstor/storageadmin/tests/test_dashboardconfig.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,7 +10,7 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 

--- a/src/rockstor/storageadmin/tests/test_disk_smart.py
+++ b/src/rockstor/storageadmin/tests/test_disk_smart.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,10 +13,10 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from unittest.mock import patch
 from rest_framework import status
-from mock import patch
 
 from storageadmin.tests.test_api import APITestMixin
 

--- a/src/rockstor/storageadmin/tests/test_disks.py
+++ b/src/rockstor/storageadmin/tests/test_disks.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
+from unittest import mock
+from unittest.mock import patch
 from rest_framework import status
-from mock import patch
 
 from storageadmin.models import Disk
 from storageadmin.tests.test_api import APITestMixin

--- a/src/rockstor/storageadmin/tests/test_email_client.py
+++ b/src/rockstor/storageadmin/tests/test_email_client.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,11 +10,12 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
+from unittest import mock
+from unittest.mock import patch
+
 from rest_framework import status
-from mock import patch
 from storageadmin.models import Appliance
 from storageadmin.tests.test_api import APITestMixin
 

--- a/src/rockstor/storageadmin/tests/test_group.py
+++ b/src/rockstor/storageadmin/tests/test_group.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,12 +13,10 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>
+along with this program. If not, see <https://www.gnu.org/licenses/>
 """
-
-
+from unittest.mock import patch
 from rest_framework import status
-from mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_login.py
+++ b/src/rockstor/storageadmin/tests/test_login.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,7 +10,7 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 

--- a/src/rockstor/storageadmin/tests/test_network.py
+++ b/src/rockstor/storageadmin/tests/test_network.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,12 +13,12 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from unittest import mock
+from unittest.mock import patch
 
-import mock
 from rest_framework import status
-from mock import patch
 from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import NetworkConnection, NetworkDevice
 

--- a/src/rockstor/storageadmin/tests/test_nfs_export.py
+++ b/src/rockstor/storageadmin/tests/test_nfs_export.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,12 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
+from unittest import mock
+from unittest.mock import patch
+
 from rest_framework import status
-from mock import patch
 from storageadmin.models import Pool, Share, NFSExportGroup, NFSExport
 from storageadmin.tests.test_api import APITestMixin
 

--- a/src/rockstor/storageadmin/tests/test_oauth_app.py
+++ b/src/rockstor/storageadmin/tests/test_oauth_app.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,10 +13,10 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from unittest.mock import patch
 from rest_framework import status
-from mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_pool_balance.py
+++ b/src/rockstor/storageadmin/tests/test_pool_balance.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import Pool, PoolBalance
 

--- a/src/rockstor/storageadmin/tests/test_pool_balance_huey.py
+++ b/src/rockstor/storageadmin/tests/test_pool_balance_huey.py
@@ -1,6 +1,23 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
 from huey.contrib.djhuey import HUEY
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import Pool, PoolBalance
 from storageadmin.views.pool_balance import is_pending_balance_task

--- a/src/rockstor/storageadmin/tests/test_pool_scrub.py
+++ b/src/rockstor/storageadmin/tests/test_pool_scrub.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2013 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,13 +13,13 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-# import mock
+
 from rest_framework import status
 
 # from rest_framework.test import APITestCase
-from mock import patch
+from unittest.mock import patch
 
 # from storageadmin.models import Pool
 from storageadmin.tests.test_api import APITestMixin

--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from django.conf import settings
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 
 import fs.btrfs
 from storageadmin.models import Disk, Pool, PoolBalance

--- a/src/rockstor/storageadmin/tests/test_samba.py
+++ b/src/rockstor/storageadmin/tests/test_samba.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,10 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
+
 from rest_framework import status
 
 from storageadmin.exceptions import RockStorAPIException

--- a/src/rockstor/storageadmin/tests/test_sftp.py
+++ b/src/rockstor/storageadmin/tests/test_sftp.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 
 from storageadmin.models import Share, SFTP
 from storageadmin.tests.test_api import APITestMixin

--- a/src/rockstor/storageadmin/tests/test_share_acl.py
+++ b/src/rockstor/storageadmin/tests/test_share_acl.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,15 +10,13 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-
 
 from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework import serializers
-import mock
-from mock import patch
+from unittest.mock import patch
 
 from storageadmin import serializers
 from storageadmin.models import Snapshot, Pool, Share

--- a/src/rockstor/storageadmin/tests/test_share_commands.py
+++ b/src/rockstor/storageadmin/tests/test_share_commands.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,13 +13,14 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <httsp://www.gnu.org/licenses/>.
 """
+from unittest import mock
+from unittest.mock import patch
 
 from rest_framework import status
 from rest_framework.response import Response
-import mock
-from mock import patch
+
 from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import Share, Snapshot
 

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import Pool, Share
 

--- a/src/rockstor/storageadmin/tests/test_snapshot.py
+++ b/src/rockstor/storageadmin/tests/test_snapshot.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,12 +10,11 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 
 from storageadmin.tests.test_api import APITestMixin
 

--- a/src/rockstor/storageadmin/tests/test_tls_certificate.py
+++ b/src/rockstor/storageadmin/tests/test_tls_certificate.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_update_subscription.py
+++ b/src/rockstor/storageadmin/tests/test_update_subscription.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2013 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
 
 

--- a/src/rockstor/storageadmin/tests/test_user.py
+++ b/src/rockstor/storageadmin/tests/test_user.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,11 +13,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>
+along with this program. If not, see <https://www.gnu.org/licenses/>
 """
 
 from rest_framework import status
-from mock import patch
+from unittest.mock import patch
 
 # the following settings should be test variant.
 from django.conf import settings

--- a/src/rockstor/system/tests/test_directory_services.py
+++ b/src/rockstor/system/tests/test_directory_services.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from system.exceptions import CommandException
 from system.directory_services import domain_workgroup

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2018 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,11 +10,11 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import operator
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from system.osi import get_dev_byid_name, Disk, scan_disks, get_byid_name_map
 

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from system.pkg_mgmt import (
     pkg_update_check,

--- a/src/rockstor/system/tests/test_system_network.py
+++ b/src/rockstor/system/tests/test_system_network.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 RockStor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -10,10 +10,10 @@ WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from system.exceptions import CommandException
 from system.network import get_dev_config, get_con_config


### PR DESCRIPTION
Imports changed to reflect now build-in unittest.mock.

Fixes #2575

## Includes copywrite changes:
- Added missing copyright.
- Majority in affected directories updated re date https.

## Testing
Post the proposed changes we no longer have any test failing due to the issue/pr title:
```
...
Ran 252 tests in 26.009s

FAILED (failures=5, errors=3)

```