### PR TITLE
Failure to re-create venv after Poetry update in 5.0.6-0 rpm #2788

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,10 +38,10 @@ pipx list
 # poetry env remove --all  # removes all venvs associated with a pyproject.toml
 # rm -rf ~/.cache/pypoetry/virtualenvs/*  # to delete default location venvs.
 # ** --no-ansi avoids special characters **
-echo "PATH=${PATH}" > poetry-install.txt
+env > poetry-install.txt
 poetry --version >> poetry-install.txt
 # /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
-poetry install --no-interaction --no-ansi >> poetry-install.txt 2>&1
+poetry install -vvv --no-interaction --no-ansi >> poetry-install.txt 2>&1
 echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,10 @@ echo "Adopting installs' LANG=${LANG}"
 export PIPX_HOME=/opt/pipx  # virtual environment location, default ~/.local/pipx
 export PIPX_BIN_DIR=/usr/local/bin  # binary location for pipx-installed apps, default ~/.local/bin
 export PIPX_MAN_DIR=/usr/local/share/man  # manual page location for pipx-installed apps, default ~/.local/share/man
-python3.11 -m pipx install poetry==1.7.1
+# https://python-poetry.org/docs/#installing-with-pipx
+pipx ensurepath
+pipx install --python python3.11 poetry==1.7.1
+pipx list
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml
 # specific configuration, i.e. virtualenv in cwd/.venv
@@ -38,7 +41,7 @@ python3.11 -m pipx install poetry==1.7.1
 echo "PATH=${PATH}" > poetry-install.txt
 poetry --version >> poetry-install.txt
 # /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
-/usr/local/bin/poetry install --no-interaction --no-ansi >> poetry-install.txt 2>&1
+poetry install --no-interaction --no-ansi >> poetry-install.txt 2>&1
 echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,9 @@ fi
 PATH="${PATH//'/root/.local/bin:'/''}" # null all legacy poetry paths
 # We are run, outside of development, only by RPM's %posttrans.
 # As such our .venv dir has already been removed in %post (update mode).
+echo "Unset VIRTUAL_ENV"
+# Redundant from rockstor 5.0.3-0 onwards: src/rockstor/system/pkg_mgmt.py
+unset VIRTUAL_ENV
 PATH="${PATH//'/opt/rockstor/.venv/bin:'/''}" # null now removed .venv from path.
 
 echo "build.sh has PATH=$PATH"

--- a/build.sh
+++ b/build.sh
@@ -14,11 +14,19 @@ PATH="${PATH//'/root/.local/bin:'/''}" # null all legacy poetry paths
 # We are run, outside of development, only by RPM's %posttrans.
 # As such our .venv dir has already been removed in %post (update mode).
 PATH="${PATH//'/opt/rockstor/.venv/bin:'/''}" # null now removed .venv from path.
+
 echo "build.sh has PATH=$PATH"
+echo
+# Establish LANG from install.
+source /etc/locale.conf
+echo "Adopting installs' LANG=${LANG}"
+
 # Install Poetry via PIPX as a global app
 # https://peps.python.org/pep-0668/#guide-users-towards-virtual-environments
+# https://pipx.pypa.io/stable/installation/
 export PIPX_HOME=/opt/pipx  # virtual environment location, default ~/.local/pipx
 export PIPX_BIN_DIR=/usr/local/bin  # binary location for pipx-installed apps, default ~/.local/bin
+export PIPX_MAN_DIR=/usr/local/share/man  # manual page location for pipx-installed apps, default ~/.local/share/man
 python3.11 -m pipx install poetry==1.7.1
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml
@@ -27,12 +35,10 @@ python3.11 -m pipx install poetry==1.7.1
 # poetry env remove --all  # removes all venvs associated with a pyproject.toml
 # rm -rf ~/.cache/pypoetry/virtualenvs/*  # to delete default location venvs.
 # ** --no-ansi avoids special characters **
-# Resolve Python 3.6 Poetry issue re char \u2022: (bullet)
-# https://github.com/python-poetry/poetry/issues/3078
-export LANG=C.UTF-8
-export PYTHONIOENCODING=utf8
+echo "PATH=${PATH}" > poetry-install.txt
+poetry --version >> poetry-install.txt
 # /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
-/usr/local/bin/poetry install --no-interaction --no-ansi > poetry-install.txt 2>&1
+/usr/local/bin/poetry install --no-interaction --no-ansi >> poetry-install.txt 2>&1
 echo
 
 # Add js libs. See: https://github.com/rockstor/rockstor-jslibs


### PR DESCRIPTION
## Includes
- Remove now redundant Py3.6 work-around re Poetry and LANG env var.
- Establish LANG from install.
- Record PATH & `poetry --version` in poetry-install.txt before venv install.
