### PR TITLE
SMB config for TimeMachine has typo #2952

### DIFF
--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -77,7 +77,7 @@ def rockstor_smb_config(fo, exports):
             fo.write("    veto files = /.{}*/\n".format(e.snapshot_prefix))
         elif e.time_machine:
             fo.write("    vfs objects = catia fruit streams_xattr\n")
-            fo.write("    fruit:timemachine = yes\n")
+            fo.write("    fruit:time machine = yes\n")
             fo.write("    fruit:metadata = stream\n")
             fo.write("    fruit:veto_appledouble = no\n")
             fo.write("    fruit:posix_rename = no\n")


### PR DESCRIPTION
There was a typo in the SMB config for time machine export:
The correct option is `fruit:time machine`

Fixes #2952

Dokumentation of SMB:
https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html

Cheers
Simon