### PR TITLE
Pi4 fails on reboot #2843

### DIFF
--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -3,9 +3,11 @@ Description=Tasks required prior to starting Rockstor
 After=rockstor-build.service
 After=postgresql.service
 After=NetworkManager.service
+After=chrony-wait.service
 Requires=rockstor-build.service
 Requires=postgresql.service
 Requires=NetworkManager.service
+Wants=chrony-wait.service
 
 [Service]
 WorkingDirectory=/opt/rockstor


### PR DESCRIPTION
Add `After` and `Wants` to rockstor-pre.service to gain sensitivity to chrony-wait.service. This at least works around a prior failure in starting rockstor-pre.service on initial, and all subsequent reboots on a Pi4: non-persistent RTC (Real Time Clock).

The very first boot was successful however: thought to be related to its installer instance JeOS first-boot wizard and the context of having also to wait on rockstor-build.service (venv). Both of which modify the service startup timing considerably.

Fixes #2843 