### PR TITLE
Update .gitignore with Rockstor build artifacts #2644

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,13 @@ node_modules/
 
 # VS Code
 .vscode
+
+# Rockstor build
+.initrock
+PKG-INFO
+certs/
+jslibs/
+poetry-install.txt
+rockstor-jslibs.tar.gz*
+rockstor-tasks-huey.db*
+static/


### PR DESCRIPTION
Per comment in https://github.com/rockstor/rockstor-core/pull/2641#discussion_r1285107554 , splitting these changes out as their own changeset.

These allow for development in a "live" Rockstor testing instance, without worrying about accidentally committing a database or the jslibs, etc.

Closes #2644 