### PR TITLE
remove django-braces dependency #2709

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -71,14 +71,6 @@ argon2 = ["argon2-cffi (>=16.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
-name = "django-braces"
-version = "1.13.0"
-description = "Reusable, generic mixins for Django"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "django-oauth-toolkit"
 version = "1.1.2"
 description = "OAuth2 Provider for Django"
@@ -360,7 +352,7 @@ testing = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -419,7 +411,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "14e5c2104e790522c30ce67df3344d7262465898b9806b9b0ce14c2446d6961d"
+content-hash = "27778270ece10dc680f3d8c7be55dbe99aa5960215e0270908d4f5ed6939bf28"
 
 [metadata.files]
 bidict = [
@@ -586,10 +578,6 @@ distro = [
 django = [
     {file = "Django-2.2.28-py3-none-any.whl", hash = "sha256:365429d07c1336eb42ba15aa79f45e1c13a0b04d5c21569e7d596696418a6a45"},
     {file = "Django-2.2.28.tar.gz", hash = "sha256:0200b657afbf1bc08003845ddda053c7641b9b24951e52acd51f6abda33a7413"},
-]
-django-braces = [
-    {file = "django-braces-1.13.0.tar.gz", hash = "sha256:ba68e98b817c6f01d71d10849f359979617b3fe4cefb7f289adefddced092ddc"},
-    {file = "django_braces-1.13.0-py2.py3-none-any.whl", hash = "sha256:a457d74ea29478123c0c4652272681b3cea0bf1232187fd9f9b6f1d97d32a890"},
 ]
 django-oauth-toolkit = [
     {file = "django-oauth-toolkit-1.1.2.tar.gz", hash = "sha256:5eb68432e0869451bad81d127bb2de7a20cb5c5343518bc8d24befe6eaa34e16"},
@@ -839,8 +827,8 @@ supervisor = [
     {file = "supervisor-4.2.4.tar.gz", hash = "sha256:40dc582ce1eec631c3df79420b187a6da276bbd68a4ec0a8f1f123ea616b97a2"},
 ]
 urllib3 = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 urlobject = [
     {file = "URLObject-2.1.1.tar.gz", hash = "sha256:06462b6ab3968e7be99442a0ecaf20ac90fdf0c50dca49126019b7bf803b1d17"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ django = "~2.2"
 django-oauth-toolkit = "==1.1.2"
 djangorestframework = "==3.13.1"  # Last version to support Django 2.2 (up to 4.0)
 django-pipeline = "*"
-django-braces = "==1.13.0"  # look to 1.14.0 (30 Dec 2019) as Django 1.11.0+ now
 oauthlib = "==3.1.0"  # Last Python 2.7 compat + 3.7 compat.
 python-engineio = "==4.8.0"
 python-socketio = "==5.9.0"


### PR DESCRIPTION
Remove now defunct django-braces dependency. Likely left over from a prior requirement.

## Includes
- Incidental/unrelated update to urllib3 2.0.6 to 2.0.7.

Fixes #2709
