### PR TITLE
Rock-on install wizard obfuscates share container info #2886

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -622,10 +622,13 @@ RockonShareChoice = RockstorWizardPage.extend({
             this.validator.showErrors();
             return $.Deferred().reject();
         }
-
         var share_map = {};
         var volumes = this.volumes.filter(function(volume) {
-            share_map[this.$('#' + volume.id).val()] = volume.get('dest_dir');
+            co_id = volume.get('container');
+            if(share_map[co_id] === undefined ) {
+                share_map[co_id] = {};
+            }
+            share_map[co_id][this.$('#' + volume.id).val()] = volume.get('dest_dir');
             return volume;
         }, this);
         this.model.set('share_map', share_map);
@@ -838,14 +841,20 @@ RockonInstallSummary = RockstorWizardPage.extend({
 
     render: function() {
         RockstorWizardPage.prototype.render.apply(this, arguments);
-        var container_env_map = {}
+        var container_env_map = {};
         for (const [container, container_envs] of Object.entries(this.env_map)) {
             for (const [env, value] of Object.entries(container_envs)) {
                 container_env_map[`${env}:container-id:${container}`] = value
             }
         }
+        var container_share_map = {};
+        for (const [container, container_shares] of Object.entries(this.share_map)) {
+            for (const [share, value] of Object.entries(container_shares)) {
+                container_share_map[`${share}:container-id:${container}`] = value
+            }
+        }
         this.$('#ph-summary-table').html(this.table_template({
-            share_map: this.share_map,
+            share_map: container_share_map,
             port_map: this.port_map,
             cc_map: this.cc_map,
             dev_map: this.dev_map,

--- a/src/rockstor/storageadmin/views/rockon_id.py
+++ b/src/rockstor/storageadmin/views/rockon_id.py
@@ -112,19 +112,23 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                 containers = DContainer.objects.filter(rockon=rockon)
                 for co in containers:
                     co_id = str(co.id)
-                    for sname in share_map.keys():
-                        dest_dir = share_map[sname]
-                        if not Share.objects.filter(name=sname).exists():
-                            e_msg = "Invalid share ({}).".format(sname)
-                            handle_exception(Exception(e_msg), request)
-                        if DVolume.objects.filter(
-                            container=co, dest_dir=dest_dir
-                        ).exists():
-                            so = Share.objects.get(name=sname)
-                            vo = DVolume.objects.get(container=co, dest_dir=dest_dir)
-                            vo.share = so
-                            vo.save()
-                    # {'host_port' : 'container_port', ... }
+                    # share_map={'2': {'share-name1': '/etc/bareos'}, '3': {'share-name2': '/etc/bareos'}
+                    if co_id in share_map:
+                        for sname in share_map[co_id].keys():
+                            dest_dir = share_map[co_id][sname]
+                            if not Share.objects.filter(name=sname).exists():
+                                e_msg = "Invalid share ({}).".format(sname)
+                                handle_exception(Exception(e_msg), request)
+                            if DVolume.objects.filter(
+                                container=co, dest_dir=dest_dir
+                            ).exists():
+                                so = Share.objects.get(name=sname)
+                                vo = DVolume.objects.get(
+                                    container=co, dest_dir=dest_dir
+                                )
+                                vo.share = so
+                                vo.save()
+                    # port_map={'host_port': 'container_port', ... }
                     for p in port_map.keys():
                         if DPort.objects.filter(hostp=p).exists():
                             dup_po = DPort.objects.get(hostp=p)
@@ -178,6 +182,7 @@ class RockOnIdView(rfc.GenericView, NetworkMixin):
                         cco = DCustomConfig.objects.get(rockon=rockon, key=c)
                         cco.val = cc_map[c]
                         cco.save()
+                    # env_map={'85': {'PASSWORD': '***'}, '86': {'DB_ADMIN_PASSWORD': '+++', ...}, ...}
                     if co_id in env_map:
                         for e in env_map[co_id].keys():
                             if not DContainerEnv.objects.filter(


### PR DESCRIPTION
Ensure Rock-on install wizard maintains container awareness re requested Share mapping. Enabling more robust back-end Share to container volume mapping in multi-container Rock-ons.

Fixes #2886 

# Testing
Issue detailed multi-container reproducer Rock-on (in Draft PR) successfully mapped two different containers with the same internal volume mapping `/etc/bareos` to two different Shares:

## Requested Share:Volume mapping:

![Rock-on-pre-install-summary-shares](https://github.com/user-attachments/assets/1ec22c6f-26b5-4018-b4a4-6b9e1ad0ae87)

## Resulting Share:Volume mapping:

![Rock-on-installed-summary-shares](https://github.com/user-attachments/assets/45ad685a-2ba6-4fa3-94d0-9f9d0922e35f)

---

Prior to the proposed changes, both `/etc/bareos` volume mappings from the two different containers in the reproducer Rock-on were inadvertently mapped to the last Share specified against a container volume of `/etc/bareos`. As described in the linked issue.

Linking to a recent (now merged) parallel fix for Rock-on `environment` elements: #2887
