### PR TITLE
[t] Indicate Tailscale install requirement #2845

### DIFF
--- a/src/rockstor/system/tailscale.py
+++ b/src/rockstor/system/tailscale.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import logging
+import os.path
 import re
 import time
 from typing import List
@@ -41,6 +42,22 @@ TS_UI_SETTINGS = [
 ]
 logger = logging.getLogger(__name__)
 
+TS_NOT_INSTALLED_E_MSG = (
+    "Tailscale is NOT installed by default. "
+    "See docs How-tos & guides: `Tailscale install` "
+    "https://rockstor.com/docs/howtos/tailscale_install.html"
+)
+
+
+def tailscale_not_found(binary: str = TAILSCALE) -> OSError | None:
+    """
+    Check for TAILSCALE binary.
+    @param binary: full path expected.
+    """
+    if not os.path.isfile(binary):
+        raise FileNotFoundError
+    return None
+
 
 def tailscale_up(config: dict = None, timeout: int = None):
     """Start tailscale
@@ -49,6 +66,7 @@ def tailscale_up(config: dict = None, timeout: int = None):
     Adds the timeout flag is specified (used to generate authURL during the
     LOGIN action from the webUI).
     """
+    tailscale_not_found()
     # Construct tailscale up command
     cmd = [
         TAILSCALE,

--- a/src/rockstor/system/tests/test_tailscale.py
+++ b/src/rockstor/system/tests/test_tailscale.py
@@ -23,6 +23,7 @@ from system.tailscale import (
     tailscale_up,
     validate_ts_hostname,
     tailscale_down,
+    tailscale_not_found,
 )
 
 
@@ -30,7 +31,6 @@ class TailscaleTests(unittest.TestCase):
     """
     The tests in this suite can be run via the following command:
     cd /opt/rockstor/src/rockstor
-    export DJANGO_SETTINGS_MODULE=settings
     poetry run django-admin test -p test_tailscale.py -v 2
     """
 
@@ -49,7 +49,7 @@ class TailscaleTests(unittest.TestCase):
         params.append("--shields-up")
         expected.append("shields_up")
 
-        for (param, exp) in zip(params, expected):
+        for param, exp in zip(params, expected):
             returned = extract_param(param)
             self.assertEqual(
                 returned,
@@ -169,6 +169,10 @@ class TailscaleTests(unittest.TestCase):
         self.patch_run_command = patch("system.tailscale.run_command")
         self.mock_run_command = self.patch_run_command.start()
         self.mock_run_command.return_value = [""], [""], 0
+        # mock tailscale_not_found()
+        self.patch_tailscale_not_found = patch("system.tailscale.tailscale_not_found")
+        self.mock_tailscale_not_found = self.patch_tailscale_not_found.start()
+        self.mock_tailscale_not_found.return_value = None
 
         # enable_ip_forwarding() should not be called
         config = {"hostname": "rockdevtest", "reset": "yes", "ssh": "yes"}


### PR DESCRIPTION
Introduces `tailscale` binary os.path.isfile sensitivity to inform the associated Web-UI errors: enabling more context regarding our NOT pre-installing tailscale.

Fixes #2845 