### PR TITLE
resolve indeterminate or inappropriate postgresql alternative conf #2632

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs
 # Set jslibs_version of GitHub release:
-jslibs_version=5.0.1
+jslibs_version=5.0.2
 jslibs_url=https://github.com/rockstor/rockstor-jslibs/archive/refs/tags/"${jslibs_version}".tar.gz
 
 #  Check for rpm embedded, or previously downloaded jslibs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rockstor"
-version = "5.0.1"
+version = "5.0.2"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 homepage = "https://rockstor.com/"
 repository = "https://github.com/rockstor/rockstor-core"


### PR DESCRIPTION
Rockstor-core counterpart to rockstor-rpmbuild repo:
Issue: https://github.com/rockstor/rockstor-rpmbuild/pull/38
PR: https://github.com/rockstor/rockstor-rpmbuild/issues/34

- Updates pyproject.toml and build.sh to new version corresponding to released rpm with fix.

Fixes #2632 