### PR TITLE
(t) Samba shares not accessible - 5.0.6-0 & 5.0.7-0 #2794

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,14 @@
+# NO SECRETS - ENVIRONMENTAL VARIABLES ONLY
+# All entires should be compatible with all of the following uses:
+# - poetry-plugin-dotenv: https://pypi.org/project/poetry-plugin-dotenv/
+# - python-dotenv: https://pypi.org/project/python-dotenv/
+# - systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
+# - bash `source` command: https://www.gnu.org/software/bash/manual/bash.html#index-source
+
+# password-store working directory: GNUPG/gpg encrypted.
+# https://www.passwordstore.org/
+# https://git.zx2c4.com/password-store/about/
+PASSWORD_STORE_DIR=/root/.password-store
+
+# Django
+DJANGO_SETTINGS_MODULE=settings

--- a/conf/rockstor-bootstrap.service
+++ b/conf/rockstor-bootstrap.service
@@ -4,10 +4,9 @@ After=rockstor.service
 Requires=rockstor.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
-ExecStart=/opt/rockstor/.venv/bin/bootstrap
+EnvironmentFile=/opt/rockstor/.env
+ExecStart=/usr/local/bin/poetry run bootstrap
 Type=oneshot
 RemainAfterExit=yes
 

--- a/conf/rockstor-build.service
+++ b/conf/rockstor-build.service
@@ -10,9 +10,8 @@ Requires=NetworkManager.service
 Requires=NetworkManager-wait-online.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 ExecStart=/opt/rockstor/build.sh
 Type=oneshot
 RemainAfterExit=yes

--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -8,9 +8,8 @@ Requires=postgresql.service
 Requires=NetworkManager.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 # Avoid `pass` stdout leaking generated passwords (N.B. 2>&1 >/dev/null failed).
 StandardOutput=null
 # Idempotent: failure tolerated for pgp as key likely already exists (rc 2).

--- a/conf/rockstor.service
+++ b/conf/rockstor.service
@@ -4,9 +4,8 @@ After=rockstor-pre.service
 Requires=rockstor-pre.service
 
 [Service]
-Environment="DJANGO_SETTINGS_MODULE=settings"
-Environment="PASSWORD_STORE_DIR=/root/.password-store"
 WorkingDirectory=/opt/rockstor
+EnvironmentFile=/opt/rockstor/.env
 ExecStart=/usr/local/bin/poetry run supervisord -c /opt/rockstor/etc/supervisord.conf
 ExecStop=/usr/local/bin/poetry run supervisorctl shutdown
 ExecReload=/usr/local/bin/poetry run supervisorctl reload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = [
     "build.sh",  # master build script
     "poetry.toml",  # poetry config
     "poetry.lock",  # current poetry established dependency lock file.
+    ".env",  # poetry-plugin-dotenv default source file.
     { path = "conf" },  # Configuration directories
     { path = "etc" },
     { path = "var" },  # Some processes depend on this tree existing.

--- a/src/rockstor/scripts/initrock.py
+++ b/src/rockstor/scripts/initrock.py
@@ -116,9 +116,10 @@ ROCKSTOR_LEGACY_SYSTEMD_SERVICES = [
 #       use None to use the current mask of the target file defined at <path>.
 # services: Python List of service(s) to restart, if any, after modifying the file.
 LocalFile = namedtuple("LocalFile", "path mask services")
+# samba_config's "root preexec = ..." migrations do not required service restarts.
 LOCAL_FILES = {
     "samba_config": LocalFile(
-        path="/etc/samba/smb.conf", mask=None, services=["nmb", "smb"]
+        path="/etc/samba/smb.conf", mask=None, services=None
     ),
     "rockstor_crontab": LocalFile(
         path="/etc/cron.d/rockstortab", mask=stat.S_IRUSR | stat.S_IWUSR, services=None
@@ -463,6 +464,33 @@ def establish_poetry_paths():
     logger.info("### DONE establishing poetry path to binaries in local files.")
 
 
+def update_smb_conf_preexec():
+    """
+    5.0.8-0 onwards adopts a new smb.conf preexec command for all new Samba exports.
+    Modify existing shares accordingly. Example for test_share01:
+        root preexec = "/opt/rockstor/.venv/bin/mnt-share test_share01"
+        root preexec = sh -c "cd /opt/rockstor/ && poetry run mnt-share test_share01"
+    Avoids premature DB requirement re:
+    - refresh_smb_config(list(SambaShare.objects.all()))
+    - refresh_smb_discovery(list(SambaShare.objects.all()))
+    """
+    logger.info("### BEGIN Establishing SMB config preexec update...")
+    smb_conf = LOCAL_FILES["samba_config"]
+    pattern = f'"{BASE_DIR}.venv/bin/'
+    replacement = f'sh -c "cd {BASE_DIR} && poetry run '
+    if os.path.isfile(smb_conf.path):
+        fh, npath = mkstemp()
+        altered = replace_pattern_inline(smb_conf.path, npath, pattern, replacement)
+        if altered:  # smb_conf.mask assumed None
+            shutil.copystat(smb_conf.path, npath)
+            shutil.move(npath, smb_conf.path)
+            logger.info("smb.conf preexec format updated")
+        else:
+            os.remove(npath)
+            logger.info("smb.conf preexec already updated")
+    logger.info("### DONE Establishing SMB config preexec update...")
+
+
 def set_api_client_secret():
     """
     Set/reset the API client secret which is used internally by OAUTH_INTERNAL_APP = "cliapp",
@@ -648,6 +676,8 @@ def main():
     establish_systemd_services()
 
     establish_poetry_paths()
+
+    update_smb_conf_preexec()
 
 
 if __name__ == "__main__":

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -49,14 +49,15 @@ def test_parm(config="/etc/samba/smb.conf"):
 
 
 def rockstor_smb_config(fo, exports):
-    mnt_helper = os.path.join(settings.ROOT_DIR, ".venv/bin/mnt-share")
+    mnt_helper = "poetry run mnt-share"
     fo.write("{}\n".format(RS_SHARES_HEADER))
     for e in exports:
         admin_users = ""
         for au in e.admin_users.all():
             admin_users = "{}{} ".format(admin_users, au.username)
         fo.write("[{}]\n".format(e.share.name))
-        fo.write('    root preexec = "{} {}"\n'.format(mnt_helper, e.share.name))
+        # Requires `poetry run` in ROOT_DIR to gain .env defined environment.
+        fo.write(f"    root preexec = sh -c \"cd {settings.ROOT_DIR} && {mnt_helper} {e.share.name}\"\n")
         fo.write("    root preexec close = yes\n")
         fo.write("    comment = {}\n".format(e.comment.encode("utf-8")))
         fo.write("    path = {}\n".format(e.path))


### PR DESCRIPTION
Introduce 'poetry-plugin-dotenv' to enable Poetry to establish environmental variables from a .env file. Add PASSWORD_STORE_DIR & DJANGO_SETTINGS_MODULE variables to inform OS level 'password-store' app, & our .venv Django of their configuration.

Fixes #2794 

## Includes:
- Additional logging to poetry-install.txt to indicate plugins installed.
- Include new `.env` file in project.toml for sdist inclusion.
- NO SECRETS indicator in new .env file.
- Add `source .env` to build.sh to ease development, the .env file is also read by build.sh's dedicated rockstor-build.service.
- Pin, in build.sh, poetry-plugin-dotenv to latest 0.6.11
- Adopt new `poetry run mnt-share share-name`, with required `cd`, in new `root preexec` Samba share config creation.
- Incidentally fix legacy Poetry removal regression introduced when build.sh execution was moved to a systemd service from rpm %posttrans.
- Add smb.conf preexec migration procedure to initrock.
- Remove redundant smb & nmb restarts from prior preexec migrations.
- Resource .env file in all relevant rockstor*.service files via `EnvironmentFile=` directive.
- Normalise on `/usr/local/bin/poetry run` script invocation in all relevant rockstor*.service files.
- Modify developer instructions (build.sh) to account for new poetry-plugin-dotenv.