### PR TITLE
Leap 15.6: SFTP share error - library paths changed #2856

### DIFF
--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -28,6 +28,7 @@ MOUNT = "/usr/bin/mount"
 UMOUNT = "/usr/bin/umount"
 
 USERMOD = "/usr/sbin/usermod"
+LDD = "/usr/bin/ldd"
 
 SYSTEMCTL = "/usr/bin/systemctl"
 

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -19,7 +19,6 @@ import collections
 import logging
 import os
 import re
-import platform
 import shutil
 import stat
 from shutil import move, copy
@@ -28,7 +27,7 @@ from tempfile import mkstemp
 import distro
 from django.conf import settings
 
-from system.osi import run_command
+from system.osi import run_command, get_libs
 from system.constants import (
     MKDIR,
     MOUNT,
@@ -73,6 +72,7 @@ SSHD_CONFIG = {
     ),
 }
 
+PROGS_IN_CHROOT = ["/usr/bin/bash", "/usr/bin/rsync"]
 
 def sshd_config_opener(path, flags):
     return os.open(path, flags, mode=stat.S_IRUSR | stat.S_IWUSR)
@@ -232,75 +232,23 @@ def sftp_mount(share, mnt_prefix, sftp_mnt_prefix, mnt_map, editable="rw"):
 
 
 def rsync_for_sftp(chroot_loc):
+    """
+    Populate passed chroot_loc path with libraries sufficient for PROGS_IN_CHROOT.
+    Dependencies retrieved via ldd.
+    """
     user = chroot_loc.split("/")[-1]
-    run_command([MKDIR, "-p", "{}/bin".format(chroot_loc)], log=True)
-    run_command([MKDIR, "-p", "{}/usr/bin".format(chroot_loc)], log=True)
-    run_command([MKDIR, "-p", "{}/lib64".format(chroot_loc)], log=True)
-    run_command([MKDIR, "-p", "{}/usr/lib64".format(chroot_loc)], log=True)
+    run_command([MKDIR, "-p", f"{chroot_loc}/usr/bin"], log=True)
+    run_command([MKDIR, "-p", f"{chroot_loc}/lib64"], log=True)
+    run_command([MKDIR, "-p", f"{chroot_loc}/usr/lib64"], log=True)
 
-    copy("/bin/bash", "{}/bin".format(chroot_loc))
-    copy("/usr/bin/rsync", "{}/usr/bin".format(chroot_loc))
-
-    ld_linux_so = "/lib64/ld-linux-x86-64.so.2"
-    if platform.machine() == "aarch64":
-        ld_linux_so = "/lib64/ld-linux-aarch64.so.1"
-
-    libs_d = {
-        "rockstor": [
-            ld_linux_so,
-            "/lib64/libacl.so.1",
-            "/lib64/libattr.so.1",
-            "/lib64/libc.so.6",
-            "/lib64/libdl.so.2",
-            "/lib64/libpopt.so.0",
-            "/lib64/libtinfo.so.5",
-        ],
-        # Account for distro 1.7.0 onwards reporting "opensuse" for id in opensuse-leap.
-        "opensuse": [
-            "/lib64/libacl.so.1",
-            "/lib64/libz.so.1",
-            "/usr/lib64/libpopt.so.0",
-            "/usr/lib64/libslp.so.1",
-            "/lib64/libc.so.6",
-            "/lib64/libattr.so.1",
-            "/usr/lib64/libcrypto.so.1.1",
-            "/lib64/libpthread.so.0",
-            ld_linux_so,
-            "/lib64/libdl.so.2",
-            "/lib64/libreadline.so.7",
-            "/lib64/libtinfo.so.6",
-        ],
-        "opensuse-leap": [
-            "/lib64/libacl.so.1",
-            "/lib64/libz.so.1",
-            "/usr/lib64/libpopt.so.0",
-            "/usr/lib64/libslp.so.1",
-            "/lib64/libc.so.6",
-            "/lib64/libattr.so.1",
-            "/usr/lib64/libcrypto.so.1.1",
-            "/lib64/libpthread.so.0",
-            ld_linux_so,
-            "/lib64/libdl.so.2",
-            "/lib64/libreadline.so.7",
-            "/lib64/libtinfo.so.6",
-        ],
-        "opensuse-tumbleweed": [
-            "/lib64/libc.so.6",
-            "/usr/lib64/libacl.so.1",
-            "/lib64/libz.so.1",
-            "/usr/lib64/libpopt.so.0",
-            "/usr/lib64/libslp.so.1",
-            ld_linux_so,
-            "/usr/lib64/libcrypto.so.1.1",
-            "/lib64/libpthread.so.0",
-            "/lib64/libdl.so.2",
-            "/lib64/libreadline.so.8",
-            "/lib64/libtinfo.so.6",
-        ],
-    }
-
-    for l in libs_d[settings.OS_DISTRO_ID]:
-        copy(l, "{}{}".format(chroot_loc, l))
+    lib_list: list[str] = []
+    # Copy chroot binaries and resolve lib dependencies
+    for prog in PROGS_IN_CHROOT:
+        copy(prog, f"{chroot_loc}/usr/bin")
+        lib_list = lib_list + get_libs(prog)
+    # Copy libs for PROGS_IN_CHROOT to chroot
+    for lib in set(lib_list):
+        copy(lib, f"{chroot_loc}{lib}")
     run_command([USERMOD, "-s", "/bin/bash", user], log=True)
 
 

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -238,6 +238,7 @@ def rsync_for_sftp(chroot_loc):
     """
     user = chroot_loc.split("/")[-1]
     run_command([MKDIR, "-p", f"{chroot_loc}/usr/bin"], log=True)
+    run_command([MKDIR, "-p", f"{chroot_loc}/lib"], log=True)
     run_command([MKDIR, "-p", f"{chroot_loc}/lib64"], log=True)
     run_command([MKDIR, "-p", f"{chroot_loc}/usr/lib64"], log=True)
 

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -25,6 +25,7 @@ from system.osi import (
     run_command,
     replace_pattern_inline,
     root_disk,
+    get_libs,
 )
 
 
@@ -3905,3 +3906,117 @@ class OSITests(unittest.TestCase):
                     f"returned = {returned}.\n"
                     f"expected = {expected}.",
                 )
+
+    def test_get_libs(self):
+        """
+        Test get libs ldd wrapper.
+        TO RUN:
+        cd /opt/rockstor/src/rockstor/system/tests
+        /opt/rockstor/.venv/bin/python -m unittest test_osi.OSITests.test_get_libs
+        """
+        # Leap 15.6 x86_64 `ldd /usr/bin/bash`
+        prog = ["/usr/bin/bash"]
+        out = [
+            [
+                "\tlinux-vdso.so.1 (0x00007ffcd2518000)",
+                "\tlibreadline.so.7 => /lib64/libreadline.so.7 (0x00007f061a400000)",
+                "\tlibdl.so.2 => /lib64/libdl.so.2 (0x00007f061aca6000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f061a000000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f061ac75000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f061acb3000)",
+                "",
+            ]
+        ]
+        err = [[""]]
+        rc = [0]
+        expected_result = [
+            [
+                "/lib64/libreadline.so.7",
+                "/lib64/libdl.so.2",
+                "/lib64/libc.so.6",
+                "/lib64/libtinfo.so.6",
+                "/lib64/ld-linux-x86-64.so.2",
+            ]
+        ]
+        # Tumbleweed x86_64 `ldd /usr/bin/bash`
+        prog.append("/usr/bin/bash")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x00007f1570574000)",
+                "\tlibreadline.so.8 => /lib64/libreadline.so.8 (0x00007f1570423000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f1570200000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f15701c5000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f1570576000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libreadline.so.8",
+                "/lib64/libc.so.6",
+                "/lib64/libtinfo.so.6",
+                "/lib64/ld-linux-x86-64.so.2",
+            ]
+        )
+        # Tumbleweed aarch64 `ldd /usr/bin/bash`
+        prog.append("/usr/bin/bash")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x0000ffff9085b000)",
+                "\tlibreadline.so.8 => /lib64/libreadline.so.8 (0x0000ffff906a0000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x0000ffff904e0000)",
+                "\t/lib/ld-linux-aarch64.so.1 (0x0000ffff9081e000)",
+                "\tlibtinfo.so.6 => /lib64/libtinfo.so.6 (0x0000ffff90490000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libreadline.so.8",
+                "/lib64/libc.so.6",
+                "/lib/ld-linux-aarch64.so.1",
+                "/lib64/libtinfo.so.6",
+            ]
+        )
+        # Tumbleweed aarch64 `ldd /usr/bin/rsync`
+        prog.append("/usr/bin/rsync")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x0000ffffbf6e4000)",
+                "\tlibacl.so.1 => /lib64/libacl.so.1 (0x0000ffffbf5c0000)",
+                "\tlibz.so.1 => /lib64/libz.so.1 (0x0000ffffbf580000)",
+                "\tlibpopt.so.0 => /lib64/libpopt.so.0 (0x0000ffffbf550000)",
+                "\tliblz4.so.1 => /lib64/liblz4.so.1 (0x0000ffffbf510000)",
+                "\tlibzstd.so.1 => /lib64/libzstd.so.1 (0x0000ffffbf450000)",
+                "\tlibxxhash.so.0 => /lib64/libxxhash.so.0 (0x0000ffffbf420000)",
+                "\tlibcrypto.so.3 => /lib64/libcrypto.so.3 (0x0000ffffbee00000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x0000ffffbf260000)",
+                "\t/lib/ld-linux-aarch64.so.1 (0x0000ffffbf6a7000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libacl.so.1",
+                "/lib64/libz.so.1",
+                "/lib64/libpopt.so.0",
+                "/lib64/liblz4.so.1",
+                "/lib64/libzstd.so.1",
+                "/lib64/libxxhash.so.0",
+                "/lib64/libcrypto.so.3",
+                "/lib64/libc.so.6",
+                "/lib/ld-linux-aarch64.so.1",
+            ]
+        )
+        # p in prog is cosmetic as we mock run_command.
+        for p, o, e, r, expected in zip(prog, out, err, rc, expected_result):
+            self.mock_run_command.return_value = (o, e, r)
+            returned = get_libs(p)
+            self.maxDiff = None
+            self.assertListEqual(returned, expected)


### PR DESCRIPTION
Move to dynamic discovery of bash & rsync libraries when populating ssh / sftp share chroot. Incidental dropping of the redundant chroot `bin` dir, we now use only `/usr/bin` for both the `bash`, and `rsync` binaries.

Fixes #2856 

---
Associated development draft PR: #2857 