### PR TITLE
Testing counterpart Revise Stable Updates activation re legacy shop removal #2603

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -206,17 +206,15 @@ $(document).ready(function(){
 	<p>
 	  Please follow these steps to activate Stable Updates.<br>
     <div style="text-align: center;">
-         <i>Steps 2 & 3 will be automated away as we integrate with our new Open Collective.</i>
+         <strong><i>Steps 1 & 2 will each send confirmation / information emails.</i></strong>
       </div>
 	</p>
 	<ol>
-    <li>Become a "Stable Updates subscription" contributor/member at our
+    <li>Become a "Stable Updates subscription" contributor / member at our
         <a href="https://opencollective.com/the-rockstor-project/contribute" target="_blank">Open Collective.</a></li>
-    <li><a href="https://shop.rockstor.com/pages/frontpage" target="_blank">Open our shop</a> by entering the password emailed to you in step 1.</li>
-	  <li>Order your Activation code
-        <a href="https://shop.rockstor.com/products/stable-release-channel-subscription#applianceid={{applianceId}}" target="_blank">here</a>
-        - sent via email within 5 minutes.</li>
-	  <li>Enter your Activation code below.</li>
+    <li>Enter / Edit / Check your <span style="color:green">Current Appliance ID</span> in your
+      <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.</li>
+    <li>Enter your Activation code below, emailed by <strong>Appman</strong> immediately after step 2.</li>
 	</ol>
         Thank you for helping to support Rockstor's development.
 	<form id="activate-stable-form" name="aform" class="form-horizontal">
@@ -232,7 +230,7 @@ $(document).ready(function(){
 	  </div>
 	  <p style="color:green">Current Appliance ID: {{applianceId}}</p>
     <br>
-    Note our complementary self service <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.
+    Note your complementary self service <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.
     <br>
     The above 'Current Appliance ID' should match that within Appman for this computer.
 	  <div class="modal-footer">


### PR DESCRIPTION
Modify our "Activate Stable updates" dialog instructions in accordance with our removal of the now legacy/redundant shop that has now been replaced by Appman's initial integration with our newly established Open Collective.

(cherry picked from commit ae3f342e341b2a5955a15c8b872a968e68fd5636)

Fixes #2603 
Testing branch counterpart to issue #2599 (Pull request #2601)