### PR TITLE
WIP_Add Django Debug Toolbar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,11 @@
 # exit on error
 set -o errexit
 
+DEV_MODE=0
+if [ "$1" = "--dev" ]; then
+    DEV_MODE=1
+fi
+
 # Install Poetry, a dependency management, packaging, and build system.
 # Uninstall legacy/transitional Poetry version of 1.1.15
 PATH="/root/.local/bin:$PATH"  # ensure legacy path.
@@ -48,7 +53,14 @@ env > poetry-install.txt
 poetry --version >> poetry-install.txt
 poetry self show plugins >> poetry-install.txt
 # /usr/local/bin/poetry -> /opt/pipx/venvs/poetry
-poetry install -vvv --no-interaction --no-ansi >> poetry-install.txt 2>&1
+
+if [ $DEV_MODE -eq 1 ]; then
+	echo "Install djdt."
+  poetry install -vvv --no-interaction --no-ansi --with dev >> poetry-install-dev.txt 2>&1
+else
+	echo "Normal install."
+  poetry install -vvv --no-interaction --no-ansi >> poetry-install.txt 2>&1
+fi
 echo
 
 # Source package version from pyproject.toml's (version = "5.0.14") via `poetry version` output:

--- a/poetry.lock
+++ b/poetry.lock
@@ -408,6 +408,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "4.4.6"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_debug_toolbar-4.4.6-py3-none-any.whl", hash = "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"},
+    {file = "django_debug_toolbar-4.4.6.tar.gz", hash = "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044"},
+]
+
+[package.dependencies]
+django = ">=4.2.9"
+sqlparse = ">=0.2"
+
+[[package]]
 name = "django-oauth-toolkit"
 version = "2.4.0"
 description = "OAuth2 Provider for Django"
@@ -1416,4 +1431,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "0c21eddc7cfacd5630b92eedc3aaf632e9ff8636a034e3f671bdd7911321836c"
+content-hash = "c77696aa47193490bc669d04c12dd14251851f45a4a238e7c233188d14d6ca3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 black = "*"
+django-debug-toolbar = "^4.4.6"
 
 [tool.poetry.scripts]
 # https://python-poetry.org/docs/pyproject#scripts

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -162,6 +162,7 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE = (
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     # New in 1.8, 1.11 newly sets Content-Length header.
     # 'django.middleware.common.CommonMiddleware',
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -200,6 +201,7 @@ INSTALLED_APPS = (
     "smart_manager",
     "oauth2_provider",
     "huey.contrib.djhuey",
+    "debug_toolbar",
 )
 
 # https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES
@@ -470,3 +472,16 @@ OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed
 # Note that the following will capture the build os version.
 # For live updates (running system) we call distro.version() directly in code.
 OS_DISTRO_VERSION = distro.version()  # 3, 15.0 ,20181107
+
+# Django Debug Toolbar-related settings and confrguration
+INTERNAL_IPS = [
+    "127.0.0.1", # It seems requests always come from this when using DRF
+]
+
+# https://django-debug-toolbar.readthedocs.io/en/stable/configuration.html
+DEBUG_TOOLBAR_CONFIG = {
+    # Update to the latest AJAX request
+    # Without this, we can only catch the initial request
+    # which is not helpful in most of our cases
+    "UPDATE_ON_FETCH": True
+}

--- a/src/rockstor/urls.py
+++ b/src/rockstor/urls.py
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 from django.urls import include, re_path
 from django.views.static import serve
 from django.conf import settings
+from debug_toolbar.toolbar import debug_toolbar_urls
 
 from smart_manager.views import (
     BaseServiceView,
@@ -149,4 +150,4 @@ urlpatterns = [
     re_path(
         r"^api/update-subscriptions/", include("storageadmin.urls.update_subscription")
     ),
-]
+] + debug_toolbar_urls()


### PR DESCRIPTION
Initial commit adding Django Debug Toolbar #2939 

- Add django-debug-toolbar package to the optional `dev` dependency group
- Add `--dev` flag to build.sh to run `poetry install` with that flag
- Add DjDTB to settings.py
- Add DjDTB urls

This pull request is created with the only purpose to illustrate what would need to be implemented to use Django Debug Toolbar.
Ideally, all changes to `settings.py` and `urls.py` would need to be scripted as well so that no manual configuration would be required.

To run this branch, first checkout, then build from source with the new `--dev` flag. For instance, I run the following:
```
cd /opt/rockstor
systemctl stop rockstor rockstor-pre rockstor-build rockstor-bootstrap postgresql && systemctl start postgresql && ./build.sh --dev && poetry run initrock && systemctl enable --now rockstor-bootstrap && poetry run debug-mode ON
```

Note that `DEBUG` must be True for the toolbar to show up.