### PR TITLE
Leap 15.6: SFTP share error - library paths changed #2856

### DIFF
--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -28,6 +28,7 @@ MOUNT = "/usr/bin/mount"
 UMOUNT = "/usr/bin/umount"
 
 USERMOD = "/usr/sbin/usermod"
+LDD = "/usr/bin/ldd"
 
 SYSTEMCTL = "/usr/bin/systemctl"
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -2006,7 +2006,7 @@ def get_libs(program_path: str) -> list[str]:
             line_fields: list = each_line.strip().split()
             match len(line_fields):
                 case 2:
-                    if re.match("linux-vdso", each_line) is not None:
+                    if re.match("linux-vdso", line_fields[0]) is not None:
                         continue
                     else:
                         libs.append(line_fields[0])

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -45,6 +45,7 @@ from system.constants import (
     DEFAULT_MNT_DIR,
     UDEVADM,
     SHUTDOWN,
+    LDD,
 )
 
 logger = logging.getLogger(__name__)
@@ -1990,6 +1991,28 @@ def get_devname(device_name, addPath=False):
             return fields[0]
     # a non one word reply was received on the first line from udevadm or
     return None
+
+
+def get_libs(program_path: str) -> list[str]:
+    """
+    Wrapper around `ldd program_path` 
+    @param program_path: Binary to query ldd about 
+    @return: list of OS paths or empty list if error or non found.
+    """
+    libs: list[str] = []
+    out, err, rc = run_command([LDD, f"{program_path}"], throw=False)
+    if len(out) > 0 and rc == 0:
+        for each_line in out:
+            line_fields: list = each_line.strip().split()
+            match len(line_fields):
+                case 2:
+                    if re.match("linux-vdso", each_line) is not None:
+                        continue
+                    else:
+                        libs.append(line_fields[0])
+                case 4:
+                    libs.append(line_fields[2])
+    return libs
 
 
 def update_hdparm_service(hdparm_command_list, comment):

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -19,7 +19,6 @@ import collections
 import logging
 import os
 import re
-import platform
 import shutil
 import stat
 from shutil import move, copy
@@ -238,7 +237,6 @@ def rsync_for_sftp(chroot_loc):
     Dependencies retrieved via ldd.
     """
     user = chroot_loc.split("/")[-1]
-    run_command([MKDIR, "-p", f"{chroot_loc}/bin"], log=True)
     run_command([MKDIR, "-p", f"{chroot_loc}/usr/bin"], log=True)
     run_command([MKDIR, "-p", f"{chroot_loc}/lib64"], log=True)
     run_command([MKDIR, "-p", f"{chroot_loc}/usr/lib64"], log=True)

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -3918,12 +3918,12 @@ class OSITests(unittest.TestCase):
         prog = ["/usr/bin/bash"]
         out = [
             [
-                "linux-vdso.so.1 (0x00007ffcd2518000)",
-                "libreadline.so.7 => /lib64/libreadline.so.7 (0x00007f061a400000)",
-                "libdl.so.2 => /lib64/libdl.so.2 (0x00007f061aca6000)",
-                "libc.so.6 => /lib64/libc.so.6 (0x00007f061a000000)",
-                "libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f061ac75000)",
-                "/lib64/ld-linux-x86-64.so.2 (0x00007f061acb3000)",
+                "\tlinux-vdso.so.1 (0x00007ffcd2518000)",
+                "\tlibreadline.so.7 => /lib64/libreadline.so.7 (0x00007f061a400000)",
+                "\tlibdl.so.2 => /lib64/libdl.so.2 (0x00007f061aca6000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f061a000000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f061ac75000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f061acb3000)",
                 "",
             ]
         ]
@@ -3942,11 +3942,11 @@ class OSITests(unittest.TestCase):
         prog.append("/usr/bin/bash")
         out.append(
             [
-                "linux-vdso.so.1 (0x00007f1570574000)",
-                "libreadline.so.8 => /lib64/libreadline.so.8 (0x00007f1570423000)",
-                "libc.so.6 => /lib64/libc.so.6 (0x00007f1570200000)",
-                "libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f15701c5000)",
-                "/lib64/ld-linux-x86-64.so.2 (0x00007f1570576000)",
+                "\tlinux-vdso.so.1 (0x00007f1570574000)",
+                "\tlibreadline.so.8 => /lib64/libreadline.so.8 (0x00007f1570423000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f1570200000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f15701c5000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f1570576000)",
                 "",
             ]
         )
@@ -3964,11 +3964,11 @@ class OSITests(unittest.TestCase):
         prog.append("/usr/bin/bash")
         out.append(
             [
-                "linux-vdso.so.1 (0x0000ffff9085b000)",
-                "libreadline.so.8 => /lib64/libreadline.so.8 (0x0000ffff906a0000)",
-                "libc.so.6 => /lib64/libc.so.6 (0x0000ffff904e0000)",
-                "/lib/ld-linux-aarch64.so.1 (0x0000ffff9081e000)",
-                "libtinfo.so.6 => /lib64/libtinfo.so.6 (0x0000ffff90490000)",
+                "\tlinux-vdso.so.1 (0x0000ffff9085b000)",
+                "\tlibreadline.so.8 => /lib64/libreadline.so.8 (0x0000ffff906a0000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x0000ffff904e0000)",
+                "\t/lib/ld-linux-aarch64.so.1 (0x0000ffff9081e000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x0000ffff90490000)",
                 "",
             ]
         )
@@ -3986,16 +3986,16 @@ class OSITests(unittest.TestCase):
         prog.append("/usr/bin/rsync")
         out.append(
             [
-                "linux-vdso.so.1 (0x0000ffffbf6e4000)",
-                "libacl.so.1 => /lib64/libacl.so.1 (0x0000ffffbf5c0000)",
-                "libz.so.1 => /lib64/libz.so.1 (0x0000ffffbf580000)",
-                "libpopt.so.0 => /lib64/libpopt.so.0 (0x0000ffffbf550000)",
-                "liblz4.so.1 => /lib64/liblz4.so.1 (0x0000ffffbf510000)",
-                "libzstd.so.1 => /lib64/libzstd.so.1 (0x0000ffffbf450000)",
-                "libxxhash.so.0 => /lib64/libxxhash.so.0 (0x0000ffffbf420000)",
-                "libcrypto.so.3 => /lib64/libcrypto.so.3 (0x0000ffffbee00000)",
-                "libc.so.6 => /lib64/libc.so.6 (0x0000ffffbf260000)",
-                "/lib/ld-linux-aarch64.so.1 (0x0000ffffbf6a7000)",
+                "\tlinux-vdso.so.1 (0x0000ffffbf6e4000)",
+                "\tlibacl.so.1 => /lib64/libacl.so.1 (0x0000ffffbf5c0000)",
+                "\tlibz.so.1 => /lib64/libz.so.1 (0x0000ffffbf580000)",
+                "\tlibpopt.so.0 => /lib64/libpopt.so.0 (0x0000ffffbf550000)",
+                "\tliblz4.so.1 => /lib64/liblz4.so.1 (0x0000ffffbf510000)",
+                "\tlibzstd.so.1 => /lib64/libzstd.so.1 (0x0000ffffbf450000)",
+                "\tlibxxhash.so.0 => /lib64/libxxhash.so.0 (0x0000ffffbf420000)",
+                "\tlibcrypto.so.3 => /lib64/libcrypto.so.3 (0x0000ffffbee00000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x0000ffffbf260000)",
+                "\t/lib/ld-linux-aarch64.so.1 (0x0000ffffbf6a7000)",
                 "",
             ]
         )


### PR DESCRIPTION
Move to dynamic discovery of bash & rsync libraries when populating ssh / sftp share chroot.

Fixes #2856 