### PR TITLE
Py3.6 ModuleNotFoundError: 'crontabwindow', 'nfsd_calls' - tests #2578

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
+++ b/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
@@ -18,7 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import sys
 import json
 from datetime import datetime, timedelta
-import crontabwindow  # load crontabwindow module
+from scripts.scheduled_tasks import crontabwindow
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper
 from django.utils.timezone import utc

--- a/src/rockstor/smart_manager/agents/__init__.py
+++ b/src/rockstor/smart_manager/agents/__init__.py
@@ -1,6 +1,6 @@
-from nfsd_calls import (
+from smart_manager.agents.nfsd_calls import (
     process_nfsd_calls,
-    share_distribution,  # noqa E501
+    share_distribution,
     share_client_distribution,
     nfs_uid_gid_distribution,
-)  # noqa E501
+)


### PR DESCRIPTION
Fix missing path on import within the tested code. This represents a follow-up more directly to 
"Preliminary python 3.6 port - development #2564" #2567
where the majority of import paths were fixed via:

> Use full path in initial import conversions. Python 3
> has more stringent import path requirements.
> 

Fixes #2578 

## Testing
from Fixes issue references we have:

### Before patch:
```
ERROR: rockstor.scripts.tests.test_reboot_shutdown (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: rockstor.scripts.tests.test_reboot_shutdown
...
ModuleNotFoundError: No module named 'crontabwindow'
```
and
```
ERROR: rockstor.smart_manager.agents (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: rockstor.smart_manager.agents
...
ModuleNotFoundError: No module named 'nfsd_calls'
```

### After patch:
```
buildvm:/opt/rockstor/src/rockstor # poetry run django-admin test -v 2
...
test_validate_reboot_shutdown_meta (rockstor.scripts.tests.test_reboot_shutdown.RebootShutdownScriptTests) ... ok
```
and
```
buildvm:/opt/rockstor/src/rockstor/smart_manager # poetry run django-admin test -v 2
...
Ran 17 tests in 2.223s

OK
```

Full test run with this patch applied:
```
buildvm:/opt/rockstor/src/rockstor # poetry run django-admin test -v 2

test_snmp_0 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_0_1 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_1 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_2 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_3 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_4 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_5 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_6 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_snmp_7 (rockstor.smart_manager.tests.test_snmp.SNMPTests) ... ok
test_delete_invalid (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_valid (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_get (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_invalid_type (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_name_exists (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_post_valid (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_invalid (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_put_valid (rockstor.smart_manager.tests.test_task_scheduler.TaskSchedulerTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_get (rockstor.storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_appliances.AppliancesTests) ... ok
test_auto_update_status_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_bootstrap_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_current_user_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_current_version_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_disable_auto_update_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_enable_auto_update_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_kernel_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_reboot (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_disk_state (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_pool_state (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_share_state (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_refresh_snapshot_state (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_shutdown (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_update_check_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_update_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_uptime_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_utcnow_command (rockstor.storageadmin.tests.test_commands.CommandTests) ... ok
test_get_sname (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_update_rockon_shares (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_valid_requests (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... FAIL
test_validate_install_config (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_service_status (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_validate_task_definitions (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... FAIL
test_validate_taskdef_meta (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ERROR
test_validate_update_config (rockstor.storageadmin.tests.test_config_backup.ConfigBackupTests) ... ok
test_get_requests (rockstor.storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_put_requests (rockstor.storageadmin.tests.test_dashboardconfig.DashboardConfigTests) ... ok
test_get (rockstor.storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_reqeusts_1 (rockstor.storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_disk_smart.DiskSmartTests) ... ok
test_blink_drive (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_btrfs_disk_import_fail (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_disable_smart (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_scan (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_disk_wipe (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_enable_smart_when_available (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_command (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_invalid_disk_wipe (rockstor.storageadmin.tests.test_disks.DiskTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_email_client.EmailTests) ... ok
test_get (rockstor.storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_email_client.EmailTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_email_client.EmailTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_group.GroupTests) ... ok
test_get_requests (rockstor.storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_group.GroupTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_login.LoginTests) ... ok
test_delete (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_get_base (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_devices_not_list (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_nclistview_post_invalid (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_put (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_put_invalid_id (rockstor.storageadmin.tests.test_network.NetworkTests) ... ok
test_adv_nfs_get (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_adv_nfs_post_requests (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host1 (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_admin_host2 (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_invalid_get (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_put_requests (rockstor.storageadmin.tests.test_nfs_export.NFSExportTests) ... ok
test_get (rockstor.storageadmin.tests.test_oauth_app.OauthAppTests) ... ok
test_get (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_invalid_balance_command (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_invalid_pool (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_status_running_cli_balance (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_valid_balance (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_valid_status_command (rockstor.storageadmin.tests.test_pool_balance.PoolBalanceTests) ... ok
test_post_valid_balance_follow_through (rockstor.storageadmin.tests.test_pool_balance_huey.PoolBalanceTestsHuey) ... ok
test_get (rockstor.storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_pool_scrub.PoolScrubTests) ... ok
test_balance_in_progress_fencing (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_compression (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_delete_pool_with_share (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_get (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_post_requests_name_clash (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_post_requests_raid_level (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_put_requests_command (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_put_requests_nonexistent_disk (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_requests_nonexistent_pool (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_invalid_root_pool_edits (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_mount_options (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_name_regex (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_put_requests_add_remove_disks (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid0_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid10_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid1_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid5_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid6_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid_migration_fencing_add_command (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_raid_migration_fencing_remove_command (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_single_crud (rockstor.storageadmin.tests.test_pools.PoolTests) ... ok
test_create_samba_share (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_existing_export (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_create_samba_share_incorrect_share (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_2 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_get_non_existent (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_post_requests_no_admin (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_1 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_put_requests_2 (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_validate_input_error (rockstor.storageadmin.tests.test_samba.SambaTests) ... ok
test_delete_requests_1 (rockstor.storageadmin.tests.test_sftp.SFTPTests) ... ok
test_delete_requests_2 (rockstor.storageadmin.tests.test_sftp.SFTPTests) ... ok
test_get (rockstor.storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_sftp.SFTPTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_sftp.SFTPTests) ... ok
test_clone_command (rockstor.storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_rollback_command (rockstor.storageadmin.tests.test_share_commands.ShareCommandTests) ... ok
test_compression (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_create (rockstor.storageadmin.tests.test_shares.ShareTests) ... FAIL
test_delete_exported_replicated (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_no_exports_services_snaps (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_os_exception (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_rock_ons_root (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_with_regular_snapshot (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_get (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_clone_command (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... FAIL
test_get (rockstor.storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_tls_certificate.TlscertificateTests) ... ok
test_get (rockstor.storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_update_subscription.UpdateSubscriptionTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_duplicate_name2 (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_email_validation (rockstor.storageadmin.tests.test_user.UserTests) ... FAIL
test_get (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_invalid_UID (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_post_requests (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_pubkey_validation (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_put_requests (rockstor.storageadmin.tests.test_user.UserTests) ... ok
test_balance_status_all (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_cancel_requested (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_finished (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_in_progress (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_finished (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_running (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_unknown_mnt (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_unknown_parsing (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_unknown_unmounted (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_internal_zero_allocate (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_pause_requested (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_paused (rockstor.fs.tests.test_btrfs.BTRFSTests)
Test to see if balance_status() correctly identifies a Paused balance ... ok
test_balance_status_unknown_parsing (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_balance_status_unknown_unmounted (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_btrfsprogs_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_default_subvol (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_degraded_pools_found (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_dev_stats_zero (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_all (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_device_scan_parameter (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_dev_io_error_stats (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_levels_identification (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_profile (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_pool_raid_profile_unknown_matched (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_all (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_compression (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_property_ro (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_2 (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_get_snap_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_exists (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_is_subvol_nonexistent (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_parse_snap_details (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_pool_missing_dev_count (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_extra_finished (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_extra_halted (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_extra_running (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_cancelled (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_cancelled_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_conn_reset_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_finished (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_finished_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_halted (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_halted_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_running (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_scrub_status_raw_running_legacy (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_share_id (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_fresh (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_legacy_system_pool_used (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_boot_to_snapshot_root_user_share (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_post_btrfs_subvol_list_path_changes (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_system_pool_used (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_shares_info_systemwide_exclusion_datapool (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_home_rollback_snap (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_mid_replication (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_no_snaps (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_snapshot_idmap_snapper_root (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_volume_usage (rockstor.fs.tests.test_btrfs.BTRFSTests) ... ok
test_all_devices_offline (rockstor.scripts.tests.test_reboot_shutdown.RebootShutdownScriptTests) ... ok
test_run_conditions_met (rockstor.scripts.tests.test_reboot_shutdown.RebootShutdownScriptTests) ... ok
test_validate_reboot_shutdown_meta (rockstor.scripts.tests.test_reboot_shutdown.RebootShutdownScriptTests) ... ok
test_domain_workgroup (rockstor.system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_invalid (rockstor.system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_domain_workgroup_missing (rockstor.system.tests.test_directory_services.SystemDirectoryServicesTests) ... ok
test_get_byid_name_map (rockstor.system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_no_byid_dir (rockstor.system.tests.test_osi.OSITests) ... ok
test_get_byid_name_map_prior_command_mock (rockstor.system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name (rockstor.system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_no_devlinks (rockstor.system.tests.test_osi.OSITests) ... ok
test_get_dev_byid_name_node_not_found (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_27_plus_disks_regression_issue (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_btrfs_in_partition (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_dell_perk_h710_md1220_36_disks (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_data_disk (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_intel_bios_raid_sys_disk (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_on_bcache (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_luks_sys_disk (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_mdraid_sys_disk (rockstor.system.tests.test_osi.OSITests) ... ok
test_scan_disks_nvme_sys_disk (rockstor.system.tests.test_osi.OSITests) ... ok
test_pkg_changelog (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_get_con_config (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_con_not_found (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_con_config_exception (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_dev_not_found (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok
test_get_dev_config_exception (rockstor.system.tests.test_system_network.SystemNetworkTests) ... ok

...
----------------------------------------------------------------------
Ran 253 tests in 25.784s

FAILED (failures=5, errors=1)
```