### PR TITLE
Web-UI update fails to recreate venv #2652

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -463,6 +463,8 @@ def update_run(subscription=None, update_all_other=False):
                 )
             )
             atfo.write(pkg_refresh_cmd)
+            # Unset inherited VIRTUAL_ENV environmental variable before invoking rpm/zypper
+            atfo.write('unset VIRTUAL_ENV\n')
             # account for moving from dev/source to package type install:
             atfo.write(pkg_in_up_rockstor)
             # rockstor-bootstrap Requires rockstor which Requires rockstor-pre (initrock)


### PR DESCRIPTION
Unset no longer required, and counterproductive to Poetry venv rebuild, VIRTUAL_ENV environmental variable within the programmatically created AT update script.

Fixes #2652 

See issue text for development context.