### PR TITLE
SSL Certificate update doesn't reload nginx #2606

### DIFF
--- a/src/rockstor/storageadmin/views/tls_certificate.py
+++ b/src/rockstor/storageadmin/views/tls_certificate.py
@@ -26,7 +26,7 @@ from system.osi import run_command
 from shutil import move
 from tempfile import mkstemp
 from django.conf import settings
-from system.services import superctl
+from system.services import systemctl
 import logging
 
 logger = logging.getLogger(__name__)
@@ -89,5 +89,5 @@ class TLSCertificateView(rfc.GenericView):
                 handle_exception(Exception(e_msg), request)
             move(cpath, "%s/rockstor.cert" % settings.CERTDIR)
             move(kpath, "%s/rockstor.key" % settings.CERTDIR)
-            superctl("nginx", "restart")
+            systemctl("nginx", "reload")
             return Response(TLSCertificateSerializer(co).data)


### PR DESCRIPTION
Use systemctl wrapper to reload nginx post SSL cert reconfig. From Rockstor v4.5.4-0 onwards nginx is no longer managed by supervisord.
# Includes
- Nginx reload not restart to avoid Web-UI service interruption and enable confirmation dialog display.

(cherry picked from commit 6284eb75014b148d7bdfa33b9a4828de49f33863)

Fixes #2606 