### PR TITLE
(t) Update django-pipeline to 1.7.0 #2646

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -82,7 +82,7 @@ requests = ">=2.13.0"
 
 [[package]]
 name = "django-pipeline"
-version = "1.6.9"
+version = "1.7.0"
 description = "Pipeline is an asset packaging library for Django."
 category = "main"
 optional = false
@@ -346,12 +346,12 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">= 3.6, < 3.9"
-content-hash = "19dc63a5e62eb552b7207bde82a139b0038ecadadfa71ea3b6f2e56af0448b9c"
+content-hash = "fb6e94460ce403d35e64a5408875a38149fc392847e38d36fe6962da1ed31ef6"
 
 [metadata.files]
 certifi = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
@@ -443,8 +443,8 @@ django-oauth-toolkit = [
     {file = "django_oauth_toolkit-1.1.2-py2.py3-none-any.whl", hash = "sha256:c006e804ecfdc98ffeb943100dbb0b5e6d82c969c7cb672bc999f1f3a403cb01"},
 ]
 django-pipeline = [
-    {file = "django-pipeline-1.6.9.tar.gz", hash = "sha256:3eb391e59525beedf0a45d4b6ef7e6a3e69f720b7560a1a305e115eb33d5fb6c"},
-    {file = "django_pipeline-1.6.9-py2.py3-none-any.whl", hash = "sha256:3ed7e5913c521a568ab3a9866d83b239b8c8c2e03a4d99689a87788aec3fa256"},
+    {file = "django-pipeline-1.7.0.tar.gz", hash = "sha256:0ded22b974e3d627c27fc490ef5b23fcdcf0cdb00b704d628b5ca6d0b010d6fe"},
+    {file = "django_pipeline-1.7.0-py2.py3-none-any.whl", hash = "sha256:f7da70f00aa4baea3e0811f88927a116425deee05871fa2bfd2f8247f42d8847"},
 ]
 djangorestframework = [
     {file = "djangorestframework-3.9.3-py2.py3-none-any.whl", hash = "sha256:1d22971a5fc98becdbbad9710ca2a9148dd339f6cbea4c3ddbed2cb84bab94e1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ python = ">= 3.6, < 3.9"
 django = "==1.11.29"
 django-oauth-toolkit = "==1.1.2"
 djangorestframework = "==3.9.3"
-django-pipeline = "==1.6.9"
+django-pipeline = "==1.7.0" # last version listed with Python 3.6 and Django 1.11 compatibility
 django-braces = "==1.13.0"  # look to 1.14.0 (30 Dec 2019) as Django 1.11.0+ now
 oauthlib = "==3.1.0"  # Last Python 2.7 compat + 3.7 compat.
 python-engineio = "==2.3.2"  # Revisit version post 3.0.0


### PR DESCRIPTION
Fixes #2646 
@phillxnet , @Hooverdan96: ready for review.

This pull request simply proposes to update django-pipeline from 1.6.9 to 1.7.0.
See #2646 for rationale.

**Note**: Poetry automatically updated the `certifi` package to its latest version: 2023.7.22.

# Testing
This branch was deployed to a 15.4 and a 15.5 VM with their `/opt/rockstor` folder wiped, and then rockstor was successfully built from source. I then browsed through various pages in the webUI and all loaded successfully without any "file not found" error.

Furthermore, all unit tests pass (ran on Leap 15.5):
```
buildvm155:/opt/rockstor # cd src/rockstor/ && /root/.local/bin/poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 13.363s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
/opt/rockstor
```