### PR TITLE
Scheduled shutdown task fails due to type issue #2805

### DIFF
--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -294,15 +294,14 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 ).format(e.__str__())
                 handle_exception(Exception(e_msg), request)
 
-        # default has shutdown and reboot with delay set to now
-        # having normal sytem power off with now = 1 min
-        # reboot and shutdown requests from WebUI don't have request.auth
-        # while same requests over rest api (ex. scheduled tasks) have
-        # an auth token, so if we detect a token we delay with 3 mins
-        # to grant connected WebUI user to close it or cancel shutdown/reboot
-        delay = "now"
+        # Default has shutdown and reboot with delay set to "now".
+        # Reboot and shutdown requests from WebUI don't have request.auth,
+        # while same requests over rest api (e.g. scheduled tasks) have
+        # an auth token, so if we detect a token we set delay to 3 minutes
+        # to notify cli users ahead of time.
+        delay: str = "now"
         if request.auth is not None:
-            delay = 3
+            delay = "3"
 
         if command == "shutdown":
             msg = "The system will now be shutdown."

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1363,11 +1363,11 @@ def get_virtio_disk_serial(device_name):
     return out[0]
 
 
-def system_shutdown(delta="now"):
+def system_shutdown(delta: str = "now"):
     # New delta param default to now used to pass a 2 min delay
     # for scheduled tasks reboot/shutdown
     try:
-        cmd = [SHUTDOWN, "-h", delta]
+        cmd: list[str] = [SHUTDOWN, "-h", delta]
         o, e, rc = run_command(cmd)
     except CommandException as e:
         # Catch / log harmless -15 return code - command executes as expected.
@@ -1379,11 +1379,11 @@ def system_shutdown(delta="now"):
     return o, e, rc
 
 
-def system_reboot(delta="now"):
+def system_reboot(delta: str = "now"):
     # New delta param default to now used to pass a 2 min delay
     # for scheduled tasks reboot/shutdown
     try:
-        cmd = [SHUTDOWN, "-r", delta]
+        cmd: list[str] = [SHUTDOWN, "-r", delta]
         o, e, rc = run_command(cmd)
     except CommandException as e:
         # Catch / log harmless -15 return code - command executes as expected.


### PR DESCRIPTION
Add type hints to the shutdown/reboot run_command() wrapper parameters in osi.py, and to command.py's use of these wrappers. Includes fix for legacy inadvertent integer in delay during scheduled task calls.

Fixes #2805
