### PR TITLE
Explicitly set REALM when querying workgroup #2671

### DIFF
--- a/src/rockstor/system/directory_services.py
+++ b/src/rockstor/system/directory_services.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2021 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
@@ -295,7 +295,7 @@ def leave_domain(config, method="sssd"):
         run_command(cmd, log=True)
 
 
-def domain_workgroup(domain=None, method="sssd"):
+def domain_workgroup(domain: str, method: str = "sssd") -> str:
     """
     Fetches the Workgroup value from an Active Directory domain
     to be fed to Samba configuration.
@@ -303,20 +303,17 @@ def domain_workgroup(domain=None, method="sssd"):
     :param method: String - SSSD or Winbind (default is sssd)
     :return:
     """
-    cmd = [NET, "ads", "workgroup", "-S", domain]
-    if method == "winbind":
-        cmd = [ADCLI, "info", domain]
-    o, e, rc = run_command(cmd)
+    cmd = [NET, "ads", "workgroup", f"--realm={domain.upper()}"]
     match_str = "Workgroup:"
     if method == "winbind":
+        cmd = [ADCLI, "info", domain]
         match_str = "domain-short = "
-    for l in o:
-        l = l.strip()
-        if re.match(match_str, l) is not None:
-            return l.split(match_str)[1].strip()
-    raise Exception(
-        "Failed to retrieve Workgroup. out: {} err: {} rc: {}".format(o, e, rc)
-    )
+    o, e, rc = run_command(cmd, log=True)
+    for line in o:
+        line = line.strip()
+        if re.match(match_str, line) is not None:
+            return line.split(match_str)[1].strip()
+    raise Exception(f"Failed to retrieve Workgroup. out: {o} err: {e} rc: {rc}")
 
 
 def validate_idmap_range(config):

--- a/src/rockstor/system/tests/test_directory_services.py
+++ b/src/rockstor/system/tests/test_directory_services.py
@@ -22,8 +22,9 @@ from system.directory_services import domain_workgroup
 class SystemDirectoryServicesTests(unittest.TestCase):
     """
     The tests in this suite can be run via the following command:
-    cd <root dir of rockstor ie /opt/rockstor>
-    ./bin/test --settings=test-settings -v 3 -p test_directory_services*
+    cd /opt/rockstor/src/rockstor
+    export DJANGO_SETTINGS_MODULE=settings
+    poetry run django-admin test -p test_directory_services.py -v 2
     """
 
     def setUp(self):
@@ -50,8 +51,8 @@ class SystemDirectoryServicesTests(unittest.TestCase):
             returned,
             expected,
             msg="Un-expected domain_workgroup() result:\n "
-            "returned = ({}).\n "
-            "expected = ({}).".format(returned, expected),
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
         )
 
     def test_domain_workgroup_invalid(self):
@@ -62,7 +63,7 @@ class SystemDirectoryServicesTests(unittest.TestCase):
         domain = "bogusad.bogusdomain.com"
         self.mock_run_command.side_effect = CommandException(
             err=["Didn't find the cldap server!", ""],
-            cmd=["/usr/bin/net", "ads", "workgroup", "-S", domain],
+            cmd=["/usr/bin/net", "ads", "workgroup", f"--realm={domain.upper()}"],
             out=[""],
             rc=255,
         )


### PR DESCRIPTION
Fixes #2671 
@phillxnet, @Hooverdan96, ready for review.

During Active Directory activation, we query the Workgroup information from the AD server using `net ads workgroup`. This normally gets its parameters from `smb.conf` but we need here to explicitly give the required server information at the command call given we usually work with an empty `smb.conf` file at this stage.

This Pull request switches from using the `-S|--server` flag to the `--realm` flag as that has proven more robust.

# Functional testing
Rockstor built from this branch on Leap 15.5 can successfully activate the Active Directory service configured to connect to a Samba 4-backed AD domain controller found at `samdom.example.com`.

# Unit testing
```
buildvm155:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 13.149s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```
