### PR TITLE
Add option for ZSTD compression #2618

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -2333,7 +2333,7 @@ def get_property(mnt_pt, prop_name=None):
     properties. But if called with a single property then the value and type
     appropriate for that property ie:
     string for label (in presented in properties),
-    string for compression ie: lzo, zlib (if presented in properties),
+    string for compression ie: lzo, zlib (if presented in properties), zstd,
     and Boolean for prop_name='ro'
     If prop_name specified but not found then None is returned.
     N.B. compression property for subvol only, vol/pool uses mount option.

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -363,7 +363,7 @@ REST_FRAMEWORK = {
 
 CONFROOT = '{}/conf'.format(BASE_DIR)
 CERTDIR = '{}/certs'.format(BASE_DIR)
-COMPRESSION_TYPES = ('lzo', 'zlib', 'no',)
+COMPRESSION_TYPES = ('lzo', 'zlib', 'zstd', 'no',)
 
 SNAP_TS_FORMAT = '%Y%m%d%H%M'
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -48,6 +48,7 @@
                         <option value="no">Don't enable compression</option>
                         <option value="zlib">zlib</option>
                         <option value="lzo">lzo</option>
+                        <option value="zstd">zstd</option>
                     </select>
                 </div>
             </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
@@ -6,12 +6,14 @@
                 {{pool.compression}}
             {{else}}
             <strong>
-            <a href="#" id="comprOptn" data-type="select"
-            data-title="Pool compression algorithm.<br><strong>zlib: </strong>
-            slower than lzo but higher compression ratio.<br><strong>lzo: </strong>faster than zlib but lower compression ratio.<br>
-            Pool level compression applies to all it's Shares.<br>Alternatively: consider Share level compression.
-            <br>Unchanged data remains at prior setting until balanced."
-            >{{pool.compression}}
+            <a href="#" id="comprOptn" data-type="select" data-title="Pool compression algorithm.<br>
+            <strong>zlib: </strong>slower than LZO but higher compression ratio.<br>
+            <strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br>
+            <strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>
+            Pool level compression applies to all it's Shares.<br>
+            Alternatively: consider Share level compression.<br>
+            Unchanged data remains at prior setting until balanced.">
+                {{pool.compression}}
             </a>
             </strong>
             {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -61,11 +61,13 @@
                     {{this.compression}}
                 {{else}}
                     <strong><a href="#" class="cmpOptns" data-name="cmpOptns" data-type="select" data-mntoptn="{{this.mnt_options}}"
-                               data-value="{{this.compression}}" data-pid="{{this.id}}" data-title="Pool compression algorithm.
-                               <br><strong>zlib: </strong>slower than lzo but higher compression ratio.<br><strong>lzo: </strong>
-                               faster than zlib but lower compression ratio.<br>Pool level compression applies to all it's Shares.
-                               <br>Alternatively: consider Share level compression.<br>Unchanged data remains at prior setting
-                               until balanced.">
+                               data-value="{{this.compression}}" data-pid="{{this.id}}" data-title="Pool compression algorithm.<br>
+                                <strong>zlib: </strong>slower than LZO but higher compression ratio.<br>
+                                <strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br>
+                                <strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>
+                                Pool level compression applies to all it's Shares.<br>
+                                Alternatively: consider Share level compression.<br>
+                                Unchanged data remains at prior setting until balanced.">
                     {{this.compression}}</a></strong>
                 {{/if}}
             </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/add_share_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/add_share_template.jst
@@ -47,6 +47,7 @@
             <option value="no">Inherit from pool wide configuration</option>
             <option value="zlib">zlib</option>
             <option value="lzo">lzo</option>
+            <option value="zstd">zstd</option>
           </select>
         </div>
       </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -192,7 +192,7 @@ AddPoolView = Backbone.View.extend({
         this.$('#compression').tooltip({
             html: true,
             placement: 'right',
-            title: 'Choose a Pool compression algorithm.<br><strong>zlib: </strong>slower than lzo but higher compression ratio.<br><strong>lzo: </strong>faster than zlib but lower compression ratio.<br>Pool level compression applies to all it\'s Shares.<br>Alternatively: consider Share level compression.<br>This setting can be changed at any time.'
+            title: 'Choose a Pool compression algorithm.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>Pool level compression applies to all its Shares.<br>Alternatively: consider Share level compression.<br>This setting can be changed at any time.'
         });
 
         $('#add-pool-form').validate({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_share.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_share.js
@@ -116,7 +116,7 @@ AddShareView = Backbone.View.extend({
                 _this.$('#compression').tooltip({
                     html: true,
                     placement: 'right',
-                    title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than lzo but higher compression ratio.<br><strong>lzo: </strong>faster than zlib but lower compression ratio.'
+                    title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.'
                 });
 
                 $('#add-share-form').validate({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -57,6 +57,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         this.cOpts = {
             'no': 'Dont enable compression',
             'zlib': 'zlib',
+            'zstd': 'zstd',
             'lzo': 'lzo'
         };
         this.initHandlebarHelpers();
@@ -155,6 +156,7 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
             source: [
                 {value: 'no', text: 'no'},
                 {value: 'zlib', text: 'zlib'},
+                {value: 'zstd', text: 'zstd'},
                 {value: 'lzo', text: 'lzo'}
             ],
             success: function(response, newCompr) {

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -95,6 +95,7 @@ PoolsView = RockstorLayoutView.extend({
             source: [
                      {value: 'no', text: 'no'},
                      {value: 'zlib', text: 'zlib'},
+                     {value: 'zstd', text: 'zstd'},
                      {value: 'lzo', text: 'lzo'}
             ],
             success: function(response, newCompr){

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
@@ -99,6 +99,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.cOpts = {
             'no': 'Dont enable compression',
             'zlib': 'zlib',
+            'zstd': 'zstd',
             'lzo': 'lzo'
         };
         this.cView = this.options.cView;
@@ -348,7 +349,7 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.$('#ph-compression-info #compression').tooltip({
             html: true,
             placement: 'top',
-            title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than lzo but higher compression ratio.<br><strong>lzo: </strong>faster than zlib but lower compression ratio.'
+            title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.'
         });
     },
 

--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -442,6 +442,7 @@ class PoolTests(APITestMixin):
         - enable zlib
         - disable lzo - compression-test-pool
         - enable lzo
+        - change compression from lzo to zstd - compression-test-pool
         """
 
         # create pool with invalid compression
@@ -453,7 +454,7 @@ class PoolTests(APITestMixin):
         }
         e_msg = (
             "Unsupported compression algorithm (derp). "
-            "Use one of ('lzo', 'zlib', 'no')."
+            "Use one of ('lzo', 'zlib', 'zstd', 'no')."
         )
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
@@ -541,6 +542,15 @@ class PoolTests(APITestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
         self.assertEqual(response.data["compression"], "lzo")
+
+        # change compression from lzo to zstd on compression-test-pool
+        comp_zstd = {"compression": "zstd"}
+        # call remount pool command with new compression setting request (put)
+        response = self.client.put(
+            "{}/{}/remount".format(self.BASE_URL, pId), data=comp_zstd
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
+        self.assertEqual(response.data["compression"], "zstd")
 
     def test_mount_options(self):
         """
@@ -658,7 +668,7 @@ class PoolTests(APITestMixin):
 
         # test invalid compress-force applied via remount command
         data2 = {"mnt_options": "compress-force=1"}
-        e_msg = "compress-force is only allowed with ('lzo', 'zlib', 'no')."
+        e_msg = "compress-force is only allowed with ('lzo', 'zlib', 'zstd', 'no')."
         response = self.client.put(
             "{}/{}/remount".format(self.BASE_URL, pId), data=data2
         )

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -260,7 +260,7 @@ class ShareTests(APITestMixin):
         data["compression"] = "invalid"
         e_msg2 = (
             "Unsupported compression algorithm (invalid). Use one of "
-            "('lzo', 'zlib', 'no')."
+            "('lzo', 'zlib', 'zstd', 'no')."
         )
         response3 = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
@@ -447,6 +447,7 @@ class ShareTests(APITestMixin):
         - enable zlib
         - disable lzo
         - enable lzo
+        - change compression from lzo to zstd
         """
 
         # create share with invalid compression
@@ -458,7 +459,7 @@ class ShareTests(APITestMixin):
         }
         e_msg = (
             "Unsupported compression algorithm (derp). "
-            "Use one of ('lzo', 'zlib', 'no')."
+            "Use one of ('lzo', 'zlib', 'zstd', 'no')."
         )
         response = self.client.post(self.BASE_URL, data=compression_test_share)
         self.assertEqual(
@@ -531,6 +532,14 @@ class ShareTests(APITestMixin):
         )
         self.assertEqual(response8.status_code, status.HTTP_200_OK, msg=response8.data)
         self.assertEqual(response8.data["compression_algo"], "lzo")
+
+        # change compression from lzo to zstd
+        compression_zstd = {"compression": "zstd"}
+        response9 = self.client.put(
+            "{}/{}".format(self.BASE_URL, sId), data=compression_zstd
+        )
+        self.assertEqual(response9.status_code, status.HTTP_200_OK, msg=response.data)
+        self.assertEqual(response9.data["compression_algo"], "zstd")
 
     def test_delete_exported_replicated(self):
         """


### PR DESCRIPTION
What a dev wants, a dev gets... At least when he can spare some time away from his crying child. Don't worry, she's OK.

Implemented the ZSTD option by hunting through and finding all the references to zlib and adding a zstd option next to it. I hope I found all the right places, that tooltip text sure could be a constant somewhere... I took the text from the btrfs rtd page: https://btrfs.readthedocs.io/en/latest/Compression.html but if we want to *ahem* compress it, that's fine as well.

Anywho, the results are good for the pool:
![Screenshot from 2023-07-12 19-43-15](https://github.com/rockstor/rockstor-core/assets/1148665/a7066382-f5c1-41de-981a-29204c4fb356)

and shares:
![image](https://github.com/rockstor/rockstor-core/assets/1148665/106d1de3-27f3-4906-be0b-0a9d7853a3ba)


Closes #2618 