### PR TITLE
Disk activity widget inactive - Tumbleweed #2844

### DIFF
--- a/src/rockstor/system/constants.py
+++ b/src/rockstor/system/constants.py
@@ -37,3 +37,10 @@ UDEVADM = "/usr/bin/udevadm"
 SHUTDOWN = "/sbin/shutdown"
 
 TAILSCALE = "/usr/bin/tailscale"
+
+# Major block device number:str to ignore (commonality ordered):
+# https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+# 7: Loopback
+# 11: SCSI CD-ROM
+# 2: Floppy disks
+BLOCK_DEV_EXCLUDE: list[str] = ["7", "11", "2"]

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -3585,6 +3585,31 @@ class OSITests(unittest.TestCase):
                 "sda": "wwn-0x690b11c0223db60025bb4a6c79bc0d52",
             }
         )
+        # TW 20240716 VM with virtio & SCSI disks, plus SCSI CDROM.
+        out.append(
+            [
+                "total 0",
+                "lrwxrwxrwx 1 root root 10 Jul 23 10:37 virtio-112358-part3 -> ../../vda3",
+                "lrwxrwxrwx 1 root root 10 Jul 23 10:37 virtio-112358-part2 -> ../../vda2",
+                "lrwxrwxrwx 1 root root 10 Jul 23 10:37 virtio-112358-part1 -> ../../vda1",
+                "lrwxrwxrwx 1 root root  9 Jul 23 10:37 virtio-112358 -> ../../vda",
+                "lrwxrwxrwx 1 root root  9 Jul 23 10:37 ata-QEMU_HARDDISK_QM00003 -> ../../sda",
+                "lrwxrwxrwx 1 root root  9 Jul 23 10:37 ata-QEMU_DVD-ROM_QM00001 -> ../../sr0",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            {
+                "vda3": "virtio-112358-part3",
+                "vda2": "virtio-112358-part2",
+                "vda1": "virtio-112358-part1",
+                "vda": "virtio-112358",
+                "sda": "ata-QEMU_HARDDISK_QM00003",
+                "sr0": "ata-QEMU_DVD-ROM_QM00001",
+            }
+        )
         for o, e, r, expected in zip(out, err, rc, expected_result):
             self.mock_run_command.return_value = (o, e, r)
             returned = get_byid_name_map()


### PR DESCRIPTION
Add filter to `/proc/diskstats` excluding block loopback major device 7. This avoids a failed byid_name lookup via byid_disk_map() as loop* block devices do not have byid names, and are not devices of interest.

Includes
- Additional sanity check on diskstats re ignoring < 14 columns.
- Filter out SCSI CD-ROM and Floppy disks re /proc/diskstats.
- Associated comment & TODO updates/additions.
- Minor type hint improvement.
- Updated get_byid_name_map() test data re newer kernels.

Fixes #2844 