### PR TITLE
Improve OS independence re unit tests #2633

### DIFF
--- a/src/rockstor/smart_manager/tests/test_snmp.py
+++ b/src/rockstor/smart_manager/tests/test_snmp.py
@@ -15,9 +15,18 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from unittest.mock import patch
 
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+
+"""
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_snmp.py
+"""
 
 
 class SNMPTests(APITestCase):
@@ -41,6 +50,11 @@ class SNMPTests(APITestCase):
         """
         config happy path
         """
+        self.patch_configure_snmp = patch(
+            "smart_manager.views.snmp_service.configure_snmp"
+        )
+        self.mock_configure_snmp = self.patch_configure_snmp.start()
+
         config = {
             "syslocation": "Rockstor Labs",
             "syscontact": "rocky@rockstor.com",
@@ -159,6 +173,10 @@ class SNMPTests(APITestCase):
         """
         start/stop tests
         """
+        self.patch_systemctl = patch("smart_manager.views.snmp_service.systemctl")
+        self.mock_systemctl = self.patch_systemctl.start()
+        self.mock_systemctl.return_value = [""], [""], 0
+
         self.session_login()
         response = self.client.post("%s/start" % self.BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)

--- a/src/rockstor/storageadmin/fixtures/test_user.json
+++ b/src/rockstor/storageadmin/fixtures/test_user.json
@@ -1,0 +1,47 @@
+[
+{
+    "model": "storageadmin.user",
+    "pk": 1,
+    "fields": {
+        "user": [
+            "admin"
+        ],
+        "username": "admin",
+        "uid": 1003,
+        "gid": 100,
+        "public_key": null,
+        "shell": "/bin/bash",
+        "homedir": "/home/radmin",
+        "email": null,
+        "admin": true,
+        "group": 1,
+        "smb_shares": []
+    }
+},
+{
+    "model": "storageadmin.user",
+    "pk": 2,
+    "fields": {
+        "user": null,
+        "username": "testuser",
+        "uid": 1004,
+        "gid": 100,
+        "public_key": null,
+        "shell": "/bin/bash",
+        "homedir": "/home/testuser",
+        "email": null,
+        "admin": false,
+        "group": 1,
+        "smb_shares": []
+    }
+},
+{
+    "model": "storageadmin.group",
+    "pk": 1,
+    "fields": {
+        "gid": 100,
+        "groupname": "users",
+        "admin": true
+    }
+}
+]

--- a/src/rockstor/storageadmin/tests/test_commands.py
+++ b/src/rockstor/storageadmin/tests/test_commands.py
@@ -17,6 +17,14 @@ from rest_framework import status
 from storageadmin.tests.test_api import APITestMixin
 
 
+"""
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_commands.py
+"""
+
+
 class CommandTests(APITestMixin):
     # Proposed fixture = "test_commands.json" was "fix5.json"
     fixtures = ["test_api.json"]
@@ -73,6 +81,18 @@ class CommandTests(APITestMixin):
             "storageadmin.views.command.import_snapshots"
         )
         cls.mock_import_snapshots = cls.patch_import_snapshots.start()
+
+        cls.patch_get_unlocked_luks_containers_uuids = patch(
+            "storageadmin.views.disk.get_unlocked_luks_containers_uuids"
+        )
+        cls.mock_get_unlocked_luks_containers_uuids = (
+            cls.patch_get_unlocked_luks_containers_uuids.start()
+        )
+        cls.mock_get_unlocked_luks_containers_uuids.return_value = []
+
+        cls.patch_enable_quota = patch("storageadmin.views.disk.enable_quota")
+        cls.mock_enable_quota = cls.patch_enable_quota.start()
+        cls.mock_enable_quota.return_value = [""], [""], 0
 
     @classmethod
     def tearDownClass(cls):

--- a/src/rockstor/storageadmin/tests/test_config_backup.py
+++ b/src/rockstor/storageadmin/tests/test_config_backup.py
@@ -13,6 +13,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 from unittest import mock
+from unittest.mock import patch
 from rest_framework import status
 
 from storageadmin.models import ConfigBackup
@@ -37,14 +38,16 @@ System needs 2 non system pools:
 - Create 1 share named 'test_share01'
 - Create 1 share named 'test_share02'
 
+cd /opt/rockstor
 export DJANGO_SETTINGS_MODULE="settings"
 poetry run django-admin dumpdata storageadmin.pool storageadmin.share \
 --natural-foreign --indent 4 > \
 src/rockstor/storageadmin/fixtures/test_config_backup.json
 
 To run the tests:
+cd /opt/rockstor/src/rockstor
 export DJANGO_SETTINGS_MODULE="settings"
-cd src/rockstor && poetry run django-admin test -v 2 -p test_config_backup.py
+poetry run django-admin test -v 2 -p test_config_backup.py
 """
 
 
@@ -1244,6 +1247,10 @@ class ConfigBackupTests(APITestMixin):
         # cls.rockon_emby = RockOn(id=74, name="Emby server")
 
         # TODO: may need to mock os.path.isfile
+
+        cls.patch_backup_config = patch("storageadmin.views.config_backup.backup_config")
+        cls.mock_backup_config = cls.patch_backup_config.start()
+        cls.mock_backup_config.return_value = None
 
     @classmethod
     def tearDownClass(cls):

--- a/src/rockstor/storageadmin/tests/test_disks.py
+++ b/src/rockstor/storageadmin/tests/test_disks.py
@@ -23,6 +23,14 @@ from storageadmin.models import Disk
 from storageadmin.tests.test_api import APITestMixin
 
 
+"""
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_disks.py
+"""
+
+
 class DiskTests(APITestMixin):
     # Proposed fixture = ['test_disks.json']
     fixtures = ["test_api.json"]
@@ -39,6 +47,14 @@ class DiskTests(APITestMixin):
 
         cls.patch_scan_disks = patch("storageadmin.views.disk.scan_disks")
         cls.mock_scan_disks = cls.patch_scan_disks.start()
+
+        cls.patch_get_unlocked_luks_containers_uuids = patch(
+            "storageadmin.views.disk.get_unlocked_luks_containers_uuids"
+        )
+        cls.mock_get_unlocked_luks_containers_uuids = (
+            cls.patch_get_unlocked_luks_containers_uuids.start()
+        )
+        cls.mock_get_unlocked_luks_containers_uuids.return_value = []
 
         cls.patch_blink_disk = patch("storageadmin.views.disk.blink_disk")
         cls.mock_blink_disk = cls.patch_blink_disk.start()

--- a/src/rockstor/storageadmin/tests/test_email_client.py
+++ b/src/rockstor/storageadmin/tests/test_email_client.py
@@ -20,6 +20,14 @@ from storageadmin.models import Appliance
 from storageadmin.tests.test_api import APITestMixin
 
 
+"""
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_email_client.py
+"""
+
+
 class EmailTests(APITestMixin):
     # Proposed fixture "test_appliances.json"
     fixtures = ["test_api.json"]
@@ -54,6 +62,9 @@ class EmailTests(APITestMixin):
 
         cls.patch_update_sasl = patch("storageadmin.views.email_client.update_sasl")
         cls.mock_update_sasl = cls.patch_update_sasl.start()
+
+        cls.patch_update_master = patch("storageadmin.views.email_client.update_master")
+        cls.mock_update_master = cls.patch_update_master.start()
 
         # all values as per fixture
         cls.temp_appliance = Appliance(

--- a/src/rockstor/storageadmin/tests/test_network.py
+++ b/src/rockstor/storageadmin/tests/test_network.py
@@ -23,6 +23,13 @@ from storageadmin.tests.test_api import APITestMixin
 from storageadmin.models import NetworkConnection, NetworkDevice
 
 
+"""
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_network.py
+"""
+
 class NetworkTests(APITestMixin):
     # TODO Move as many by-hand mocks to now functional fixture setup.
     # TODO Provide command to create fixture
@@ -31,7 +38,6 @@ class NetworkTests(APITestMixin):
     # Proposed fixture = "test_network.json"
     # TODO: Needs changing as API url different ie connection|devices|refresh
     # see referenced pr in setUpClass
-    # ./bin/test -v 2 -p test_network.py
     fixtures = ["test_api.json"]
     BASE_URL = "/api/network"
 
@@ -91,6 +97,11 @@ class NetworkTests(APITestMixin):
                 "ipv4_dns_search": None,
             }
         }
+
+        # system.network.get_con_list()
+        cls.patch_get_con_list = patch("system.network.get_con_list")
+        cls.mock_get_con_list = cls.patch_get_con_list.start()
+        cls.mock_get_con_list.return_value = []
 
         # valid_connection
         cls.patch_valid_connection = patch("system.network.valid_connection")


### PR DESCRIPTION
- Add missing mock in test_commands.py re enable_quota() & get_unlocked_luks_containers_uuids().
- add missing mock in test_email_client.py re update_master().
- add missing mock in test_samba.py re refresh_smb_discovery().
- add missing mocks in test_snmp.py re systemd interaction.
- add missing mock in test_network.py re nmcli call.
- add missing mock in test_snapshot.py re refresh_nfs_exports.
- add missing mock in test_config_backup.py re file expectation.
- add missing mock in test_disks.py re dmsetup call.
- revise & update test_user.py re fixtures use. Re-enables a number of remarked-out user tests awaiting this revision. Improves readability, scope, and specificity re test names.

Includes improved instructions on running each test set for all test files modified.

Fixes #2633 