### PR TITLE
Use regular expressions to validate tailscale hostname #2714

### DIFF
--- a/src/rockstor/system/tailscale.py
+++ b/src/rockstor/system/tailscale.py
@@ -104,32 +104,20 @@ def extract_param(param: str) -> str:
 
 
 def validate_ts_hostname(config: dict) -> dict:
-    """Ensure hostname is alphanumeric with hyphens only
-    No special character (including hyphens) is allowed as a custom hostname.
+    """Applies a set of rules to validate hostname
+    Keep each character in hostname only if:
+    - not a special character
+    - not a unicode character
+    - is hyphen
+    - replace underscore with hyphen
 
-    "hostname": "rock-dev_@#~!$%^&*()+123"
+    "hostname": "rock-dev_@#~!$%^&*()+123ü"
     should return
     "hostname": "rock-dev-123"
     """
     if "hostname" in config:
         config["hostname"] = re.sub("_", "-", config["hostname"])
-        to_exclude = [
-            "@",
-            "#",
-            "~",
-            "!",
-            "$",
-            "%",
-            "^",
-            "&",
-            "*",
-            "(",
-            ")",
-            "+",
-        ]
-        config["hostname"] = "".join(
-            c for c in config["hostname"] if not c in to_exclude
-        )
+        config["hostname"] = re.sub("[^a-zA-Z0-9-]", "", config["hostname"])
     return config
 
 

--- a/src/rockstor/system/tests/test_tailscale.py
+++ b/src/rockstor/system/tests/test_tailscale.py
@@ -60,14 +60,14 @@ class TailscaleTests(unittest.TestCase):
             )
 
     def test_tailscale_validate_hostname(self):
-        """Ensure alphanumeric and no underscore in hostname"""
+        """Ensure alphanumeric, no underscore, and no unicode in hostname"""
         test_config = {
             "accept_routes": "yes",
             "advertise_exit_node": "yes",
             "advertise_routes": "192.168.1.0/24",
             "exit_node": "100.1.1.1",
             "exit_node_allow_lan_access": "true",
-            "hostname": "rock-dev_@#~!$%^&*()+123",
+            "hostname": "rock-dev_@#~!$%^&*()+123ü",
             "reset": "yes",
             "ssh": "yes",
             "custom_config": "--shields-up\n--accept-risk=all",


### PR DESCRIPTION
Fixes #2714 
@Hooverdan96, @phillxnet: ready for review.

Following up on @Hooverdan96's suggestion to leverage regular expressions to better validate the hostname key in the Tailscale service config.

The current mechanism uses a hard-coded list of characters to exclude them from a custom tailscale hostname if present. This is rather ugly and does not scale to all the characters (such as unicode) that need to be excluded.

Switch to using regular expressions to exclude only characters from the hostname that do not belong to that regular expression.

All tests still pass...
```
buildvm155:/opt/rockstor/src/rockstor # poetry run django-admin test
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 278 tests in 15.039s

OK
```

... and I was able to configure and turn ON the Tailscale service with a custom hostname being taken in effect (as seen on the Tailscale machines dashboard).