### PR TITLE
(t) replication spawn error #2766

### DIFF
--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -201,7 +201,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
 
         ctx = zmq.Context()
         frontend = ctx.socket(zmq.ROUTER)
-        frontend.set_hwm(value=10)
+        # frontend.set_hwm(value=10)
         frontend.bind(f"tcp://{self.listener_interface}:{ self.listener_port}")
 
         backend = ctx.socket(zmq.ROUTER)

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -258,6 +258,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                         logger.debug(
                             f"Active Receiver: {rs}. Messages processed: {count}"
                         )
+
                 if command == b"sender-ready":
                     logger.debug(f"initial greeting command '{command}' received from {address}")
                     # Start a new receiver and send the appropriate response
@@ -294,14 +295,14 @@ class ReplicaScheduler(ReplicationMixin, Process):
                             self.local_receivers[address] = nr
                         continue
                     except Exception as e:
-                        msg = f"Exception while starting the new receiver for {address}: {e.__str__()}"
+                        msg = f"Exception while starting the new receiver for {address}: {e.__str__()}".encode("utf-8")
                         logger.error(msg)
                         frontend.send_multipart(
-                            [address, b"receiver-init-error", msg.encode("utf-8")]
+                            [address, b"receiver-init-error", msg]
                         )
                 else:
                     # do we hit hwm? is the dealer still connected?
-                    backend.send_multipart([address, command, msg.encode("utf-8")])
+                    backend.send_multipart([address, command, msg])
 
             elif backend in events and events[backend] == zmq.POLLIN:
                 # backend.recv_multipart() returns all as type <class 'bytes'>
@@ -327,7 +328,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                     finally:
                         backend.send_multipart([address, rcommand, msg.encode("utf-8")])
                 elif address in self.remote_senders.keys():
-                    logger.debug(f"Identity/address {address}, found in remove_senders.keys()")
+                    logger.debug(f"Identity/address {address}, found in remote_senders.keys()")
                     if (
                         command == b"receiver-ready"
                         or command == b"receiver-error"

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -229,18 +229,14 @@ class ReplicaScheduler(ReplicationMixin, Process):
             # is terminated, as long as data is coming in.
             # Get all events: returns imidiately if any exist, or waits for timeout.
             # Event list of tuples of the form (socket, event_mask)):
-            events_list = poller.poll(timeout=2000)
-            logger.debug(f"LISTENER_BROKER: frontend & backend events_list poll = {events_list}")
+            events_list = poller.poll(timeout=2000)  # Wait period in milliseconds
+            logger.debug(f"EVENT_LIST poll = {events_list}")
             # Dictionary mapping of socket : event_mask.
-            events = dict(events_list)  # Wait period in milliseconds
+            events = dict(events_list)
             if frontend in events and events[frontend] == zmq.POLLIN:
                 # frontend.recv_multipart() returns all as type <class 'bytes'>
-                #
                 address, command, msg = frontend.recv_multipart()
-                logger.debug("frontend.recv_multipart() returns")
-                logger.debug(f"address = {address}, type {type(address)}")
-                logger.debug(f"command = {command}, type {type(command)}")
-                logger.debug(f"msg = {msg}, type {type(msg)}")
+                logger.debug(f"frontend.recv_multipart() -> command={command}, msg={msg}")
                 # Keep a numerical events tally of per remote sender's events:
                 if address not in self.remote_senders:
                     self.remote_senders[address] = 1

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -239,7 +239,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                             f"Active Receiver: {rs}. Messages processed: {count}"
                         )
                 if command == b"sender-ready":
-                    logger.debug(f"initial greeting from {address}")
+                    logger.debug(f"initial greeting command '{command}' received from {address}")
                     # Start a new receiver and send the appropriate response
                     try:
                         start_nr = True

--- a/src/rockstor/smart_manager/replication/listener_broker.py
+++ b/src/rockstor/smart_manager/replication/listener_broker.py
@@ -306,6 +306,9 @@ class ReplicaScheduler(ReplicationMixin, Process):
             elif backend in events and events[backend] == zmq.POLLIN:
                 # backend.recv_multipart() returns all as type <class 'bytes'>
                 address, command, msg = backend.recv_multipart()
+                # In the following conditional:
+                # if redefines msg as str
+                # elif leaves msg as bytes
                 if command == b"new-send":
                     rid = int(msg)
                     logger.debug(f"new-send request received for {rid}")
@@ -339,7 +342,7 @@ class ReplicaScheduler(ReplicationMixin, Process):
                         # a new receiver has started. reply to the sender that
                         # must be waiting
                     logger.debug(f"command: {command}, sending to frontend.")
-                    tracker = frontend.send_multipart([address, command, msg.encode("utf-8")], copy=False, track=True)
+                    tracker = frontend.send_multipart([address, command, msg], copy=False, track=True)
                     if not tracker.done:
                         logger.debug(f"Waiting max 2 seconds for send of commmand ({command})")
                         # https://pyzmq.readthedocs.io/en/latest/api/zmq.html#notdone

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from multiprocessing import Process
@@ -26,12 +26,11 @@ import time
 from django.conf import settings
 from django import db
 from contextlib import contextmanager
-from util import ReplicationMixin
+from smart_manager.replication.util import ReplicationMixin
 from fs.btrfs import get_oldest_snap, remove_share, set_property, is_subvol, mount_share
 from system.osi import run_command
 from storageadmin.models import Pool, Share, Appliance
 from smart_manager.models import ReplicaShare, ReceiveTrail
-import shutil
 from cli import APIWrapper
 import logging
 
@@ -92,7 +91,7 @@ class Receiver(ReplicationMixin, Process):
         try:
             yield
         except Exception as e:
-            logger.error("%s. Exception: %s" % (self.msg, e.__str__()))
+            logger.error(f"{self.msg}. Exception: {e.__str__()}")
             if self.rtid is not None:
                 try:
                     data = {
@@ -109,10 +108,10 @@ class Receiver(ReplicationMixin, Process):
 
             if self.ack is True:
                 try:
-                    command = "receiver-error"
+                    command = b"receiver-error"
                     self.dealer.send_multipart(
                         [
-                            "receiver-error",
+                            b"receiver-error",
                             b"%s. Exception: %s" % (str(self.msg), str(e.__str__())),
                         ]
                     )
@@ -130,11 +129,8 @@ class Receiver(ReplicationMixin, Process):
                             "the broker" % self.identity
                         )
                 except Exception as e:
-                    msg = (
-                        "Id: %s. Exception while sending %s back "
-                        "to the broker. Aborting" % (self.identity, command)
-                    )
-                    logger.error("%s. Exception: %s" % (msg, e.__str__()))
+                    msg = f"Id: {self.identity}. Exception while sending {command} back to the broker. Aborting"
+                    logger.error(f"{msg}. Exception: {e.__str__()}")
             self._sys_exit(3)
 
     def _delete_old_snaps(self, share_name, share_path, num_retain):
@@ -143,24 +139,24 @@ class Receiver(ReplicationMixin, Process):
             if self.delete_snapshot(share_name, oldest_snap):
                 return self._delete_old_snaps(share_name, share_path, num_retain)
 
-    def _send_recv(self, command, msg=""):
+    def _send_recv(self, command: bytes, msg: bytes = b""):
         rcommand = rmsg = None
         self.dealer.send_multipart([command, msg])
         # Retry logic doesn't make sense atm. So one long patient wait.
         socks = dict(self.poll.poll(60000))  # 60 seconds.
         if socks.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
-        logger.debug(
-            "Id: %s command: %s rcommand: %s" % (self.identity, command, rcommand)
-        )
+        logger.debug(f"Id: {self.identity} command: {command} rcommand: {rcommand}")
         return rcommand, rmsg
 
     def _latest_snap(self, rso):
         for snap in ReceiveTrail.objects.filter(
             rshare=rso, status="succeeded"
         ).order_by("-id"):
-            if is_subvol("%s/%s" % (self.snap_dir, snap.snap_name)):
-                return str(snap.snap_name)  # cannot be unicode for zmq message
+            if is_subvol(f"{self.snap_dir}/{snap.snap_name}"):
+                return str(snap.snap_name).encode(
+                    "utf8"
+                )  # cannot be unicode for zmq message
         logger.error(
             "Id: %s. There are no replication snapshots on the "
             "system for "
@@ -171,30 +167,35 @@ class Receiver(ReplicationMixin, Process):
 
     def run(self):
         logger.debug(
-            "Id: %s. Starting a new Receiver for meta: %s" % (self.identity, self.meta)
+            f"Id: {self.identity}. Starting a new Receiver for meta: {self.meta}"
         )
-        self.msg = "Top level exception in receiver"
+        self.msg = b"Top level exception in receiver"
         latest_snap = None
         with self._clean_exit_handler():
             self.law = APIWrapper()
             self.poll = zmq.Poller()
             self.dealer = self.ctx.socket(zmq.DEALER)
-            self.dealer.setsockopt_string(zmq.IDENTITY, u"%s" % self.identity)
+            self.dealer.setsockopt_string(zmq.IDENTITY, "%s" % self.identity)
             self.dealer.set_hwm(10)
             self.dealer.connect("ipc://%s" % settings.REPLICATION.get("ipc_socket"))
             self.poll.register(self.dealer, zmq.POLLIN)
 
             self.ack = True
-            self.msg = "Failed to get the sender ip for appliance: %s" % self.sender_id
+            self.msg = (
+                f"Failed to get the sender ip for appliance: {self.sender_id}".encode(
+                    "utf-8"
+                )
+            )
             self.sender_ip = Appliance.objects.get(uuid=self.sender_id).ip
 
             if not self.incremental:
-                self.msg = "Failed to verify/create share: %s." % self.sname
+                self.msg = f"Failed to verify/create share: {self.sname}.".encode(
+                    "utf-8"
+                )
                 self.create_share(self.sname, self.dest_pool)
 
-                self.msg = (
-                    "Failed to create the replica metadata object "
-                    "for share: %s." % self.sname
+                self.msg = f"Failed to create the replica metadata object for share: {self.sname}.".encode(
+                    "utf-8"
                 )
                 data = {
                     "share": self.sname,
@@ -203,27 +204,28 @@ class Receiver(ReplicationMixin, Process):
                 }
                 self.rid = self.create_rshare(data)
             else:
-                self.msg = (
-                    "Failed to retreive the replica metadata "
-                    "object for share: %s." % self.sname
+                self.msg = f"Failed to retreive the replica metadata object for share: {self.sname}.".encode(
+                    "utf-8"
                 )
                 rso = ReplicaShare.objects.get(share=self.sname)
                 self.rid = rso.id
                 # Find and send the current snapshot to the sender. This will
                 # be used as the start by btrfs-send diff.
                 self.msg = (
-                    "Failed to verify latest replication snapshot on the system."
+                    b"Failed to verify latest replication snapshot on the system."
                 )
                 latest_snap = self._latest_snap(rso)
 
-            self.msg = "Failed to create receive trail for rid: %d" % self.rid
+            self.msg = f"Failed to create receive trail for rid: {self.rid}".encode(
+                "utf-8"
+            )
             data = {
                 "snap_name": self.snap_name,
             }
             self.rtid = self.create_receive_trail(self.rid, data)
 
             # delete the share, move the oldest snap to share
-            self.msg = "Failed to promote the oldest Snapshot to Share."
+            self.msg = b"Failed to promote the oldest Snapshot to Share."
             oldest_snap = get_oldest_snap(
                 self.snap_dir, self.num_retain_snaps, regex="_replication_"
             )
@@ -232,7 +234,7 @@ class Receiver(ReplicationMixin, Process):
                 self.refresh_share_state()
                 self.refresh_snapshot_state()
 
-            self.msg = "Failed to prune old Snapshots"
+            self.msg = b"Failed to prune old Snapshots"
             self._delete_old_snaps(self.sname, self.snap_dir, self.num_retain_snaps + 1)
 
             # TODO: The following should be re-instantiated once we have a
@@ -245,10 +247,14 @@ class Receiver(ReplicationMixin, Process):
 
             sub_vol = "%s%s/%s" % (settings.MNT_PT, self.dest_pool, self.sname)
             if not is_subvol(sub_vol):
-                self.msg = "Failed to create parent subvolume %s" % sub_vol
+                self.msg = f"Failed to create parent subvolume {sub_vol}".encode(
+                    "utf-8"
+                )
                 run_command([BTRFS, "subvolume", "create", sub_vol])
 
-            self.msg = "Failed to create snapshot directory: %s" % self.snap_dir
+            self.msg = f"Failed to create snapshot directory: {self.snap_dir}".encode(
+                "utf-8"
+            )
             run_command(["/usr/bin/mkdir", "-p", self.snap_dir])
             snap_fp = "%s/%s" % (self.snap_dir, self.snap_name)
 
@@ -261,13 +267,12 @@ class Receiver(ReplicationMixin, Process):
                     "exists. Not starting a new receive process"
                     % (self.identity, snap_fp)
                 )
-                self._send_recv("snap-exists")
+                self._send_recv(b"snap-exists")
                 self._sys_exit(0)
 
             cmd = [BTRFS, "receive", self.snap_dir]
-            self.msg = (
-                "Failed to start the low level btrfs receive "
-                "command(%s). Aborting." % cmd
+            self.msg = f"Failed to start the low level btrfs receive command({cmd}). Aborting.".encode(
+                "utf-8"
             )
             self.rp = subprocess.Popen(
                 cmd,
@@ -277,20 +282,14 @@ class Receiver(ReplicationMixin, Process):
                 stderr=subprocess.PIPE,
             )
 
-            self.msg = "Failed to send receiver-ready"
-            rcommand, rmsg = self._send_recv("receiver-ready", latest_snap or "")
+            self.msg = b"Failed to send receiver-ready"
+            rcommand, rmsg = self._send_recv(b"receiver-ready", latest_snap or b"")
             if rcommand is None:
                 logger.error(
-                    "Id: %s. No response from the broker for "
-                    "receiver-ready command. Aborting." % self.identity
+                    f"Id: {self.identity}. No response from the broker for receiver-ready command. Aborting."
                 )
                 self._sys_exit(3)
 
-            term_commands = (
-                "btrfs-send-init-error",
-                "btrfs-send-unexpected-termination-error",
-                "btrfs-send-nonzero-termination-error",
-            )
             num_tries = 10
             poll_interval = 6000  # 6 seconds
             num_msgs = 0
@@ -302,12 +301,13 @@ class Receiver(ReplicationMixin, Process):
                     # milliseconds) for every message
                     num_tries = 10
                     command, message = self.dealer.recv_multipart()
-                    if command == "btrfs-send-stream-finished":
+                    logger.debug(f"command = {command}, of type:", type(command))
+                    if command == b"btrfs-send-stream-finished":
                         # this command concludes fsdata transfer. After this,
                         # btrfs-recev process should be
                         # terminated(.communicate).
                         if self.rp.poll() is None:
-                            self.msg = "Failed to terminate btrfs-recv command"
+                            self.msg = b"Failed to terminate btrfs-recv command"
                             out, err = self.rp.communicate()
                             out = out.split("\n")
                             err = err.split("\n")
@@ -317,21 +317,20 @@ class Receiver(ReplicationMixin, Process):
                                 % (self.identity, cmd, out, err, self.rp.returncode)
                             )
                         if self.rp.returncode != 0:
-                            self.msg = (
-                                "btrfs-recv exited with unexpected "
-                                "exitcode(%s). " % self.rp.returncode
+                            self.msg = f"btrfs-recv exited with unexpected exitcode({self.rp.returncode}).".encode(
+                                "utf-8"
                             )
                             raise Exception(self.msg)
                         data = {
                             "status": "succeeded",
                             "kb_received": self.total_bytes_received / 1024,
                         }
-                        self.msg = (
-                            "Failed to update receive trail for rtid: %d" % self.rtid
+                        self.msg = f"Failed to update receive trail for rtid: {self.rtid}".encode(
+                            "utf-8"
                         )
                         self.update_receive_trail(self.rtid, data)
 
-                        self._send_recv("btrfs-recv-finished")
+                        self._send_recv(b"btrfs-recv-finished")
                         self.refresh_share_state()
                         self.refresh_snapshot_state()
 
@@ -343,10 +342,13 @@ class Receiver(ReplicationMixin, Process):
                         )
                         self._sys_exit(0)
 
-                    if command in term_commands:
-                        self.msg = (
-                            "Terminal command(%s) received from the "
-                            "sender. Aborting." % command
+                    if (
+                        command == b"btrfs-send-init-error"
+                        or command == b"btrfs-send-unexpected-termination-error"
+                        or command == b"btrfs-send-nonzero-termination-error"
+                    ):
+                        self.msg = f"Terminal command({command}) received from the sender. Aborting.".encode(
+                            "utf-8"
                         )
                         raise Exception(self.msg)
 
@@ -354,7 +356,7 @@ class Receiver(ReplicationMixin, Process):
                         self.rp.stdin.write(message)
                         self.rp.stdin.flush()
                         # @todo: implement advanced credit request system.
-                        self.dealer.send_multipart([b"send-more", ""])
+                        self.dealer.send_multipart([b"send-more", b""])
                         num_msgs += 1
                         self.total_bytes_received += len(message)
                         if num_msgs == 1000:
@@ -378,22 +380,20 @@ class Receiver(ReplicationMixin, Process):
                         out = out.split("\n")
                         err = err.split("\n")
                         logger.error(
-                            "Id: %s. btrfs-recv died unexpectedly. "
-                            "cmd: %s out: %s. err: %s" % (self.identity, cmd, out, err)
+                            f"Id: {self.identity}. btrfs-recv died unexpectedly. "
+                            f"cmd: {cmd} out: {out}. err: {err}"
                         )
                         msg = (
-                            "Low level system error from btrfs receive "
-                            "command. cmd: %s out: %s err: %s for rtid: %s"
-                            % (cmd, out, err, self.rtid)
-                        )
+                            f"Low level system error from btrfs receive command. "
+                            f"cmd: {cmd} out: {out} err: {err} for rtid: {self.rtid}"
+                        ).encode("utf-8")
                         data = {
                             "status": "failed",
                             "error": msg,
                         }
                         self.msg = (
-                            "Failed to update receive trail for "
-                            "rtid: %d." % self.rtid
-                        )
+                            f"Failed to update receive trail for rtid: {self.rtid}."
+                        ).encode("utf-8")
                         self.update_receive_trail(self.rtid, data)
                         self.msg = msg
                         raise Exception(self.msg)
@@ -405,5 +405,5 @@ class Receiver(ReplicationMixin, Process):
                     )
                     logger.error("Id: %s. %s" % (self.identity, msg))
                     if num_tries == 0:
-                        self.msg = "%s. Terminating the receiver." % msg
+                        self.msg = f"{msg}. Terminating the receiver.".encode("utf-8")
                         raise Exception(self.msg)

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -167,9 +167,8 @@ class Receiver(ReplicationMixin, Process):
 
             self.ack = True
             self.msg = (
-                f"Failed to get the sender ip for appliance: {self.sender_id}".encode(
-                    "utf-8"
-                )
+                f"Failed to get the sender ip for appliance: {self.sender_id}. "
+                "Ensure receiver has sender in System -> Appliances.".encode("utf-8")
             )
             self.sender_ip = Appliance.objects.get(uuid=self.sender_id).ip
 

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -321,7 +321,7 @@ class Receiver(ReplicationMixin, Process):
                     # milliseconds) for every message
                     num_tries = 10
                     command, message = self.dealer.recv_multipart()
-                    logger.debug(f"command = {command}, of type: {type(command)}")
+                    logger.debug(f"command = {command}")
                     if command == b"btrfs-send-stream-finished":
                         # this command concludes fsdata transfer. After this,
                         # btrfs-recev process should be

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -142,7 +142,7 @@ class Receiver(ReplicationMixin, Process):
 
     def _send_recv(self, command: bytes, msg: bytes = b""):
         logger.debug(
-            f"RECEIVER: _send_recv called with command: {command}, msg: {msg}."
+            f"_send_recv called with command: {command}, msg: {msg}."
         )
         rcommand = rmsg = b""
         tracker = self.dealer.send_multipart([command, msg], copy=False, track=True)
@@ -154,7 +154,7 @@ class Receiver(ReplicationMixin, Process):
         if events.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
         logger.debug(
-            f"Id: {self.identity} RECEIVER: _send_recv command: {command} rcommand: {rcommand}"
+            f"Id: {self.identity} _send_recv command: {command} rcommand: {rcommand}"
         )
         logger.debug(f"remote message: {rmsg}")
         return rcommand, rmsg
@@ -310,15 +310,8 @@ class Receiver(ReplicationMixin, Process):
             start_time = time.time()
             while True:
                 events = dict(self.poller.poll(timeout=6000))  # 6 seconds
-                logger.debug(f"RECEIVER events dict = {events}")
-                if events != {}:
-                    for key in events:
-                        logger.debug(f"events index ({key}), has value {events[key]}")
-                else:
-                    logger.debug("EVENTS EMPTY")
+                logger.debug(f"Events dict = {events}")
                 if events.get(self.dealer) == zmq.POLLIN:
-                    # reset to wait upto 60(poll_interval x num_tries
-                    # milliseconds) for every message
                     num_tries = 10
                     command, message = self.dealer.recv_multipart()
                     logger.debug(f"command = {command}")

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -129,13 +129,13 @@ class Receiver(ReplicationMixin, Process):
 
     def _send_recv(self, command: bytes, msg: bytes = b""):
         logger.debug(f"RECEIVER: _send_recv called with command: {command}, msg: {msg}.")
-        rcommand = rmsg = None
+        rcommand = rmsg = b""
         self.dealer.send_multipart([command, msg])
         # Retry logic doesn't make sense atm. So one long patient wait.
         socks = dict(self.poll.poll(60000))  # 60 seconds.
         if socks.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
-        logger.debug(f"Id: {self.identity} command: {command} rcommand: {rcommand}")
+        logger.debug(f"Id: {self.identity} RECEIVER: _send_recv command: {command} rcommand: {rcommand}")
         logger.debug(f"remote message: {rmsg}")
         return rcommand, rmsg
 
@@ -270,7 +270,7 @@ class Receiver(ReplicationMixin, Process):
 
             self.msg = b"Failed to send receiver-ready"
             rcommand, rmsg = self._send_recv(b"receiver-ready", b"")
-            if rcommand is None:
+            if rcommand == b"":
                 logger.error(
                     f"Id: {self.identity}. No response from the broker for receiver-ready command. Aborting."
                 )

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -40,7 +40,9 @@ BTRFS = "/sbin/btrfs"
 
 
 class Receiver(ReplicationMixin, Process):
-    def __init__(self, identity, meta):
+    sname: str
+
+    def __init__(self, identity: bytes, meta):
         self.identity = identity
         self.meta = json.loads(meta)
         self.src_share = self.meta["share"]
@@ -126,7 +128,7 @@ class Receiver(ReplicationMixin, Process):
                 return self._delete_old_snaps(share_name, share_path, num_retain)
 
     def _send_recv(self, command: bytes, msg: bytes = b""):
-        logger.debug(f"_send_recv called with command: {command}, msg: {msg}.")
+        logger.debug(f"RECEIVER: _send_recv called with command: {command}, msg: {msg}.")
         rcommand = rmsg = None
         self.dealer.send_multipart([command, msg])
         # Retry logic doesn't make sense atm. So one long patient wait.
@@ -134,7 +136,7 @@ class Receiver(ReplicationMixin, Process):
         if socks.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
         logger.debug(f"Id: {self.identity} command: {command} rcommand: {rcommand}")
-        logger.debug((f"remote message: {rmsg}"))
+        logger.debug(f"remote message: {rmsg}")
         return rcommand, rmsg
 
     def _latest_snap(self, rso):
@@ -285,7 +287,7 @@ class Receiver(ReplicationMixin, Process):
                     # milliseconds) for every message
                     num_tries = 10
                     command, message = self.dealer.recv_multipart()
-                    logger.debug(f"command = {command}, of type:", type(command))
+                    logger.debug(f"command = {command}, of type: {type(command)}")
                     if command == b"btrfs-send-stream-finished":
                         # this command concludes fsdata transfer. After this,
                         # btrfs-recev process should be

--- a/src/rockstor/smart_manager/replication/receiver.py
+++ b/src/rockstor/smart_manager/replication/receiver.py
@@ -126,6 +126,7 @@ class Receiver(ReplicationMixin, Process):
                 return self._delete_old_snaps(share_name, share_path, num_retain)
 
     def _send_recv(self, command: bytes, msg: bytes = b""):
+        logger.debug(f"_send_recv called with command: {command}, msg: {msg}.")
         rcommand = rmsg = None
         self.dealer.send_multipart([command, msg])
         # Retry logic doesn't make sense atm. So one long patient wait.
@@ -133,6 +134,7 @@ class Receiver(ReplicationMixin, Process):
         if socks.get(self.dealer) == zmq.POLLIN:
             rcommand, rmsg = self.dealer.recv_multipart()
         logger.debug(f"Id: {self.identity} command: {command} rcommand: {rcommand}")
+        logger.debug((f"remote message: {rmsg}"))
         return rcommand, rmsg
 
     def _latest_snap(self, rso):
@@ -265,7 +267,7 @@ class Receiver(ReplicationMixin, Process):
             )
 
             self.msg = b"Failed to send receiver-ready"
-            rcommand, rmsg = self._send_recv(b"receiver-ready", latest_snap or b"")
+            rcommand, rmsg = self._send_recv(b"receiver-ready", b"")
             if rcommand is None:
                 logger.error(
                     f"Id: {self.identity}. No response from the broker for receiver-ready command. Aborting."

--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2012-2020 RockStor, Inc. <http://rockstor.com>
+Copyright (c) 2012-2023 RockStor, Inc. <https://rockstor.com>
 This file is part of RockStor.
 
 RockStor is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from multiprocessing import Process
@@ -26,7 +26,7 @@ import json
 import time
 from django.conf import settings
 from contextlib import contextmanager
-from util import ReplicationMixin
+from smart_manager.replication.util import ReplicationMixin
 from fs.btrfs import get_oldest_snap, is_subvol
 from smart_manager.models import ReplicaTrail
 from cli import APIWrapper
@@ -40,6 +40,8 @@ BTRFS = "/sbin/btrfs"
 
 class Sender(ReplicationMixin, Process):
     def __init__(self, uuid, receiver_ip, replica, rt=None):
+        self.law = None
+        self.poll = None
         self.uuid = uuid
         self.receiver_ip = receiver_ip
         self.receiver_port = replica.data_port
@@ -52,12 +54,12 @@ class Sender(ReplicationMixin, Process):
         self.rt2 = None
         self.rt2_id = None
         self.rid = replica.id
-        self.identity = u"%s-%s" % (self.uuid, self.rid)
+        self.identity = "%s-%s" % (self.uuid, self.rid)
         self.sp = None
         # Latest snapshot per Receiver(comes along with receiver-ready)
         self.rlatest_snap = None
         self.ctx = zmq.Context()
-        self.msg = ""
+        self.msg = b""
         self.update_trail = False
         self.total_bytes_sent = 0
         self.ppid = os.getpid()
@@ -70,9 +72,7 @@ class Sender(ReplicationMixin, Process):
         try:
             yield
         except Exception as e:
-            logger.error(
-                "Id: %s. %s. Exception: %s" % (self.identity, self.msg, e.__str__())
-            )
+            logger.error(f"Id: {self.identity}. {self.msg}. Exception: {e.__str__()}")
             if self.update_trail:
                 try:
                     data = {
@@ -82,8 +82,7 @@ class Sender(ReplicationMixin, Process):
                     self.update_replica_status(self.rt2_id, data)
                 except Exception as e:
                     logger.error(
-                        "Id: %s. Exception occured while updating "
-                        "replica status: %s" % (self.identity, e.__str__())
+                        f"Id: {self.identity}. Exception occurred while updating replica status: {e.__str__()}"
                     )
             self._sys_exit(3)
 
@@ -96,7 +95,7 @@ class Sender(ReplicationMixin, Process):
     def _init_greeting(self):
         self.send_req = self.ctx.socket(zmq.DEALER)
         self.send_req.setsockopt_string(zmq.IDENTITY, self.identity)
-        self.send_req.connect("tcp://%s:%d" % (self.receiver_ip, self.receiver_port))
+        self.send_req.connect(f"tcp://{self.receiver_ip}:{self.receiver_port}")
         msg = {
             "pool": self.replica.dpool,
             "share": self.replica.share,
@@ -105,12 +104,12 @@ class Sender(ReplicationMixin, Process):
             "uuid": self.uuid,
         }
         msg_str = json.dumps(msg)
-        self.send_req.send_multipart(["sender-ready", b"%s" % msg_str])
-        logger.debug("Id: %s Initial greeting: %s" % (self.identity, msg))
+        self.send_req.send_multipart([b"sender-ready", msg_str.encode("utf-8")])
+        logger.debug(f"Id: {self.identity} Initial greeting: {msg}")
         self.poll.register(self.send_req, zmq.POLLIN)
 
-    def _send_recv(self, command, msg=""):
-        self.msg = "Failed while send-recv-ing command(%s)" % command
+    def _send_recv(self, command: bytes, msg: bytes = b""):
+        self.msg = f"Failed while send-recv-ing command({command})".encode("utf-8")
         rcommand = rmsg = None
         self.send_req.send_multipart([command, b"%s" % msg])
         # There is no retry logic here because it's an overkill at the moment.
@@ -121,31 +120,24 @@ class Sender(ReplicationMixin, Process):
         if socks.get(self.send_req) == zmq.POLLIN:
             rcommand, rmsg = self.send_req.recv_multipart()
         if (
-            len(command) > 0 or (rcommand is not None and rcommand != "send-more")
+            len(command) > 0 or (rcommand is not None and rcommand != b"send-more")
         ) or (  # noqa E501
             len(command) > 0 and rcommand is None
         ):
             logger.debug(
-                "Id: %s Server: %s:%d scommand: %s rcommand: %s"
-                % (
-                    self.identity,
-                    self.receiver_ip,
-                    self.receiver_port,
-                    command,
-                    rcommand,
-                )
+                f"Id: {self.identity} Server: {self.receiver_ip}:{self.receiver_port} scommand: {command} rcommand: {rcommand}"
             )
         return rcommand, rmsg
 
-    def _delete_old_snaps(self, share_path):
+    def _delete_old_snaps(self, share_path: str):
         oldest_snap = get_oldest_snap(
             share_path, self.max_snap_retain, regex="_replication_"
         )
         if oldest_snap is not None:
-            logger.debug(
-                "Id: %s. Deleting old snapshot: %s" % (self.identity, oldest_snap)
+            logger.debug(f"Id: {self.identity}. Deleting old snapshot: {oldest_snap}")
+            self.msg = f"Failed to delete snapshot: {oldest_snap}. Aborting.".encode(
+                "utf-8"
             )
-            self.msg = "Failed to delete snapshot: %s. Aborting." % oldest_snap
             if self.delete_snapshot(self.replica.share, oldest_snap):
                 return self._delete_old_snaps(share_path)
 
@@ -155,7 +147,7 @@ class Sender(ReplicationMixin, Process):
         # it may not be the one refered by self.rt(latest) but a previous one.
         # We need to make sure to *only* send the incremental send that
         # receiver expects.
-        self.msg = "Failed to validate/refresh ReplicaTrail."
+        self.msg = "Failed to validate/refresh ReplicaTrail.".encode("utf-8")
         if self.rlatest_snap is None:
             # Validate/update self.rt to the one that has the expected Snapshot
             # on the system.
@@ -184,16 +176,15 @@ class Sender(ReplicationMixin, Process):
         if self.rt.snap_name != self.rlatest_snap:
             self.msg = (
                 "Mismatch on starting snapshot for "
-                "btrfs-send. Sender picked %s but Receiver wants "
-                "%s, which takes precedence." % (self.rt.snap_name, self.rlatest_snap)
-            )
+                f"btrfs-send. Sender picked {self.rt.snap_name} but Receiver wants "
+                f"{self.rlatest_snap}, which takes precedence."
+            ).encode("utf-8")
             for rt in ReplicaTrail.objects.filter(
                 replica=self.replica, status="succeeded"
             ).order_by("-id"):
                 if rt.snap_name == self.rlatest_snap:
-                    self.msg = "%s. successful trail found for %s" % (
-                        self.msg,
-                        self.rlatest_snap,
+                    self.msg = f"{self.msg}. successful trail found for {self.rlatest_snap}".encode(
+                        "utf-8"
                     )
                     snap_path = "%s%s/.snapshots/%s/%s" % (
                         settings.MNT_PT,
@@ -202,54 +193,44 @@ class Sender(ReplicationMixin, Process):
                         self.rlatest_snap,
                     )
                     if is_subvol(snap_path):
-                        self.msg = (
-                            "Snapshot(%s) exists in the system and "
-                            "will be used as the parent" % snap_path
+                        self.msg = f"Snapshot({snap_path}) exists in the system and will be used as the parent".encode(
+                            "utf-8"
                         )
-                        logger.debug("Id: %s. %s" % (self.identity, self.msg))
+                        logger.debug(f"Id: {self.identity}. {self.msg}")
                         return rt
-                    self.msg = (
-                        "Snapshot(%s) does not exist on the system. "
-                        "So cannot use it." % snap_path
+                    self.msg = f"Snapshot({snap_path}) does not exist on the system. So cannot use it.".encode(
+                        "utf-8"
                     )
                     raise Exception(self.msg)
             raise Exception(
-                "%s. No succeeded trail found for %s." % (self.msg, self.rlatest_snap)
+                f"{self.msg}. No succeeded trail found for {self.rlatest_snap}."
             )
 
-        snap_path = "%s%s/.snapshots/%s/%s" % (
-            settings.MNT_PT,
-            self.replica.pool,
-            self.replica.share,
-            self.rlatest_snap,
-        )
+        snap_path = f"{settings.MNT_PT}{self.replica.pool}/.snapshots/{self.replica.share}/{self.rlatest_snap}"
         if is_subvol(snap_path):
             return self.rt
         raise Exception(
-            "Parent Snapshot(%s) to use in btrfs-send does not "
-            "exist in the system." % snap_path
+            f"Parent Snapshot({snap_path}) to use in btrfs-send does not exist in the system."
         )
 
     def run(self):
-
-        self.msg = "Top level exception in sender: %s" % self.identity
+        self.msg = f"Top level exception in sender: {self.identity}".encode("utf-8")
         with self._clean_exit_handler():
             self.law = APIWrapper()
             self.poll = zmq.Poller()
             self._init_greeting()
 
-            #  create a new replica trail if it's the very first time
+            # Create a new replica trail if it's the very first time,
             # or if the last one succeeded
-            self.msg = (
-                "Failed to create local replica trail for snap_name:"
-                " %s. Aborting." % self.snap_name
+            self.msg = f"Failed to create local replica trail for snap_name: {self.snap_name}. Aborting.".encode(
+                "utf-8"
             )
             self.rt2 = self.create_replica_trail(self.replica.id, self.snap_name)
             self.rt2_id = self.rt2["id"]
 
             # prune old snapshots.
             self.update_trail = True
-            self.msg = "Failed to prune old snapshots"
+            self.msg = "Failed to prune old snapshots".encode("utf-8")
             share_path = "%s%s/.snapshots/%s" % (
                 settings.MNT_PT,
                 self.replica.pool,
@@ -264,11 +245,19 @@ class Sender(ReplicationMixin, Process):
             #  create a snapshot only if it's not already from a previous
             #  failed attempt.
             # TODO: If one does exist we fail which seems harsh as we may be
-            # TODO: able to pickup where we left of depending on the failure.
-            self.msg = "Failed to create snapshot: %s. Aborting." % self.snap_name
+            #  able to pickup where we left of depending on the failure.
+            self.msg = f"Failed to create snapshot: {self.snap_name}. Aborting.".encode(
+                "utf-8"
+            )
             self.create_snapshot(self.replica.share, self.snap_name)
 
             retries_left = settings.REPLICATION.get("max_send_attempts")
+
+            self.msg = (
+                "Place-holder message just after sender snapshot creation".encode(
+                    "utf-8"
+                )
+            )
 
             poll_interval = 6000  # 6 seconds
             while True:
@@ -276,28 +265,24 @@ class Sender(ReplicationMixin, Process):
                 if socks.get(self.send_req) == zmq.POLLIN:
                     # not really necessary because we just want one reply for
                     # now.
-                    retries_left = settings.REPLICATION.get("max_send_attempts")
                     command, reply = self.send_req.recv_multipart()
-                    if command == "receiver-ready":
+                    logger.debug(f"command = {command}, of type", type(command))
+                    if command == b"receiver-ready":
                         if self.rt is not None:
                             self.rlatest_snap = reply
                             self.rt = self._refresh_rt()
                         logger.debug(
-                            "Id: %s. command(%s) and message(%s) "
-                            "received. Proceeding to send fsdata."
-                            % (self.identity, command, reply)
+                            f"Id: {self.identity}. command({command}) and message({reply}) received. Proceeding to send fsdata."
                         )
                         break
                     else:
-                        if command in "receiver-init-error":
-                            self.msg = (
-                                "%s received for %s. extended reply: "
-                                "%s. Aborting." % (command, self.identity, reply)
+                        if command == b"receiver-init-error":
+                            self.msg = f"{command} received for {self.identity}. extended reply: {reply}. Aborting.".encode(
+                                "utf-8"
                             )
-                        elif command == "snap-exists":
+                        elif command == b"snap-exists":
                             logger.debug(
-                                "Id: %s. %s received. Not sending "
-                                "fsdata" % (self.identity, command)
+                                f"Id: {self.identity}. {command} received. Not sending fsdata"
                             )
                             data = {
                                 "status": "succeeded",
@@ -306,7 +291,7 @@ class Sender(ReplicationMixin, Process):
                             self.msg = (
                                 "Failed to  update replica status for "
                                 "%s" % self.snap_id
-                            )
+                            ).encode("utf-8")
                             self.update_replica_status(self.rt2_id, data)
                             self._sys_exit(0)
                         else:
@@ -314,18 +299,16 @@ class Sender(ReplicationMixin, Process):
                                 "unexpected reply(%s) for %s. "
                                 "extended reply: %s. Aborting"
                                 % (command, self.identity, reply)
-                            )
+                            ).encode("utf-8")
                         raise Exception(self.msg)
                 else:
                     retries_left -= 1
                     logger.debug(
-                        "Id: %s. No response from receiver. Number "
-                        "of retry attempts left: %d" % (self.identity, retries_left)
+                        f"Id: {self.identity}. No response from receiver. Number of retry attempts left: {retries_left}"
                     )
                     if retries_left == 0:
-                        self.msg = "Receiver(%s:%d) is unreachable. Aborting." % (
-                            self.receiver_ip,
-                            self.receiver_port,
+                        self.msg = f"Receiver({self.receiver_ip}:{self.receiver_port}) is unreachable. Aborting.".encode(
+                            "utf-8"
                         )
                         raise Exception(self.msg)
                     self.send_req.setsockopt(zmq.LINGER, 0)
@@ -340,6 +323,7 @@ class Sender(ReplicationMixin, Process):
                 self.snap_name,
             )
             cmd = [BTRFS, "send", snap_path]
+            logger.debug(f"init btrfs 'send' cmd {cmd}")
             if self.rt is not None:
                 prev_snap = "%s%s/.snapshots/%s/%s" % (
                     settings.MNT_PT,
@@ -352,6 +336,7 @@ class Sender(ReplicationMixin, Process):
                     "%s -- %s" % (self.identity, prev_snap, snap_path)
                 )
                 cmd = [BTRFS, "send", "-p", prev_snap, snap_path]
+                logger.debug(f"differential btrfs 'send' cmd {cmd}")
             else:
                 logger.info(
                     "Id: %s. Sending full replica: %s" % (self.identity, snap_path)
@@ -365,10 +350,10 @@ class Sender(ReplicationMixin, Process):
             except Exception as e:
                 self.msg = (
                     "Failed to start the low level btrfs send "
-                    "command(%s). Aborting. Exception: " % (cmd, e.__str__())
-                )
-                logger.error("Id: %s. %s" % (self.identity, self.msg))
-                self._send_recv("btrfs-send-init-error")
+                    f"command({cmd}). Aborting. Exception: {e.__str__()}"
+                ).encode("utf-8")
+                logger.error(f"Id: {self.identity}. {self.msg}")
+                self._send_recv(b"btrfs-send-init-error")
                 self._sys_exit(3)
 
             alive = True
@@ -396,19 +381,18 @@ class Sender(ReplicationMixin, Process):
                         "Exception occurred while reading low "
                         "level btrfs "
                         "send data for %s. Aborting." % self.snap_id
-                    )
+                    ).encode("utf-8")
                     if alive:
                         self.sp.terminate()
                     self.update_trail = True
-                    self._send_recv("btrfs-send-unexpected-termination-error")
+                    self._send_recv(b"btrfs-send-unexpected-termination-error")
                     self._sys_exit(3)
 
-                self.msg = (
-                    "Failed to send fsdata to the receiver for %s. "
-                    "Aborting." % (self.snap_id)
+                self.msg = f"Failed to send fsdata to the receiver for {self.snap_id}. Aborting.".encode(
+                    "utf-8"
                 )
                 self.update_trail = True
-                command, message = self._send_recv("", fs_data)
+                command, message = self._send_recv(b"", fs_data)
                 self.total_bytes_sent += len(fs_data)
                 num_msgs += 1
                 if num_msgs == 1000:
@@ -418,23 +402,25 @@ class Sender(ReplicationMixin, Process):
                         "Id: %s Sender alive. Data transferred: "
                         "%s. Rate: %s/sec." % (self.identity, dsize, drate)
                     )
-                if command is None or command == "receiver-error":
+                if command is None or command == b"receiver-error":
                     # command is None when the remote side vanishes.
                     self.msg = (
-                        "Got null or error command(%s) message(%s) "
-                        "from the Receiver while"
-                        " transmitting fsdata. Aborting." % (command, message)
-                    )
+                        f"Got null or error command({command}) message({message}) "
+                        "from the Receiver while "
+                        "transmitting fsdata. Aborting."
+                    ).encode("utf-8")
                     raise Exception(message)
 
                 if not alive:
                     if self.sp.returncode != 0:
                         # do we mark failed?
                         command, message = self._send_recv(
-                            "btrfs-send-nonzero-termination-error"
+                            b"btrfs-send-nonzero-termination-error"
                         )
                     else:
-                        command, message = self._send_recv("btrfs-send-stream-finished")
+                        command, message = self._send_recv(
+                            b"btrfs-send-stream-finished"
+                        )
 
                 if os.getppid() != self.ppid:
                     logger.error(
@@ -448,14 +434,12 @@ class Sender(ReplicationMixin, Process):
                 "status": "succeeded",
                 "kb_sent": self.total_bytes_sent / 1024,
             }
-            self.msg = (
-                "Failed to update final replica status for %s"
-                ". Aborting." % self.snap_id
+            self.msg = f"Failed to update final replica status for {self.snap_id}. Aborting.".encode(
+                "utf-8"
             )
             self.update_replica_status(self.rt2_id, data)
             dsize, drate = self.size_report(self.total_bytes_sent, t0)
             logger.debug(
-                "Id: %s. Send complete. Total data transferred: %s."
-                " Rate: %s/sec." % (self.identity, dsize, drate)
+                f"Id: {self.identity}. Send complete. Total data transferred: {dsize}. Rate: {drate}/sec."
             )
             self._sys_exit(0)

--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -250,6 +250,7 @@ class Sender(ReplicationMixin, Process):
             poll_interval = 6000  # 6 seconds
             while True:
                 socks = dict(self.poll.poll(poll_interval))
+                logger.debug(f"Sender socks dict = {socks}")
                 if socks.get(self.send_req) == zmq.POLLIN:
                     # not really necessary because we just want one reply for
                     # now.

--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -36,8 +36,10 @@ logger = logging.getLogger(__name__)
 
 
 class Sender(ReplicationMixin, Process):
+    uuid: str
     total_bytes_sent: int
     identity: str
+    rlatest_snap: str | None
 
     def __init__(self, uuid: str, receiver_ip, replica, rt: int | None = None):
         self.law = None
@@ -283,7 +285,7 @@ class Sender(ReplicationMixin, Process):
                     logger.debug(f"command = {command}, of type {type(command)}")
                     if command == b"receiver-ready":
                         if self.rt is not None:
-                            self.rlatest_snap = reply
+                            self.rlatest_snap = reply.decode("utf-8")
                             self.rt = self._refresh_rt()
                         logger.debug(
                             f"Id: {self.identity}. command({command}) and message({reply}) received. Proceeding to send fsdata."

--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -250,10 +250,9 @@ class Sender(ReplicationMixin, Process):
                 )
             )
 
-            poll_interval = 6000  # 6 seconds
             while True:
-                socks = dict(self.poll.poll(poll_interval))
-                logger.debug(f"Sender socks dict = {socks}")
+                socks = dict(self.poll.poll(6000))
+                logger.debug(f"SENDER socks dict = {socks}")
                 if socks != {}:
                     for key in socks:
                         logger.debug(f"socks index ({key}), has value {socks[key]}")

--- a/src/rockstor/smart_manager/replication/util.py
+++ b/src/rockstor/smart_manager/replication/util.py
@@ -38,6 +38,7 @@ class ReplicationMixin(object):
         return self.raw.api_call(url=f"shares/{sname}")
 
     def update_replica_status(self, rtid: int, data):
+        logger.debug(f"update_replica_status(rtid={rtid}, data={data})")
         try:
             url = f"sm/replicas/trail/{rtid}"
             return self.law.api_call(url, data=data, calltype="put")
@@ -82,6 +83,7 @@ class ReplicationMixin(object):
         return rshare["id"]
 
     def create_rshare(self, data) -> int:
+        logger.debug(f"create_rshare(data={data})")
         try:
             url = "sm/replicas/rshare"
             rshare = self.law.api_call(
@@ -95,8 +97,10 @@ class ReplicationMixin(object):
             raise e
 
     def create_receive_trail(self, rid: int, data) -> int:
+        logger.debug(f"create_receive_trail(rid={rid}, data={data})")
         url = f"sm/replicas/rtrail/rshare/{rid}"
         rt = self.law.api_call(url, data=data, calltype="post", save_error=False)
+        logger.debug(f"create_receive_trail() -> {rt['id']}")
         return rt["id"]
 
     def update_receive_trail(self, rtid: int, data):

--- a/src/rockstor/smart_manager/replication/util.py
+++ b/src/rockstor/smart_manager/replication/util.py
@@ -65,6 +65,7 @@ class ReplicationMixin(object):
             raise Exception(msg)
 
     def create_replica_trail(self, rid: int, snap_name: str):
+        logger.debug(f"Replication create_replica_trail(rid={rid}, snap_name={snap_name})")
         url = f"sm/replicas/trail/replica/{rid}"
         return self.law.api_call(
             url,
@@ -153,7 +154,7 @@ class ReplicationMixin(object):
         share with the given snapshot. Intended for use in receive.py to turn
         the oldest snapshot into an existing share via unmount, mv, mount
         cycle.
-        :param sname: Existing share name
+        :param sname: Existing share-name
         :param snap_name: Name of snapshot to supplant given share with.
         :return: False if there is a failure.
         """
@@ -184,8 +185,8 @@ class ReplicationMixin(object):
                 return False
             raise e
 
-    def create_share(self, sname: str, pool):
-        print("pool parameter is of type:", type(pool))
+    def create_share(self, sname: str, pool: str):
+        print(f"Replication 'create_share' called with sname {sname}, pool {pool}")
         try:
             url = "shares"
             data = {

--- a/src/rockstor/smart_manager/replication/util.py
+++ b/src/rockstor/smart_manager/replication/util.py
@@ -35,7 +35,7 @@ class ReplicationMixin(object):
                 client_id=a.client_id, client_secret=a.client_secret, url=url
             )
         # TODO: update url to include senders shareId as sname is now invalid
-        return self.raw.api_call(url="shares/%s" % sname)
+        return self.raw.api_call(url=f"shares/{sname}")
 
     def update_replica_status(self, rtid: int, data):
         try:
@@ -89,9 +89,7 @@ class ReplicationMixin(object):
             return rshare["id"]
         except RockStorAPIException as e:
             # Note replica_share.py post() generates this exception message.
-            if (
-                e.detail == "Replicashare(%s) already exists." % data["share"]
-            ):  # noqa E501
+            if e.detail == f"Replicashare({data['share']}) already exists.":  # noqa E501
                 return self.rshare_id(data["share"])
             raise e
 
@@ -247,7 +245,7 @@ class ReplicationMixin(object):
         :return: "1023 Bytes" or "4.28 KB" etc given num=1023 or num=4384 )
         """
         if num < 1024 or len(units) == 1:
-            return "%.2f %s" % (num, units[0])
+            return f"{num:.2f} {units[0]}"
         return self.humanize_bytes(num / 1024, units[1:])
 
     def size_report(self, num: int, t0):

--- a/src/rockstor/smart_manager/replication/util.py
+++ b/src/rockstor/smart_manager/replication/util.py
@@ -17,6 +17,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import time
+from typing import Any
+
 from storageadmin.exceptions import RockStorAPIException
 from storageadmin.models import Appliance, Share
 from cli import APIWrapper
@@ -232,29 +234,23 @@ class ReplicationMixin(object):
         except Exception as e:
             logger.error(f"Exception while refreshing Share state: {e.__str__()}")
 
-    def humanize_bytes(
-        self,
-        num: int,
-        units=(
-            "Bytes",
-            "KB",
-            "MB",
-            "GB",
-        ),
-    ):
+    def humanize_bytes(self, num: float, units=("Bytes", "KB", "MB", "GB")) -> str:
         """
         Recursive routine to establish and then return the most appropriate
         num expression given the contents of units. Ie 1023 Bytes or 4096 KB
         :param num: Assumed to be in Byte units.
         :param units: list of units to recurse through
-        :return: "1023 Bytes" or "4.28 KB" etc given num=1023 or num=4384 )
+        :return: "1023 Bytes" or "4.28 KB" etc. given num=1023 or num=4384
         """
         if num < 1024 or len(units) == 1:
             return f"{num:.2f} {units[0]}"
         return self.humanize_bytes(num / 1024, units[1:])
 
-    def size_report(self, num: int, t0):
-        t1 = time.time()
-        dsize = self.humanize_bytes(float(num))
-        drate = self.humanize_bytes(float(num / (t1 - t0)))
+    def size_report(self, num: int, time_started: float):
+        """
+        Takes num of bytes, and a start time, and returns humanized output.
+        """
+        time_now = time.time()
+        dsize: str = self.humanize_bytes(float(num))
+        drate: str = self.humanize_bytes(float(num / (time_now - time_started)))
         return dsize, drate


### PR DESCRIPTION
Update replication code re Py3.*
- Modernise previously missed replication imports re Py3.*
- Force bytes format for replication messages and commands. Required as zmq needs bytes format for these.
- Minor modification re Pythnon 3 behaviour re dict.keys(), we replied on an implicit Python 2 behaviour.
- Move to Fstrings.
- Parameter/return type hinting.
- Removed an unused local variable.
- black format update

Closes #2766 

Supersedes prior draft PR #2769 to accommodate required re-base.