### PR TITLE
Make explicit to systemd our NetworkManager dependency #2685

### DIFF
--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Tasks required prior to starting Rockstor
 After=postgresql.service
+After=NetworkManager.service
 Requires=postgresql.service
+Requires=NetworkManager.service
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=settings"


### PR DESCRIPTION
Adds `After` &  `Requires` for NetworkManager.service to rockstor-pre.service. Primarily to surface to admins our dependency on nmcli.

Fixes #2685 

## Testing:

### Before:
```
rleap15-5:~ # systemd-analyze dot --require rockstor-pre.service
digraph systemd {
        "rockstor-pre.service"->"-.mount" [color="black"];
        "rockstor-pre.service"->"sysinit.target" [color="black"];
        "rockstor-pre.service"->"system.slice" [color="black"];
        "rockstor-pre.service"->"postgresql.service" [color="black"];
        "rockstor-pre.service"->"opt.mount" [color="black"];
        "rockstor-pre.service"->"shutdown.target" [color="red"];
        "rockstor.service"->"rockstor-pre.service" [color="black"];
}
...
```

### After:
```
lbuildvm:~ # systemd-analyze dot --require rockstor-pre.service
digraph systemd {
        "rockstor-pre.service"->"NetworkManager.service" [color="black"];
        "rockstor-pre.service"->"system.slice" [color="black"];
        "rockstor-pre.service"->"postgresql.service" [color="black"];
        "rockstor-pre.service"->"sysinit.target" [color="black"];
        "rockstor-pre.service"->"-.mount" [color="black"];
        "rockstor-pre.service"->"opt.mount" [color="black"];
        "rockstor-pre.service"->"shutdown.target" [color="red"];
        "rockstor.service"->"rockstor-pre.service" [color="black"];
        "multi-user.target"->"rockstor-pre.service" [color="grey66"];
}
...
```
# Caveat
We seem to have now inherited, via the new association/requires,  the multi-user.target. This may well put us a little later on in the boot sequence.