### PR TITLE
Restore config backup functionality #2569

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1440,9 +1440,9 @@ def md5sum(fpath):
     if not os.path.isfile(fpath):
         return None
     md5 = hashlib.md5()
-    with open(fpath) as tfo:
-        for l in tfo.readlines():
-            md5.update(l.encode())
+    with open(fpath, "rb") as tfo:
+        for line in tfo.readlines():
+            md5.update(line)
     return md5.hexdigest()
 
 


### PR DESCRIPTION
Fixes #2569 
@phillxnet , @Hooverdan96 , ready to review

Following our move to Py3.6, we were unable to create a new config backup due to a failure to get the md5 digest of a gzip file (such as a config backup). Our config backup restore was also failing to the presence of a Py2.7-specific bit of code.

This pull-request:
- adjusts `md5sum()` to be able to read a compressed file as well.
- ensures the task def validation returns the share/pool id as string
- add type hints to help ensure proper types are used/returned
- minor docstrings adjustments
- Copyright update

# Highlights
As detailed in https://github.com/rockstor/rockstor-core/issues/2569#issuecomment-1583139382, the `md5sum()` function that is changed here is used other parts of Rockstor; the returned md5 digest remains the same, however (see comment linked for details and verification).

Note also that 2 shortcomings were identified, and 2 x TODOs were thus left as a reminder; these should be the focus of dedicated issues.

**Only scheduled tasks** were confirmed as being successfully restored here as these were the culprits behind the failing unit tests. Restore of other things still need to be confirmed.

# Demonstration
1. A config backup was created on a VM running the latest `master` branch, and downloaded to local disk
2. The `/opt/rockstor` dir was wiped and replaced with this current branch
3. Build Rockstor, and Upload the uncompressed config backup taken in step 1. We can thus confirm that the backup is compressed by Rockstor and correctly processed:
```
[09/Jun/2023 09:23:21] ERROR [storageadmin.views.config_backup:614] Not a gzipped file (b'[{')
Traceback (most recent call last):
  File "/opt/rockstor/src/rockstor/storageadmin/views/config_backup.py", line 612, in get_queryset
    f.read()
  File "/usr/lib64/python3.6/gzip.py", line 276, in read
    return self._buffer.read(size)
  File "/usr/lib64/python3.6/gzip.py", line 463, in read
    if not self._read_gzip_header():
  File "/usr/lib64/python3.6/gzip.py", line 411, in _read_gzip_header
    raise OSError('Not a gzipped file (%r)' % magic)
OSError: Not a gzipped file (b'[{')
[09/Jun/2023 09:23:21] INFO [storageadmin.views.config_backup:617] The file backup-2023-06-08-165248.json is not gzipped, so compress it now.
[09/Jun/2023 09:23:21] DEBUG [system.osi:225] Running command: /usr/bin/gzip /opt/rockstor/static/config-backups/backup-2023-06-08-165248.json
```
4. Restore this backup from the webUI, all scheduled tasks present in the backup are successfully restored:
```
[09/Jun/2023 09:25:06] INFO [storageadmin.views.config_backup:234] Started restoring scheduled tasks.
[09/Jun/2023 09:25:06] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/tasks. Payload: {'name': 'root_scrub', 'task_type': 'scrub', 'crontab': '42 3 * * 5', 'crontabwindow': '*-*-*-*-*-*', 'enabled': False, 'meta': {'pool_name': 'ROOT', 'pool': '1'}}
[09/Jun/2023 09:25:06] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/tasks. Payload: {'name': 'snap-daily_rs01', 'task_type': 'snapshot', 'crontab': '42 3 * * 5', 'crontabwindow': '*-*-*-*-*-*', 'enabled': True, 'meta': {'writable': True, 'visible': True, 'prefix': 'snap_daily_rs01', 'share': '2', 'max_count': '4'}}
[09/Jun/2023 09:25:06] INFO [storageadmin.views.config_backup:57] Successfully created resource: https://localhost/api/sm/tasks. Payload: {'name': 'reboot_test', 'task_type': 'reboot', 'crontab': '42 3 1 * *', 'crontabwindow': '*-*-*-*-*-*', 'enabled': True, 'meta': {}}
[09/Jun/2023 09:25:06] INFO [storageadmin.views.config_backup:238] Finished restoring scheduled tasks.
[09/Jun/2023 09:25:06] INFO [storageadmin.tasks:64] Task [restore_config], id: 00db558d-c54a-487a-9e4c-5589372b2ba3 completed OK
```
![image](https://github.com/rockstor/rockstor-core/assets/30297881/977dcbfa-cec1-43a2-8f37-6a2a8872e1f3)

# Unit tests
This PR also brings us back to all tests now passing:
```
rockdev:/opt/rockstor # cd src/rockstor/ ; poetry run django-admin test  ; cd -
(...)
.............................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 253 tests in 11.761s

OK
```