### PR TITLE
SyntaxWarning: "is not" with a literal #2713

### DIFF
--- a/src/rockstor/storageadmin/views/email_client.py
+++ b/src/rockstor/storageadmin/views/email_client.py
@@ -201,7 +201,7 @@ def update_postfix(smtp_server, port, revert=False):
                 # "inet_protocols = all" as we need this to be:
                 # "inet_protocols = ipv4" as our NetworkManager is ipv4 only.
                 # Or if we find duplicates of our to-be-installed settings;
-                if len(line) > 0 and line[0] is not "#":
+                if len(line) > 0 and line[0] != "#":
                     # TODO: Revert ipv4 only once network config is ipv6 aware.
                     if re.match("inet_protocols = all", line) is not None:
                         tfo.write("inet_protocols = ipv4\n")

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -236,7 +236,7 @@ def uninstall(rid, new_state="available", task=None):
         if rockon is not None:
             # During non live update we do uninstall-install under task.name "update"
             # During this cycle we want to maintain our taskid stamp.
-            if new_state is not "pending_update" and task is not None:
+            if new_state != "pending_update" and task is not None:
                 rockon.taskid = None
             else:
                 logger.info(
@@ -376,7 +376,7 @@ def generic_install(rockon):
         cmd.extend(device_ops(c))
         if c.uid is not None:
             uid = c.uid
-            if c.uid is -1:
+            if c.uid == -1:
                 uid = vol_owner_uid(c)
             # @todo: what if the uid does not exist? Create a user with
             # username=container-name?

--- a/src/rockstor/system/luks.py
+++ b/src/rockstor/system/luks.py
@@ -238,7 +238,7 @@ def get_unlocked_luks_containers_uuids():
                 # Initial call to gain backing device name for our container
                 container_dev = get_open_luks_container_dev(each_line)
                 # strip leading /dev/ from device name if any returned.
-                if container_dev is not "":
+                if container_dev != "":
                     container_dev = container_dev.split("/")[-1]
                     # should now have name without path ie 'vdd' ready to
                     # index our uuid_name_map.
@@ -348,7 +348,7 @@ def update_crypttab(uuid, keyfile_entry):
             if re.match("UUID=", line_fields[1]) is not None:
                 # we have our native UUID reference so split and compare
                 source_dev_fields = line_fields[1].split("=")
-                if len(source_dev_fields) is not 2:
+                if len(source_dev_fields) != 2:
                     # ie "UUID=" with no value which is non legit so skip
                     continue
                 # we should have a UUID=<something> entry so examine it


### PR DESCRIPTION
Modify conditionals to address Py3.8's added warnings.

Fixes #2713 

## Testing
Post the proposed changes we have:
```
lbuildvm:/opt/rockstor/src/rockstor # poetry run python -Wd /opt/rockstor/.venv/bin/django-admin test -v 2
/opt/rockstor/.venv/lib/python3.9/site-packages/django/utils/version.py:98: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  loose_version = LooseVersion(version)
Creating test database for alias 'default' ('test_storageadmin')...
...
----------------------------------------------------------------------
Ran 278 tests in 27.020s

OK
...
```
With the remaining warning pertaining to #2696 Re Py3.10 and our Django.