### PR TITLE
surface Distro Version to breadcrumb bar (2668)

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/router.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/router.js
@@ -979,8 +979,7 @@ $(document).ready(function() {
     };
 
     var distroInfo = function(data) {
-        $('#distro-info').text("Uses " + data.distro);
-        $('#distro-info').attr('title', data.version);
+        $('#distro-info').text("Uses " + data.distro + ": " + data.version);
     };
 
     var displayLocaleTime = function(data) {


### PR DESCRIPTION
Fixes #2668.  Instead of showing the distro version via the mouse over, this change will show it directly as part of the breadcrumb bar.

After the changes and `static` collection, the version now shows up alongside the distro name and kernel version:

<img width="250" alt="image" src="https://github.com/rockstor/rockstor-core/assets/35113775/43c9dc8f-a9ae-4bef-9551-42058c4e0d8d">

A mouseover doesn't show up anymore.
Changes also survive reboots.

Not sure whether that was necessary, but in any case ran the tests:

```
Ran 253 tests in 40.992s
```
