### PR TITLE
user admin enable without password change not internal error #2635

### DIFF
--- a/src/rockstor/storageadmin/views/user.py
+++ b/src/rockstor/storageadmin/views/user.py
@@ -257,7 +257,7 @@ class UserDetailView(UserMixin, rfc.GenericView):
                                 "enable admin access. Please provide "
                                 "a new password."
                             )
-                            handle_exception(Exception(e_msg), request)
+                            handle_exception(Exception(e_msg), request, status_code=400)
                         auser = DjangoUser.objects.create_user(username, None, new_pw)
                         auser.is_active = True
                         auser.save()


### PR DESCRIPTION
Return HTTP_400_BAD_REQUEST not HTTP_500_INTERNAL_SERVER_ERROR.

Fixes #2635 

## Before proposed change

We return an internal server error code of 500 to our client side which results in our Web-UI providing a back-trace/debugging type feedback on an internal error that has not happened.

![before-with-500](https://github.com/rockstor/rockstor-core/assets/2521585/a5a0228c-5836-414f-826e-d56a65dcdf52)

## After patch

The change to a 400 bad client request error code results in the following more appropriate Web-UI dialog:

![after-with-400](https://github.com/rockstor/rockstor-core/assets/2521585/9f0e7e0c-941b-4965-b56e-d7958d3675e0)

## Counterpart unit test changes

This pull request and its associated issue address a small tested code modification surfaced while improving our tests in this area in work done against issue:
"Improve OS independence re unit tests #2633"
The appropriate testing change will be included in a referenced pull reqeust against that issue.
