### PR TITLE
Change Quota Status Display Wording #2810

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/share/shares_table.jst
@@ -41,9 +41,9 @@
                 (<strong><span style="color:red">{{this.pool.mount_status}}</span></strong>)
             {{/if}}
             {{# if this.pool.quotas_enabled}}
-                Enabled
+                Quotas Enabled
             {{else}}
-                <strong><span style="color:red">Disabled</span></strong>
+                <strong><span style="color:red">Quotas Disabled</span></strong>
             {{/if}}
         </td>
         <td>


### PR DESCRIPTION
Fixes #2810.

update to shares_table.jst

Testing:
Changed wording (including Quotas to clarify what this status refers to) shows up on screen now:

![image](https://github.com/rockstor/rockstor-core/assets/35113775/2367c95c-dcfe-4373-8bf5-1fc427698779)

For good measure, also ran test suite.

```
# poetry run django-admin test -v 2

----------------------------------------------------------------------
Ran 279 tests in 46.885s

OK
```
