### PR TITLE
Save network usage processed data as List object #2577

### DIFF
--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 # TODO: Let's deprecate gevent in favor of django channels and we won't need
@@ -44,6 +44,7 @@ from glob import glob  # noqa E402
 # https://docs.djangoproject.com/en/1.11/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage
 import django
 from django.conf import settings  # noqa E402
+
 django.setup()
 
 from system.pinmanager import (
@@ -729,8 +730,8 @@ class NetworkWidgetNamespace(RockstorIO):
             with open("/proc/net/dev") as sfo:
                 sfo.readline()
                 sfo.readline()
-                for l in sfo.readlines():
-                    fields = l.split()
+                for line in sfo.readlines():
+                    fields = line.split()
                     if fields[0][:-1] not in interfaces:
                         continue
                     cur_stats[fields[0][:-1]] = fields[1:]
@@ -739,13 +740,15 @@ class NetworkWidgetNamespace(RockstorIO):
                 results = []
                 for interface in cur_stats.keys():
                     if interface in prev_stats:
-                        data = list(map(
-                            lambda x, y: float(x) / interval
-                            if x < y
-                            else (float(x) - float(y)) / interval,
-                            cur_stats[interface],
-                            prev_stats[interface],
-                        ))
+                        data = list(
+                            map(
+                                lambda x, y: float(x) / interval
+                                if x < y
+                                else (float(x) - float(y)) / interval,
+                                cur_stats[interface],
+                                prev_stats[interface],
+                            )
+                        )
                         results.append(
                             {
                                 "device": interface,

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -739,13 +739,13 @@ class NetworkWidgetNamespace(RockstorIO):
                 results = []
                 for interface in cur_stats.keys():
                     if interface in prev_stats:
-                        data = map(
+                        data = list(map(
                             lambda x, y: float(x) / interval
                             if x < y
                             else (float(x) - float(y)) / interval,
                             cur_stats[interface],
                             prev_stats[interface],
-                        )
+                        ))
                         results.append(
                             {
                                 "device": interface,


### PR DESCRIPTION
Fixes #2577 
@phillxnet, ready for review

The network widget was not displaying any data due to a change in what the `map()` function returns:
- Python2: a list
- Python3: an iterator

We then pick many elements of that object to construct our "payload" to the widget. Because is is now an iterator, this worked only the first element, but then returned empty for all others, leading to an empty payload to the widget.

Saving this as a list allows us to get back to previous behavior, resulting in a functional widget:
![image](https://github.com/rockstor/rockstor-core/assets/30297881/4b2f82b8-2fe2-45a9-8ee7-4dcfb4a55fe4)
