### PR TITLE
Inactive NFS export validation #2924

### DIFF
--- a/src/rockstor/storageadmin/models/nfs_export_group.py
+++ b/src/rockstor/storageadmin/models/nfs_export_group.py
@@ -28,9 +28,10 @@ class NFSExportGroup(models.Model):
     INSECURE = "insecure"
 
     """hostname string in /etc/exports"""
-    host_str = models.CharField(max_length=4096, validators=[validators.validate_nfs_host_str])
+    host_str = models.CharField(
+        max_length=4096, validators=[validators.validate_nfs_host_str]
+    )
     """mount options"""
-    """mount read only by default"""
     MODIFY_CHOICES = (
         (READ_ONLY, "ro"),
         (READ_WRITE, "rw"),
@@ -69,3 +70,4 @@ class NFSExportGroup(models.Model):
 
     class Meta:
         app_label = "storageadmin"
+        ordering = ["-id"]

--- a/src/rockstor/storageadmin/views/nfs_exports.py
+++ b/src/rockstor/storageadmin/views/nfs_exports.py
@@ -170,6 +170,7 @@ class NFSExportGroupListView(NFSExportMixin, rfc.GenericView):
 
             cur_exports = list(NFSExport.objects.all())
             eg = NFSExportGroup(**options)
+            eg.clean_fields(exclude="admin_host")
             eg.save()
             for s in shares:
                 mnt_pt = "%s%s" % (settings.MNT_PT, s.name)
@@ -237,6 +238,7 @@ class NFSExportGroupDetailView(NFSExportMixin, rfc.GenericView):
                     s, options["host_str"], request, export_id=int(export_id)
                 )
             NFSExportGroup.objects.filter(id=export_id).update(**options)
+            NFSExportGroup.objects.filter(id=export_id)[0].clean_fields(exclude="admin_host")
             NFSExportGroup.objects.filter(id=export_id)[0].save()
             cur_exports = list(NFSExport.objects.all())
             for e in NFSExport.objects.filter(export_group=eg):


### PR DESCRIPTION
Enable intended NFS model field validations during POST & PUT by calling NFSExportGroup.clean_fields() prior to model.save().

N.B. There exists a build-in `choices=` field validator that takes precedence for the fields: 'editable', and 'syncable'. So only the 'host_str' field actively exercises the custom validators. I.e. we have redundant validators for 'editable', and 'syncable'. This redundancy is not the focus of this fix: only re-enabling model field validation.

Fixes #2924 

## Includes
- Above fix regarding model field validation.
- Incidental fix for newer Django warning surfaced by recent NFS test updates: "Pagination may yield inconsistent results with an unordered object_list ...". Adds a default ordering on `id` in NFSExportGroup model.
- Remove outdated model comment regarding editable default: NFSExportGroup model
- nfs_export_group.py model definition file black re-formatted.