### PR TITLE
Py3.6 test_user.py fail re string interpretation #2582

### DIFF
--- a/src/rockstor/storageadmin/tests/test_user.py
+++ b/src/rockstor/storageadmin/tests/test_user.py
@@ -271,7 +271,7 @@ class UserTests(APITestMixin):
         )
         # N.B. in the above we are expecting 500 currently.
         self.assertEqual(
-            response.data[0], "{'email': [u'Enter a valid email address.']}"
+            response.data[0], "{'email': ['Enter a valid email address.']}"
         )
 
     def test_pubkey_validation(self):


### PR DESCRIPTION
Modify our test to expect the Py3.6 output from the Django upstream validation we use on our user.email field: removing the explicit unicode designator that no longer appears.

Fixes #2582 

## Testing
### Before patch
```
buildvm:/opt/rockstor/src/rockstor/storageadmin # poetry run django-admin test -v 2 -p test_user.py
...
test_email_validation (rockstor.storageadmin.tests.test_user.UserTests) ... FAIL
...

======================================================================
FAIL: test_email_validation (rockstor.storageadmin.tests.test_user.UserTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/rockstor/src/rockstor/storageadmin/tests/test_user.py", line 274, in test_email_validation
    response.data[0], "{'email': [u'Enter a valid email address.']}"
AssertionError: "{'email': ['Enter a valid email address.']}" != "{'email': [u'Enter a valid email address.']}"
- {'email': ['Enter a valid email address.']}
+ {'email': [u'Enter a valid email address.']}
?            +

----------------------------------------------------------------------
Ran 8 tests in 1.270s

FAILED (failures=1)
```

### After patch
```
buildvm:/opt/rockstor/src/rockstor/storageadmin # poetry run django-admin test -v 2 -p test_user.py
...
test_email_validation (rockstor.storageadmin.tests.test_user.UserTests) ... ok
...
----------------------------------------------------------------------
Ran 8 tests in 1.264s

OK
```