### PR TITLE
Ease database diagnosis via local IP access configuration #2730

### DIFF
--- a/conf/pg_hba.conf
+++ b/conf/pg_hba.conf
@@ -96,3 +96,9 @@ local   test_smartdb         rocky                                   md5
 # local   replication     all                                     peer
 # host    replication     all             127.0.0.1/32            ident
 # host    replication     all             ::1/128                 ident
+
+# "host" IPv4 & IPv6 connections - e.g. IDE localhost only DB diagnostics
+# host   storageadmin    rocky              127.0.0.1/32            md5
+# host   smartdb         rocky              127.0.0.1/32            md5
+# host   storageadmin    rocky              ::1/128                 md5
+# host   smartdb         rocky              ::1/128                 md5


### PR DESCRIPTION
Add to Postgresql's Host Based Authentication config (pg_hba.conf), remarked out examples of enabling IPv4 & IPv6 based access, from localhost. Typical DB interfaces found in IDEs are limited to IP access only, and so cannot connect using the unix socket only configuration used by Rockstor.

Fixes #2730 