### PR TITLE
Rockon pre & post-install summaries are inconsistent #2904

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/settings_summary_table.jst
@@ -2,24 +2,24 @@
 <table class="table table-condensed table-bordered table-hover table-striped tablesorter">
 <thead>
   <tr>
-     <th>Resource type&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Type of the system resource on Rockstor. Eg: Share, port numbers etc.. Custom type is for arbitrary variables needed by the Rock-on that may not map to a system resource." rel="tooltip"></i></th>
-    <th>Name&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Name of the resource according to Rockstor. Eg: Share names, port numbers etc.." rel="tooltip"></i></th>
-    <th>Mapped representation&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Name/representation of the resource inside the Rock-on. Eg: Shares map to directories, ports map to (possibly different)ports to send traffic to the Rock-on, etc.." rel="tooltip"></i></th>
+    <th>Resource type&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Eg: Share, Port, Environmental variable etc. Custom type is for arbitrary variables needed by the Rock-on that may not map to an external resource." rel="tooltip"></i></th>
+    <th>Internal Reference&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Resource reference from inside the Rock-on/docker-containers. E.g.: internal directories, internal port numbers, Environmental variable names, etc.." rel="tooltip"></i></th>
+    <th>External Reference / Configured value&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Rockstor's reference for the given resource. E.g.: mapped Share, external Port, Environment variable value configured, etc.." rel="tooltip"></i></th>
   </tr>
 </thead>
 {{#each volumes}}
     <tr>
         <td>Share</td>
-        <td>{{this.share_name}}</td>
         <td>{{this.dest_dir}}</td>
+        <td>{{this.share_name}}</td>
     </tr>
 {{/each}}
 {{display_newVolumes}}
 {{#each ports}}
     <tr>
         <td>Port</td>
-        <td>{{this.hostp}}</td>
         <td>{{this.containerp}}{{isPublished this.id this.publish}}</td>
+        <td>{{this.hostp}}</td>
         <!--<td>{{this.containerp}}{{isPublished this.id}}</td>-->
     </tr>
 {{/each}}
@@ -37,22 +37,22 @@
 {{#each cc}}
     <tr>
         <td>Custom</td>
-        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
         <td>{{this.key}}</td>
+        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
     </tr>
 {{/each}}
 {{#each device}}
     <tr>
         <td>Device</td>
-        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
         <td>{{this.dev}}</td>
+        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
     </tr>
 {{/each}}
 {{#each env}}
     <tr>
         <td>Env</td>
-        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
         <td>{{this.key}}</td>
+        <td>{{this.val}}&nbsp;&nbsp<i class="fa fa-info-circle" title="{{this.description}}" rel="tooltip"></i></td>
     </tr>
 {{/each}}
 {{#each labels}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/summary_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/summary_table.jst
@@ -1,23 +1,23 @@
 <table class="table table-condensed table-bordered table-hover table-striped tablesorter">
 <thead>
   <tr>
-    <th>Resource type&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Type of the system resource on Rockstor. Eg: Share, port numbers etc.. Custom type is for arbitrary variables needed by the Rock-on that may not map to a system resource." rel="tooltip"></i></th>
-    <th>Name&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Name of the resource according to Rockstor. Eg: Share names, port numbers etc.." rel="tooltip"></i></th>
-    <th>Mapped representation&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Name/representation of the resource inside the Rock-on. Eg: Shares map to directories, ports map to (possibly different)ports to send traffic to the Rock-on, etc.." rel="tooltip"></i></th>
+    <th>Resource type&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Eg: Share, Port, Environmental variable etc. Custom type is for arbitrary variables needed by the Rock-on that may not map to an external resource." rel="tooltip"></i></th>
+    <th>Internal Reference&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Resource reference from inside the Rock-on/docker-containers. E.g.: internal directories, internal port numbers, Environmental variable names, etc.." rel="tooltip"></i></th>
+    <th>External Reference / Configured value&nbsp;&nbsp<i class="fa fa-info-circle fa-lg" title="Rockstor's reference for the given resource. E.g.: mapped Share, external Port, Environment variable value configured, etc.." rel="tooltip"></i></th>
   </tr>
 </thead>
   {{#each share_map}}
   <tr>
     <td>Share</td>
-    <td>{{@key}}</td>
     <td>{{this}}</td>
+    <td>{{@key}}</td>
   </tr>
   {{/each}}
   {{#each port_map}}
   <tr>
     <td>Port</td>
-    <td>{{@key}}</td>
     <td>{{this}}</td>
+    <td>{{@key}}</td>
   </tr>
   {{/each}}
   {{#each cc_map}}
@@ -30,7 +30,7 @@
   {{#each dev_map}}
   <tr>
     <td>Device</td>
-    <td>{{@dev}}</td>
+    <td>{{@key}}</td>
     <td>{{this}}</td>
   </tr>
   {{/each}}


### PR DESCRIPTION
Clarify header and mouse-over text in both associated tables. Normalise on column order (as per header) as per existing pre-install summary table.

Includes:
- Bug fix re some internal/external header-to-contents columns swapped.
- Incidental bugfix re empty internal (to Rock-on) device cell entries.

Fixes #2904

---

## Caveat

We have, post this proposal, one significant anomaly remaining.

In the first of the following summary dialog proofs (Pre install) we list for example `container-id:22` against the share name in the `External Reference / Configured value` column. It would be more appropriate to indicate this container reference against the corresponding `Internal Reference` column. And to of course resolve the id to the actual container name. However; this change is far deeper than is appropriate at this stage of our late testing phase development. And is to be addressed in due-course as we progress through itterative testing/stable phases. The main focus of this issue/PR set was to, with trivial template changes only, address confusing column switches and miss-representations only. In the same manner it would be nice to also surface container (by name) references in the final installed summaries. This, similarly, will be considered once we have addressed more pressing matters such as an update to our backbone dependencies.
