### PR TITLE
Rockons: Invalid environment variable (...) #1588

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -807,7 +807,11 @@ RockonEnvironment = RockonCustomChoice.extend({
         }
         var env_map = {};
         var envars = this.custom_config.filter(function(cvar) {
-            env_map[cvar.get('key')] = this.$('#' + cvar.id).val();
+            co_id = cvar.get('container');
+            if(env_map[co_id] == undefined) {
+                env_map[co_id] = {};
+            }
+            env_map[co_id][cvar.get('key')] = this.$('#' + cvar.id).val();
             return cvar;
         }, this);
         this.model.set('env_map', env_map);
@@ -834,12 +838,18 @@ RockonInstallSummary = RockstorWizardPage.extend({
 
     render: function() {
         RockstorWizardPage.prototype.render.apply(this, arguments);
+        var container_env_map = {}
+        for (const [container, container_envs] of Object.entries(this.env_map)) {
+            for (const [env, value] of Object.entries(container_envs)) {
+                container_env_map[`${env}:container-id:${container}`] = value
+            }
+        }
         this.$('#ph-summary-table').html(this.table_template({
             share_map: this.share_map,
             port_map: this.port_map,
             cc_map: this.cc_map,
             dev_map: this.dev_map,
-            env_map: this.env_map
+            env_map: container_env_map
         }));
         return this;
     },


### PR DESCRIPTION
Rock-on front-end install wizard does not collate container info regarding Rock-on defined environment elements. Affects multi-container Rock-ons only. Results in back-end failure to successfully assign user-input environmental variables. Resolved by adding a container id dimension to the environmental matrix created by the install wizard, and updating the back-end Rock-on instantiator to take advantage of this info. Previously a reverse engineering approach was taken: which cannot work for example, where two containers, within the same Rock-on definition, use the same environmental variable name.

Thanks to GitHub user @anatox - the majority of this PR is based on their prior submission to the project - alas un-merged at the time.

Also adds
- Rock-on install debug log re front-end info received.
- Fixes, partly, resulting installer wizard summary feedback bug.

Supersedes PR #1688
Fixes #1588

---

@anatox My apologies for failing to maintain git attribution here: I did cherry pick from your original proposal (older master branch), but in sub-commit changes and this failed to maintain git attribution.