### PR TITLE
Remove obsolete browser compatibility - html5shim #2920

### DIFF
--- a/src/rockstor/storageadmin/templates/storageadmin/base.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/base.html
@@ -36,11 +36,6 @@
     <link href="/static/storageadmin/css/bootstrap-editable.css" rel="stylesheet"/>
     <link href="/static/js/lib/select2/4.0.3/css/select2.min.css" rel="stylesheet" />
 
-
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <script>
       /*
       *

--- a/src/rockstor/storageadmin/templates/storageadmin/login.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/login.html
@@ -31,10 +31,6 @@
     <link href="/css/bootstrap-responsive.css" rel="stylesheet">
     -->
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <script>
         /*
          *

--- a/src/rockstor/storageadmin/templates/storageadmin/setup.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/setup.html
@@ -28,10 +28,6 @@
     <link href="/static/storageadmin/css/bootstrap.min.css" rel="stylesheet">
     <link href="/static/storageadmin/css/style.css" rel="stylesheet">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <script>
       /*
       *

--- a/src/rockstor/storageadmin/templates/storageadmin/user_create.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/user_create.html
@@ -25,10 +25,6 @@
     <link href="/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="/css/style.css" rel="stylesheet">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
Remove now obsolete and dead html5.js shim load conditional on IE 6-8 client browser discovery.

Fixes #2920 