### PR TITLE
Address compression cosmetics #2640

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -2333,7 +2333,7 @@ def get_property(mnt_pt, prop_name=None):
     properties. But if called with a single property then the value and type
     appropriate for that property ie:
     string for label (in presented in properties),
-    string for compression ie: lzo, zlib (if presented in properties), zstd,
+    string for compression ie: zlib (if presented in properties), lzo, zstd,
     and Boolean for prop_name='ro'
     If prop_name specified but not found then None is returned.
     N.B. compression property for subvol only, vol/pool uses mount option.

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -363,7 +363,7 @@ REST_FRAMEWORK = {
 
 CONFROOT = '{}/conf'.format(BASE_DIR)
 CERTDIR = '{}/certs'.format(BASE_DIR)
-COMPRESSION_TYPES = ('lzo', 'zlib', 'zstd', 'no',)
+COMPRESSION_TYPES = ('zlib', 'lzo', 'zstd', 'no',)
 
 SNAP_TS_FORMAT = '%Y%m%d%H%M'
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
@@ -6,12 +6,13 @@
                 {{pool.compression}}
             {{else}}
             <strong>
-            <a href="#" id="comprOptn" data-type="select" data-title="Pool compression algorithm.<br>
-            <strong>zlib: </strong>slower than LZO but higher compression ratio.<br>
-            <strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br>
-            <strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>
-            Pool level compression applies to all it's Shares.<br>
-            Alternatively: consider Share level compression.<br>
+            <a href="#" id="comprOptn" data-type="select" data-title="Pool compression algorithm.<br />
+             - <strong>zlib:</strong> slower than LZO but higher compression ratio.<br />
+             - <strong>lzo:</strong> faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br />
+             - <strong>zstd:</strong> compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br />
+            <br />
+            Pool level compression applies to all its Shares.<br />
+            Alternatively: consider Share level compression.<br />
             Unchanged data remains at prior setting until balanced.">
                 {{pool.compression}}
             </a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -61,13 +61,14 @@
                     {{this.compression}}
                 {{else}}
                     <strong><a href="#" class="cmpOptns" data-name="cmpOptns" data-type="select" data-mntoptn="{{this.mnt_options}}"
-                               data-value="{{this.compression}}" data-pid="{{this.id}}" data-title="Pool compression algorithm.<br>
-                                <strong>zlib: </strong>slower than LZO but higher compression ratio.<br>
-                                <strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br>
-                                <strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>
-                                Pool level compression applies to all it's Shares.<br>
-                                Alternatively: consider Share level compression.<br>
-                                Unchanged data remains at prior setting until balanced.">
+                        data-value="{{this.compression}}" data-pid="{{this.id}}" data-title="Pool compression algorithm.<br />
+                         - <strong>zlib:</strong> slower than LZO but higher compression ratio.<br />
+                         - <strong>lzo:</strong> faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br />
+                         - <strong>zstd:</strong> compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br />
+                        <br />
+                        Pool level compression applies to all its Shares.<br />
+                        Alternatively: consider Share level compression.<br />
+                        Unchanged data remains at prior setting until balanced.">
                     {{this.compression}}</a></strong>
                 {{/if}}
             </td>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_pool.js
@@ -192,7 +192,14 @@ AddPoolView = Backbone.View.extend({
         this.$('#compression').tooltip({
             html: true,
             placement: 'right',
-            title: 'Choose a Pool compression algorithm.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br>Pool level compression applies to all its Shares.<br>Alternatively: consider Share level compression.<br>This setting can be changed at any time.'
+            title: `Choose a Pool compression algorithm.<br />
+             - <strong>zlib:</strong> slower than LZO but higher compression ratio.<br />
+             - <strong>lzo:</strong> faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br />
+             - <strong>zstd:</strong> compression comparable to ZLIB with higher compression/decompression speeds and different ratio.<br />
+            <br />
+            Pool level compression applies to all its Shares.<br />
+            Alternatively: consider Share level compression.<br />
+            This setting can be changed at any time.`
         });
 
         $('#add-pool-form').validate({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_share.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_share.js
@@ -116,7 +116,12 @@ AddShareView = Backbone.View.extend({
                 _this.$('#compression').tooltip({
                     html: true,
                     placement: 'right',
-                    title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.'
+                    title: `Choose a compression algorithm for this Share. By default, parent pool's compression algorithm is applied.<br />
+                    If you like to set pool wide compression, don't choose anything here. If you want finer control of this particular
+                    Share's compression algorithm, you can set it here.<br />
+                     - <strong>zlib:</strong> slower than LZO but higher compression ratio.<br />
+                     - <strong>lzo:</strong> faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br />
+                     - <strong>zstd:</strong> compression comparable to ZLIB with higher compression/decompression speeds and different ratio.`
                 });
 
                 $('#add-share-form').validate({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pool_details_layout_view.js
@@ -57,8 +57,8 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
         this.cOpts = {
             'no': 'Dont enable compression',
             'zlib': 'zlib',
-            'zstd': 'zstd',
-            'lzo': 'lzo'
+            'lzo': 'lzo',
+            'zstd': 'zstd'
         };
         this.initHandlebarHelpers();
         this.poolShares = new PoolShareCollection([], {
@@ -156,8 +156,8 @@ PoolDetailsLayoutView = RockstorLayoutView.extend({
             source: [
                 {value: 'no', text: 'no'},
                 {value: 'zlib', text: 'zlib'},
-                {value: 'zstd', text: 'zstd'},
-                {value: 'lzo', text: 'lzo'}
+                {value: 'lzo', text: 'lzo'},
+                {value: 'zstd', text: 'zstd'}
             ],
             success: function(response, newCompr) {
                 $.ajax({

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/pools.js
@@ -95,8 +95,8 @@ PoolsView = RockstorLayoutView.extend({
             source: [
                      {value: 'no', text: 'no'},
                      {value: 'zlib', text: 'zlib'},
-                     {value: 'zstd', text: 'zstd'},
-                     {value: 'lzo', text: 'lzo'}
+                     {value: 'lzo', text: 'lzo'},
+                     {value: 'zstd', text: 'zstd'}
             ],
             success: function(response, newCompr){
                 //use $(this) to dynamically get pool name from select dropdown.

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
@@ -99,8 +99,8 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.cOpts = {
             'no': 'Dont enable compression',
             'zlib': 'zlib',
-            'zstd': 'zstd',
-            'lzo': 'lzo'
+            'lzo': 'lzo',
+            'zstd': 'zstd'
         };
         this.cView = this.options.cView;
         this.initHandlebarHelpers();
@@ -349,7 +349,12 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
         this.$('#ph-compression-info #compression').tooltip({
             html: true,
             placement: 'top',
-            title: 'Choose a compression algorithm for this Share. By default, parent pool\'s compression algorithm is applied.<br> If you like to set pool wide compression, don\'t choose anything here. If you want finer control of this particular Share\'s compression algorithm, you can set it here.<br><strong>zlib: </strong>slower than LZO but higher compression ratio.<br><strong>lzo:</strong>faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br><strong>zstd: </strong>compression comparable to ZLIB with higher compression/decompression speeds and different ratio.'
+            title: `Choose a compression algorithm for this Share. By default, parent pool's compression algorithm is applied.<br />
+            If you like to set pool wide compression, don't choose anything here. If you want finer control of this particular
+            Share's compression algorithm, you can set it here.<br />
+             - <strong>zlib:</strong> slower than LZO but higher compression ratio.<br />
+             - <strong>lzo:</strong> faster compression and decompression than ZLIB, worse compression ratio, designed to be fast.<br />
+             - <strong>zstd:</strong> compression comparable to ZLIB with higher compression/decompression speeds and different ratio.`
         });
     },
 

--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -454,7 +454,7 @@ class PoolTests(APITestMixin):
         }
         e_msg = (
             "Unsupported compression algorithm (derp). "
-            "Use one of ('lzo', 'zlib', 'zstd', 'no')."
+            "Use one of ('zlib', 'lzo', 'zstd', 'no')."
         )
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
@@ -668,7 +668,7 @@ class PoolTests(APITestMixin):
 
         # test invalid compress-force applied via remount command
         data2 = {"mnt_options": "compress-force=1"}
-        e_msg = "compress-force is only allowed with ('lzo', 'zlib', 'zstd', 'no')."
+        e_msg = "compress-force is only allowed with ('zlib', 'lzo', 'zstd', 'no')."
         response = self.client.put(
             "{}/{}/remount".format(self.BASE_URL, pId), data=data2
         )

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -260,7 +260,7 @@ class ShareTests(APITestMixin):
         data["compression"] = "invalid"
         e_msg2 = (
             "Unsupported compression algorithm (invalid). Use one of "
-            "('lzo', 'zlib', 'zstd', 'no')."
+            "('zlib', 'lzo', 'zstd', 'no')."
         )
         response3 = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
@@ -459,7 +459,7 @@ class ShareTests(APITestMixin):
         }
         e_msg = (
             "Unsupported compression algorithm (derp). "
-            "Use one of ('lzo', 'zlib', 'zstd', 'no')."
+            "Use one of ('zlib', 'lzo', 'zstd', 'no')."
         )
         response = self.client.post(self.BASE_URL, data=compression_test_share)
         self.assertEqual(


### PR DESCRIPTION
This PR pretties up the Compression Info Tooltip, and also ensures that the ordering is consistent throughout the repo as to which algorithms are supported.

Pool overview tooltip:
![image](https://github.com/rockstor/rockstor-core/assets/1148665/cc5c68e8-f78d-464b-8501-262f80179718)
Pool overview dropdown:
![Screenshot from 2023-08-04 16-04-11](https://github.com/rockstor/rockstor-core/assets/1148665/b969b11d-9b24-4d61-8c41-88b6916802a3)

Pool detail tooltip:
![image](https://github.com/rockstor/rockstor-core/assets/1148665/81d99752-0ef4-45dd-aaba-182d127f55ef)

Pool detail dropdown:
![Screenshot from 2023-08-04 16-08-57](https://github.com/rockstor/rockstor-core/assets/1148665/b0b8a0ec-9ce7-4d6a-9b14-4796ffe8de37)

Share tooltip and dropdown:
![Screenshot from 2023-08-04 16-06-35](https://github.com/rockstor/rockstor-core/assets/1148665/2955862c-97c1-4a06-bee7-72f25adfa311)

Fixes #2640