### PR TITLE
Unit test improvements re Disk miss-attribution to ROOT pool #2828

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ rockstor-tasks-huey.db*
 
 # Poetry error logs
 poetry-installer-error*
+/build-output.txt

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -24,6 +24,7 @@ from system.osi import (
     get_byid_name_map,
     run_command,
     replace_pattern_inline,
+    root_disk,
 )
 
 
@@ -35,9 +36,9 @@ class Pool(object):
 
 class OSITests(unittest.TestCase):
     """
-    The tests in this suite can be run via the following command:
-    cd <root dir of rockstor ie /opt/rockstor>
-    ./bin/test --settings=test-settings -v 3 -p test_osi*
+    The tests in this suite can be run via the following:
+    cd /opt/rockstor/src/rockstor
+    poetry run django-admin test -v 2 -p test_osi*
     """
 
     def setUp(self):
@@ -863,7 +864,6 @@ class OSITests(unittest.TestCase):
             )
 
     def test_scan_disks_dell_perk_h710_md1220_36_disks(self):
-
         """
         Test scan_disks() with Direct attach storage shelf (Dell MD1220).
         Test data summarized from forum member kingwavy's submission in the
@@ -2448,7 +2448,7 @@ class OSITests(unittest.TestCase):
         Thanks to forum member Jorma_Tuomainen in the following forum thread
         for supplying this instance data to be used as a regression test set.
         """
-        # Test data based on 2 data drives (sdb, sdb) and an nvme system drive
+        # Test data based on 2 data drives (sda, sdb) and an nvme system drive
         # /dev/nvme0n1 as the base device.
         out = [
             [
@@ -2589,6 +2589,729 @@ class OSITests(unittest.TestCase):
                     "returned = ({}).\n "
                     "expected = ({}).".format(returned, expected),
                 )
+
+    def test_scan_disks_root_miss_attribution(self):
+        """
+        Miss-attribution of a data drive to the ROOT pool.
+        Thanks to GitHub user ubenmackin for reporting & assisting.
+        36 drive (plus cdrom) system that fails to correctly attribute ROOT pool members:
+        - ROOT block device: /dev/sdag4 is incorrectly assigned as (root=False) but otherwise correctly as (partitions={"sdag4": "btrfs"})
+        - DATA pool whole drive member: /dev/sda labelled incorrectly as: (parted=True, root=False, partitions={"sdag4": "btrfs"}),
+        with the miss-assignments leading to a Web-UI confusion re both drives being associated with the ROOT pool!
+        TO RUN:
+        cd /opt/rockstor/src/rockstor/system/tests
+        /opt/rockstor/.venv/bin/python -m unittest test_osi.OSITests.test_scan_disks_root_miss_attribution
+        """
+        # Reproducer output:
+        # lsblk -P -o NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID
+        out = [
+            'NAME="sda" MODEL="WDC WD101EMAZ-11G7DA0" SERIAL="VCGRX3EN" SIZE="9.1T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:1:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdb" MODEL="WDC WD80EDAZ-11TA3A0" SERIAL="VDKN848K" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:3:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdc" MODEL="HUS72302CLAR2000" SERIAL="YGKU60YK" SIZE="1.8T" TRAN="sas" VENDOR="HITACHI " HCTL="0:0:0:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sdd" MODEL="WDC WD60EZRX-00MVLB1" SERIAL="WD-WX31D847K0HJ" SIZE="5.5T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:2:0" TYPE="disk" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sde" MODEL="WDC WD80EDAZ-11TA3A0" SERIAL="VDKN5U2K" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:4:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdf" MODEL="WDC WD40EZRZ-00GXCB0" SERIAL="WD-WCC7K4LZHN8U" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:5:0" TYPE="disk" FSTYPE="btrfs" LABEL="ExternalBackup" UUID="8c1423ff-78ec-4267-9d1c-e05268a60517"',  # noqa E501
+            'NAME="sdg" MODEL="ST4000VN008-2DR166" SERIAL="ZGY03QJ9" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:6:0" TYPE="disk" FSTYPE="btrfs" LABEL="ExternalBackup" UUID="8c1423ff-78ec-4267-9d1c-e05268a60517"',  # noqa E501
+            'NAME="sdh" MODEL="ST4000VN008-2DR166" SERIAL="ZGY03Q9C" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:7:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdi" MODEL="WDC WD40EZRZ-00GXCB0" SERIAL="WD-WCC7K4HJ726U" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:8:0" TYPE="disk" FSTYPE="btrfs" LABEL="ExternalBackup" UUID="8c1423ff-78ec-4267-9d1c-e05268a60517"',  # noqa E501
+            'NAME="sdj" MODEL="WDC WD80EZZX-11CSGA0" SERIAL="VK0TZU1Y" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:9:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdk" MODEL="WDC WD80EZAZ-11TDBA0" SERIAL="1EKB60VZ" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:10:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdl" MODEL="WDC WD80EDAZ-11TA3A0" SERIAL="VGH41NAG" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:11:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdm" MODEL="WDC WD80EFAX-68LHPN0" SERIAL="7SGL9JSC" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:12:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdn" MODEL="WDC WD80EFAX-68LHPN0" SERIAL="7SGJWGTC" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:13:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdo" MODEL="WDC WD80EMAZ-00WJTA0" SERIAL="2TJ0YATD" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:14:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdp" MODEL="WDC WD80EZZX-11CSGA0" SERIAL="VK0RGYTY" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:15:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sr0" MODEL="CD-ROM Drive" SERIAL="CAFEBABE" SIZE="1024M" TRAN="usb" VENDOR="PiKVM   " HCTL="13:0:0:0" TYPE="rom" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sdq" MODEL="ST10000NM0226" SERIAL="ZA22Q7W00000C8115CNQ" SIZE="9T" TRAN="sas" VENDOR="SEAGATE " HCTL="0:0:17:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sdr" MODEL="HUS72302CLAR2000" SERIAL="YGKWMWKK" SIZE="1.8T" TRAN="sas" VENDOR="HITACHI " HCTL="0:0:18:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sds" MODEL="HUS72302CLAR2000" SERIAL="YFKVTMNK" SIZE="1.8T" TRAN="sas" VENDOR="HITACHI " HCTL="0:0:19:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sdt" MODEL="HGST HUH721008ALE604" SERIAL="7SH27T6C" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:20:0" TYPE="disk" FSTYPE="btrfs" LABEL="NasBackup" UUID="03c59913-ceb6-4b2a-9a27-62707a9dd73d"',  # noqa E501
+            'NAME="sdu" MODEL="ST4000NM0043 E" SERIAL="Z1ZAY35T0000C643119P" SIZE="3.6T" TRAN="sas" VENDOR="IBM-ESXS" HCTL="0:0:21:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdv" MODEL="ST4000DM000-1F2168" SERIAL="Z300WT54" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:22:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdw" MODEL="HUS72302CLAR2000" SERIAL="YFKY4LKK" SIZE="1.8T" TRAN="sas" VENDOR="HITACHI " HCTL="0:0:23:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sdx" MODEL="WDC WD40EURX-64WRWY0" SERIAL="WD-WCC4E1746586" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:24:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdy" MODEL="HGST HDS5C4040ALE630" SERIAL="PL2331LAGGUHRJ" SIZE="3.6T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:25:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdz" MODEL="ST10000NM0226" SERIAL="ZA22YJMW0000C8022Q3X" SIZE="9T" TRAN="sas" VENDOR="SEAGATE " HCTL="0:0:26:0" TYPE="disk" FSTYPE="btrfs" LABEL="SASPool" UUID="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8"',  # noqa E501
+            'NAME="sdaa" MODEL="ST4000NM0043 E" SERIAL="Z1ZANJ6J0000R631JFMH" SIZE="3.6T" TRAN="sas" VENDOR="IBM-ESXS" HCTL="0:0:27:0" TYPE="disk" FSTYPE="btrfs" LABEL="NAS" UUID="dac090f1-48b8-40a7-b333-a9813541f09b"',  # noqa E501
+            'NAME="sdab" MODEL="HGST HUH721008ALE604" SERIAL="7SGHEMVC" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:29:0" TYPE="disk" FSTYPE="btrfs" LABEL="NasBackup" UUID="03c59913-ceb6-4b2a-9a27-62707a9dd73d"',  # noqa E501
+            'NAME="sdac" MODEL="HGST HUH721008ALE604" SERIAL="7SH26E3C" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:28:0" TYPE="disk" FSTYPE="btrfs" LABEL="ChiaPool" UUID="3effcc72-05a2-4394-b229-71042ac46956"',  # noqa E501
+            'NAME="sdad" MODEL="HGST HUH721008ALE604" SERIAL="7SGZJV0C" SIZE="7.3T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:30:0" TYPE="disk" FSTYPE="btrfs" LABEL="NasBackup" UUID="03c59913-ceb6-4b2a-9a27-62707a9dd73d"',  # noqa E501
+            'NAME="sdae" MODEL="WDC WD140EDGZ-11B2DA2" SERIAL="2CGLYKDN" SIZE="12.7T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:31:0" TYPE="disk" FSTYPE="btrfs" LABEL="StorjPool" UUID="b8e4bea0-285d-460c-a8a3-816e00b596a8"',  # noqa E501
+            'NAME="sdaf" MODEL="CT500MX500SSD1" SERIAL="1906E1E91E57" SIZE="465.8G" TRAN="sata" VENDOR="ATA     " HCTL="3:0:0:0" TYPE="disk" FSTYPE="btrfs" LABEL="SSDPool" UUID="badb1a86-f340-406d-8ee0-162e3ec71140"',  # noqa E501
+            'NAME="sdag" MODEL="PNY CS900 120GB SSD" SERIAL="PNY0520228055010CFE7" SIZE="111.8G" TRAN="sata" VENDOR="ATA     " HCTL="6:0:0:0" TYPE="disk" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sdag1" MODEL="" SERIAL="" SIZE="2M" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sdag2" MODEL="" SERIAL="" SIZE="64M" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="vfat" LABEL="EFI" UUID="A48E-EDBF"',  # noqa E501
+            'NAME="sdag3" MODEL="" SERIAL="" SIZE="2G" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="swap" LABEL="SWAP" UUID="42d2c6da-102d-49f2-948e-817a10e61370"',  # noqa E501
+            'NAME="sdag4" MODEL="" SERIAL="" SIZE="109.7G" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="btrfs" LABEL="ROOT" UUID="4ac51b0f-afeb-4946-aad1-975a2a26c941"',  # noqa E501
+            'NAME="sdah" MODEL="CT500MX500SSD1" SERIAL="1906E1E92271" SIZE="465.8G" TRAN="sata" VENDOR="ATA     " HCTL="10:0:0:0" TYPE="disk" FSTYPE="btrfs" LABEL="SSDPool" UUID="badb1a86-f340-406d-8ee0-162e3ec71140"',  # noqa E501
+            'NAME="nvme0n1" MODEL="SHGP31-1000GM-2" SERIAL="AS0BN60301030BE2O" SIZE="931.5G" TRAN="nvme" VENDOR="" HCTL="" TYPE="disk" FSTYPE="btrfs" LABEL="AppPool" UUID="2beebfa1-5ac3-4d2b-85ea-56225e0704ca"',  # noqa E501
+            "",
+        ]
+        err = [""]
+        rc = 0
+        expected_result = [
+            Disk(
+                name="nvme0n1",
+                model="SHGP31-1000GM-2",
+                serial="AS0BN60301030BE2O",
+                size=976748544,
+                transport="nvme",
+                vendor=None,
+                hctl=None,
+                type="disk",
+                fstype="btrfs",
+                label="AppPool",
+                uuid="2beebfa1-5ac3-4d2b-85ea-56225e0704ca",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sda",
+                model="WDC WD101EMAZ-11G7DA0",
+                serial="VCGRX3EN",
+                size=9771050598,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:1:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdaa",
+                model="ST4000NM0043 E",
+                serial="Z1ZANJ6J0000R631JFMH",
+                size=3865470566,
+                transport="sas",
+                vendor="IBM-ESXS",
+                hctl="0:0:27:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdab",
+                model="HGST HUH721008ALE604",
+                serial="7SGHEMVC",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:29:0",
+                type="disk",
+                fstype="btrfs",
+                label="NasBackup",
+                uuid="03c59913-ceb6-4b2a-9a27-62707a9dd73d",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdac",
+                model="HGST HUH721008ALE604",
+                serial="7SH26E3C",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:28:0",
+                type="disk",
+                fstype="btrfs",
+                label="ChiaPool",
+                uuid="3effcc72-05a2-4394-b229-71042ac46956",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdad",
+                model="HGST HUH721008ALE604",
+                serial="7SGZJV0C",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:30:0",
+                type="disk",
+                fstype="btrfs",
+                label="NasBackup",
+                uuid="03c59913-ceb6-4b2a-9a27-62707a9dd73d",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdae",
+                model="WDC WD140EDGZ-11B2DA2",
+                serial="2CGLYKDN",
+                size=13636521164,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:31:0",
+                type="disk",
+                fstype="btrfs",
+                label="StorjPool",
+                uuid="b8e4bea0-285d-460c-a8a3-816e00b596a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdaf",
+                model="CT500MX500SSD1",
+                serial="1906E1E91E57",
+                size=488426700,
+                transport="sata",
+                vendor="ATA",
+                hctl="3:0:0:0",
+                type="disk",
+                fstype="btrfs",
+                label="SSDPool",
+                uuid="badb1a86-f340-406d-8ee0-162e3ec71140",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdag4",
+                model="PNY CS900 120GB SSD",
+                serial="PNY0520228055010CFE7",
+                size=115028787,
+                transport="sata",
+                vendor="ATA",
+                hctl="6:0:0:0",
+                type="disk",
+                fstype="btrfs",
+                label="ROOT",
+                uuid="4ac51b0f-afeb-4946-aad1-975a2a26c941",
+                parted=True,
+                root=True,
+                partitions={},
+            ),
+            Disk(
+                name="sdah",
+                model="CT500MX500SSD1",
+                serial="1906E1E92271",
+                size=488426700,
+                transport="sata",
+                vendor="ATA",
+                hctl="10:0:0:0",
+                type="disk",
+                fstype="btrfs",
+                label="SSDPool",
+                uuid="badb1a86-f340-406d-8ee0-162e3ec71140",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdb",
+                model="WDC WD80EDAZ-11TA3A0",
+                serial="VDKN848K",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:3:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdc",
+                model="HUS72302CLAR2000",
+                serial="YGKU60YK",
+                size=1932735283,
+                transport="sas",
+                vendor="HITACHI",
+                hctl="0:0:0:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdd",
+                model="WDC WD60EZRX-00MVLB1",
+                serial="WD-WX31D847K0HJ",
+                size=5905580032,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:2:0",
+                type="disk",
+                fstype=None,
+                label=None,
+                uuid=None,
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sde",
+                model="WDC WD80EDAZ-11TA3A0",
+                serial="VDKN5U2K",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:4:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdf",
+                model="WDC WD40EZRZ-00GXCB0",
+                serial="WD-WCC7K4LZHN8U",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:5:0",
+                type="disk",
+                fstype="btrfs",
+                label="ExternalBackup",
+                uuid="8c1423ff-78ec-4267-9d1c-e05268a60517",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdg",
+                model="ST4000VN008-2DR166",
+                serial="ZGY03QJ9",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:6:0",
+                type="disk",
+                fstype="btrfs",
+                label="ExternalBackup",
+                uuid="8c1423ff-78ec-4267-9d1c-e05268a60517",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdh",
+                model="ST4000VN008-2DR166",
+                serial="ZGY03Q9C",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:7:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdi",
+                model="WDC WD40EZRZ-00GXCB0",
+                serial="WD-WCC7K4HJ726U",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:8:0",
+                type="disk",
+                fstype="btrfs",
+                label="ExternalBackup",
+                uuid="8c1423ff-78ec-4267-9d1c-e05268a60517",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdj",
+                model="WDC WD80EZZX-11CSGA0",
+                serial="VK0TZU1Y",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:9:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdk",
+                model="WDC WD80EZAZ-11TDBA0",
+                serial="1EKB60VZ",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:10:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdl",
+                model="WDC WD80EDAZ-11TA3A0",
+                serial="VGH41NAG",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:11:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdm",
+                model="WDC WD80EFAX-68LHPN0",
+                serial="7SGL9JSC",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:12:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdn",
+                model="WDC WD80EFAX-68LHPN0",
+                serial="7SGJWGTC",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:13:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdo",
+                model="WDC WD80EMAZ-00WJTA0",
+                serial="2TJ0YATD",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:14:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdp",
+                model="WDC WD80EZZX-11CSGA0",
+                serial="VK0RGYTY",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:15:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdq",
+                model="ST10000NM0226",
+                serial="ZA22Q7W00000C8115CNQ",
+                size=9663676416,
+                transport="sas",
+                vendor="SEAGATE",
+                hctl="0:0:17:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdr",
+                model="HUS72302CLAR2000",
+                serial="YGKWMWKK",
+                size=1932735283,
+                transport="sas",
+                vendor="HITACHI",
+                hctl="0:0:18:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sds",
+                model="HUS72302CLAR2000",
+                serial="YFKVTMNK",
+                size=1932735283,
+                transport="sas",
+                vendor="HITACHI",
+                hctl="0:0:19:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdt",
+                model="HGST HUH721008ALE604",
+                serial="7SH27T6C",
+                size=7838315315,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:20:0",
+                type="disk",
+                fstype="btrfs",
+                label="NasBackup",
+                uuid="03c59913-ceb6-4b2a-9a27-62707a9dd73d",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdu",
+                model="ST4000NM0043 E",
+                serial="Z1ZAY35T0000C643119P",
+                size=3865470566,
+                transport="sas",
+                vendor="IBM-ESXS",
+                hctl="0:0:21:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdv",
+                model="ST4000DM000-1F2168",
+                serial="Z300WT54",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:22:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdw",
+                model="HUS72302CLAR2000",
+                serial="YFKY4LKK",
+                size=1932735283,
+                transport="sas",
+                vendor="HITACHI",
+                hctl="0:0:23:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdx",
+                model="WDC WD40EURX-64WRWY0",
+                serial="WD-WCC4E1746586",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:24:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdy",
+                model="HGST HDS5C4040ALE630",
+                serial="PL2331LAGGUHRJ",
+                size=3865470566,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:25:0",
+                type="disk",
+                fstype="btrfs",
+                label="NAS",
+                uuid="dac090f1-48b8-40a7-b333-a9813541f09b",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdz",
+                model="ST10000NM0226",
+                serial="ZA22YJMW0000C8022Q3X",
+                size=9663676416,
+                transport="sas",
+                vendor="SEAGATE",
+                hctl="0:0:26:0",
+                type="disk",
+                fstype="btrfs",
+                label="SASPool",
+                uuid="b3fa44e0-0a6f-4193-a1cf-2d0f248a64a8",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+        ]
+        # As all serials are available via the lsblk we can avoid mocking
+        # get_device_serial()
+        # And given no bcache we can also avoid mocking
+        # get_bcache_device_type()
+        # We have the following root_disk discovery proven in test_root_disk() test data.
+        self.mock_root_disk.return_value = "/dev/sdag"
+        self.mock_run_command.return_value = (out, err, rc)
+        # itemgetter(0) referenced the first item within our Disk
+        # collection by which to sort (key) ie name. N.B. 'name' failed.
+        expected_result.sort(key=operator.itemgetter(0))
+        returned = scan_disks(1048576, test_mode=True)
+        returned.sort(key=operator.itemgetter(0))
+        self.maxDiff = None
+        self.assertEqual(
+            returned,
+            expected_result,
+            msg="sda data member & sdag4 ROOT member confusion regression:\n ",
+        )
+        for returned_disk, expected_disk in zip(returned, expected_result):
+            self.assertDictEqual(returned_disk, expected_disk)
+
+    def test_scan_disks_root_miss_attribution_min_reproducer(self):
+        """
+        Miss-attribution of a data drive to the ROOT pool.
+        Thanks to GitHub user ubenmackin for reporting & assisting.
+        36 drive (plus cdrom) system that fails to correctly attribute ROOT pool members:
+        - ROOT block device: /dev/sdag4 is incorrectly assigned as (root=False) but otherwise correctly as (partitions={"sdag4": "btrfs"})
+        - DATA pool whole drive member: /dev/sda labelled incorrectly as: (parted=True, root=False, partitions={"sdag4": "btrfs"}),
+        with the miss-assignments leading to a Web-UI confusion re both drives being associated with the ROOT pool!
+        TO RUN:
+        cd /opt/rockstor/src/rockstor/system/tests
+        /opt/rockstor/.venv/bin/python -m unittest test_osi.OSITests.test_scan_disks_root_miss_attribution_min_reproducer
+        """
+        # Reproducer output:
+        # lsblk -P -o NAME,MODEL,SERIAL,SIZE,TRAN,VENDOR,HCTL,TYPE,FSTYPE,LABEL,UUID
+        out = [
+            'NAME="sda" MODEL="WDC WD101EMAZ-11G7DA0" SERIAL="VCGRX3EN" SIZE="9.1T" TRAN="sas" VENDOR="ATA     " HCTL="0:0:1:0" TYPE="disk" FSTYPE="btrfs" LABEL="JBOD" UUID="b86538f8-e447-48e5-84ec-b72a25c65282"',  # noqa E501
+            'NAME="sdag" MODEL="PNY CS900 120GB SSD" SERIAL="PNY0520228055010CFE7" SIZE="111.8G" TRAN="sata" VENDOR="ATA     " HCTL="6:0:0:0" TYPE="disk" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sdag1" MODEL="" SERIAL="" SIZE="2M" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="" LABEL="" UUID=""',  # noqa E501
+            'NAME="sdag2" MODEL="" SERIAL="" SIZE="64M" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="vfat" LABEL="EFI" UUID="A48E-EDBF"',  # noqa E501
+            'NAME="sdag3" MODEL="" SERIAL="" SIZE="2G" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="swap" LABEL="SWAP" UUID="42d2c6da-102d-49f2-948e-817a10e61370"',  # noqa E501
+            'NAME="sdag4" MODEL="" SERIAL="" SIZE="109.7G" TRAN="" VENDOR="" HCTL="" TYPE="part" FSTYPE="btrfs" LABEL="ROOT" UUID="4ac51b0f-afeb-4946-aad1-975a2a26c941"',  # noqa E501
+            "",
+        ]
+        err = [""]
+        rc = 0
+        expected_result = [
+            Disk(
+                name="sda",
+                model="WDC WD101EMAZ-11G7DA0",
+                serial="VCGRX3EN",
+                size=9771050598,
+                transport="sas",
+                vendor="ATA",
+                hctl="0:0:1:0",
+                type="disk",
+                fstype="btrfs",
+                label="JBOD",
+                uuid="b86538f8-e447-48e5-84ec-b72a25c65282",
+                parted=False,
+                root=False,
+                partitions={},
+            ),
+            Disk(
+                name="sdag4",
+                model="PNY CS900 120GB SSD",
+                serial="PNY0520228055010CFE7",
+                size=115028787,
+                transport="sata",
+                vendor="ATA",
+                hctl="6:0:0:0",
+                type="disk",
+                fstype="btrfs",
+                label="ROOT",
+                uuid="4ac51b0f-afeb-4946-aad1-975a2a26c941",
+                parted=True,
+                root=True,
+                partitions={},
+            ),
+
+        ]
+        # As all serials are available via the lsblk we can avoid mocking
+        # get_device_serial()
+        # And given no bcache we can also avoid mocking
+        # get_bcache_device_type()
+        # We have the following root_disk discovery proven in test_root_disk() test data.
+        self.mock_root_disk.return_value = "/dev/sdag"
+        self.mock_run_command.return_value = (out, err, rc)
+        # itemgetter(0) referenced the first item within our Disk
+        # collection by which to sort (key) ie name. N.B. 'name' failed.
+        expected_result.sort(key=operator.itemgetter(0))
+        returned = scan_disks(1048576, test_mode=True)
+        returned.sort(key=operator.itemgetter(0))
+        self.maxDiff = None
+        self.assertEqual(
+            returned,
+            expected_result,
+            msg="sda data member & sdag4 ROOT member confusion regression:\n ",
+        )
+        for returned_disk, expected_disk in zip(returned, expected_result):
+            self.assertDictEqual(returned_disk, expected_disk)
 
     def test_get_byid_name_map_prior_command_mock(self):
         """
@@ -2852,61 +3575,61 @@ class OSITests(unittest.TestCase):
     #             mocked_open.assert_called_once_with("/proc/mounts")
     #         self.assertEqual(returned, expected[1])
     #
-    #     def test_root_disk(self):
-    #         """
-    #         test root_disk() for expected function of identifying the base device name for the
-    #         root mount point by mocking a variety of outputs from "/proc/mounts"
-    #         Test earmarked for post Python 3 move as some changes were made to how read call
-    #         is interpreted in mock re readlines() and mock_open()
-    #         https://docs.python.org/3/library/unittest.mock.html#mock-open
-    #         :param self:
-    #         :return:
-    #         """
-    #
-    #         # common SD/microSD card reader/driver device name:
-    #         proc_mount_out = [
-    #             """
-    # /dev/mmcblk1p3 / btrfs rw,noatime,compress=lzo,ssd,space_cache,subvolid=258,subvol=/@/.snapshots/1/snapshot 0 0
-    # """
-    #         ]
-    #         expected_result = ["/dev/mmcblk1"]
-    #         # nvme device:
-    #         proc_mount_out.append("""
-    # /dev/nvme0n1p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
-    # """)
-    #         expected_result.append("/dev/nvme0n1")
-    #         # md device, typically md126p3 or md0p3
-    #         proc_mount_out.append("""
-    # /dev/md126p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
-    # """)
-    #         expected_result.append("/dev/md126")
-    #         # Regular virtio device:
-    #         proc_mount_out.append("""
-    # /dev/vda3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
-    # """)
-    #         expected_result.append("/dev/vda")
-    #         # root in luks device:
-    #         proc_mount_out.append("""
-    # /dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0
-    # """)
-    #         expected_result.append("/dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7")
-    #
-    #         # Based on the following article:
-    #         # https://nickolaskraus.org/articles/how-to-mock-the-built-in-function-open/
-    #         # Python 3 has "builtins.open" note the "s"
-    #         # TODO: This mock of open is currently failing with empty reads of /proc/mounts
-    #         for proc_out, expected in zip(proc_mount_out, expected_result):
-    #             mock_open = mock.mock_open(read_data=proc_out)
-    #             with mock.patch("__builtin__.open", mock_open) as mocked_open:
-    #                 returned = root_disk()
-    #                 # We assert a single call was made on "/proc/mounts"
-    #                 mocked_open.assert_called_once_with("/proc/mounts")
-    #
-    #                 # The following shows that a handle.read().splitlines() works
-    #                 # ... but not handle.readlines() such as we use in root_disk()
-    #                 # But readlines() != splitlines() on break !!! readlines splits on \n only.
-    #                 # https://discuss.python.org/t/changing-str-splitlines-to-match-file-readlines/174
-    #             self.mocked_open.assertEqual(returned, expected)
+    def test_root_disk(self):
+        """
+        Test root_disk() for expected function of identifying the base device name for the
+        root mount point by mocking a range of builtins.open("/proc/mounts") returns.
+        """
+
+        # common SD/microSD card reader/driver device name:
+        proc_mount_out = [
+            "/dev/mmcblk1p3 / btrfs rw,noatime,compress=lzo,ssd,space_cache,subvolid=258,subvol=/@/.snapshots/1/snapshot 0 0\n"  # noqa E501
+        ]
+        expected_result = ["/dev/mmcblk1"]
+
+        # nvme device:
+        proc_mount_out.append(
+            "/dev/nvme0n1p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"
+        )
+        expected_result.append("/dev/nvme0n1")
+
+        # md device, typically md126p3 or md0p3
+        proc_mount_out.append(
+            "/dev/md126p3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"
+        )
+        expected_result.append("/dev/md126")
+
+        # Regular virtio device:
+        proc_mount_out.append(
+            "/dev/vda3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"
+        )
+        expected_result.append("/dev/vda")
+
+        # Regular scsi device:
+        proc_mount_out.append(
+            "/dev/sda3 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"
+        )
+        expected_result.append("/dev/sda")
+
+        # Large drive count scsi device
+        proc_mount_out.append(
+            "/dev/sdag4 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"
+        )
+        expected_result.append("/dev/sdag")
+
+        # root in luks device:
+        proc_mount_out.append(
+            "/dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7 / btrfs rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot 0 0\n"  # noqa E501
+        )
+        expected_result.append("/dev/mapper/luks-705349f4-becf-4344-98a7-064ceba181e7")
+
+        for proc_out, expected in zip(proc_mount_out, expected_result):
+            fake_open = mock_open(read_data=proc_out)
+            with patch("builtins.open", fake_open) as mocked_open:
+                returned = root_disk()
+                # We assert a single call to builtins.open was made using "/proc/mounts"
+                mocked_open.assert_called_once_with("/proc/mounts")
+                self.assertEqual(returned, expected)
 
     def test_run_command(self):
         self.patch_popen = patch("system.osi.subprocess.Popen")


### PR DESCRIPTION
Revive/fix prior test_root_disk() awaiting now completed Py3.11 transition. Add test data to test_root_disk() re root on sdag4 dev. Add reproducer test for ROOT on sdag4 with sda as a data pool drive, where a failure was reported to properly label the root device, and a miss-attribution of sda to the ROOT pool was reported within the Web-UI.

Includes a minimum reproducer test. The full real-system command output derived test is maintained as it represents a typical larger disk count install (36). And so may help in future assertions of intended behaviour.

Fixes #2828 