### PR TITLE
(t) Samba shares broken - testing upgrade too 5.0.6-0 & 5.0.7-0 #2794

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,11 @@
 # - python-dotenv: https://pypi.org/project/python-dotenv/
 # - systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
 # - bash `source` command: https://www.gnu.org/software/bash/manual/bash.html#index-source
-#
+
 # password-store working directory: GNUPG/gpg encrypted.
 # https://www.passwordstore.org/
 # https://git.zx2c4.com/password-store/about/
 PASSWORD_STORE_DIR=/root/.password-store
+
+# Django
+DJANGO_SETTINGS_MODULE=settings

--- a/.env
+++ b/.env
@@ -1,2 +1,10 @@
-# password-store app
+# NO SECRETS - ENVIRONMENTAL VARIABLES ONLY
+# All entires should be compatible with all of the following uses:
+# - poetry-plugin-dotenv: https://pypi.org/project/poetry-plugin-dotenv/
+# - systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
+# - bash `source` command: https://www.gnu.org/software/bash/manual/bash.html#index-source
+#
+# password-store working directory: GNUPG/gpg encrypted.
+# https://www.passwordstore.org/
+# https://git.zx2c4.com/password-store/about/
 PASSWORD_STORE_DIR=/root/.password-store

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# password-store app
+PASSWORD_STORE_DIR=/root/.password-store

--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # NO SECRETS - ENVIRONMENTAL VARIABLES ONLY
 # All entires should be compatible with all of the following uses:
 # - poetry-plugin-dotenv: https://pypi.org/project/poetry-plugin-dotenv/
+# - python-dotenv: https://pypi.org/project/python-dotenv/
 # - systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
 # - bash `source` command: https://www.gnu.org/software/bash/manual/bash.html#index-source
 #

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ export PIPX_MAN_DIR=/usr/local/share/man  # manual page location for pipx-instal
 # https://python-poetry.org/docs/#installing-with-pipx
 pipx ensurepath
 pipx install --python python3.11 poetry==1.7.1
-# https://pypi.org/project/poetry-dotenv-plugin/
+# https://pypi.org/project/poetry-plugin-dotenv/
 # https://python-poetry.org/docs/master/plugins/#using-plugins
 pipx inject --verbose poetry poetry-plugin-dotenv==0.6.10
 pipx list

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 # Install Poetry, a dependency management, packaging, and build system.
 # Uninstall legacy/transitional Poetry version of 1.1.15
-PATH="$HOME/.local/bin:$PATH"  # ensure legacy path.
+PATH="/root/.local/bin:$PATH"  # ensure legacy path.
 if which poetry && poetry --version | grep -q "1.1.15"; then
   echo "Poetry version 1.1.15 found - UNINSTALLING"
   curl -sSL https://install.python-poetry.org | python3 - --uninstall

--- a/build.sh
+++ b/build.sh
@@ -82,15 +82,17 @@ fi
 
 # Ensure GNUPG is setup for 'pass' (Idempotent)
 /usr/bin/gpg --quick-generate-key --batch --passphrase '' rockstor@localhost || true
-# Init 'pass' in ~ using above GPG key, and generate Django SECRET_KEY
-export PASSWORD_STORE_DIR=/root/.password-store
+# Init 'pass' in .env defined PASSWORD_STORE_DIR using above GPG key, and generate Django SECRET_KEY
+set -o allexport
+echo "Sourcing ${pwd}.env"
+source .env  # also read by rockstor-build.service
+set +o allexport
 /usr/bin/pass init rockstor@localhost
 /usr/bin/pass generate --no-symbols --force python-keyring/rockstor/SECRET_KEY 100
 
 # Collect all static files in the STATIC_ROOT subdirectory. See settings.py.
 # /opt/rockstor/static
 # Additional collectstatic options --clear --dry-run
-export DJANGO_SETTINGS_MODULE=settings
 # must be run in project root:
 poetry run django-admin collectstatic --no-input --verbosity 2
 echo
@@ -99,9 +101,8 @@ echo "ROCKSTOR BUILD SCRIPT COMPLETED"
 echo
 echo "If installing from source, from scratch, for development; i.e. NOT via RPM:"
 echo "Note GnuPG & password-store ExecStartPre steps in /opt/rockstor/conf/rockstor-pre.service"
-echo "1. Run 'cd /opt/rockstor'."
-echo "2. Run 'systemctl start postgresql'."
-echo "3. Run 'export DJANGO_SETTINGS_MODULE=settings'."
-echo "4. Run 'export PASSWORD_STORE_DIR=/root/.password-store'."
-echo "5. Run 'poetry run initrock' as root (equivalent to rockstor-pre.service ExecStart)."
-echo "6. Run 'systemctl enable --now rockstor-bootstrap'."
+echo "1. Run 'systemctl start postgresql'."
+echo "2. Run 'cd /opt/rockstor'."
+ecjp "3. Run './build.sh'."
+echo "4. Run 'poetry run initrock' as root (equivalent to rockstor-pre.service ExecStart)."
+echo "5. Run 'systemctl enable --now rockstor-bootstrap'."

--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,9 @@ export PIPX_MAN_DIR=/usr/local/share/man  # manual page location for pipx-instal
 # https://python-poetry.org/docs/#installing-with-pipx
 pipx ensurepath
 pipx install --python python3.11 poetry==1.7.1
+# https://pypi.org/project/poetry-dotenv-plugin/
+# https://python-poetry.org/docs/master/plugins/#using-plugins
+pipx inject --verbose poetry poetry-plugin-dotenv==0.6.5
 pipx list
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml
@@ -43,6 +46,7 @@ pipx list
 # ** --no-ansi avoids special characters **
 env > poetry-install.txt
 poetry --version >> poetry-install.txt
+poetry self show plugins >> poetry-install.txt
 # /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
 poetry install -vvv --no-interaction --no-ansi >> poetry-install.txt 2>&1
 echo
@@ -79,7 +83,7 @@ fi
 # Ensure GNUPG is setup for 'pass' (Idempotent)
 /usr/bin/gpg --quick-generate-key --batch --passphrase '' rockstor@localhost || true
 # Init 'pass' in ~ using above GPG key, and generate Django SECRET_KEY
-export Environment="PASSWORD_STORE_DIR=/root/.password-store"
+export PASSWORD_STORE_DIR=/root/.password-store
 /usr/bin/pass init rockstor@localhost
 /usr/bin/pass generate --no-symbols --force python-keyring/rockstor/SECRET_KEY 100
 

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ pipx ensurepath
 pipx install --python python3.11 poetry==1.7.1
 # https://pypi.org/project/poetry-dotenv-plugin/
 # https://python-poetry.org/docs/master/plugins/#using-plugins
-pipx inject --verbose poetry poetry-plugin-dotenv==0.6.5
+pipx inject --verbose poetry poetry-plugin-dotenv==0.6.10
 pipx list
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml

--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,6 @@ echo "If installing from source, from scratch, for development; i.e. NOT via RPM
 echo "Note GnuPG & password-store ExecStartPre steps in /opt/rockstor/conf/rockstor-pre.service"
 echo "1. Run 'systemctl start postgresql'."
 echo "2. Run 'cd /opt/rockstor'."
-ecjp "3. Run './build.sh'."
+echo "3. Run './build.sh'."
 echo "4. Run 'poetry run initrock' as root (equivalent to rockstor-pre.service ExecStart)."
 echo "5. Run 'systemctl enable --now rockstor-bootstrap'."

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ pipx ensurepath
 pipx install --python python3.11 poetry==1.7.1
 # https://pypi.org/project/poetry-plugin-dotenv/
 # https://python-poetry.org/docs/master/plugins/#using-plugins
-pipx inject --verbose poetry poetry-plugin-dotenv==0.6.10
+pipx inject --verbose poetry poetry-plugin-dotenv==0.6.11
 pipx list
 
 # Install project dependencies defined in cwd pyproject.toml using poetry.toml

--- a/conf/rockstor-bootstrap.service
+++ b/conf/rockstor-bootstrap.service
@@ -4,10 +4,9 @@ After=rockstor.service
 Requires=rockstor.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
-ExecStart=/opt/rockstor/.venv/bin/bootstrap
+EnvironmentFile=/opt/rockstor/.env
+ExecStart=/usr/local/bin/poetry run bootstrap
 Type=oneshot
 RemainAfterExit=yes
 

--- a/conf/rockstor-build.service
+++ b/conf/rockstor-build.service
@@ -10,9 +10,8 @@ Requires=NetworkManager.service
 Requires=NetworkManager-wait-online.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 ExecStart=/opt/rockstor/build.sh
 Type=oneshot
 RemainAfterExit=yes

--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -8,9 +8,8 @@ Requires=postgresql.service
 Requires=NetworkManager.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 # Avoid `pass` stdout leaking generated passwords (N.B. 2>&1 >/dev/null failed).
 StandardOutput=null
 # Idempotent: failure tolerated for pgp as key likely already exists (rc 2).

--- a/conf/rockstor.service
+++ b/conf/rockstor.service
@@ -4,9 +4,8 @@ After=rockstor-pre.service
 Requires=rockstor-pre.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 ExecStart=/usr/local/bin/poetry run supervisord -c /opt/rockstor/etc/supervisord.conf
 ExecStop=/usr/local/bin/poetry run supervisorctl shutdown
 ExecReload=/usr/local/bin/poetry run supervisorctl reload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = [
     "build.sh",  # master build script
     "poetry.toml",  # poetry config
     "poetry.lock",  # current poetry established dependency lock file.
+    ".env",  # poetry-plugin-dotenv default source file.
     { path = "conf" },  # Configuration directories
     { path = "etc" },
     { path = "var" },  # Some processes depend on this tree existing.

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -116,9 +116,10 @@ ROCKSTOR_LEGACY_SYSTEMD_SERVICES = [
 #       use None to use the current mask of the target file defined at <path>.
 # services: Python List of service(s) to restart, if any, after modifying the file.
 LocalFile = namedtuple("LocalFile", "path mask services")
+# samba_config's "root preexec = ..." migrations do not required service restarts.
 LOCAL_FILES = {
     "samba_config": LocalFile(
-        path="/etc/samba/smb.conf", mask=None, services=["nmb", "smb"]
+        path="/etc/samba/smb.conf", mask=None, services=None
     ),
     "rockstor_crontab": LocalFile(
         path="/etc/cron.d/rockstortab", mask=stat.S_IRUSR | stat.S_IWUSR, services=None

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -56,8 +56,8 @@ def rockstor_smb_config(fo, exports):
         for au in e.admin_users.all():
             admin_users = "{}{} ".format(admin_users, au.username)
         fo.write("[{}]\n".format(e.share.name))
-        # Requires `poetry run` in systemd directory
-        fo.write(f"    root preexec = sh -c 'cd {settings.ROOT_DIR} && {mnt_helper} {e.share.name}'\n")
+        # Requires `poetry run` in ROOT_DIR to gain .env defined environment.
+        fo.write(f"    root preexec = sh -c \"cd {settings.ROOT_DIR} && {mnt_helper} {e.share.name}\"\n")
         fo.write("    root preexec close = yes\n")
         fo.write("    comment = {}\n".format(e.comment.encode("utf-8")))
         fo.write("    path = {}\n".format(e.path))

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -49,14 +49,15 @@ def test_parm(config="/etc/samba/smb.conf"):
 
 
 def rockstor_smb_config(fo, exports):
-    mnt_helper = os.path.join(settings.ROOT_DIR, ".venv/bin/mnt-share")
+    mnt_helper = "poetry run mnt-share"
     fo.write("{}\n".format(RS_SHARES_HEADER))
     for e in exports:
         admin_users = ""
         for au in e.admin_users.all():
             admin_users = "{}{} ".format(admin_users, au.username)
         fo.write("[{}]\n".format(e.share.name))
-        fo.write('    root preexec = "{} {}"\n'.format(mnt_helper, e.share.name))
+        # Requires `poetry run` in systemd directory
+        fo.write(f"    root preexec = sh -c 'cd {settings.ROOT_DIR} && {mnt_helper} {e.share.name}'\n")
         fo.write("    root preexec close = yes\n")
         fo.write("    comment = {}\n".format(e.comment.encode("utf-8")))
         fo.write("    path = {}\n".format(e.path))


### PR DESCRIPTION
Introduce 'poetry-plugin-dotenv' to enable Poetry to establish environmental variables from a .env file. Add PASSWORD_STORE_DIR & DJANGO_SETTINGS_MODULE variables to inform OS level 'password-store' app of our configuration, and to centralise DJANGO_SETTINGS_MODULE's definition.

## Includes:
- Additional logging to poetry-install.txt to indicate plugins installed.
- Modify export statement for PASSWORD_STORE_DIR in build.sh, this is also now set via a recent rockstor-build.service file addition.
- Include new `.env` file in project.toml for sdist inclusion.
- Adopt new `poetry run mnt-share share-name`, with required `cd`, in
new `root preexec` Samba share config creation.
- Add preexec migration to initrock.
- Centralise definition of PASSWORD_STORE_DIR environmental variable to .env file.
- Move definition of DJANGO_SETTINGS_MODULE environmental variable to .env file.
- Fix a legacy Poetry removal regression in as yet unpublished (via rpm) testing changes.
- Remove smb & nmb service restarts on prior preexec migration mechanism.


---

Note: draft status - in development.
