### PR TITLE
Set `Meta.base_manager_name` on 'storageadmin.Disk' #2666

### DIFF
--- a/src/rockstor/storageadmin/models/disk.py
+++ b/src/rockstor/storageadmin/models/disk.py
@@ -31,8 +31,6 @@ from system.osi import (
 class AttachedManager(models.Manager):
     """Manager subclass to return only attached disks"""
 
-    use_for_related_fields = True
-
     def attached(self):
         # Return default queryset after excluding name="detached-*" items.
         # Alternative lookup type __regex=r'^detached-'
@@ -151,3 +149,4 @@ class Disk(models.Model):
 
     class Meta:
         app_label = "storageadmin"
+        base_manager_name = "attached"


### PR DESCRIPTION
Fixes #2666 
@phillxnet, @Hooverdan96: it is ready for review but I'm leaving the PR as draft because I'm still not 100% I tested correctly; see below for more details.

This pull request simply applies the changes requested by the warning detailed in #2666.

# Functional testing
@phillxnet, this area is your expertise, I believe, so the following testing may not be the most relevant/best.
If I'm correct, this model manager is used to list a disk as detached. I thus tested that as follows:
1. Attach a new disk to the VM
2. Create a pool with this disk
3. Turn off the VM and remove the disk
4. Turn the VM back ON and navigate to the "Disks" page: the disk that was removed in step 3 does show as "-detached".
5. Pressing the "Rescan" button does not throw any error and does not trigger the deprecation warning described in #2666 anymore.

# Unit testing
```
buildvm155:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 16.888s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```