### PR TITLE
Py3.6 Update certifi, urllib3, idna #2588

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,10 @@
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
@@ -167,11 +167,11 @@ redis = ["redis (>=3.0.0)"]
 
 [[package]]
 name = "idna"
-version = "2.10"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "oauthlib"
@@ -299,11 +299,11 @@ testing = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
@@ -346,12 +346,12 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.6"
-content-hash = "bdde4a0b353ef4526f82d73b824193ea5e19d4d728f380f31047eac5be39e333"
+content-hash = "73604f05077875739bb3783394e2ed10fd8263a8c43f354a52759ea89292d060"
 
 [metadata.files]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
@@ -578,8 +578,8 @@ huey = [
     {file = "huey-2.3.0.tar.gz", hash = "sha256:76978840a875607cd77c283c4ebf3ea5071b2ec06a1ac428d63be0d88f1e7070"},
 ]
 idna = [
-    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
-    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
@@ -683,8 +683,8 @@ supervisor = [
     {file = "supervisor-4.2.4.tar.gz", hash = "sha256:40dc582ce1eec631c3df79420b187a6da276bbd68a4ec0a8f1f123ea616b97a2"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 urlobject = [
     {file = "URLObject-2.1.1.tar.gz", hash = "sha256:06462b6ab3968e7be99442a0ecaf20ac90fdf0c50dca49126019b7bf803b1d17"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ python = "~3.6"
 # [tool.poetry.group.django.dependencies]
 django = "==1.11.29"
 django-oauth-toolkit = "==1.1.2"
+pytz = "==2022.6"
 djangorestframework = "==3.9.3"
 django-pipeline = "==1.6.9"
 django-braces = "==1.13.0"  # look to 1.14.0 (30 Dec 2019) as Django 1.11.0+ now
@@ -76,11 +77,7 @@ gevent-websocket = "*"
 gunicorn = "==19.10.0"  # buildout previously used 19.7.1
 
 # [tool.poetry.group.requests.dependencies]
-requests = "==2.27.1"  # Last Python 2/3 version, requires chardet
-idna = "==2.10"  # Requests (2.27.1) requires idna<3,>=2.5
-certifi = "==2021.10.8"  # Requests (2.27.1) requires certifi>=2017.4.17
-urllib3 = "==1.26.12"  # Requests (2.27.1) requires urllib3<1.27,>=1.21.1
-pytz = "==2022.6"
+requests = "==2.27.1"  # Last Python 2.7/3.6 version
 
 # [tool.poetry.group.tools.dependencies]
 six = "==1.16.0"  # 1.14.0 (15 Jan 2020) Python 2/3 compat lib


### PR DESCRIPTION
Remove version pinning as these are secondary dependencies on our unchanged direct dependency of requests.
"poetry update" resulted in:

  • Updating certifi (2021.10.8 -> 2023.5.7)
  • Updating idna (2.10 -> 3.4)
  • Updating urllib3 (1.26.12 -> 1.26.16)

Fixes #2588

## Testing
We have no change from our current testing branch unittest status of:
```
Ran 253 tests in 25.671s

FAILED (failures=2, errors=1)

```