### PR TITLE
Improve rockstor.service re robustness #2657

### DIFF
--- a/conf/rockstor.service
+++ b/conf/rockstor.service
@@ -7,6 +7,10 @@ Requires=rockstor-pre.service
 Environment="DJANGO_SETTINGS_MODULE=settings"
 WorkingDirectory=/opt/rockstor
 ExecStart=/root/.local/bin/poetry run supervisord -c /opt/rockstor/etc/supervisord.conf
+ExecStop=/root/.local/bin/poetry run supervisorctl shutdown
+ExecReload=/root/.local/bin/poetry run supervisorctl reload
+# Generally not recommended but used here to honour supervisord's remit re process management.
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Interact better with supervisord by not overriding shutdown.
- Adds ExecStop instructing supervisord accordingly.
- Adds ExecReload (for completeness as unused).
- systemd's charge in this service is supervisord only, limit our KillMode to 'process' accordingly. This avoids an additional 1 minute timeout during our AT update script execution.
Note that we currently run supervisord in foreground mode.

Fixes #2657 