### PR TITLE
Update specifics of Python version in pyproject.toml etc #2620

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,13 @@
 set -o errexit
 
 # Install Poetry, a dependency management, packaging, and build system.
-# We currently require Python 2.7 compatibility which was last in v1.1.15.
+# We currently require Python 3.6 compatibility which was last in v1.1.15.
 # We use the official installer which installs to: ~/.local/share/pypoetry.
 # The installer is python 3 only: https://python-poetry.org/docs/#installation
 # N.B. there is no harm in re-running this installer.
+# For first-install on Tumbleweed instances with Py3.11 as default:
+# 1. uninstall vai: curl -sSL https://install.python-poetry.org | python3 - --uninstall
+# 2. change 3 to 3.8 in the following:
 curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.1.15 python3 -
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml

--- a/poetry.lock
+++ b/poetry.lock
@@ -345,8 +345,8 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "~3.6"
-content-hash = "e9c4715506bb4e7a04848ec8e6556b223dcd7ee7df2f11b7da9496644ee6606f"
+python-versions = ">= 3.6, < 3.9"
+content-hash = "19dc63a5e62eb552b7207bde82a139b0038ecadadfa71ea3b6f2e56af0448b9c"
 
 [metadata.files]
 certifi = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,13 @@ generate-setup-file = false
 
 [tool.poetry.dependencies]
 # We use groups (>=1.2.0) to clarify our dependencies (essentially labels):
-# We currently need Poetry 1.1.15 for it's Python 2.7 compatibility.
+# We currently need Poetry 1.1.15 for it's Python 2.7/3.6 compatibility.
+# https://python-poetry.org/history/#120b1---2022-03-17
+# 1.20b1 dropped Python 3.6 support.
 # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
 #
-# https://python-poetry.org/docs/1.1/dependency-specification/
-python = "~3.6"
+# https://python-poetry.org/docs/dependency-specification
+python = ">= 3.6, < 3.9"
 
 # [tool.poetry.group.django.dependencies]
 django = "==1.11.29"

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -87,7 +87,7 @@ MEDIA_URL = '/media/'
 
 # Establish BASE_DIR from ourselves (./src/rockstor/settings.py)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-# print "BASE_DIR={}".format(BASE_DIR)  # "/opt/rockstor" via 'django-admin runserver'
+# print("BASE_DIR={}".format(BASE_DIR))  # "/opt/rockstor" via 'django-admin runserver'
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"


### PR DESCRIPTION
Move from Python 3.6.*, to above 3.6 and below 3.9. Primarily to accommodate both Leap default Python, and Tumbleweed optional Python. Also update comments re Py3.6 & TW Py3.8 caveat.

Fixes #2620 