### PR TITLE
Add rockstor-build systemd service #2793

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,14 @@ set -o errexit
 
 # Install Poetry, a dependency management, packaging, and build system.
 # Uninstall legacy/transitional Poetry version of 1.1.15
-PATH="$HOME/.local/bin:$PATH"  # account for more constrained environments.
+PATH="$HOME/.local/bin:$PATH"  # ensure legacy path.
 if which poetry && poetry --version | grep -q "1.1.15"; then
   echo "Poetry version 1.1.15 found - UNINSTALLING"
   curl -sSL https://install.python-poetry.org | python3 - --uninstall
   rm --force /root/.local/bin/poetry  # remove dangling dead link.
 fi
 PATH="${PATH//'/root/.local/bin:'/''}" # null all legacy poetry paths
-# We are run, outside of development, only by RPM's %posttrans.
+# We are run by rockstor-build.service.
 # As such our .venv dir has already been removed in %post (update mode).
 echo "Unset VIRTUAL_ENV"
 # Redundant when updating from rockstor 5.0.3-0 onwards: src/rockstor/system/pkg_mgmt.py
@@ -88,7 +88,7 @@ export Environment="PASSWORD_STORE_DIR=/root/.password-store"
 # Additional collectstatic options --clear --dry-run
 export DJANGO_SETTINGS_MODULE=settings
 # must be run in project root:
-/usr/local/bin/poetry run django-admin collectstatic --no-input --verbosity 2
+poetry run django-admin collectstatic --no-input --verbosity 2
 echo
 
 echo "ROCKSTOR BUILD SCRIPT COMPLETED"

--- a/conf/rockstor-build.service
+++ b/conf/rockstor-build.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Build Rockstor
+ConditionPathIsDirectory=!/opt/rockstor/.venv
+After=postgresql.service
+After=NetworkManager.service
+After=NetworkManager-wait-online.service
+Requires=postgresql.service
+Requires=NetworkManager.service
+# https://pypi.org/ to install/update Poetry, & have it build/rebuild .venv.
+Requires=NetworkManager-wait-online.service
+
+[Service]
+Environment="DJANGO_SETTINGS_MODULE=settings"
+Environment="PASSWORD_STORE_DIR=/root/.password-store"
+WorkingDirectory=/opt/rockstor
+ExecStart=/opt/rockstor/build.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Tasks required prior to starting Rockstor
+After=rockstor-build.service
 After=postgresql.service
 After=NetworkManager.service
+Requires=rockstor-build.service
 Requires=postgresql.service
 Requires=NetworkManager.service
 

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -95,6 +95,7 @@ SYSTEMD_DIR = "/usr/lib/systemd/system"
 SYSTEMD_OVERRIDE_DIR = "/etc/systemd/system"
 
 ROCKSTOR_SYSTEMD_SERVICES = [
+    "rockstor-build.service",  # Build/Rebuild .venv & jslibs, init `pass`.
     "rockstor-pre.service",  # Loads us (initrock.py).
     "rockstor.service",
     "rockstor-bootstrap.service",

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -458,7 +458,7 @@ def update_run(subscription=None, update_all_other=False):
             # Unset inherited VIRTUAL_ENV environmental variable before invoking rpm/zypper
             atfo.write("unset VIRTUAL_ENV\n")
             atfo.write(pkg_in_up_rockstor)
-            # rockstor-bootstrap Requires rockstor which Requires rockstor-pre (initrock)
+            # rockstor-bootstrap Requires rockstor which Requires rockstor-pre (initrock) which Requires rockstor-build
             atfo.write("{} start rockstor-bootstrap\n".format(SYSTEMCTL))
         else:  # update_all_other True so update all bar the rockstor package.
             logger.info(


### PR DESCRIPTION
Move build.sh execution from within rpm %posttrans script to it's own dedicated rockstor-build.service. Enabling greater fidelity and control over the environment and timing; and eases development and user feedback on build.sh failures in the future.

Partnered with rockstor.spec changes in rockstor-rpmbuild repo.

## Includes
- New rockstor-build.service file.
- After= & Requires= entries in rockstor-pre on rockstor-build, to extend our service cascade.
- Trivial build.sh and pkg_mgmt.py comment updates.
- Add the new rockstor-build.service to initrock.py to assist in asserting the service akin to all other rockstor services. Mostly redundant given our rpm service management, but nice-to-have.

Fixes #2793 

---
Partner Pull Request:
- rockstor-rpmbuild: "Move build.sh execution from %posttrans to rockstor-build.service ...": https://github.com/rockstor/rockstor-rpmbuild/pull/63