### PR TITLE
Py3.6 Scheduled tasks import paths fix, snapshot & scub #2570

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/crontabwindow.py
+++ b/src/rockstor/scripts/scheduled_tasks/crontabwindow.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,13 +13,19 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from datetime import datetime, time
 
-# Crontabwindow created as a separate module to avoid code duplication on
-# snapshots and scrubs tasks
+"""
+Crontabwindow created as a separate module to avoid code duplication:
+See scheduled_tasks/
+- snapshots.py
+- pool_scrub.py
+- reboot_shutdown.py
+"""
+
 
 
 def crontab_range(range):

--- a/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
+++ b/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,14 +13,14 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import time
 import sys
 import json
 from datetime import datetime
-import crontabwindow  # load crontabwindow module
+from scripts.scheduled_tasks import crontabwindow
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper
 from django.utils.timezone import utc

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,13 +13,13 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sys
 import json
 from datetime import datetime
-import crontabwindow  # load crontabwindow module
+from scripts.scheduled_tasks import crontabwindow
 from storageadmin.models import Share, Snapshot
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper


### PR DESCRIPTION
Fix missing import paths for Py3.6. Follow-up/counter-part to the test.lead pull request #2579 - indicating we have a lack of test coverage here as these failing imports were not uncovered by our tests as the shutdown one was in the referenced pull request.

Affected snapshot & scrub tasks post the Py3.6 transition. Copywrite date and http to https updated on changed files.

Fixes #2570 

Testing details to follow.