### PR TITLE
Scrub status "unknown" - Leap 15.6 OS base #2872

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ psycopg = "~3"
 psycogreen = "==1.0"
 gevent = "*"  # can be an extra dependency to gunicorn.
 gunicorn = "*"
+packaging = "*"  # 'btrfs version' parsing.
 
 # [tool.poetry.group.tools.dependencies]
 six = "==1.16.0"  # 1.14.0 (15 Jan 2020) Python 2/3 compat lib


### PR DESCRIPTION
Adopt packaging library as a direct dependency to enable more sophisticated btrfs-progs version assessment. Previously already an indirect dependency of gunicorn. Moving to explicit dependency to avoid issues re gunicorn's deprecation in the future.

Includes
- Additional test data pertaining to Leap 15.6 and newer, re btrfs-progs version.
- Additional test data re exception handling (fail through) re non PEP 440 compliant 'btrfs-progs version' output.

Fixes #2872 