### PR TITLE
Failure to remove legacy poetry version in 5.0.6-0 rpm #2782

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,10 @@ if which poetry && poetry --version | grep -q "1.1.15"; then
   curl -sSL https://install.python-poetry.org | python3 - --uninstall
   rm --force /root/.local/bin/poetry  # remove dangling dead link.
 fi
-# bash substring replace: null all legacy poetry paths - mid-instance
-PATH="${PATH//':/root/.local/bin'/''}"
-# bash substring remove (front): our above added temp legacy poetry path.
-PATH="${PATH#'/root/.local/bin:'}"
+PATH="${PATH//'/root/.local/bin:'/''}" # null all legacy poetry paths
+# We are run, outside of development, only by RPM's %posttrans.
+# As such our .venv dir has already been removed in %post (update mode).
+PATH="${PATH//'/opt/rockstor/.venv/bin:'/''}" # null now removed .venv from path.
 echo "build.sh has PATH=$PATH"
 # Install Poetry via PIPX as a global app
 # https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments
@@ -31,6 +31,7 @@ python3.11 -m pipx install poetry==1.7.1
 # https://github.com/python-poetry/poetry/issues/3078
 export LANG=C.UTF-8
 export PYTHONIOENCODING=utf8
+# /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
 /usr/local/bin/poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
 echo
 

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,10 @@ if which poetry && poetry --version | grep -q "1.1.15"; then
   echo "Poetry version 1.1.15 found - UNINSTALLING"
   curl -sSL https://install.python-poetry.org | python3 - --uninstall
   rm --force /root/.local/bin/poetry  # remove dangling dead link.
-  # bash substring replace with "" our legacy poetry path.
-  PATH="${PATH//':/root/.local/bin'/''}"
 fi
+# bash substring replace with "" our temp legacy poetry path.
+PATH="${PATH//':/root/.local/bin'/''}"
+echo "build.sh has PATH=$PATH"
 # Install Poetry via PIPX as a global app
 # https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments
 export PIPX_HOME=/opt/pipx  # virtual environment location, default ~/.local/pipx

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,10 @@ if which poetry && poetry --version | grep -q "1.1.15"; then
   curl -sSL https://install.python-poetry.org | python3 - --uninstall
   rm --force /root/.local/bin/poetry  # remove dangling dead link.
 fi
-# bash substring replace with "" our temp legacy poetry path.
+# bash substring replace: null all legacy poetry paths - mid-instance
 PATH="${PATH//':/root/.local/bin'/''}"
+# bash substring remove (front): our above added temp legacy poetry path.
+PATH="${PATH#'/root/.local/bin:'}"
 echo "build.sh has PATH=$PATH"
 # Install Poetry via PIPX as a global app
 # https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -o errexit
 
 # Install Poetry, a dependency management, packaging, and build system.
 # Uninstall legacy/transitional Poetry version of 1.1.15
+PATH="$HOME/.local/bin:$PATH"  # account for more constrained environments.
 if which poetry && poetry --version | grep -q "1.1.15"; then
   echo "Poetry version 1.1.15 found - UNINSTALLING"
   curl -sSL https://install.python-poetry.org | python3 - --uninstall

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,9 @@ PATH="$HOME/.local/bin:$PATH"  # account for more constrained environments.
 if which poetry && poetry --version | grep -q "1.1.15"; then
   echo "Poetry version 1.1.15 found - UNINSTALLING"
   curl -sSL https://install.python-poetry.org | python3 - --uninstall
+  rm --force /root/.local/bin/poetry  # remove dangling dead link.
+  # bash substring replace with "" our legacy poetry path.
+  PATH="${PATH//':/root/.local/bin'/''}"
 fi
 # Install Poetry via PIPX as a global app
 # https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments


### PR DESCRIPTION
Add legacy poetry install path to avoid failing its uninstall. Without this additional path, when build.sh is run from within RPM's constrained %posttrans scriptlet, we fail to find and uninstall our prior 1.1.15 poetry version. This leads to having both poetry 1.1.15 (via upstream installer) and our new pipx installed poetry 1.7.1. After having checked-for/uninstalled this legacy version we then need to remove the associated legacy path.

Fixes #2782 