### PR TITLE
SSL Certificate update doesn't reload nginx #2566

### DIFF
--- a/src/rockstor/storageadmin/views/tls_certificate.py
+++ b/src/rockstor/storageadmin/views/tls_certificate.py
@@ -26,7 +26,7 @@ from system.osi import run_command
 from shutil import move
 from tempfile import mkstemp
 from django.conf import settings
-from system.services import superctl
+from system.services import systemctl
 import logging
 
 logger = logging.getLogger(__name__)
@@ -89,5 +89,5 @@ class TLSCertificateView(rfc.GenericView):
                 handle_exception(Exception(e_msg), request)
             move(cpath, "%s/rockstor.cert" % settings.CERTDIR)
             move(kpath, "%s/rockstor.key" % settings.CERTDIR)
-            superctl("nginx", "restart")
+            systemctl("nginx", "reload")
             return Response(TLSCertificateSerializer(co).data)


### PR DESCRIPTION
Use systemctl wrapper to reload nginx post SSL cert reconfig. From Rockstor v4.5.4-0 onwards nginx is no longer managed by supervisord.

# Includes
- Nginx reload not restart to avoid Web-UI service interruption and enable confirmation dialog display.

Fixes #2566 

## Testing
https://doc.opensuse.org/documentation/leap/reference/html/book-reference/cha-apache2.html
```
zypper in --no-recommends apache2-utils apache2
gensslcert -h
buildvm:~ # gensslcert -o "The Rockstor Project" -c PT -email support@rockstor.com
comment         mod_ssl server certificate
C               PT
ST              unknown
L               unknown
U               web server
O               The Rockstor Project
CN              buildvm.lan
email           mail
altName         DNS:buildvm.lan
srvdays         730
CAdays          2190
```
Then used the contents of the following generated files, by way of a test certificate set, to complete the form presented within the Web-UI under SYSTEM -> SSL Certificate:

## SSLCertificateFile (Certificate)

/etc/apache2/ssl.crt/buildvm.lan-server.crt

## SSLCertificateKeyFile (Private Key)

/etc/apache2/ssl.key/buildvm.lan-server.key

Resulting confirmation dialog:

![Cert-update-success-dialog](https://github.com/rockstor/rockstor-core/assets/2521585/58789a45-232c-4ba1-bc08-7da3ab782813)

After accepting the dialog we are re-presented with adding an exception option given our 'fake' self-signed testing certificate as per the following installation step:
https://rockstor.com/docs/installation/installer-howto.html#visit-rockstor-s-web-ui

And by selecting "Advance" in the above we have a "View Certificate" link which confirms our new Certificate info:

![view-cert](https://github.com/rockstor/rockstor-core/assets/2521585/20fe1a30-b1da-4030-8fe3-a42d8a3e27d9)





