### PR TITLE
Add/Update help icon linking to docs #2720

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -23,7 +23,10 @@
     <div class="col-md-12">
         <div class="panel panel-default">
 
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#active-directory-ad" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
 
             <div class="panel-body">
                 <form class="form-horizontal" id="active-directory-form" name="aform">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_active-directory.jst
@@ -1,22 +1,22 @@
 <script>
-  /*
-  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
-  * This file is part of RockStor.
-  *
-  * RockStor is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published
-  * by the Free Software Foundation; either version 2 of the License,
-  * or (at your option) any later version.
-  *
-  * RockStor is distributed in the hope that it will be useful, but
-  * WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <https://www.gnu.org/licenses/>.
-  *
-  */
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+    * This file is part of RockStor.
+    *
+    * RockStor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * RockStor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
+    *
+    */
 </script>
 
 <div class="row">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -27,7 +27,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}} Service</div>
+            <div class="panel-heading">Configure {{serviceName}} Service
+                <a href="https://rockstor.com/docs/interface/system/services.html#rock-ons-docker-plugin-system" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="docker-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ldap.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -22,7 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#lightweight-directory-access-protocol-ldap" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="ldap-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nis.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nis.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -22,7 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#network-information-server-nis" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="nis-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ntpd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_ntpd.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -22,7 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#ntp" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="ntpd-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_nut.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-   * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+   * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
    * This file is part of RockStor.
    *
    * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
    * General Public License for more details.
    *
    * You should have received a copy of the GNU General Public License
-   * along with this program. If not, see <http://www.gnu.org/licenses/>.
+   * along with this program. If not, see <https://www.gnu.org/licenses/>.
    *
    */
 </script>
@@ -22,7 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#nut-ups" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="nut-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_replication.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_replication.jst
@@ -1,28 +1,31 @@
 <script>
-  /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
-  * This file is part of RockStor.
-  *
-  * RockStor is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published
-  * by the Free Software Foundation; either version 2 of the License,
-  * or (at your option) any later version.
-  *
-  * RockStor is distributed in the hope that it will be useful, but
-  * WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
-  *
-  */
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+    * This file is part of RockStor.
+    *
+    * RockStor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * RockStor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
+    *
+    */
 </script>
 
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#replication" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="replication-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_rockstor.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_rockstor.jst
@@ -1,28 +1,31 @@
 <script>
-  /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
-    * This file is part of RockStor.
-    *
-    * RockStor is free software; you can redistribute it and/or modify
-    * it under the terms of the GNU General Public License as published
-    * by the Free Software Foundation; either version 2 of the License,
-    * or (at your option) any later version.
-    *
-    * RockStor is distributed in the hope that it will be useful, but
-    * WITHOUT ANY WARRANTY; without even the implied warranty of
-    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    * General Public License for more details.
-    *
-    * You should have received a copy of the GNU General Public License
-    * along with this program. If not, see <http://www.gnu.org/licenses/>.
-    *
-    */
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+      * This file is part of RockStor.
+      *
+      * RockStor is free software; you can redistribute it and/or modify
+      * it under the terms of the GNU General Public License as published
+      * by the Free Software Foundation; either version 2 of the License,
+      * or (at your option) any later version.
+      *
+      * RockStor is distributed in the hope that it will be useful, but
+      * WITHOUT ANY WARRANTY; without even the implied warranty of
+      * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+      * General Public License for more details.
+      *
+      * You should have received a copy of the GNU General Public License
+      * along with this program. If not, see <https://www.gnu.org/licenses/>.
+      *
+      */
 </script>
 
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#rockstor" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="rockstor-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_shellinaboxd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_shellinaboxd.jst
@@ -1,28 +1,31 @@
 <script>
-  /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
-  * This file is part of RockStor.
-  *
-  * RockStor is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published
-  * by the Free Software Foundation; either version 2 of the License,
-  * or (at your option) any later version.
-  *
-  * RockStor is distributed in the hope that it will be useful, but
-  * WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
-  *
-  */
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+    * This file is part of RockStor.
+    *
+    * RockStor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * RockStor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
+    *
+    */
 </script>
 
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}} Service</div>
+            <div class="panel-heading">Configure {{serviceName}} Service
+                <a href="https://rockstor.com/docs/interface/system/services.html#shell-in-a-box" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="shellinaboxd-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smartd.jst
@@ -1,6 +1,6 @@
 <script>
     /*
-    * Copyright (c) 2012-2019 RockStor, Inc. <http://rockstor.com>
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
     * This file is part of RockStor.
     *
     * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
     * General Public License for more details.
     *
     * You should have received a copy of the GNU General Public License
-    * along with this program. If not, see <http://www.gnu.org/licenses/>.
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
     *
     */
 </script>
@@ -22,7 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}} Daemon</div>
+            <div class="panel-heading">Configure {{serviceName}} Daemon
+                <a href="https://rockstor.com/docs/interface/system/services.html#s-m-a-r-t" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
 
                 <form class="form-horizontal" id="smartd-form" name="aform">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_smb.jst
@@ -1,6 +1,6 @@
 <script>
   /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
+  * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
   * This file is part of RockStor.
   *
   * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
   * General Public License for more details.
   *
   * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  * along with this program. If not, see <https://www.gnu.org/licenses/>.
   *
   */
 </script>
@@ -22,8 +22,10 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}}</div>
-
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#samba" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
             <div class="panel-body">
                 <form class="form-horizontal" id="smb-form" name="aform">
                     <div class="messages"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_snmpd.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_snmpd.jst
@@ -1,29 +1,32 @@
 <script>
-  /*
-  * Copyright (c) 2012-2016 RockStor, Inc. <http://rockstor.com>
-  * This file is part of RockStor.
-  *
-  * RockStor is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published
-  * by the Free Software Foundation; either version 2 of the License,
-  * or (at your option) any later version.
-  *
-  * RockStor is distributed in the hope that it will be useful, but
-  * WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program. If not, see <http://www.gnu.org/licenses/>.
-  *
-  */
+    /*
+    * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
+    * This file is part of RockStor.
+    *
+    * RockStor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * RockStor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <https://www.gnu.org/licenses/>.
+    *
+    */
 </script>
 
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
 
-            <div class="panel-heading">Configure {{serviceName}}</div>
+            <div class="panel-heading">Configure {{serviceName}}
+                <a href="https://rockstor.com/docs/interface/system/services.html#snmp" target="_blank"
+                   title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
+            </div>
 
             <div class="panel-body">
                 <form class="form-horizontal" id="snmpd-form" name="aform">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_tailscaled.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_tailscaled.jst
@@ -22,8 +22,8 @@
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure the {{ serviceName }} service &nbsp;
-                <a href="https://rockstor.com/docs" target="_blank"
+            <div class="panel-heading">Configure {{ serviceName }}
+                <a href="https://rockstor.com/docs/interface/system/services.html#tailscale" target="_blank"
                    title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
             </div>
             <div class="panel-body">


### PR DESCRIPTION
Fixes #2720 

In the configuration modals for our Services, some include links to their respective docs while other do not.

This pull requests harmonizes these discrepancies by adding the same help icon linking to the Service's section in our docs.

Also includes:
  - minor update of Tailscale service configuration header so that it matches the other services
  - update copyright statements

The configuration modals for all affected services were verified:
  - to include the new/updated HELP icon
  - to link to the appropriate section of our docs
