### PR TITLE
Add GitHub Action to trigger post-release updates across repositories #2596

### DIFF
--- a/.github/workflows/trigger_updates.yml
+++ b/.github/workflows/trigger_updates.yml
@@ -1,0 +1,54 @@
+name: Trigger updates
+on: workflow_dispatch
+jobs:
+  set-vars:
+    name: Get version, release, and notes
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-ver.outputs.version }}
+      release: ${{ steps.set-rel.outputs.release }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set Version
+        id: set-ver
+        run: |
+          echo "version=$(gh release list --limit 1 -R rockstor/rockstor-core | cut -f1 | cut -d "-" -f1)" >> "$GITHUB_OUTPUT"
+      - name: Set Release
+        id: set-rel
+        run: |
+          echo "release=$(gh release list --limit 1 -R rockstor/rockstor-core | cut -f1 | cut -d "-" -f2)" >> "$GITHUB_OUTPUT"
+
+  trigger_rockstor-jslibs_release:
+    name: Trigger a release in the rockstor-jslibs repo
+    runs-on: ubuntu-latest
+    needs: set-vars
+    env:
+      VERSION: ${{ needs.set-vars.outputs.version }}
+      GH_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
+    steps:
+      - name: trigger the rockstor-jslibs workflow
+        id: trigger-jslibs-workflow
+        run: |
+          gh workflow run update_release.yml \
+          -f version=$VERSION \
+          -f target_branch=${GITHUB_REF_NAME} \
+          -R rockstor/rockstor-jslibs
+
+  trigger_rockstor-rpmbuild-updates:
+    name: Trigger the update of the rockstor-rpmbuild repo
+    runs-on: ubuntu-latest
+    needs: set-vars
+    env:
+      VERSION: ${{ needs.set-vars.outputs.version }}
+      RELEASE: ${{ needs.set-vars.outputs.release }}
+      GH_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
+    steps:
+      - name: trigger the rockstor-jslibs workflow
+        id: trigger-jslibs-workflow
+        run: |
+          gh workflow run update_spec_file.yml \
+          -f version=$VERSION \
+          -f release=$RELEASE \
+          -f target_branch=${GITHUB_REF_NAME} \
+          -R rockstor/rockstor-rpmbuild


### PR DESCRIPTION
Fixes #2596 

After each release, we are currently manually performing the required changes and udpates across our repositories.
This pull request proposes to add a GitHub Action workflow to trigger these changes automatically.

This workflow needs to be manually triggered against either the `master` or `testing` branch, according to the release that was created. This workflow will gather the release-version information, and trigger the workflows triggering the required edits in the two other repositories:
  - in rockstor-jslibs: the workflow simply creates a new release according to version, targeting the base branch (`master` or `testing` according to what was chosen when manually triggering the workflow here).
  - in rockstor-rpmbuild: the workflow edits `rockstor.spec` according to version-release and adds the changelog according to the release notes present in rockstor-core. It then pushes the changes to rockstor-rpmbuild (as a new branch) and creates a pull request against the base branch (`master` or `testing`).

@phillxnet: in order to have this workflow run on either the `master` or `testing` branch, it needs to be present in both branches. I'm submitting this PR against `master` as it needs to be present in `master` even if we want to run it against `testing`. This means we'll have to add it to `testing` as well.