### PR TITLE
Rockons: Invalid environment variable (...) #1588

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -807,7 +807,11 @@ RockonEnvironment = RockonCustomChoice.extend({
         }
         var env_map = {};
         var envars = this.custom_config.filter(function(cvar) {
-            env_map[cvar.get('key')] = this.$('#' + cvar.id).val();
+            co_id = cvar.get('container');
+            if(env_map[co_id] == undefined) {
+                env_map[co_id] = {};
+            }
+            env_map[co_id][cvar.get('key')] = this.$('#' + cvar.id).val();
             return cvar;
         }, this);
         this.model.set('env_map', env_map);

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -838,12 +838,18 @@ RockonInstallSummary = RockstorWizardPage.extend({
 
     render: function() {
         RockstorWizardPage.prototype.render.apply(this, arguments);
+        var container_env_map = {}
+        for (const [container, container_envs] of Object.entries(this.env_map)) {
+            for (const [env, value] of Object.entries(container_envs)) {
+                container_env_map[`${env}:container-id:${container}`] = value
+            }
+        }
         this.$('#ph-summary-table').html(this.table_template({
             share_map: this.share_map,
             port_map: this.port_map,
             cc_map: this.cc_map,
             dev_map: this.dev_map,
-            env_map: this.env_map
+            env_map: container_env_map
         }));
         return this;
     },

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -73,7 +73,6 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
     @transaction.atomic
     def post(self, request, rid, command):
         with self._handle_exception(request):
-
             if not docker_status():
                 e_msg = "Docker service is not running. Start it and try again."
                 handle_exception(Exception(e_msg), request)
@@ -107,6 +106,9 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                 dev_map = request.data.get("devices", {})
                 cc_map = request.data.get("cc", {})
                 env_map = request.data.get("environment", {})
+                logger.debug(
+                    f"install request with share_map={share_map}, port_map={port_map}, dev_map={dev_map}, cc_map={cc_map}, env_map={env_map}"
+                )
                 containers = DContainer.objects.filter(rockon=rockon)
                 for co in containers:
                     for sname in share_map.keys():

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -111,6 +111,7 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                 )
                 containers = DContainer.objects.filter(rockon=rockon)
                 for co in containers:
+                    co_id = str(co.id)
                     for sname in share_map.keys():
                         dest_dir = share_map[sname]
                         if not Share.objects.filter(name=sname).exists():
@@ -177,15 +178,16 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                         cco = DCustomConfig.objects.get(rockon=rockon, key=c)
                         cco.val = cc_map[c]
                         cco.save()
-                    for e in env_map.keys():
-                        if not DContainerEnv.objects.filter(
-                            container=co, key=e
-                        ).exists():
-                            e_msg = ("Invalid environment variable ({}).").format(e)
-                            handle_exception(Exception(e_msg), request)
-                        ceo = DContainerEnv.objects.get(container=co, key=e)
-                        ceo.val = env_map[e]
-                        ceo.save()
+                    if co_id in env_map:
+                        for e in env_map[co_id].keys():
+                            if not DContainerEnv.objects.filter(
+                                container=co, key=e
+                            ).exists():
+                                e_msg = ("Invalid environment variable ({}).").format(e)
+                                handle_exception(Exception(e_msg), request)
+                            ceo = DContainerEnv.objects.get(container=co, key=e)
+                            ceo.val = env_map[co_id][e]
+                            ceo.save()
                 task_result_handle = install(rockon.id)
                 rockon.taskid = task_result_handle.id
                 rockon.state = "pending_install"


### PR DESCRIPTION
Based on #1688 by @anatox from 2017! lightly modified for current testing branch.

Rock-on front-end install wizard does not collate container info regarding Rock-on defined `environment` elements. Affects multi-container Rock-ons only. Results in back-end failure to successfully assign user-input environmental variables. Resolve by adding a containerid dimension to the environmental matrix created by the install wizard, and updating the back-end Rock-on instantiator to take advantage of this info. Previously a reverse engineering approach was taken: which cannot work for example, where two containers, within the same Rock-on definition, use the same environmental variable name.

See Issue #1588
