### PR TITLE
update use of python distro module re 1.7.0+ changes #2426

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,11 +38,11 @@ python-versions = "*"
 
 [[package]]
 name = "distro"
-version = "1.6.0"
+version = "1.8.0"
 description = "Distro - an OS platform information API"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "django"
@@ -346,7 +346,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.6"
-content-hash = "a6453052ab301486bdd4e821d0eea7186083112517cb51847c6f69dc18f2ce8e"
+content-hash = "e9c4715506bb4e7a04848ec8e6556b223dcd7ee7df2f11b7da9496644ee6606f"
 
 [metadata.files]
 certifi = [
@@ -427,8 +427,8 @@ dbus-python = [
     {file = "dbus-python-1.2.18.tar.gz", hash = "sha256:92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"},
 ]
 distro = [
-    {file = "distro-1.6.0-py2.py3-none-any.whl", hash = "sha256:c8713330ab31a034623a9515663ed87696700b55f04556b97c39cd261aa70dc7"},
-    {file = "distro-1.6.0.tar.gz", hash = "sha256:83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424"},
+    {file = "distro-1.8.0-py3-none-any.whl", hash = "sha256:99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff"},
+    {file = "distro-1.8.0.tar.gz", hash = "sha256:02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8"},
 ]
 django = [
     {file = "Django-1.11.29-py2.py3-none-any.whl", hash = "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ psutil = "==5.9.4"
 # mock = "==1.0.1" now part of std lib in Python 3.3 onwards as unittest.mock
 # pyzmq requires libzmq5 on system unless in wheel form.
 pyzmq = "==19.0.2"  # Last specifying Python 2 on PyPi page.
-distro = "==1.6.0"  # Last Python 2/3 version that works as we expect.
+distro = "*"
 URLObject = "==2.1.1"
 # https://pypi.org/project/supervisor/ 4.1.0 onwards embeds unmaintained meld3
 supervisor = "==4.2.4"

--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -36,8 +36,9 @@ logger = logging.getLogger(__name__)
 
 DOCKERD = "/usr/bin/dockerd"
 
-# Distro's for which we have known working conf/docker-distroid.service files.
-KNOWN_DISTRO_IDS = ["rockstor", "opensuse-leap", "opensuse-tumbleweed"]
+# Distros for which we have had known working conf/docker-distroid.service files.
+# This mechanism has now been superseded but is maintained just-in-case for now.
+KNOWN_DISTRO_IDS = ["rockstor", "opensuse", "opensuse-tumbleweed"]
 
 
 class DockerServiceView(BaseServiceDetailView):

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -27,8 +27,9 @@ from system.pkg_mgmt import (
 class SystemPackageTests(unittest.TestCase):
     """
     The tests in this suite can be run via the following command:
-    cd <root dir of rockstor ie /opt/rockstor-dev>
-    ./bin/test --settings=test-settings -v 3 -p test_pkg_mgmt*
+    cd /opt/rockstor/src/rockstor
+    export DJANGO_SETTINGS_MODULE=settings
+    poetry run django-admin test -p test_pkg_mgmt.py -v 2
     """
 
     def setUp(self):
@@ -36,7 +37,7 @@ class SystemPackageTests(unittest.TestCase):
         self.mock_run_command = self.patch_run_command.start()
 
         # We need to test the conditions of distro.id() returning one of:
-        # rockstor, opensuse-leap, opensuse-tumbleweed
+        # rockstor, opensuse, (was opensuse-leap), opensuse-tumbleweed
         self.patch_distro = patch("system.pkg_mgmt.distro")
         self.mock_distro = self.patch_distro.start()
 
@@ -106,15 +107,16 @@ class SystemPackageTests(unittest.TestCase):
         yum check-update -q -x rock*
         and:
         output format of:
-        distro.id = "opensuse-leap"
+        distro.id = "opensuse" N.B. this was "opensuse-leap" in distro <= 1.6.0
         zypper -q list-updates
         and:
         distro.id = "opensuse-tumbleweed"
-        same command as for opensuse-leap
+        same command as for "opensuse"
         """
         # Mock pkg_changelog to allow for isolated testing of yum_check
         self.patch_pkg_changelog = patch("system.pkg_mgmt.pkg_changelog")
         self.mock_pkg_changelog = self.patch_pkg_changelog.start()
+        # TODO:
 
         def fake_pkg_changelog(*args, **kwargs):
             """
@@ -265,7 +267,7 @@ class SystemPackageTests(unittest.TestCase):
             ]
         )
         rc.append(106)
-        dist_id.append("opensuse-leap")
+        dist_id.append("opensuse")
         #
         for o, e, r, expected, distro in zip(out, err, rc, expected_result, dist_id):
             self.mock_run_command.return_value = (o, e, r)
@@ -382,7 +384,7 @@ class SystemPackageTests(unittest.TestCase):
         rc = [0]
         expected_results = [("3.9.2-50.2093", "2019-Nov-30")]
         # Leap15.1 dnf-yum
-        dist_id.append("opensuse-leap")
+        dist_id.append("opensuse")
         out.append(
             [
                 "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
@@ -594,7 +596,7 @@ class SystemPackageTests(unittest.TestCase):
         rc.append(1)
         expected_result.append(None)
         # Leap15.1 dnf-yum - rockstor package installed with update available:
-        dist_id.append("opensuse-leap")
+        dist_id.append("opensuse")
         out.append(
             [
                 "Last metadata expiration check: 0:00:10 ago on Mon 02 Dec 2019 06:22:10 PM GMT.",


### PR DESCRIPTION
Unpin direct dependency 'distro' and update pkg tests re
>= 1.7.0 versions returning id 'opensuse' for Leap versions,
rather than the prior behaviour of 'opensuse-leap'.

Fixes #2426 

## Testing:
```
cd /opt/rockstor/src/rockstor
export DJANGO_SETTINGS_MODULE=settings
poetry run django-admin test -p test_pkg_mgmt.py -v 2
...
test_pkg_changelog (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_latest_available (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_pkg_update_check (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_rpm_build_info (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok
test_zypper_repos_list (rockstor.system.tests.test_pkg_mgmt.SystemPackageTests) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.011s
```