### PR TITLE
Use user.is_authenticated as an attribute #2664

### DIFF
--- a/src/rockstor/storageadmin/views/home.py
+++ b/src/rockstor/storageadmin/views/home.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from django.shortcuts import render
@@ -27,6 +27,7 @@ from django.conf import settings
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 def login_page(request):
     return render(request, "login.html")
@@ -65,7 +66,7 @@ def home(request):
         "update_channel": update_channel,
     }
     logger.debug("context={}".format(context))
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         logger.debug("ABOUT TO RENDER INDEX")
         return render(request, "index.html", context)
     else:


### PR DESCRIPTION
Fix #2664 
@phillxnet, @Hooverdan96: ready for review

Prior to Django 1.10, `user.is_authenticated()` was a method. Since then, compatibility was ensured but this compatibility will be removed in Django 2.0.  See #2664 for more details and background.

This Pull Request (PR) simply proposes to move to using the `user.is_authenticated` attribute instead.

# Functional testing
Prior to this PR, fully refreshing a webpage (Ctrl + Shift + R) would show the warning described in #2664.
After this PR, this no longer appears.

# Unit testing
All tests still pass:
```
buildvm155:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 14.807s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```
