### PR TITLE
Don't throw exception when getting supervisord service status #2681

### DIFF
--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2023 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
@@ -21,10 +21,12 @@ import re
 import shutil
 import stat
 from tempfile import mkstemp
+from typing import Tuple, List
 
 from django.conf import settings
-from system.osi import run_command
+
 from system.constants import SYSTEMCTL
+from system.osi import run_command
 from system.ssh import is_sftp_running
 
 SUPERCTL_BIN = "{}.venv/bin/supervisorctl".format(settings.ROOT_DIR)
@@ -138,8 +140,10 @@ def set_autostart(service, switch):
     shutil.move(npath, SUPERVISORD_CONF)
 
 
-def superctl(service, switch):
-    out, err, rc = run_command([SUPERCTL_BIN, switch, service])
+def superctl(
+    service: str, switch: str, throw: bool = True
+) -> Tuple[List[str], List[str], int]:
+    out, err, rc = run_command([SUPERCTL_BIN, switch, service], throw=throw)
     set_autostart(service, switch)
     if switch == "status":
         status = out[0].split()[1]
@@ -189,7 +193,7 @@ def service_status(service_name, config=None):
         # Delegate sshd's sftp subsystem status check to system.ssh.py call.
         return is_sftp_running(return_boolean=False)
     elif service_name in ("replication", "data-collector", "ztask-daemon"):
-        return superctl(service_name, "status")
+        return superctl(service_name, "status", throw=False)
     elif service_name == "smb":
         out, err, rc = run_command(
             [SYSTEMCTL, "--lines=0", "status", "smb"], throw=False


### PR DESCRIPTION
Fixes #2681 
@phillxnet, @Hooverdan96: ready for review.

We currently throw an Exception when checking the status of a surpervisor-controlled service such as replication. This leads to an exception being thrown even when expected (service is off), which can itself interrupt other parts such as our `get_services` websocket.

This pull-request adds a new arg to `superctl()` allowing for the possibility to not throw an exception. Note that `run_command()`'s default for throw is `True`, so we respect this here.

# Functional testing
The Samba service was toggled ON.
Within 15 sec (websocket "refresh" interval), the status of all services was refreshed and the toggle button was re-aligned with the others, and stayed ON.
The Samba service was then toggled back OFF and the opposite was observed: button switched to OFF and was re-aligned to the other buttons within 15 secs.

# Unit testing
All tests still pass. Note that this was tested on Leap 15.4 only:
```
buildvm:/opt/rockstor # cd src/rockstor/ && poetry run django-admin test ; cd -
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 262 tests in 15.827s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```