### PR TITLE
Replication secret encrypted in Web-UI #2759

### DIFF
--- a/src/rockstor/storageadmin/models/oauth_app.py
+++ b/src/rockstor/storageadmin/models/oauth_app.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,12 +13,13 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from django.db import models
 from oauth2_provider.models import Application
 from storageadmin.models import User
+from settings import OAUTH_INTERNAL_APP, CLIENT_SECRET
 
 
 class OauthApp(models.Model):
@@ -30,7 +31,16 @@ class OauthApp(models.Model):
         return self.application.client_id
 
     def client_secret(self, *args, **kwargs):
+        # For our internal app, we return our 'pass' secret:
+        if self.application.name == OAUTH_INTERNAL_APP:
+            return CLIENT_SECRET
         return self.application.client_secret
+
+    @property
+    def is_internal(self, *args, **kwargs):
+        if self.application.name == OAUTH_INTERNAL_APP:
+            return True
+        return False
 
     class Meta:
         app_label = "storageadmin"

--- a/src/rockstor/storageadmin/serializers.py
+++ b/src/rockstor/storageadmin/serializers.py
@@ -276,6 +276,7 @@ class SFTPSerializer(serializers.ModelSerializer):
 class OauthAppSerializer(serializers.ModelSerializer):
     client_id = serializers.CharField()
     client_secret = serializers.CharField()
+    is_internal = serializers.BooleanField()
 
     class Meta:
         model = OauthApp

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/access_keys/access_keys.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/access_keys/access_keys.jst
@@ -1,6 +1,6 @@
 <script>
 /*
- * Copyright (c) 2012-2014 RockStor, Inc. <http://rockstor.com>
+ * Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
  * This file is part of RockStor.
  * 
  * RockStor is free software; you can redistribute it and/or modify
@@ -14,7 +14,7 @@
  * General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  * 
  */
 </script>
@@ -26,7 +26,7 @@
     <!-- Content -->
     <div class="messages"></div>
     <div id="access-keys-table-ph">
-    {{#if collectionNotEmpty}}
+      {{#if collectionNotEmpty}}
         <table id="access-keys-table" class="table table-bordered table-striped data-table">
           <thead>
           <tr>
@@ -41,7 +41,11 @@
             <tr>
             <td>{{this.name}}</td>
             <td>{{this.client_id}}</td>
-            <td>{{this.client_secret}}</td>
+            {{#if this.is_internal}}
+                <td>{{this.client_secret}}</td>
+            {{else}}
+                <td>Secret encrypted: only available during creation</td>
+            {{/if}}
             <td><a id="delete-access-key" data-id="{{this.id}}" data-name="{{this.name}}" data-action="delete" rel="tooltip" title="Delete access key">
             <i class="glyphicon glyphicon-trash"></i></a>
             </td>

--- a/src/rockstor/storageadmin/views/oauth_app.py
+++ b/src/rockstor/storageadmin/views/oauth_app.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from rest_framework.response import Response
@@ -80,15 +80,12 @@ class OauthAppView(rfc.GenericView):
 
             if app.name == settings.OAUTH_INTERNAL_APP:
                 e_msg = (
-                    "Application with id ({}) cannot be deleted because "
-                    "it is "
-                    "used internally by Rockstor. If you really need to "
-                    "delete it, login as root and use "
-                    "{}.venv/bin/delete-api-key command. If you do delete it, "
-                    "please create another one with the same name as it "
-                    "is required by Rockstor "
-                    "internally."
-                ).format(id, settings.ROOT_DIR)
+                    f"Application name ({settings.OAUTH_INTERNAL_APP}), id ({id}) "
+                    "cannot be deleted because it is used internally by Rockstor. "
+                    "To force delete, run as root: "
+                    f"'{settings.ROOT_DIR}.venv/bin/delete-api-key'."
+                    "To avoid dysfunction, it must be recreated using the same name."
+                )
                 handle_exception(Exception(e_msg), request, status_code=400)
 
             app.application.delete()


### PR DESCRIPTION
Special-case our internal cliapp re secret availability. Indicate all non-internal Access Key secrets as only available during creation.

Closes #2759 

## Includes
- Surfacing our pass/PGP encrypted raw secret to authenticated Web-UI logins.
- Indicate all other API credentials as not available.
- Brevity improvements re deletion attempt on cliapp message.

![show-only-internal-cliapp-secret](https://github.com/rockstor/rockstor-core/assets/2521585/ccd59cc6-6680-40c4-8e24-e456904170af)
