### PR TITLE
5.0.6-0 to 5.0.9-0 Configuration Backup file upload fails #2846

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -203,8 +203,11 @@ INSTALLED_APPS = (
     "huey.contrib.djhuey",
 )
 
-# STATICFILES_STORAGE = "pipeline.storage.PipelineManifestStorage"
+# https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES
 STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
     "staticfiles": {
         "BACKEND": "pipeline.storage.PipelineManifestStorage",
     },


### PR DESCRIPTION
Thanks to Hooverdan96 for diagnosing this issue. Our last major Djando update assumed a `default` STORAGES index that appears to not default to existing. Provide the `default` STORAGES config entry to appease Django and fix the consequently broken config backup file upload function.

Fixes #2846 