### PR TITLE
Implement Tailscale service #2679

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ jslibs/
 poetry-install.txt
 rockstor-jslibs.tar.gz*
 rockstor-tasks-huey.db*
-static/
+/static/
 
 # Rockstor error tgz
 /src/rockstor/logs/error.tgz

--- a/src/rockstor/scripts/prep_db.py
+++ b/src/rockstor/scripts/prep_db.py
@@ -20,7 +20,7 @@ from smart_manager.models import Service
 from storageadmin.models import Setup
 
 
-def register_services():
+def register_services() -> None:
     services = {
         "NFS": "nfs",
         "Samba": "smb",
@@ -39,6 +39,7 @@ def register_services():
         "Bootstrap": "rockstor-bootstrap",
         "Shell In A Box": "shellinaboxd",
         "Rockstor": "rockstor",
+        "Tailscale": "tailscaled",
     }
 
     # N.B. all other services have null as their default config with service.

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -886,18 +886,15 @@ class ServicesNamespace(RockstorIO):
     start = False
 
     def on_connect(self, sid, environ):
-
         self.emit("connected", {"key": "services:connected", "data": "connected"})
         self.start = True
         self.spawn(self.send_service_statuses, sid)
 
     def on_disconnect(self, sid):
-
         self.cleanup(sid)
         self.start = False
 
     def send_service_statuses(self):
-
         while self.start:
 
             data = {}
@@ -914,7 +911,6 @@ class ServicesNamespace(RockstorIO):
                 data[service.name] = {}
                 output, error, return_code = service_status(service.name, config=config)
                 data[service.name]["running"] = return_code
-
             self.emit("get_services", {"data": data, "key": "services:get_services"})
             gevent.sleep(15)
 
@@ -1122,7 +1118,6 @@ class SysinfoNamespace(RockstorIO):
                 data["status"] = "errors"
                 data["message"] = "Pools found with device errors: "
                 data["message"] += "({})".format(", ".join(labels))
-
             self.emit("pool_dev_stats", {"key": "sysinfo:pool_dev_stats", "data": data})
 
             gevent.sleep(30)

--- a/src/rockstor/smart_manager/fixtures/services.json
+++ b/src/rockstor/smart_manager/fixtures/services.json
@@ -1,128 +1,155 @@
 [
 {
-  "pk": 1, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "Replication", 
-    "name": "replication"
-  }
+    "model": "smart_manager.service",
+    "pk": 1,
+    "fields": {
+        "name": "replication",
+        "display_name": "Replication",
+        "config": null
+    }
 },
 {
-  "pk": 2, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "Samba", 
-    "name": "smb"
-  }
+    "model": "smart_manager.service",
+    "pk": 2,
+    "fields": {
+        "name": "smb",
+        "display_name": "Samba",
+        "config": "{\"workgroup\": \"WORKGROUP\"}"
+    }
 },
 {
-  "pk": 3, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "NFS", 
-    "name": "nfs"
-  }
+    "model": "smart_manager.service",
+    "pk": 3,
+    "fields": {
+        "name": "nfs",
+        "display_name": "NFS",
+        "config": null
+    }
 },
 {
-  "pk": 4, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "AD", 
-    "name": "winbind"
-  }
+    "model": "smart_manager.service",
+    "pk": 5,
+    "fields": {
+        "name": "ntpd",
+        "display_name": "NTP",
+        "config": null
+    }
 },
 {
-  "pk": 5, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "NTP", 
-    "name": "ntpd"
-  }
+    "model": "smart_manager.service",
+    "pk": 6,
+    "fields": {
+        "name": "nis",
+        "display_name": "NIS",
+        "config": null
+    }
 },
 {
-  "pk": 6, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "NIS", 
-    "name": "nis"
-  }
+    "model": "smart_manager.service",
+    "pk": 7,
+    "fields": {
+        "name": "ldap",
+        "display_name": "LDAP",
+        "config": null
+    }
 },
 {
-  "pk": 7, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "LDAP", 
-    "name": "ldap"
-  }
+    "model": "smart_manager.service",
+    "pk": 8,
+    "fields": {
+        "name": "sftp",
+        "display_name": "SFTP",
+        "config": null
+    }
 },
 {
-  "pk": 8, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "SFTP", 
-    "name": "sftp"
-  }
+    "model": "smart_manager.service",
+    "pk": 9,
+    "fields": {
+        "name": "rockstor",
+        "display_name": "Rockstor",
+        "config": null
+    }
 },
 {
-  "pk": 9, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "Data Collector", 
-    "name": "data-collector"
-  }
+    "model": "smart_manager.service",
+    "pk": 10,
+    "fields": {
+        "name": "smartd",
+        "display_name": "S.M.A.R.T",
+        "config": null
+    }
 },
 {
-  "pk": 10, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "Service Monitor", 
-    "name": "service-monitor"
-  }
+    "model": "smart_manager.service",
+    "pk": 11,
+    "fields": {
+        "name": "active-directory",
+        "display_name": "Active Directory",
+        "config": null
+    }
 },
 {
-  "pk": 11, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "AFP", 
-    "name": "netatalk"
-  }
+    "model": "smart_manager.service",
+    "pk": 12,
+    "fields": {
+        "name": "nut",
+        "display_name": "NUT-UPS",
+        "config": null
+    }
 },
 {
-  "pk": 12, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "Task Scheduler", 
-    "name": "task-scheduler"
-  }
+    "model": "smart_manager.service",
+    "pk": 13,
+    "fields": {
+        "name": "snmpd",
+        "display_name": "SNMP",
+        "config": null
+    }
 },
 {
-  "pk": 13, 
-  "model": "smart_manager.service", 
-  "fields": {
-    "config": null, 
-    "display_name": "SNMP", 
-    "name": "snmpd"
-  }
+    "model": "smart_manager.service",
+    "pk": 14,
+    "fields": {
+        "name": "docker",
+        "display_name": "Rock-on",
+        "config": null
+    }
 },
 {
-  "pk": 14,
-  "model": "smart_manager.service",
-  "fields": {
-    "config": null,
-    "display_name": "NUT-UPS",
-    "name": "nut"
-  }
+    "model": "smart_manager.service",
+    "pk": 15,
+    "fields": {
+        "name": "shellinaboxd",
+        "display_name": "Shell In A Box",
+        "config": "{\"detach\": false, \"css\": \"white-on-black\", \"shelltype\": \"LOGIN\"}"
+    }
+},
+{
+    "model": "smart_manager.service",
+    "pk": 17,
+    "fields": {
+        "name": "ztask-daemon",
+        "display_name": "ZTaskd",
+        "config": null
+    }
+},
+{
+    "model": "smart_manager.service",
+    "pk": 18,
+    "fields": {
+        "name": "rockstor-bootstrap",
+        "display_name": "Bootstrap",
+        "config": null
+    }
+},
+{
+    "model": "smart_manager.service",
+    "pk": 21,
+    "fields": {
+        "name": "tailscaled",
+        "display_name": "Tailscale",
+        "config": null
+    }
 }
 ]

--- a/src/rockstor/smart_manager/tests/test_tailscaled.py
+++ b/src/rockstor/smart_manager/tests/test_tailscaled.py
@@ -1,0 +1,197 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+"""
+proposed fixture = "test_tailscaled.json"
+
+cd /opt/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin dumpdata --database smart_manager smart_manager.service
+--natural-foreign --indent 4 >
+src/rockstor/smart_manager/fixtures/services.json
+
+To run the tests:
+cd /opt/rockstor/src/rockstor
+export DJANGO_SETTINGS_MODULE="settings"
+poetry run django-admin test -v 2 -p test_tailscaled.py
+"""
+
+
+class TailscaledTests(APITestCase):
+    databases = "__all__"
+    fixtures = ["test_api.json", "services.json"]
+    BASE_URL = "/api/sm/services/tailscaled"
+
+    @classmethod
+    def setUpClass(cls):
+        super(TailscaledTests, cls).setUpClass()
+
+        # POST mocks
+        cls.patch_systemctl = patch("smart_manager.views.tailscaled_service.systemctl")
+        cls.mock_systemctl = cls.patch_systemctl.start()
+        cls.mock_systemctl.return_value = [""], [""], 0
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TailscaledTests, cls).tearDownClass()
+
+    def session_login(self):
+        self.client.login(username="admin", password="admin")
+
+    def test_tailscaled_unauthorized(self):
+        """
+        unauthorized access
+        """
+        response = self.client.get(self.BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_tailscaled_post_config_valid(self):
+        """
+        config happy path
+        """
+        config = {
+            "accept_routes": "yes",
+            "advertise_exit_node": "yes",
+            "advertise_routes": "192.168.1.0/24",
+            "exit_node": "100.1.1.1",
+            "exit_node_allow_lan_access": "true",
+            "hostname": "rockdev",
+            "reset": "yes",
+            "ssh": "yes",
+            "custom_config": "--shields-up\n--accept-risk=all",
+        }
+
+        data = {"config": config}
+        self.session_login()
+        response = self.client.post(f"{self.BASE_URL}/config", data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
+
+    def test_tailscaled_post_config_no_config(self):
+        """
+        config without input
+        """
+        self.session_login()
+        response = self.client.post(f"{self.BASE_URL}/config")
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST,
+            msg=response.content,
+        )
+
+    def test_tailscaled_login_start_stop(self):
+        """
+        start/stop tests
+        """
+        # mock tailscale_up() used by LOGIN, START
+        self.patch_tailscale_up = patch(
+            "smart_manager.views.tailscaled_service.tailscale_up"
+        )
+        self.mock_tailscale_up = self.patch_tailscale_up.start()
+        self.mock_tailscale_up.return_value = [""], [""], 0
+
+        # mock tailscale_down() used by STOP
+        self.patch_tailscale_down = patch(
+            "smart_manager.views.tailscaled_service.tailscale_down"
+        )
+        self.mock_tailscale_down = self.patch_tailscale_down.start()
+        self.mock_tailscale_down.return_value = [""], [""], 0
+
+        self.session_login()
+
+        # First, configure the service
+        config = {
+            "accept_routes": "yes",
+            "advertise_exit_node": "yes",
+            "advertise_routes": "192.168.1.0/24",
+            "exit_node": "100.1.1.1",
+            "exit_node_allow_lan_access": "true",
+            "hostname": "rockdev",
+            "reset": "yes",
+            "ssh": "yes",
+            "custom_config": "--shields-up\n--accept-risk=all",
+        }
+        data = {"config": config}
+        response = self.client.post(f"{self.BASE_URL}/config", data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.content)
+
+        # Then test login
+
+        # we need to mock a "NeedsLogin with authURL" get_tailscale_status()
+        self.patch_get_tailscale_status = patch("system.tailscale.get_tailscale_status")
+        self.mock_get_tailscale_status = self.patch_get_tailscale_status.start()
+        ts_status = {
+            "Version": "1.50.0-ta920f0231-geb5b0beea",
+            "TUN": True,
+            "BackendState": "NeedsLogin",
+            "AuthURL": "https://login.tailscale.com/a/1223456abc",
+            "TailscaleIPs": None,
+            "Self": {
+                "ID": "",
+                "PublicKey": "nodekey:0000000000000000000000000000000000000000000000000000000000000000",
+                "HostName": "rockstortest",
+                "DNSName": "",
+                "OS": "linux",
+                "UserID": 0,
+                "TailscaleIPs": None,
+                "Addrs": [],
+                "CurAddr": "",
+                "Relay": "",
+                "RxBytes": 0,
+                "TxBytes": 0,
+                "Created": "0001-01-01T00:00:00Z",
+                "LastWrite": "0001-01-01T00:00:00Z",
+                "LastSeen": "0001-01-01T00:00:00Z",
+                "LastHandshake": "0001-01-01T00:00:00Z",
+                "Online": False,
+                "ExitNode": False,
+                "ExitNodeOption": False,
+                "Active": False,
+                "PeerAPIURL": None,
+                "InNetworkMap": False,
+                "InMagicSock": False,
+                "InEngine": False,
+            },
+            "Health": ["not in map poll"],
+            "MagicDNSSuffix": "",
+            "CurrentTailnet": None,
+            "CertDomains": None,
+            "Peer": None,
+            "User": None,
+            "ClientVersion": None,
+        }
+        self.mock_get_tailscale_status.return_value = ts_status
+
+        response2 = self.client.post(f"{self.BASE_URL}/config/login")
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, msg=response2.content
+        )
+
+        # Then test start
+        response3 = self.client.post(f"{self.BASE_URL}/start")
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, msg=response3.content
+        )
+        # Finally, test stop
+        response4 = self.client.post(f"{self.BASE_URL}/stop")
+        self.assertEqual(
+            response4.status_code, status.HTTP_200_OK, msg=response4.content
+        )

--- a/src/rockstor/smart_manager/urls/services.py
+++ b/src/rockstor/smart_manager/urls/services.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from django.conf.urls import url
@@ -37,9 +37,11 @@ from smart_manager.views import (
     ServiceMonitorView,
     TaskSchedulerServiceView,
     ZTaskdServiceView,
+    TailscaledServiceView,
 )
 
 command_regex = "config|start|stop"
+action_regex = "login|logout"
 
 urlpatterns = [
     # Services
@@ -102,4 +104,12 @@ urlpatterns = [
     ),
     url(r"^rockstor$", RockstorServiceView.as_view()),
     url(r"^rockstor/(?P<command>%s)$" % command_regex, RockstorServiceView.as_view()),
+    url(r"^tailscaled$", TailscaledServiceView.as_view()),
+    url(
+        r"^tailscaled/(?P<command>%s)$" % command_regex, TailscaledServiceView.as_view()
+    ),
+    url(
+        r"^tailscaled/(?P<command>%s)/(?P<action>%s)$" % (command_regex, action_regex),
+        TailscaledServiceView.as_view(),
+    ),
 ]

--- a/src/rockstor/smart_manager/views/__init__.py
+++ b/src/rockstor/smart_manager/views/__init__.py
@@ -55,3 +55,4 @@ from smart_manager.views.ztaskd_service import ZTaskdServiceView  # noqa E501
 from smart_manager.views.bootstrap_service import BootstrapServiceView  # noqa E501
 from smart_manager.views.shellinaboxd_service import ShellInABoxServiceView  # noqa E501
 from smart_manager.views.rockstor_service import RockstorServiceView  # noqa E501
+from smart_manager.views.tailscaled_service import TailscaledServiceView  # noqa E501

--- a/src/rockstor/smart_manager/views/tailscaled_service.py
+++ b/src/rockstor/smart_manager/views/tailscaled_service.py
@@ -1,0 +1,135 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+import json
+import logging
+
+from django.db import transaction
+from rest_framework.response import Response
+
+from smart_manager.models import Service
+from smart_manager.views.base_service import BaseServiceDetailView
+from storageadmin.exceptions import RockStorAPIException
+from storageadmin.util import handle_exception
+from system.services import systemctl
+from system.tailscale import (
+    tailscale_up,
+    validate_ts_custom_config,
+    get_ts_auth_url,
+    tailscale_down,
+    validate_ts_hostname,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TailscaledServiceView(BaseServiceDetailView):
+    name = "tailscaled"
+
+    @transaction.atomic
+    def post(self, request, command, action=None):
+        service = Service.objects.get(name=self.name)
+
+        if action == "login":
+            # The tailscaled daemon should already be running when the Tailscale
+            # service is configured, but still ensure that here
+            systemctl(self.name, "start")
+            config = None
+            try:
+                config = self._get_config(service)
+            except Exception as e:
+                logger.exception(e)
+                e_msg = (
+                    "Cannot start without configuration. "
+                    "Please configure (System->Services) and try again."
+                )
+                handle_exception(Exception(e_msg), request)
+            # Start tailscale up so that it's creating the authURL
+            tailscale_up(config=config, timeout=2)
+
+            # Retrieve AuthURL and make sure it has been generated
+            auth_url = get_ts_auth_url()
+            logger.debug(f"Tailscale login URL was retrieved as: {auth_url}")
+            # Save auth_url to service config so that we can create the login button
+            config["auth_url"] = auth_url
+            service.config = json.dumps(config)
+            service.save()
+
+        elif action == "logout":
+            logger.debug("LOGOUT from tailscale is not yet implemented")
+
+        elif command == "config":
+            config = request.data.get("config", None)
+            logger.debug(f"{service.display_name} config: {config}")
+            if config is None:
+                e_msg = (
+                    f"No configuration for the {service.display_name} service could be found. "
+                    "Please try again. If the problem persists, email support@rockstor.com "
+                    "with this message, or inquire on our forum (https://forum.rockstor.com)."
+                )
+                raise RockStorAPIException(status_code=400, detail=e_msg)
+            # Ensure hostname complies with requirements and adjust as needed
+            config = validate_ts_hostname(config)
+            # Parse and validate the custom_config key
+            if "custom_config" in config:
+                cc_lines = config["custom_config"].split("\n")
+                cc_lines = validate_ts_custom_config(cc_lines)
+                config["custom_config"] = cc_lines
+            self._save_config(service, config)
+
+            # As the user saves the Tailscale service config, we assume they want
+            # to use it so we enable and start the tailscaled daemon.
+            # This will create the tailscale tun device and allow us to get
+            # an authURL during the "login" action
+            systemctl(self.name, "stop")
+            systemctl(self.name, "enable")
+            systemctl(self.name, "start")
+
+        elif command == "start":
+            config = None
+            try:
+                config = self._get_config(service)
+            except Exception as e:
+                logger.exception(e)
+                e_msg = (
+                    "Cannot start without configuration. "
+                    "Please configure (System->Services) and try again."
+                )
+                handle_exception(Exception(e_msg), request)
+
+            # Start tailscale
+            tailscale_up(config=config)
+
+        elif command == "stop":
+            config = None
+            try:
+                # Ensure that auth_url is no-longer in the service's config
+                config = self._get_config(service)
+                found = config.pop("auth_url", None)
+                if found is not None:
+                    self._save_config(service, config)
+            except Exception as e:
+                logger.exception(e)
+                e_msg = (
+                    "An error occurred while trying to cleanup the auth_url "
+                    "from the service's configuration."
+                )
+                handle_exception(Exception(e_msg), request)
+            finally:
+                tailscale_down(config=config)
+
+        return Response()

--- a/src/rockstor/storageadmin/static/storageadmin/css/style.css
+++ b/src/rockstor/storageadmin/static/storageadmin/css/style.css
@@ -892,9 +892,6 @@ label.error { font-size: 12px; color: #b94a48; }
 hr.module-sep { margin: 0; border: 0; border-top: 1px solid #ddd;
 }
 
-/* Services page */
-
-#services-table th { text-align: left; }
 
 /* Setup wizard */
 .step-titles {

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
@@ -20,7 +20,7 @@
 </script>
 
 <div class="alert alert-warning">
-    <p>We strongly recommend that you create a separate Share(at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.</p>
+    <p>We strongly recommend that you create a separate Share (at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.</p>
     <p>To create a new Share, <a href="#add_share">click here.</a></p>
 </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_tailscaled.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_tailscaled.jst
@@ -1,0 +1,147 @@
+<script>
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+    * This file is part of RockStor.
+    *
+    * RockStor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * RockStor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
+    *
+    */
+</script>
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">Configure the {{ serviceName }} service &nbsp;
+                <a href="https://rockstor.com/docs" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
+            <div class="panel-body">
+                <form class="form-horizontal" id="tailscaled-form" name="tailscaled-form">
+                    <p>All settings below are entirely <b>optional</b>. See <a
+                            href="https://tailscale.com/kb/1241/tailscale-up/" target="_blank">Tailscale's
+                        documentation</a> for a full description of each setting.</p>
+                    <div class="messages"></div>
+                    <div id="ip-forwarding-warning" class="alert alert-warning" style="display: none;">
+                        <h4>Warning! The current settings will enable IP forwarding on this machine.</h4>
+                        <p>Enabling the <em>subnet router</em> or <em>exit node</em> features require IP forwarding
+                            to be enabled on this machine (see Tailscale documentation
+                            <a href="https://tailscale.com/kb/1019/subnets/" target="_blank"
+                               title="Subnet router documentation">here</a>
+                            and <a href="https://tailscale.com/kb/1103/exit-nodes/" target="_blank"
+                                   title="Exit node documentation">here</a>
+                            for more details). With the current settings, Rockstor will thus: </p>
+                        <ul>
+                            <li>enable IPv4 and IPv6 forwarding upon turning ON the Tailscale service</li>
+                            <li>disable IPv4 and IPv6 forwarding upon turning OFF the Tailscale service</li>
+                        </ul>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="accept_routes">Accept routes</label>
+                        <div class="col-sm-8">
+                            {{ display_options "accept_routes"}}
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="advertise_exit_node">Advertise exit node</label>
+                        <div class="col-sm-8">
+                            {{ display_options "advertise_exit_node" "mutually-exclusive"}}
+                        </div>
+                    </div>
+
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="subnet_router">Use this machine as a subnet
+                            router</label>
+                        <div class="col-sm-8">
+                            {{ display_options "subnet_router"}}
+                        </div>
+
+                        <div class="col-sm-8">
+                            <input class="form-control" type="text" id="advertise_routes" name="advertise_routes"
+                                   value="{{ config.advertise_routes }}" placeholder="Click YES to enable this field"
+                                   disabled>
+                            Physical subnet routes to expose to your entire Tailscale network.
+                        </div>
+                    </div>
+
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="exit_node">Exit node to use</label>
+                        <div class="col-sm-8">
+                            <input class="form-control" type="text" id="exit_node" name="exit_node"
+                                   value="{{ config.exit_node }}" placeholder="100.x.y.z"
+                                   title="Tailscale 100.x.y.z IP address of the exit node.">
+                            <input class="checkbox-inline" type="checkbox" id="exit_node_allow_lan_access"
+                                   name="exit_node_allow_lan_access" title="Please enter an exit node first"
+                                   {{#if config.exit_node_allow_lan_access}}
+                                   checked="true"
+                                    {{ else }}
+                                   disabled
+                                    {{/if}}>
+                            Allow direct access to the local network when routing traffic via this exit node?
+                        </div>
+                    </div>
+
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="hostname">Hostname</label>
+                        <div class="col-sm-8">
+                            <input class="form-control" type="text" id="hostname" name="hostname"
+                                   value="{{ config.hostname }}" placeholder="rockstor">
+                        </div>
+                    </div>
+
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="reset">Reset unspecified settings to default</label>
+                        <div class="col-sm-8">
+                            {{ display_options "reset"}}
+                        </div>
+                    </div>
+
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="ssh">Enable <a
+                                href="https://tailscale.com/kb/1193/tailscale-ssh" target="_blank">Tailscale
+                            SSH</a></label>
+                        <div class="col-sm-8">
+                            {{ display_options "ssh"}}
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="col-sm-4 control-label" for="custom_config">Custom configuration </label>
+                        <div class="col-sm-8">
+                            <textarea rows="5" columns="40" id="custom_config" name="custom_config"
+                                      class="form-control">{{ display_ts_custom_config }}</textarea>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="col-sm-4 col-sm-offset-4">
+                            <button id="cancel" class="btn btn-default">Cancel</button>
+                            <button type="Submit" id="submit" class="btn btn-primary">Submit</button>
+                        </div>
+                    </div>
+                </form>
+
+            </div>            <!-- panel-body -->
+        </div>
+        <!-- panel-default -->
+    </div>
+    <!-- col-md-8 -->
+</div>
+<!-- row -->

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/services.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/services.jst
@@ -26,7 +26,7 @@
         <br>
         <div id="services-list">
             <div id="service">
-                <table id="services-table" class="table table-bordered table-striped table-condensed data-table" width="100%">
+                <table id="services-table" class="table table-bordered table-striped table-condensed data-table">
                     <thead>
                         <tr>
                             <th scope="col">Name</th>
@@ -43,11 +43,15 @@
                                 {{/ifTooltipExist}}
                             </td>
                             <td id="{{this.name}}-status">
+                                {{#if this.needs_auth}}
+                                    <button id="login" class="btn btn-primary actions-tailscale" data-service-name="{{this.name}}">Login</button>
+                                {{else}}
                                 <input type="checkbox" data-service-name="{{this.name}}" data-size="mini" {{#if this.status}} checked {{/if}}>
                                 <div class="command-status" data-service-name="{{this.name}}">&nbsp;</div>
                                 <div class="simple-overlay" id="{{this.name}}-err-popup">
                                     <div class="overlay-content"></div>
                                 </div>
+                                {{/if}}
                             </td>
                         </tr>
                         {{/each}}

--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -34,3 +34,5 @@ SYSTEMCTL = "/usr/bin/systemctl"
 # Works in Leap 15.4 (systemd-249.16-150400.8.28.3) and Tumbleweed (systemd-253.4-2.1)
 UDEVADM = "/usr/bin/udevadm"
 SHUTDOWN = "/sbin/shutdown"
+
+TAILSCALE = "/usr/bin/tailscale"

--- a/src/rockstor/system/network.py
+++ b/src/rockstor/system/network.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,19 +13,22 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import json
 import logging
+import os
 import re
 
-from .exceptions import CommandException
-from .osi import run_command, to_boolean
-from .docker import dnets, docker_status, dnet_inspect
+from system.docker import dnets, docker_status, dnet_inspect
+from system.exceptions import CommandException
+from system.osi import run_command, to_boolean
 
 NMCLI = "/usr/bin/nmcli"
 DEFAULT_MTU = 1500
+SYSCTL = "/sbin/sysctl"
+SYSCTL_CONFD_PATH = "/etc/sysctl.d/"
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +54,7 @@ def get_dev_list():
 def get_dev_config(dev_list):
     """
     Takes a list of connection devices and returns a dictionary with
-    each device's config as seens by Network Manager
+    each device's config as seen by Network Manager
     :param dev_list: list returned by get_dev_list()
     :return: dictionary
     """
@@ -97,14 +100,23 @@ def get_con_list():
     Returns a list of connections as seen by Network Manager.
     :return: list
     """
-    o, e, rc = run_command([NMCLI, "-t", "-f", "uuid", "c", "show",])
+    o, e, rc = run_command(
+        [
+            NMCLI,
+            "-t",
+            "-f",
+            "uuid",
+            "c",
+            "show",
+        ]
+    )
     return o
 
 
 def get_con_config(con_list):
     """
     Takes a list of connections and returns a dictionary with
-    each connection's config as seens by Network Manager
+    each connection's config as seen by Network Manager
     :param con_list: list returned by get_con_list()
     :return: dictionary
     """
@@ -118,7 +130,7 @@ def get_con_config(con_list):
 
     def parse_aux_addresses(dtmap):
         """
-        Parses auxilliary addresses of a docker network and
+        Parses auxiliary addresses of a docker network and
         returns a flat list.
         :param dtmap:
         :return:
@@ -147,7 +159,14 @@ def get_con_config(con_list):
             "ipv6_dns_search": None,
         }
         try:
-            o, e, rc = run_command([NMCLI, "c", "show", uuid,])
+            o, e, rc = run_command(
+                [
+                    NMCLI,
+                    "c",
+                    "show",
+                    uuid,
+                ]
+            )
         except CommandException as e:
             # in case the connection disappears
             if e.rc == 10:
@@ -433,3 +452,54 @@ def new_bond_connection(
     new_connection_helper(name, ipaddr, gateway, dns_servers, search_domains)
     new_member_helper(name, members, "bond-slave")
     reload_connection(name)
+
+
+def enable_ip_forwarding(name: str, priority: int):
+    """Enable IP forwarding
+    Write a sysctl.d conf file and load it into sysctl configuration
+
+    :type name: name of the conf file(s) to create
+    :param priority: priority of the conf file(s) to create
+    """
+    out_fn = f"{SYSCTL_CONFD_PATH}{priority}-{name}.conf"
+    logger.debug(f"Write sysctl.d conf file to enable IP forwarding: {out_fn}")
+    try:
+        with open(out_fn, "w") as f:
+            f.write("net.ipv4.ip_forward = 1\n")
+            f.write("net.ipv6.conf.all.forwarding = 1\n")
+    except IOError as e:
+        logger.exception(e)
+        e_msg = (
+            f"The sysctl configuration file couldn't be written to disk at {out_fn}."
+        )
+        raise IOError(e_msg)
+    # Load into sysctl configuration
+    cmd = [
+        SYSCTL,
+        "-p",
+        f"{out_fn}",
+    ]
+    return run_command(cmd, log=True)
+
+
+def disable_ip_forwarding(name: str):
+    """Disable IP forwarding
+    Find and delete the conf file with name matching the related service
+    and manually set IP forwarding to 0 (as config reload is not enough).
+    See https://github.com/rockstor/rockstor-core/issues/2679#issuecomment-1751421374
+    """
+    # Logic taken from https://docs.python.org/3.9/library/os.html#os.scandir
+    with os.scandir(SYSCTL_CONFD_PATH) as it:
+        for entry in it:
+            if entry.name.endswith(f"{name}.conf") and entry.is_file():
+                logger.debug(f"Delete {entry.path}")
+                os.remove(entry.path)
+    # Manually disable IP forwarding
+    cmd = [
+        SYSCTL,
+        "-w",
+        "net.ipv4.ip_forward=0",
+        "-w",
+        "net.ipv6.conf.all.forwarding=0",
+    ]
+    return run_command(cmd, log=True)

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -35,7 +35,16 @@ from distutils.util import strtobool
 from django.conf import settings
 
 from system.exceptions import CommandException, NonBTRFSRootException
-from system.constants import SYSTEMCTL, MKDIR, RMDIR, MOUNT, UMOUNT, DEFAULT_MNT_DIR, UDEVADM, SHUTDOWN
+from system.constants import (
+    SYSTEMCTL,
+    MKDIR,
+    RMDIR,
+    MOUNT,
+    UMOUNT,
+    DEFAULT_MNT_DIR,
+    UDEVADM,
+    SHUTDOWN,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +222,7 @@ def run_command(
     throw=True,
     log=False,
     input=None,
+    raw=False,
 ):
     try:
         # We force run_command to always use en_US
@@ -222,7 +232,7 @@ def run_command(
         fake_env["LANG"] = "en_US.UTF-8"
         # cmd = map(str, cmd)
         if log:
-            logger.debug("Running command: {}".format(" ".join(cmd)))
+            logger.debug(f"Running command: {' '.join(cmd)}")
         p = subprocess.Popen(
             cmd,
             shell=shell,
@@ -234,7 +244,9 @@ def run_command(
             universal_newlines=True,  # 3.7 adds text parameter universal_newlines alias
         )
         out, err = p.communicate(input=input)
-        out = out.split("\n")
+        # raw=True allows parsing of a JSON output directly, for instance
+        if not raw:
+            out = out.split("\n")
         err = err.split("\n")
         rc = p.returncode
     except Exception as e:

--- a/src/rockstor/system/services.py
+++ b/src/rockstor/system/services.py
@@ -15,7 +15,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-
+import json
 import os
 import re
 import shutil
@@ -25,7 +25,7 @@ from typing import Tuple, List
 
 from django.conf import settings
 
-from system.constants import SYSTEMCTL
+from system.constants import SYSTEMCTL, TAILSCALE
 from system.osi import run_command
 from system.ssh import is_sftp_running
 
@@ -71,6 +71,7 @@ def init_service_op(service_name, command, throw=True):
         "rockstor-bootstrap",
         "rockstor",
         "systemd-shutdownd",
+        "tailscaled",
     )
     if service_name not in supported_services:
         raise Exception("unknown service: {}".format(service_name))
@@ -109,7 +110,7 @@ def systemctl(service_name, switch):
 def set_autostart(service, switch):
     """
     Configure autostart setting for supervisord managed services eg:-
-    nginx, gunicorn, smart_manager daemon, replication daemon, data-collector,
+    gunicorn, smart_manager daemon, replication daemon, data-collector,
     and ztask-daemon. Works by rewriting autostart lines in  SUPERVISORD_CONF
     http://supervisord.org/
     :param service:
@@ -223,6 +224,11 @@ def service_status(service_name, config=None):
             return "", "", active_directory_rc
         # bootstrap switch subsystem interprets -1 as ON so returning 1 instead
         return "", "", 1
+    elif service_name == "tailscaled":
+        if config is not None:
+            return "", "", tailscale_service_status()
+        # Tailscale service is not configured: return 1
+        return "", "", 1
 
     return init_service_op(service_name, "status", throw=False)
 
@@ -329,3 +335,44 @@ def write_avahi_service(tfo, **kwargs):
         else:
             tfo.write("   <{}>{}</{}>\n".format(k, v, k))
     tfo.write(" </service>\n")
+
+
+def tailscale_service_status() -> int:
+    """Return granular status of the Tailscale service
+    The final Tailscale service can have the following states:
+      - Daemon OFF: return 1
+      - Daemon ON, Client not auth'd: return 5
+      - Daemon ON, Client auth started but not completed: return 5
+      - Daemon ON, Client auth'd: return 0
+      - Daemon ON, Client down: return 1
+
+    :return: int
+    """
+    systemd_service_name = "tailscaled"
+    if not is_systemd_service_active(systemd_service_name):
+        return 1
+    else:
+        ts_status_out = get_tailscale_status()
+        backend_state = ts_status_out["BackendState"]
+        if backend_state == "Running":
+            return 0
+        if backend_state == "Stopped":
+            return 1
+        if backend_state == "NeedsLogin":
+            return 5
+
+
+def get_tailscale_status() -> dict:
+    """Get full tailscale status JSON output"""
+    o, e, _ = run_command(
+        [
+            TAILSCALE,
+            "status",
+            "--json",
+        ],
+        # We need raw here to be able to load as JSON
+        raw=True,
+        log=True,
+    )
+    ts_status_out = json.loads(o)
+    return ts_status_out

--- a/src/rockstor/system/tailscale.py
+++ b/src/rockstor/system/tailscale.py
@@ -1,0 +1,204 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+import logging
+import re
+import time
+from typing import List
+
+from storageadmin.exceptions import RockStorAPIException
+from system.constants import TAILSCALE
+from system.network import enable_ip_forwarding, disable_ip_forwarding
+
+from system.osi import run_command
+from system.services import get_tailscale_status
+
+# Config options supported in webUI
+# (used to filter out eventual duplicates in ts_custom_config)
+TS_UI_SETTINGS = [
+    "accept_routes",
+    "advertise_exit_node",
+    "advertise_routes",
+    "exit_node",
+    "exit_node_allow_lan_access",
+    "hostname",
+    "reset",
+    "ssh",
+]
+logger = logging.getLogger(__name__)
+
+
+def tailscale_up(config: dict = None, timeout: int = None):
+    """Start tailscale
+    Wrapper around `tailscale up`. It first gets args from config (if any)
+    and constructs the tailscale up command accordingly.
+    Adds the timeout flag is specified (used to generate authURL during the
+    LOGIN action from the webUI).
+    """
+    # Construct tailscale up command
+    cmd = [
+        TAILSCALE,
+        "up",
+    ]
+    if config is not None:
+        cmd = construct_tailscale_up_command(config)
+        # Enable IP forwarding if needed (subnet router or exit node enabled)
+        if any(key in config for key in ("advertise_exit_node", "advertise_routes")):
+            enable_ip_forwarding(name="tailscale", priority=99)
+    # Add short timeout to just trigger the creation of authURL
+    if timeout:
+        cmd.append(f"--timeout={timeout}s")
+    return run_command(cmd, log=True, throw=False)
+
+
+def tailscale_down(config: dict = None):
+    """Stop tailscale
+    Wrapper around `tailscale down`.
+    """
+    cmd = [
+        TAILSCALE,
+        "down",
+    ]
+    o, e, rc = run_command(cmd, log=True, throw=False)
+    if config is not None:
+        if any(key in config for key in ("advertise_exit_node", "advertise_routes")):
+            disable_ip_forwarding(name="tailscale")
+    return o, e, rc
+
+
+def extract_param(param: str) -> str:
+    """Get and format the name of a custom parameter
+    Isolates the name of the parameter from its cli format and
+    returns it after brief formatting.
+
+    There are 2 types of params:
+      - in the form --<key>=<value>
+      - in the form --<key>
+
+    These would return, for instance:
+      - "--accept-risk=all" -> "accept_risk"
+      - "--shields-up" -> "shields_up"
+    """
+    if re.search("=", param) is not None:
+        param = param.split("=")[0]
+    param = param.split("--")[1]
+
+    # Tailscale cli params use "-" whereas Rockstor uses "_" for storage
+    param = re.sub("-", "_", param)
+
+    return param
+
+
+def validate_ts_hostname(config: dict) -> dict:
+    """Ensure hostname is alphanumeric with hyphens only
+    No special character (including hyphens) is allowed as a custom hostname.
+
+    "hostname": "rock-dev_@#~!$%^&*()+123"
+    should return
+    "hostname": "rock-dev-123"
+    """
+    if "hostname" in config:
+        config["hostname"] = re.sub("_", "-", config["hostname"])
+        to_exclude = [
+            "@",
+            "#",
+            "~",
+            "!",
+            "$",
+            "%",
+            "^",
+            "&",
+            "*",
+            "(",
+            ")",
+            "+",
+        ]
+        config["hostname"] = "".join(
+            c for c in config["hostname"] if not c in to_exclude
+        )
+    return config
+
+
+def validate_ts_custom_config(custom_config: List) -> List:
+    """Validate Tailscale service custom config
+    Check for the existence of duplicates in the custom config section
+    and filter them out if any.
+
+    :param custom_config: list of parsed custom config
+    :return: list of filtered custom config
+    """
+    # Keep only param in the form '--<param>'
+    custom_config = [x for x in custom_config if re.match("--", x)]
+    # Keep only settings not already in UI modal
+    filtered_conf = [
+        setting
+        for setting in custom_config
+        if extract_param(setting) not in TS_UI_SETTINGS
+    ]
+    return filtered_conf
+
+
+def construct_tailscale_up_command(config: dict) -> List:
+    """Construct the tailscale up command from service config"""
+    yes_flags = ["yes", "true"]
+    cmd = [
+        TAILSCALE,
+        "up",
+    ]
+    for param in config:
+        if param == "auth_url":
+            # do not add auth_url to cmd as it is not valid
+            continue
+        elif param == "custom_config":
+            for flag in config[param]:
+                cmd.append(flag)
+        elif config[param] in yes_flags:
+            cmd.append("--" + re.sub("_", "-", param))
+        else:
+            formatted_key = re.sub("_", "-", param)
+            cmd.append(f"--{formatted_key}={config[param]}")
+    return cmd
+
+
+def get_ts_auth_url() -> str:
+    """Get AuthURL from tailscale status output
+    Query the json output from `tailscale status --json`
+    to get the generated AuthURL. Repeat every sec for 10 sec or raise
+    a RockstorAPIException.
+    """
+    cur_wait = 0
+    while True:
+        logger.debug(f"Attempt number {cur_wait} to get AUTH_URL")
+        ts_status = get_tailscale_status()
+        auth_url = ts_status["AuthURL"]
+        if len(auth_url) > 0:
+            break
+        if cur_wait > 10:
+            logger.error(
+                f"Waited too long ({cur_wait} seconds) for tailscale "
+                "to generate login URL... giving up."
+            )
+            # break
+            e_msg = (
+                f"Waited too long ({cur_wait} seconds) for tailscale to generate the login URL. "
+                "Please try again. If the problem persists, email support@rockstor.com "
+                "with this message, or inquire on our forum (https://forum.rockstor.com)."
+            )
+            raise RockStorAPIException(status_code=400, detail=e_msg)
+        time.sleep(1)
+        cur_wait += 1
+    return auth_url

--- a/src/rockstor/system/tests/test_services.py
+++ b/src/rockstor/system/tests/test_services.py
@@ -1,0 +1,236 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+import unittest
+from unittest.mock import patch
+
+from system.constants import SYSTEMCTL
+from system.services import tailscale_service_status, init_service_op
+
+
+class ServicesTests(unittest.TestCase):
+    """
+    The tests in this suite can be run via the following command:
+    cd /opt/rockstor/src/rockstor
+    export DJANGO_SETTINGS_MODULE=settings
+    poetry run django-admin test -p test_services.py -v 2
+    """
+
+    def test_init_service_op_unsupported_service(self):
+        service_name = "unsupported_service"
+        command = "status"
+        expected_msg = f"unknown service: {service_name}"
+
+        with self.assertRaises(Exception) as cm:
+            # Set throw to False as otherwise an Exception would be raised
+            # due to a problem unrelated to a supported/unsupported service name
+            # (which is the focus for this test)
+            init_service_op(service_name, command, throw=False)
+
+        # Verify the message returned by the Exception
+        returned_msg = str(cm.exception)
+        self.assertEqual(
+            returned_msg,
+            expected_msg,
+            msg="Un-expected exception message returned:\n "
+            f"returned = {returned_msg}.\n "
+            f"expected = {expected_msg}.",
+        )
+
+    def test_init_service_op_valid(self):
+        """test final command returned"""
+        supported_services = (
+            "nfs-server",
+            "nmb",
+            "smb",
+            "sshd",
+            "ypbind",
+            "rpcbind",
+            "ntpd",
+            "snmpd",
+            "docker",
+            "smartd",
+            "shellinaboxd",
+            "sssd",
+            "nut-server",
+            "rockstor-bootstrap",
+            "rockstor",
+            "systemd-shutdownd",
+            "tailscaled",
+        )
+        cmds = [
+            "start",
+            "stop",
+            "restart",
+            "enable",
+            "disable",
+            "status",
+        ]
+        self.patch_run_command = patch("system.services.run_command")
+        # Test that run_command was called as expected
+        for s in supported_services:
+            for c in cmds:
+                self.mock_run_command = self.patch_run_command.start()
+                init_service_op(service_name=s, command=c)
+                if c == "status":
+                    self.mock_run_command.assert_called_once_with(
+                        [SYSTEMCTL, c, s, "--lines=0"], throw=True
+                    )
+                else:
+                    self.mock_run_command.assert_called_once_with(
+                        [SYSTEMCTL, c, s], throw=True
+                    )
+                self.patch_run_command.stop()
+
+    def test_tailscale_service_status(self):
+        """
+        Returns specific integers based on get_tailscale_status() output.
+        We thus need to test each to catch any change in syntax/naming.
+        """
+        # Should return 1 if tailscaled systemd service is inactive
+        self.patch_is_systemd_service_active = patch(
+            "system.services.is_systemd_service_active"
+        )
+        self.mock_is_systemd_service_active = (
+            self.patch_is_systemd_service_active.start()
+        )
+        self.mock_is_systemd_service_active.return_value = False
+        expected = 1
+        returned = tailscale_service_status()
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_service_status() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+        # Mock tailscaled systemd service as active
+        # and test various status outputs
+        self.mock_is_systemd_service_active.return_value = True
+        ts_status_out = []
+        expected = []
+
+        # NOTE: the real ts_status_outputs can be very large so
+        # the expected ts_status_out below are shortened and anonymized
+        # for convenience and clarity. We only need one key in all of that.
+
+        # Tailscaled ON, not logged in
+        ts_status_out.append(
+            {
+                "Version": "1.50.0-ta920f0231-geb5b0beea",
+                "TUN": True,
+                "BackendState": "NeedsLogin",
+                "AuthURL": "",
+                "TailscaleIPs": None,
+                "Self": {},
+                "Health": ["state=NeedsLogin, wantRunning=false"],
+                "MagicDNSSuffix": "",
+                "CurrentTailnet": None,
+                "CertDomains": None,
+                "Peer": None,
+                "User": None,
+                "ClientVersion": None,
+            }
+        )
+        expected.append(5)
+
+        # Tailscaled ON, AuthURL created
+        ts_status_out.append(
+            {
+                "Version": "1.50.0-ta920f0231-geb5b0beea",
+                "TUN": True,
+                "BackendState": "NeedsLogin",
+                "AuthURL": "https://login.tailscale.com/a/1223456abc",
+                "TailscaleIPs": None,
+                "Self": {},
+                "Health": ["not in map poll"],
+                "MagicDNSSuffix": "",
+                "CurrentTailnet": None,
+                "CertDomains": None,
+                "Peer": None,
+                "User": None,
+                "ClientVersion": None,
+            }
+        )
+        expected.append(5)
+
+        # Tailscaled ON, logged in
+        ts_status_out.append(
+            {
+                "Version": "1.50.0-ta920f0231-geb5b0beea",
+                "TUN": True,
+                "BackendState": "Running",
+                "AuthURL": "",
+                "TailscaleIPs": [
+                    "100.100.100.100",
+                    "a1b1:a2b2:a3b3:a4b4:a5b5:a6b6:a7b7:a8b8",
+                ],
+                "Self": {},
+                "Health": None,
+                "MagicDNSSuffix": "tailXXXXX.ts.net",
+                "CurrentTailnet": {
+                    "Name": "email@address.com",
+                    "MagicDNSSuffix": "tailXXXXX.ts.net",
+                    "MagicDNSEnabled": True,
+                },
+                "CertDomains": None,
+                "Peer": {},
+                "User": {},
+                "ClientVersion": None,
+            }
+        )
+        expected.append(0)
+
+        # Tailscaled ON, down
+        ts_status_out.append(
+            {
+                "Version": "1.50.0-ta920f0231-geb5b0beea",
+                "TUN": True,
+                "BackendState": "Stopped",
+                "AuthURL": "",
+                "TailscaleIPs": [
+                    "100.100.100.100",
+                    "a1b1:a2b2:a3b3:a4b4:a5b5:a6b6:a7b7:a8b8",
+                ],
+                "Self": {},
+                "Health": ["state=Stopped, wantRunning=false"],
+                "MagicDNSSuffix": "tailXXXXX.ts.net",
+                "CurrentTailnet": {
+                    "Name": "email@address.com",
+                    "MagicDNSSuffix": "tailXXXXX.ts.net",
+                    "MagicDNSEnabled": True,
+                },
+                "CertDomains": None,
+                "Peer": {},
+                "User": {},
+                "ClientVersion": None,
+            }
+        )
+        expected.append(1)
+
+        # Need to mock get_tailscale_status
+        self.patch_get_tailscale_status = patch("system.services.get_tailscale_status")
+        self.mock_get_tailscale_status = self.patch_get_tailscale_status.start()
+
+        for (ts_out, exp) in zip(ts_status_out, expected):
+            self.mock_get_tailscale_status.return_value = ts_out
+            returned = tailscale_service_status()
+            self.assertEqual(
+                returned,
+                exp,
+                msg="Un-expected tailscale_service_status() result:\n "
+                f"returned = ({returned}).\n "
+                f"expected = ({exp}).",
+            )

--- a/src/rockstor/system/tests/test_tailscale.py
+++ b/src/rockstor/system/tests/test_tailscale.py
@@ -1,0 +1,321 @@
+"""
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+This file is part of RockStor.
+RockStor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+RockStor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+import unittest
+from unittest.mock import patch
+
+from system.constants import TAILSCALE
+from system.tailscale import (
+    extract_param,
+    validate_ts_custom_config,
+    construct_tailscale_up_command,
+    tailscale_up,
+    validate_ts_hostname,
+    tailscale_down,
+)
+
+
+class TailscaleTests(unittest.TestCase):
+    """
+    The tests in this suite can be run via the following command:
+    cd /opt/rockstor/src/rockstor
+    export DJANGO_SETTINGS_MODULE=settings
+    poetry run django-admin test -p test_tailscale.py -v 2
+    """
+
+    def test_tailscale_extract_param(self):
+        """Test get params name from dict
+        These would return, for instance:
+          - "--accept-risk=all" -> "accept_risk"
+          - "--shields-up" -> "shields_up"
+        """
+        params = []
+        expected = []
+
+        params.append("--accept-risk=all")
+        expected.append("accept_risk")
+
+        params.append("--shields-up")
+        expected.append("shields_up")
+
+        for (param, exp) in zip(params, expected):
+            returned = extract_param(param)
+            self.assertEqual(
+                returned,
+                exp,
+                msg="Un-expected extract_param() result:\n "
+                f"returned = {returned}.\n "
+                f"expected = {exp}.",
+            )
+
+    def test_tailscale_validate_hostname(self):
+        """Ensure alphanumeric and no underscore in hostname"""
+        test_config = {
+            "accept_routes": "yes",
+            "advertise_exit_node": "yes",
+            "advertise_routes": "192.168.1.0/24",
+            "exit_node": "100.1.1.1",
+            "exit_node_allow_lan_access": "true",
+            "hostname": "rock-dev_@#~!$%^&*()+123",
+            "reset": "yes",
+            "ssh": "yes",
+            "custom_config": "--shields-up\n--accept-risk=all",
+        }
+        expected = {
+            "accept_routes": "yes",
+            "advertise_exit_node": "yes",
+            "advertise_routes": "192.168.1.0/24",
+            "exit_node": "100.1.1.1",
+            "exit_node_allow_lan_access": "true",
+            "hostname": "rock-dev-123",
+            "reset": "yes",
+            "ssh": "yes",
+            "custom_config": "--shields-up\n--accept-risk=all",
+        }
+        returned = validate_ts_hostname(test_config)
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected validate_ts_hostname() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+    def test_tailscale_validate_ts_custom_config(self):
+        """
+        Should return only elements of custom configs:
+          - starting with '--'
+          - not in TS_UI_SETTINGS
+          - not in TS_UI_SETTINGS
+        """
+        test_custom_config = [
+            "--accept-risk=all",
+            "--shields-up",
+            "no-heading-hyphens",
+            "--accept-routes",
+            "--ssh",
+        ]
+        expected = [
+            "--accept-risk=all",
+            "--shields-up",
+        ]
+        returned = validate_ts_custom_config(test_custom_config)
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected validate_ts_custom_config() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+    def test_tailscale_construct_tailscale_up_command(self):
+        """Builds the tailscale up command from config"""
+        test_config = {
+            "accept_routes": "yes",
+            "advertise_exit_node": "yes",
+            "advertise_routes": "192.168.1.0/24",
+            "exit_node": "100.1.1.1",
+            "exit_node_allow_lan_access": "true",
+            "hostname": "rockdev",
+            "reset": "yes",
+            "ssh": "yes",
+            "auth_url": "https://login.tailscale.com/a/s123456df123",
+            "custom_config": ["--accept-risk=all", "--shields-up"],
+        }
+        expected = [
+            "/usr/bin/tailscale",
+            "up",
+            "--accept-routes",
+            "--advertise-exit-node",
+            "--advertise-routes=192.168.1.0/24",
+            "--exit-node=100.1.1.1",
+            "--exit-node-allow-lan-access",
+            "--hostname=rockdev",
+            "--reset",
+            "--ssh",
+            "--accept-risk=all",
+            "--shields-up",
+        ]
+        returned = construct_tailscale_up_command(test_config)
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected construct_tailscale_up_command() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+    def test_tailscale_up(self):
+        """Test enabling or not of ip forwarding
+        If the following two keys are found in the config dict,
+        then enable_ip_forwarding should be triggered. Test that.
+        """
+        # mock enable_ip_forwarding()
+        self.patch_enable_ip_forwarding = patch("system.tailscale.enable_ip_forwarding")
+        self.mock_enable_ip_forwarding = self.patch_enable_ip_forwarding.start()
+        self.mock_enable_ip_forwarding.return_value = [""], [""], 0
+        # mock run_command()
+        self.patch_run_command = patch("system.tailscale.run_command")
+        self.mock_run_command = self.patch_run_command.start()
+        self.mock_run_command.return_value = [""], [""], 0
+
+        # enable_ip_forwarding() should not be called
+        config = {"hostname": "rockdevtest", "reset": "yes", "ssh": "yes"}
+        expected_cmd = [TAILSCALE, "up", "--hostname=rockdevtest", "--reset", "--ssh"]
+        self.mock_enable_ip_forwarding.assert_not_called()
+        returned = tailscale_up(config=config)
+        self.mock_run_command.assert_called_once_with(
+            expected_cmd, log=True, throw=False
+        )
+        expected = [""], [""], 0
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_up() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+        # enable_ip_forwarding() should be called
+        config = {
+            "hostname": "rockdevtest",
+            "reset": "yes",
+            "ssh": "yes",
+            "advertise_exit_node": "yes",
+        }
+        expected_cmd = [
+            TAILSCALE,
+            "up",
+            "--hostname=rockdevtest",
+            "--reset",
+            "--ssh",
+            "--advertise-exit-node",
+        ]
+        self.patch_run_command.stop()
+        self.mock_run_command = self.patch_run_command.start()
+        self.mock_run_command.return_value = [""], [""], 0
+        self.patch_enable_ip_forwarding.stop()
+        self.mock_enable_ip_forwarding = self.patch_enable_ip_forwarding.start()
+        returned = tailscale_up(config=config)
+        self.mock_enable_ip_forwarding.assert_called_once_with(
+            name="tailscale", priority=99
+        )
+        self.mock_run_command.assert_called_once_with(
+            expected_cmd, log=True, throw=False
+        )
+        expected = [""], [""], 0
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_up() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+        # enable_ip_forwarding() should be called
+        # '--timeout' should be added
+        config = {
+            "hostname": "rockdevtest",
+            "reset": "yes",
+            "ssh": "yes",
+            "advertise_exit_node": "yes",
+        }
+        expected_cmd = [
+            TAILSCALE,
+            "up",
+            "--hostname=rockdevtest",
+            "--reset",
+            "--ssh",
+            "--advertise-exit-node",
+            "--timeout=10s",
+        ]
+        self.patch_run_command.stop()
+        self.mock_run_command = self.patch_run_command.start()
+        self.mock_run_command.return_value = [""], [""], 0
+        self.patch_enable_ip_forwarding.stop()
+        self.mock_enable_ip_forwarding = self.patch_enable_ip_forwarding.start()
+        returned = tailscale_up(config=config, timeout=10)
+        self.mock_enable_ip_forwarding.assert_called_once_with(
+            name="tailscale", priority=99
+        )
+        self.mock_run_command.assert_called_once_with(
+            expected_cmd, log=True, throw=False
+        )
+        expected = [""], [""], 0
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_up() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+    def test_tailscale_down(self):
+        """Test disabling or not of ip forwarding
+        If the following two keys are found in the config dict,
+        then disable_ip_forwarding should be triggered. Test that.
+        """
+        # mock disable_ip_forwarding()
+        self.patch_disable_ip_forwarding = patch(
+            "system.tailscale.disable_ip_forwarding"
+        )
+        self.mock_disable_ip_forwarding = self.patch_disable_ip_forwarding.start()
+        self.mock_disable_ip_forwarding.return_value = [""], [""], 0
+        # mock run_command()
+        self.patch_run_command = patch("system.tailscale.run_command")
+        self.mock_run_command = self.patch_run_command.start()
+        self.mock_run_command.return_value = [""], [""], 0
+
+        # disable_ip_forwarding() should not be called
+        config = {"hostname": "rockdevtest", "reset": "yes", "ssh": "yes"}
+        expected_cmd = [TAILSCALE, "down"]
+        self.mock_disable_ip_forwarding.assert_not_called()
+        returned = tailscale_down(config=config)
+        self.mock_run_command.assert_called_once_with(
+            expected_cmd, log=True, throw=False
+        )
+        expected = [""], [""], 0
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_down() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )
+
+        # disable_ip_forwarding() should be called
+        config = {
+            "hostname": "rockdevtest",
+            "reset": "yes",
+            "ssh": "yes",
+            "advertise_exit_node": "yes",
+        }
+        self.patch_run_command.stop()
+        self.mock_run_command = self.patch_run_command.start()
+        self.mock_run_command.return_value = [""], [""], 0
+        self.patch_disable_ip_forwarding.stop()
+        self.mock_disable_ip_forwarding = self.patch_disable_ip_forwarding.start()
+        returned = tailscale_down(config=config)
+        self.mock_disable_ip_forwarding.assert_called_once_with(name="tailscale")
+        self.mock_run_command.assert_called_once_with(
+            expected_cmd, log=True, throw=False
+        )
+        expected = [""], [""], 0
+        self.assertEqual(
+            returned,
+            expected,
+            msg="Un-expected tailscale_down() result:\n "
+            f"returned = {returned}.\n "
+            f"expected = {expected}.",
+        )


### PR DESCRIPTION
Fixes #2679
@phillxnet, @Hooverdan96: ready for review


This pull-request (PR) proposes to add a new Service (in System > Services) for Tailscale, allowing the users to connect their Rockstor machine to their existing Tailscale account entirely from Rockstor's UI, without command line interaction. See related issue for rationale.

# Overall implementation
## Introductory notes
**This PR makes the assumption that the `tailscale` package is already installed on the system**, providing the `tailscaled` daemon systemd service as well as the `tailscale` cli interface (on which this PR entirely relies). Ensuring the tailscale package is installed should thus be the subject of a dedicated issue in our rockstor-installer repository.

To better understand the implementation in this PR, it is important to note that there are two main components to Tailscale on the system:
- the `tailscaled` daemon (systemd service): creates the `tun` device and "routes" traffic. This service being active is not sufficient for having an active Tailscale connection. This is done by the `tailscale` binary (see below).
- the `tailscale` cli binary: represents the interface between the user and its Tailscale account and connection configuration. This binary **requires** the `tailscaled` daemon to up and running to do anything.

@phillxnet, Tailscale licensing is detailed at: https://github.com/tailscale/tailscale/blob/main/LICENSE
Their website (https://tailscale.com/opensource/) details:
> The client, which runs on each of a user’s devices, is mostly open source. The core client code for the Tailscale daemon used across all platforms is open source, and the full client code is open source for platforms that are also open source.
> We enthusiastically support open source operating systems such as Linux and Android, and we believe that our time and energy is best directed toward the communities for these platforms. As a result, where the operating system is open source, the daemon and GUI are open source; and where the operating system is closed, the daemon is open source and the GUI is closed source.
> This means that you can build the Linux and Android clients yourself, and you can build the Windows and macOS clients without the GUI.


## Rockstor's implementation
1. The Tailscale service is configurable. The user can thus configure a various set of parameters using Rockstor's UI. *By default, it is NOT configured*, and the `tailscaled` service is NOT running.
2. When configured, we assume the user intends on using the Tailscale service and thus start the `tailscaled` daemon. This creates the `tun` device but does not activate the Tailscale connection. This step is a requirement for the initiation of the login/authentication mechanism.
3. In this state (configured, but Service OFF), we detect if the user needs to authenticate this machine to their Tailscale account. If it is the case, we display a "Login" button *in lieu* of the usual ON/OFF toggle.
4. When clicking the "Login" button, we trigger and shortly thereafter timeout a `tailscale up` call; this generates an authURL that we then retrieve and use to open a new browser window that the user can thus use to complete the process of authentication to their Tailscale account. When completed, the Tailscale service is ON and the machine is fully connected to their Tailscale network.
5. Toggling the Tailscale service OFF disonnects the machine from their Tailscale network. It does *not* turn OFF the `tailscaled` daemon as this PR assumes the user might still want to turn it back ON (shortly) thereafter. I'm thinking of using https://github.com/rockstor/rockstor-core/issues/2332 here: when resetting the service to its default, we consider that the user does not want Tailscale anymore and we would thus stop the `tailscaled` daemon then.


# Implementation details
## Tailscale service configuration
As detailed in https://github.com/rockstor/rockstor-core/issues/2679#issuecomment-1741838236, `tailscale` supports many options, and this PR proposes to provide a simple form to set what might be the most commonly used ones.
For all other options, a *custom configuration* box is offered so that the user can manually enter what they want. **Note** that if the user enters in this custom configuration box a parameter that is already supported in the form above it, this PR considers what was defined in the form as taking precedence over the custom configuration and thus ignores it.
The configuration form includes a variety of Javascript-based validation to prevent the user to enter incompatible or invalid settings. Note that this covers the incompatibilities that I have personally witnessed... there may be more that I have not seen yet.

Just like all other services, submitting the configuration form sends that data to the new `TailscaledView` that parses it and validates it as follows:
- if `hostname` param is present: verify it is alphanumeric and does not include special characters. Underscores are also invalid so we change them to hyphens (same as what the Tailscale webUI does).
- parses the custom configuration and remove parameter if it is a duplicate of what's already in the webUI form.
After this validation, we save the config in the database.

This also *enables* and *starts* the `tailscaled` systemd service, required for the next steps.

See below for a screenshot of the configuration modal:
![image](https://github.com/rockstor/rockstor-core/assets/30297881/17cb376c-38f9-4006-9af0-24e12e3079fd)


## Tailscale service status
Unlike other Services, Tailscale needs to be authenticated to function. We thus consider the Tailscale service as **ON** if the machine is connected to the user's Tailscale network. This, however, requires authentication, explained in the next section.

For Tailscale, however, we need to have a more granular knowledge of Tailscale status than for other services (due to the reasons above). Fortunately, `tailscale` includes a subcommand (`status`) that can report a very detailed report in JSON. This includes one important key: `BackendState`. This key indeed is enough to give us the information we need:
- NeedsLogin
- Stopped
- Running

We thus have 3 states. On top of that, we also have the state of "tailscaled systemd service not active" -> 4 states. In reality, however, we just need to know the following:
- is the `tailscaled` daemon running?
- if the `tailscaled` daemon is running:
  - does `tailscale` need to be authenticated (BackendState: "NeedsLogin")? If yes: show "Login" button (see below).
  - is tailscale running?
  - is tailscale stopped?

In `services.js`, we currently use return codes as returned by systemd/supervisorctl to represent services status to display the ON/OFF toggle accordingly:
- for return code 0: running
- for return code > 0: not running

Note that systemd already returns: 0 = unit is active, 3 = unit is not active, 4 = no such unit (@phillxnet's notes).
Here, we need a new state: needs login. I thus chose to attribute a return code of 5 to represent that. This is detailed in `system.services.tailscale_service_status()`. As a result, if service status is 5, we need to display the "Login" button.


## Tailscale authentication/login
Running `tailscale up` at this point would hang, waiting for the user to visit an automatically generated URL to login/authenticate to their Tailscale account. As a result, this would make the front-end hang as well. I have thus ended up relying on the following "feature": when `tailscale up` is triggered, it checks if authentication is needed and generates an authURL, waiting for the user to copy this URL, paste it in the browser and then complete the authentication process. When completed, `tailscale up` detects that and finishes activating the tailscale connection. Now, the "detail" that this PR uses is that when that initial `tailscale up` call that generates the needed authURL finishes (successfully or not), the generated authURL can be retrieved from `tailscale status`, and is still valid for the user to complete the authentication process. Rockstor thus uses that as follows:
- when authentication is required, we display a "Login" button *in lieu* of the ON/OFF toggle (design choice to be discussed if needed).
- clicking this button calls a new endpoint with the `login` **action** (new definition in urls) that calls `tailscale up` with a timeout of 2 sec. That is enough to generate the authURL, and then completes. We can then call `tailscale status` to retrieve this authURL and save it in the config model entry. We then refresh the Backbone collection for the services to have that authURL available to our front-end and use that to open a new window with that URL. That process is contained in the `tailscaleAuthAction` function in `services.js`.
- once the authentication process is completed by the user, the tailscale service is automatically turned on (done by tailscale itself, not Rockstor).
- the latter is picked up by our automatic websocket-based service status update mechanism (polling interval: 15 sec) that will then show the Tailscale service as ON. This explains why https://github.com/rockstor/rockstor-core/pull/2682 was needed here.


# Machine expiration
By default, each machine newly connected to a Tailscale network expires in 30 days.
I've tried to mimick this as follows:
1. "remove" the machine from Tailscale's dashboard. Unfortunately, this does not stop the tailscale connection on the machine as it still shows a status of "Running".
2. in Rockstor, manually toggle the Tailscale service OFF. `tailscale status` shows it as Stopped, but not needing login, unfortunately, so we have the ON/OFF toggle still in Rockstor's UI.
3. toggling the service ON, though, triggers `tailscale up`, which then detects it needs login. In Rockstor UI, this is detected and we show the "Login" button. One can then complete the login process.

It is not as smooth as I would like, but I'm unsure how to deal with this "weird" state given the Needs login state is not detected by Tailscale before we need to know it. Maybe a "normal" machine expiration is reflected differently than manually removing it from the dashboard?

The `tailscale up` command does have a `--force-reauth` flag that will force a re-authentication. Maybe this should be included in the configuration modal as a button in case of need.

# Testing
All development and testing was conducted on Leap 15.5; all tests are passing (note that we now have 17 more tests included in this PR):
```
buildvm155:/opt/rockstor/src/rockstor # poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
.......................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 279 tests in 15.877s

OK
```

# Miscellaneous
## Services table
I had to make a few re-arrangements in the table listing all services:
- increase default display of services to 30.
- remove the `text-align: left` css that was forcing a left alignment for the buttons.
- reduce width of toggle/login buttons
The resulting table does have a lot of empty space in the center, though... This is another design choice to be discussed as/if desired.

## Change to `run_command()`
**This PR does include a change to `system.osi.run_command()**.
This change was required to easily load the JSON output from `tailscale status --json` as a dict. I've slightly edited `run_command()` to allow returning the "raw" output from `p.communicate()`, while leaving the default behavior the same as before.

## Help button link
The link included in the help button at the top of the configuration modal points to the docs' root. This should be changed to point to a dedicated description of the Tailscale service once it exists.

## Change to .gitignore
We previously had `static/` in `.gitignore` to ignore the static dir created by `collectstatic`. This, however, was not selective enough and was causing `static/` subfolders to be ignored. That included `configure_tailscaled.jst`, for instance. The change in this PR should concern only the `static/` folder located in the project's root: `/static/`.

## How the new tailscale0 tun device shows in the Network page
`tailscaled` systemd service is inactive:
![image](https://github.com/rockstor/rockstor-core/assets/30297881/e6c33e27-b15c-4a60-82a6-b57d09fa1ac9)

`tailscaled` systemd service is active, but tailscale is OFF:
![image](https://github.com/rockstor/rockstor-core/assets/30297881/5b297b96-b811-4e9d-a5c3-e87188be4995)


Tailscale service ON:
![image](https://github.com/rockstor/rockstor-core/assets/30297881/96769c97-44fe-4c6e-848d-66e2cf83e6e0)

