### PR TITLE
Migrate to New Middleware style #2662

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012 RockStor, Inc. <https://rockstor.com>
+Copyright (c) 2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -145,7 +145,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     # New in 1.8, 1.11 newly sets Content-Length header.
     # 'django.middleware.common.CommonMiddleware',
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/src/rockstor/storageadmin/middleware.py
+++ b/src/rockstor/storageadmin/middleware.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,18 +13,19 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from system.osi import run_command
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class ProdExceptionMiddleware(object):
+class ProdExceptionMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         """just log the exception"""
         e_msg = (


### PR DESCRIPTION
Fixes #2662 
@phillxnet, @Hooverdan96: ready for review.


In Django 1.10, the old `MIDDLEWARE_CLASSES` style was deprecated and we should now use `MIDDLEWARE` setting.

This Pull Request (PR) includes this move and takes advantage of the new MiddlewareMixin to help provide compatibility for our custom middleware.

With this commit in place, I no-longer see the DJango Warning described in #2662.

All unit tests still pass:
```
buildvm155:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 15.693s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
``` 

**IMPORTANT**
I have not yet tested that our custom middleware still works, unfortunately. I would need to find a way to trigger an exception and verify we still have the creation of the logs tarball.