### PR TITLE
Py3.6 test_shares.py & test_snapshot.py re boolean type #2580

### DIFF
--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -334,7 +334,8 @@ class ShareTests(APITestMixin):
             "size": 100,
             "replica": "non-bool",
         }
-        e_msg7 = "Replica must be a boolean, not (<type 'unicode'>)."
+        # Py3.6 defaults to class 'str' in our test data.
+        e_msg7 = "Replica must be a boolean, not (<class 'str'>)."
         response9 = self.client.post(self.BASE_URL, data=data5)
         self.assertEqual(
             response9.status_code,

--- a/src/rockstor/storageadmin/tests/test_snapshot.py
+++ b/src/rockstor/storageadmin/tests/test_snapshot.py
@@ -152,7 +152,8 @@ class SnapshotTests(APITestMixin):
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             msg=response.data,
         )
-        e_msg = "Element 'uvisible' must be a boolean, not (<type 'unicode'>)."
+        # Py3.6 defaults to class 'str' in our test data.
+        e_msg = "Element 'uvisible' must be a boolean, not (<class 'str'>)."
         self.assertEqual(response.data[0], e_msg)
 
         # Invalid writable bool type
@@ -176,9 +177,9 @@ class SnapshotTests(APITestMixin):
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             msg=response.data,
         )
-        # TODO consider changing tested code to unify quota types to single
-        #  as per "Invalid uvisible bool type" to remove need for escaping here.
-        e_msg = 'Element "writable" must be a boolean, not ' "(<type 'unicode'>)."
+        # Py3.6 defaults to class 'str' in our test data.
+        # Maintaining type/class report in tested code as this can help with debugging.
+        e_msg = 'Element "writable" must be a boolean, not ' "(<class 'str'>)."
         self.assertEqual(response.data[0], e_msg)
 
         # # Happy Path creating a snapshot by name snap3


### PR DESCRIPTION
Modify testing code to expect new <class 'str'> in test data presented rather than our prior Py2.7 interpretation by tested code of test data as <type 'unicode'>.  Other tests using the proper boolean type pass as expected so we are only looking at interpretation of invalid test data type here. And that this invalid type is being reported by tested code in a useful manner.

N.B. It is important to note that this type/class change is in play re our Py3.6 base.

Fixes #2580 
## Testing

### Before patch
```
AssertionError: "Replica must be a boolean, not (<class 'str'>)." != "Replica must be a boolean, not (<type 'unicode'>)."
&
AssertionError: "Element 'uvisible' must be a boolean, not (<class 'str'>)." != "Element 'uvisible' must be a boolean, not (<type 'unicode'>)."
```

### After patch

- test_share.py
```
buildvm:/opt/rockstor/src/rockstor/storageadmin # poetry run django-admin test -v 2 -p test_shares.py
...
test_compression (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_create (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_exported_replicated (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_no_exports_services_snaps (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_os_exception (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_rock_ons_root (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_delete_with_regular_snapshot (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_get (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_name_regex (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok
test_resize (rockstor.storageadmin.tests.test_shares.ShareTests) ... ok

----------------------------------------------------------------------
Ran 10 tests in 2.870s

OK
```

- test_snapshot.py
```
buildvm:/opt/rockstor/src/rockstor/storageadmin # poetry run django-admin test -v 2 -ptest_snapshot.py
...
test_clone_command (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_delete_requests (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_get (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_1 (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok
test_post_requests_2 (rockstor.storageadmin.tests.test_snapshot.SnapshotTests) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.242s

OK
```