### PR TITLE
Update Django REST Framework within Django version constraint #2695

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -91,11 +91,15 @@ python-versions = "*"
 
 [[package]]
 name = "djangorestframework"
-version = "3.9.3"
+version = "3.13.1"
 description = "Web APIs for Django, made easy."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+django = ">=2.2"
+pytz = "*"
 
 [[package]]
 name = "gevent"
@@ -360,7 +364,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "37afad77b14f6565b073da72cf7a9e967455ae3e59beddbbe9c6b57c387c7815"
+content-hash = "4695c5de93620ce46f4443c3991b4265f2046f31c5d661f412d9ed899622c6dc"
 
 [metadata.files]
 certifi = [
@@ -449,8 +453,8 @@ django-pipeline = [
     {file = "django_pipeline-2.1.0-py3-none-any.whl", hash = "sha256:e91627faee22c4c65eb7d134ef53a9d97253c99e4dd914af8ea9c8c58c01de93"},
 ]
 djangorestframework = [
-    {file = "djangorestframework-3.9.3-py2.py3-none-any.whl", hash = "sha256:1d22971a5fc98becdbbad9710ca2a9148dd339f6cbea4c3ddbed2cb84bab94e1"},
-    {file = "djangorestframework-3.9.3.tar.gz", hash = "sha256:2884763160b997073ff1e937bd820a69d23978902a3ccd0ba53a217e196239f0"},
+    {file = "djangorestframework-3.13.1-py3-none-any.whl", hash = "sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa"},
+    {file = "djangorestframework-3.13.1.tar.gz", hash = "sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee"},
 ]
 gevent = [
     {file = "gevent-23.9.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:a3c5e9b1f766a7a64833334a18539a362fb563f6c4682f9634dea72cbe24f771"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ python = "~3.9"
 # [tool.poetry.group.django.dependencies]
 django = "~2.2"
 django-oauth-toolkit = "==1.1.2"
-djangorestframework = "==3.9.3"
+djangorestframework = "==3.13.1"  # Last version to support Django 2.2 (up to 4.0)
 django-pipeline = "*"
 django-braces = "==1.13.0"  # look to 1.14.0 (30 Dec 2019) as Django 1.11.0+ now
 oauthlib = "==3.1.0"  # Last Python 2.7 compat + 3.7 compat.


### PR DESCRIPTION
Move to newest version within current Django version constraint.
- Django 2.2 -> 4.0
- Python 3.6 -> 3.10

Fixes #2695 