### PR TITLE
(t) replication spawn error #2766

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/send_replica.py
+++ b/src/rockstor/scripts/scheduled_tasks/send_replica.py
@@ -31,16 +31,12 @@ def main():
     num_tries = 3
     while True:
         req = ctx.socket(zmq.DEALER)
-        print(f"req = {req}")
         poll.register(req, zmq.POLLIN)
-        print(f"poll.register = {poll.register}")
-        ipc_socket = settings.REPLICATION.get('ipc_socket')
+        ipc_socket = settings.REPLICATION.get("ipc_socket")
         req.connect(f"ipc://{ipc_socket}")
-        print(f"req.connect = {req.connect}, ipc_socket = {ipc_socket}")
-        req.send_multipart([b"new-send", f"{rid}".encode('utf-8')])
+        req.send_multipart([b"new-send", f"{rid}".encode("utf-8")])
 
         socks = dict(poll.poll(5000))
-        # print(f"socks.get(req) = {socks.get(req)}")
         if socks.get(req) == zmq.POLLIN:
             rcommand, reply = req.recv_multipart()
             print(f"rcommand={rcommand}, reply={reply}")

--- a/src/rockstor/scripts/scheduled_tasks/send_replica.py
+++ b/src/rockstor/scripts/scheduled_tasks/send_replica.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import sys
@@ -28,17 +28,23 @@ def main():
     rid = int(sys.argv[1])
     ctx = zmq.Context()
     poll = zmq.Poller()
-    num_tries = 12
+    num_tries = 3
     while True:
         req = ctx.socket(zmq.DEALER)
+        print(f"req = {req}")
         poll.register(req, zmq.POLLIN)
-        req.connect("ipc://%s" % settings.REPLICATION.get("ipc_socket"))
-        req.send_multipart(["new-send", b"%d" % rid])
+        print(f"poll.register = {poll.register}")
+        ipc_socket = settings.REPLICATION.get('ipc_socket')
+        req.connect(f"ipc://{ipc_socket}")
+        print(f"req.connect = {req.connect}, ipc_socket = {ipc_socket}")
+        req.send_multipart([b"new-send", f"{rid}".encode('utf-8')])
 
         socks = dict(poll.poll(5000))
+        # print(f"socks.get(req) = {socks.get(req)}")
         if socks.get(req) == zmq.POLLIN:
             rcommand, reply = req.recv_multipart()
-            if rcommand == "SUCCESS":
+            print(f"rcommand={rcommand}, reply={reply}")
+            if rcommand == b"SUCCESS":
                 print(reply)
                 break
             ctx.destroy(linger=0)
@@ -46,7 +52,7 @@ def main():
         num_tries -= 1
         print(
             "No response from Replication service. Number of retry "
-            "attempts left: %d" % num_tries
+            f"attempts left: {num_tries}"
         )
         if num_tries == 0:
             ctx.destroy(linger=0)

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -15,7 +15,6 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-
 from multiprocessing import Process
 import zmq
 import os
@@ -35,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 class ReplicaScheduler(ReplicationMixin, Process):
     def __init__(self):
+        self.law = None
+        self.local_receivers = None
         self.ppid = os.getpid()
         self.senders = {}  # Active Sender(outgoing) process map.
         self.receivers = {}  # Active Receiver process map.
@@ -46,24 +47,25 @@ class ReplicaScheduler(ReplicationMixin, Process):
 
     def _prune_workers(self, workers):
         for wd in workers:
-            for w in wd.keys():
+            for w in list(wd.keys()):
                 if wd[w].exitcode is not None:
                     del wd[w]
-                    logger.debug("deleted worker: %s" % w)
+                    logger.debug(f"deleted worker: {w}")
         return workers
 
     def _prune_senders(self):
-        for s in self.senders.keys():
+        for s in list(self.senders.keys()):
             ecode = self.senders[s].exitcode
             if ecode is not None:
                 del self.senders[s]
-                logger.debug("Sender(%s) exited. exitcode: %s" % (s, ecode))
+                logger.debug(f"Sender({s}) exited. exitcode: {ecode}")
         if len(self.senders) > 0:
-            logger.debug("Active Senders: %s" % self.senders.keys())
+            logger.debug(f"Active Senders: {self.senders.keys()}")
 
     def _delete_receivers(self):
         active_msgs = []
-        for r in self.local_receivers.keys():
+        # We modify during iteration, and so require explicit list.
+        for r in list(self.local_receivers.keys()):
             msg_count = self.remote_senders.get(r, 0)
             ecode = self.local_receivers[r].exitcode
             if ecode is not None:
@@ -216,7 +218,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
 
         ctx = zmq.Context()
         frontend = ctx.socket(zmq.ROUTER)
-        frontend.set_hwm(10)
+        frontend.set_hwm(value=10)
         frontend.bind("tcp://%s:%d" % (self.listener_interface, self.listener_port))
 
         backend = ctx.socket(zmq.ROUTER)
@@ -248,7 +250,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                             "Active Receiver: %s. Messages processed:"
                             "%d" % (rs, count)
                         )
-                if command == "sender-ready":
+                if command == b"sender-ready":
                     logger.debug("initial greeting from %s" % address)
                     # Start a new receiver and send the appropriate response
                     try:
@@ -275,7 +277,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                                 # the active receiver and factor into it's
                                 # retry/robust logic. But that is for later.
                                 frontend.send_multipart(
-                                    [address, "receiver-init-error", msg]
+                                    [address, b"receiver-init-error", msg.encode("utf-8")]
                                 )
                         if start_nr:
                             nr = Receiver(address, msg)
@@ -290,17 +292,17 @@ class ReplicaScheduler(ReplicationMixin, Process):
                             "new receiver for %s: %s" % (address, e.__str__())
                         )
                         logger.error(msg)
-                        frontend.send_multipart([address, "receiver-init-error", msg])
+                        frontend.send_multipart([address, b"receiver-init-error", msg.encode("utf-8")])
                 else:
                     # do we hit hwm? is the dealer still connected?
-                    backend.send_multipart([address, command, msg])
+                    backend.send_multipart([address, command, msg.encode("utf-8")])
 
             elif backend in socks and socks[backend] == zmq.POLLIN:
                 address, command, msg = backend.recv_multipart()
-                if command == "new-send":
+                if command == b"new-send":
                     rid = int(msg)
                     logger.debug("new-send request received for %d" % rid)
-                    rcommand = "ERROR"
+                    rcommand = b"ERROR"
                     try:
                         replica = Replica.objects.get(id=rid)
                         if replica.enabled:
@@ -309,7 +311,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                                 "A new Sender started successfully for "
                                 "Replication Task(%d)." % rid
                             )
-                            rcommand = "SUCCESS"
+                            rcommand = b"SUCCESS"
                         else:
                             msg = (
                                 "Failed to start a new Sender for "
@@ -323,18 +325,18 @@ class ReplicaScheduler(ReplicationMixin, Process):
                         )
                         logger.error(msg)
                     finally:
-                        backend.send_multipart([address, rcommand, str(msg)])
+                        backend.send_multipart([address, rcommand, msg.encode("utf-8")])
                 elif address in self.remote_senders:
                     if command in (
-                        "receiver-ready",
-                        "receiver-error",
-                        "btrfs-recv-finished",
+                        b"receiver-ready",
+                        b"receiver-error",
+                        b"btrfs-recv-finished",
                     ):  # noqa E501
                         logger.debug("Identitiy: %s command: %s" % (address, command))
-                        backend.send_multipart([address, b"ACK", ""])
+                        backend.send_multipart([address, b"ACK", b""])
                         # a new receiver has started. reply to the sender that
                         # must be waiting
-                    frontend.send_multipart([address, command, msg])
+                    frontend.send_multipart([address, command, msg.encode("utf-8")])
 
             else:
                 iterations -= 1

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from multiprocessing import Process
@@ -24,9 +24,9 @@ import time
 from storageadmin.models import NetworkConnection, Appliance
 from smart_manager.models import ReplicaTrail, ReplicaShare, Replica, Service
 from django.conf import settings
-from sender import Sender
-from receiver import Receiver
-from util import ReplicationMixin
+from smart_manager.replication.sender import Sender
+from smart_manager.replication.receiver import Receiver
+from smart_manager.replication.util import ReplicationMixin
 from cli import APIWrapper
 import logging
 

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -91,7 +91,7 @@ class Receiver(ReplicationMixin, Process):
         try:
             yield
         except Exception as e:
-            logger.error("%s. Exception: %s" % (self.msg, e.__str__()))
+            logger.error(f"{self.msg}. Exception: {e.__str__()}")
             if self.rtid is not None:
                 try:
                     data = {
@@ -108,10 +108,10 @@ class Receiver(ReplicationMixin, Process):
 
             if self.ack is True:
                 try:
-                    command = "receiver-error"
+                    command = b"receiver-error"
                     self.dealer.send_multipart(
                         [
-                            "receiver-error",
+                            b"receiver-error",
                             b"%s. Exception: %s" % (str(self.msg), str(e.__str__())),
                         ]
                     )
@@ -129,11 +129,8 @@ class Receiver(ReplicationMixin, Process):
                             "the broker" % self.identity
                         )
                 except Exception as e:
-                    msg = (
-                        "Id: %s. Exception while sending %s back "
-                        "to the broker. Aborting" % (self.identity, command)
-                    )
-                    logger.error("%s. Exception: %s" % (msg, e.__str__()))
+                    msg = f"Id: {self.identity}. Exception while sending {command} back to the broker. Aborting"
+                    logger.error(f"{msg}. Exception: {e.__str__()}")
             self._sys_exit(3)
 
     def _delete_old_snaps(self, share_name, share_path, num_retain):
@@ -142,16 +139,14 @@ class Receiver(ReplicationMixin, Process):
             if self.delete_snapshot(share_name, oldest_snap):
                 return self._delete_old_snaps(share_name, share_path, num_retain)
 
-    def _send_recv(self, command, msg=""):
+    def _send_recv(self, command: bytes, msg: bytes = b""):
         rcommand = rmsg = None
         self.dealer.send_multipart([command, msg])
         # Retry logic doesn't make sense atm. So one long patient wait.
         socks = dict(self.poll.poll(60000))  # 60 seconds.
         if socks.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
-        logger.debug(
-            "Id: %s command: %s rcommand: %s" % (self.identity, command, rcommand)
-        )
+        logger.debug(f"Id: {self.identity} command: {command} rcommand: {rcommand}")
         return rcommand, rmsg
 
     def _latest_snap(self, rso):
@@ -170,30 +165,35 @@ class Receiver(ReplicationMixin, Process):
 
     def run(self):
         logger.debug(
-            "Id: %s. Starting a new Receiver for meta: %s" % (self.identity, self.meta)
+            f"Id: {self.identity}. Starting a new Receiver for meta: {self.meta}"
         )
-        self.msg = "Top level exception in receiver"
+        self.msg = b"Top level exception in receiver"
         latest_snap = None
         with self._clean_exit_handler():
             self.law = APIWrapper()
             self.poll = zmq.Poller()
             self.dealer = self.ctx.socket(zmq.DEALER)
-            self.dealer.setsockopt_string(zmq.IDENTITY, u"%s" % self.identity)
+            self.dealer.setsockopt_string(zmq.IDENTITY, "%s" % self.identity)
             self.dealer.set_hwm(10)
             self.dealer.connect("ipc://%s" % settings.REPLICATION.get("ipc_socket"))
             self.poll.register(self.dealer, zmq.POLLIN)
 
             self.ack = True
-            self.msg = "Failed to get the sender ip for appliance: %s" % self.sender_id
+            self.msg = (
+                f"Failed to get the sender ip for appliance: {self.sender_id}".encode(
+                    "utf-8"
+                )
+            )
             self.sender_ip = Appliance.objects.get(uuid=self.sender_id).ip
 
             if not self.incremental:
-                self.msg = "Failed to verify/create share: %s." % self.sname
+                self.msg = f"Failed to verify/create share: {self.sname}.".encode(
+                    "utf-8"
+                )
                 self.create_share(self.sname, self.dest_pool)
 
-                self.msg = (
-                    "Failed to create the replica metadata object "
-                    "for share: %s." % self.sname
+                self.msg = f"Failed to create the replica metadata object for share: {self.sname}.".encode(
+                    "utf-8"
                 )
                 data = {
                     "share": self.sname,
@@ -202,27 +202,28 @@ class Receiver(ReplicationMixin, Process):
                 }
                 self.rid = self.create_rshare(data)
             else:
-                self.msg = (
-                    "Failed to retreive the replica metadata "
-                    "object for share: %s." % self.sname
+                self.msg = f"Failed to retreive the replica metadata object for share: {self.sname}.".encode(
+                    "utf-8"
                 )
                 rso = ReplicaShare.objects.get(share=self.sname)
                 self.rid = rso.id
                 # Find and send the current snapshot to the sender. This will
                 # be used as the start by btrfs-send diff.
                 self.msg = (
-                    "Failed to verify latest replication snapshot on the system."
+                    b"Failed to verify latest replication snapshot on the system."
                 )
                 latest_snap = self._latest_snap(rso)
 
-            self.msg = "Failed to create receive trail for rid: %d" % self.rid
+            self.msg = f"Failed to create receive trail for rid: {self.rid}".encode(
+                "utf-8"
+            )
             data = {
                 "snap_name": self.snap_name,
             }
             self.rtid = self.create_receive_trail(self.rid, data)
 
             # delete the share, move the oldest snap to share
-            self.msg = "Failed to promote the oldest Snapshot to Share."
+            self.msg = b"Failed to promote the oldest Snapshot to Share."
             oldest_snap = get_oldest_snap(
                 self.snap_dir, self.num_retain_snaps, regex="_replication_"
             )
@@ -231,7 +232,7 @@ class Receiver(ReplicationMixin, Process):
                 self.refresh_share_state()
                 self.refresh_snapshot_state()
 
-            self.msg = "Failed to prune old Snapshots"
+            self.msg = b"Failed to prune old Snapshots"
             self._delete_old_snaps(self.sname, self.snap_dir, self.num_retain_snaps + 1)
 
             # TODO: The following should be re-instantiated once we have a
@@ -244,10 +245,14 @@ class Receiver(ReplicationMixin, Process):
 
             sub_vol = "%s%s/%s" % (settings.MNT_PT, self.dest_pool, self.sname)
             if not is_subvol(sub_vol):
-                self.msg = "Failed to create parent subvolume %s" % sub_vol
+                self.msg = f"Failed to create parent subvolume {sub_vol}".encode(
+                    "utf-8"
+                )
                 run_command([BTRFS, "subvolume", "create", sub_vol])
 
-            self.msg = "Failed to create snapshot directory: %s" % self.snap_dir
+            self.msg = f"Failed to create snapshot directory: {self.snap_dir}".encode(
+                "utf-8"
+            )
             run_command(["/usr/bin/mkdir", "-p", self.snap_dir])
             snap_fp = "%s/%s" % (self.snap_dir, self.snap_name)
 
@@ -264,9 +269,8 @@ class Receiver(ReplicationMixin, Process):
                 self._sys_exit(0)
 
             cmd = [BTRFS, "receive", self.snap_dir]
-            self.msg = (
-                "Failed to start the low level btrfs receive "
-                "command(%s). Aborting." % cmd
+            self.msg = f"Failed to start the low level btrfs receive command({cmd}). Aborting.".encode(
+                "utf-8"
             )
             self.rp = subprocess.Popen(
                 cmd,
@@ -276,19 +280,18 @@ class Receiver(ReplicationMixin, Process):
                 stderr=subprocess.PIPE,
             )
 
-            self.msg = "Failed to send receiver-ready"
-            rcommand, rmsg = self._send_recv("receiver-ready", latest_snap or "")
+            self.msg = b"Failed to send receiver-ready"
+            rcommand, rmsg = self._send_recv(b"receiver-ready", latest_snap or b"")
             if rcommand is None:
                 logger.error(
-                    "Id: %s. No response from the broker for "
-                    "receiver-ready command. Aborting." % self.identity
+                    f"Id: {self.identity}. No response from the broker for receiver-ready command. Aborting."
                 )
                 self._sys_exit(3)
 
             term_commands = (
-                "btrfs-send-init-error",
-                "btrfs-send-unexpected-termination-error",
-                "btrfs-send-nonzero-termination-error",
+                b"btrfs-send-init-error",
+                b"btrfs-send-unexpected-termination-error",
+                b"btrfs-send-nonzero-termination-error",
             )
             num_tries = 10
             poll_interval = 6000  # 6 seconds
@@ -301,12 +304,12 @@ class Receiver(ReplicationMixin, Process):
                     # milliseconds) for every message
                     num_tries = 10
                     command, message = self.dealer.recv_multipart()
-                    if command == "btrfs-send-stream-finished":
+                    if command == b"btrfs-send-stream-finished":
                         # this command concludes fsdata transfer. After this,
                         # btrfs-recev process should be
                         # terminated(.communicate).
                         if self.rp.poll() is None:
-                            self.msg = "Failed to terminate btrfs-recv command"
+                            self.msg = b"Failed to terminate btrfs-recv command"
                             out, err = self.rp.communicate()
                             out = out.split("\n")
                             err = err.split("\n")
@@ -316,21 +319,18 @@ class Receiver(ReplicationMixin, Process):
                                 % (self.identity, cmd, out, err, self.rp.returncode)
                             )
                         if self.rp.returncode != 0:
-                            self.msg = (
-                                "btrfs-recv exited with unexpected "
-                                "exitcode(%s). " % self.rp.returncode
+                            self.msg = f"btrfs-recv exited with unexpected exitcode({self.rp.returncode}).".encode(
+                                "utf-8"
                             )
                             raise Exception(self.msg)
                         data = {
                             "status": "succeeded",
                             "kb_received": self.total_bytes_received / 1024,
                         }
-                        self.msg = (
-                            "Failed to update receive trail for rtid: %d" % self.rtid
-                        )
+                        self.msg = f"Failed to update receive trail for rtid: {self.rtid}".encode("utf-8")
                         self.update_receive_trail(self.rtid, data)
 
-                        self._send_recv("btrfs-recv-finished")
+                        self._send_recv(b"btrfs-recv-finished")
                         self.refresh_share_state()
                         self.refresh_snapshot_state()
 
@@ -343,9 +343,8 @@ class Receiver(ReplicationMixin, Process):
                         self._sys_exit(0)
 
                     if command in term_commands:
-                        self.msg = (
-                            "Terminal command(%s) received from the "
-                            "sender. Aborting." % command
+                        self.msg = f"Terminal command({command}) received from the sender. Aborting.".encode(
+                            "utf-8"
                         )
                         raise Exception(self.msg)
 
@@ -353,7 +352,7 @@ class Receiver(ReplicationMixin, Process):
                         self.rp.stdin.write(message)
                         self.rp.stdin.flush()
                         # @todo: implement advanced credit request system.
-                        self.dealer.send_multipart([b"send-more", ""])
+                        self.dealer.send_multipart([b"send-more", b""])
                         num_msgs += 1
                         self.total_bytes_received += len(message)
                         if num_msgs == 1000:
@@ -377,22 +376,20 @@ class Receiver(ReplicationMixin, Process):
                         out = out.split("\n")
                         err = err.split("\n")
                         logger.error(
-                            "Id: %s. btrfs-recv died unexpectedly. "
-                            "cmd: %s out: %s. err: %s" % (self.identity, cmd, out, err)
+                            f"Id: {self.identity}. btrfs-recv died unexpectedly. "
+                            f"cmd: {cmd} out: {out}. err: {err}"
                         )
                         msg = (
-                            "Low level system error from btrfs receive "
-                            "command. cmd: %s out: %s err: %s for rtid: %s"
-                            % (cmd, out, err, self.rtid)
-                        )
+                            f"Low level system error from btrfs receive command. "
+                            f"cmd: {cmd} out: {out} err: {err} for rtid: {self.rtid}"
+                        ).encode("utf-8")
                         data = {
                             "status": "failed",
                             "error": msg,
                         }
                         self.msg = (
-                            "Failed to update receive trail for "
-                            "rtid: %d." % self.rtid
-                        )
+                            f"Failed to update receive trail for rtid: {self.rtid}."
+                        ).encode("utf-8")
                         self.update_receive_trail(self.rtid, data)
                         self.msg = msg
                         raise Exception(self.msg)
@@ -404,5 +401,5 @@ class Receiver(ReplicationMixin, Process):
                     )
                     logger.error("Id: %s. %s" % (self.identity, msg))
                     if num_tries == 0:
-                        self.msg = "%s. Terminating the receiver." % msg
+                        self.msg = f"{msg}. Terminating the receiver.".encode("utf-8")
                         raise Exception(self.msg)

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from multiprocessing import Process
@@ -26,12 +26,11 @@ import time
 from django.conf import settings
 from django import db
 from contextlib import contextmanager
-from util import ReplicationMixin
+from smart_manager.replication.util import ReplicationMixin
 from fs.btrfs import get_oldest_snap, remove_share, set_property, is_subvol, mount_share
 from system.osi import run_command
 from storageadmin.models import Pool, Share, Appliance
 from smart_manager.models import ReplicaShare, ReceiveTrail
-import shutil
 from cli import APIWrapper
 import logging
 

--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from multiprocessing import Process
@@ -26,7 +26,7 @@ import json
 import time
 from django.conf import settings
 from contextlib import contextmanager
-from util import ReplicationMixin
+from smart_manager.replication.util import ReplicationMixin
 from fs.btrfs import get_oldest_snap, is_subvol
 from smart_manager.models import ReplicaTrail
 from cli import APIWrapper


### PR DESCRIPTION
- Modernise previously missed replication imports re Py3.*
- Force bytes format for replication messages and commands.
- Minor modification re Pythnon 3 behaviour re dict.keys(),
we replied on an implicit Python 2 behaviour.
- Move to Fstrings.
- Temp debug prints.
- further parameter/return type typecasting.
- removed unused variable.
- black format update

Closes #2766