### PR TITLE
Swap order of newVolumes representation in summary table #2933

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/rockons.js
@@ -1617,20 +1617,20 @@ RockonSettingsSummary = RockstorWizardPage.extend({
     initHandlebarHelpers: function() {
         Handlebars.registerHelper('display_newVolumes', function() {
             // Display newly-defined shares and their corresponding mapping
-            // for confimation before submit in settings_summary_table.jst
+            // for confirmation before submit in settings_summary_table.jst
             var html = '';
             for (share in this.new_volumes) {
                 html += '<tr>';
                 html += '<td>Share</td>';
-                html += '<td>' + this.new_volumes[share] + '</td>';
                 html += '<td>' + share + '</td>';
+                html += '<td>' + this.new_volumes[share] + '</td>';
                 html += '</tr>';
             }
             return new Handlebars.SafeString(html);
         });
         Handlebars.registerHelper('display_newLabels', function() {
             // Display newly-defined labels and their corresponding container
-            // for confimation before submit in settings_summary_table.jst
+            // for confirmation before submit in settings_summary_table.jst
             var html = '';
             for (new_label in this.new_labels) {
                 html += '<tr>';


### PR DESCRIPTION
Fixes #2933 
@phillxnet, @Hooverdan96, ready for review

The internal:external representation of volumes:shares in the summary table showed at the end of the Add Storage to a Rock-On process was the inverse to what it should have been (inverse of table headers). The commit in this Pull Request (PR) swaps the order in the underlying Handlebar helper used to display this in the summary table to correct this.

See linked issue for more details on the cause of the problem corrected here as well as on the testing of this PR. Briefly:

## Before this PR
The internal:external representation was swapped in the summary table displayed at the end of the "Add Storage" to an already-installed Rock-On; see below the `emby-videofiles` Share:

![PR2933_PRE_add_storage_summary](https://github.com/user-attachments/assets/ad1683d5-5c35-4cc9-b250-d984097c3f40)


## After this PR
The same process leads to the correct display of the internal:external representations:
![PR2933_POST_add_storage_summary](https://github.com/user-attachments/assets/16eb0be4-3473-438c-b003-fc6905f88855)

Clicking "Next" here and following through the procedure leads to the Rock-On being updated successfully as displayed by the new Rock-On info view:
![image](https://github.com/user-attachments/assets/cbab7b6a-f096-4f27-bfc2-12ee704e7fb6)

Inspecting the underlying docker container confirms this as well:
```
buildvm:/opt/rockstor # docker inspect embyserver
(...)
        "Mounts": [
            {
                "Type": "bind",
                "Source": "/mnt2/emby-media",
                "Destination": "/media",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
            },
            {
                "Type": "bind",
                "Source": "/mnt2/emby-videofiles",
                "Destination": "/videofiles",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
            },
            {
                "Type": "bind",
                "Source": "/etc/localtime",
                "Destination": "/etc/localtime",
                "Mode": "ro",
                "RW": false,
                "Propagation": "rprivate"
            },
            {
                "Type": "bind",
                "Source": "/mnt2/emby-conf",
                "Destination": "/config",
                "Mode": "",
                "RW": true,
                "Propagation": "rprivate"
            }
        ],
(...)
```

All tests still pass:
```
buildvm:/opt/rockstor # cd /opt/rockstor/src/rockstor/ && poetry run django-admin test ; cd /opt/rockstor
Found 295 test(s).
Creating test database for alias 'default'...
Creating test database for alias 'smart_manager'...
System check identified no issues (0 silenced).
.......................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 295 tests in 17.953s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'smart_manager'...
```


