### PR TITLE
User Pincard generation fails #2958

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/users/users.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/users/users.jst
@@ -69,7 +69,8 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-        <h4 id="myModalLabel">Pincard Generator</h4>
+        <h4 id="myModalLabel">SAVE NOW - CANNOT BE VIEWED AGAIN</h4>
+        <h5>Pincard for user <span id="pincard_user" style="font-style: italic; font-weight: bold;"></span></h5>
       </div>
       <div class="modal-body">
         <div class="messages"></div>
@@ -77,11 +78,15 @@
 		<canvas id="Pincard_canvas" width="324" height="204"></canvas>
 		</p>
 		<p style="text-align: justify; font-size: small;">
-		This is your pincard for user <span id="pincard_user" style="font-style: italic; font-weight: bold;"></span>, right click on it and save as png image.<br/>
-		Generated pincard is in <a href="https://en.wikipedia.org/wiki/ISO/IEC_7810"
-		target="_blank">ISO/IEC 7810 ID-1</a> format (mm 85.60x53.98 over a 96 dpi monitor) and 
-		can be printed or applied over an ID-1 size card.
+		<strong>Right click on image and select 'Save Image As...'.</strong>
+		<hr>
+		Pincard is in <a href="https://en.wikipedia.org/wiki/ISO/IEC_7810"
+		target="_blank">ISO/IEC 7810 ID-1</a> format (85.60x53.98mm on a 96 dpi monitor),
+		compatible with ID-1 card size.
 		</p>
+		<hr>
+		<strong>Or/and highlight and copy-paste the below text version.</strong>
+		<br/><br/>
 		<p style="text-align: justify; font-size: small; font-weight: bold;" id="pins_list"></p>
       </div>
     </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/users.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/users.js
@@ -197,7 +197,7 @@ UsersView = RockstorLayoutView.extend({
             pins_string += '</tr>';
         }
         pins_string += '</tbody></table>';
-        $('#pins_list').html('Selectable Pincard pins:<br/>' + pins_string);
+        $('#pins_list').html('Text Table Pincard variant:<br/>' + pins_string);
         $('#pincard-modal').modal({
             keyboard: false,
             show: false,
@@ -244,11 +244,11 @@ UsersView = RockstorLayoutView.extend({
                         html += '<a href="#" class="delete-user" data-username="' + filteredCollection[i].get('username') + '" rel="tooltip" title="Delete user"><i class="glyphicon glyphicon-trash"></i></a>&nbsp;';
                     }
                     if (has_pincard && pincard_allowed == 'yes') {
-                        html += '<a href="#" class="add-pincard" data-username="' + filteredCollection[i].get('username') + '" data-uid="' + filteredCollection[i].get('uid') + '" rel="tooltip" title="Pincard already present - Click to generate a new Pincard"><i class="fa fa-credit-card text-success" aria-hidden="true"></i></a>';
+                        html += '<a href="#" class="add-pincard" data-username="' + filteredCollection[i].get('username') + '" data-uid="' + filteredCollection[i].get('uid') + '" rel="tooltip" title="Pincard exists. Click to renew. ALERT: VOIDS EXISTING CARD."><i class="fa fa-credit-card text-success" aria-hidden="true"></i></a>';
                     } else {
                         switch (pincard_allowed) {
                         case 'yes':
-                            html += '<a href="#" class="add-pincard" data-username="' + filteredCollection[i].get('username') + '" data-uid="' + filteredCollection[i].get('uid') + '" rel="tooltip" title="Click to generate a new Pincard"><i class="fa fa-credit-card text-success" aria-hidden="true"></i></a>';
+                            html += '<a href="#" class="add-pincard" data-username="' + filteredCollection[i].get('username') + '" data-uid="' + filteredCollection[i].get('uid') + '" rel="tooltip" title="No Pincard exists. Click to create a password reset Pincard."><i class="fa fa-credit-card text-danger" aria-hidden="true"></i></a>';
                             break;
                         case 'otp':
                             html += '<a href="#email" rel="tooltip" title="Pincard+OTP (One Time Password) via mail required, Email Alerts not enabled, click to procede"><i class="fa fa-credit-card text-warning" aria-hidden="true"></i></a>';

--- a/src/rockstor/storageadmin/templates/storageadmin/login.html
+++ b/src/rockstor/storageadmin/templates/storageadmin/login.html
@@ -144,8 +144,8 @@
 <div class="simple-overlay" id="pincard-reset-form">
     <div style="padding: 20px">
         <h3>Welcome to Pincard Manager password reset</h3><br/>
-        <h4>From this form you're able to reset passwords for every user with Pincard enabled.<br>
-            Password reset for root user (user with UID equal to 0) requires email notifications too (One Time Password sent via mail)
+        <h4>Password reset any user with access to their current Pincard.<br>
+            Note that the 'root' user (UID 0) requires an additional password sent via the email alerts system.
         </h4><br/><br/>
 		<form class="form-inline">
 			<div class="form-group">

--- a/src/rockstor/storageadmin/views/pincard.py
+++ b/src/rockstor/storageadmin/views/pincard.py
@@ -28,24 +28,21 @@ logger = logging.getLogger(__name__)
 class PincardView(rfc.GenericView):
     @transaction.atomic
     def post(self, request, command, user):
-
         with self._handle_exception(request):
-
+            logger.debug(f"Command ({command}) received for username: ({user}).")
             if command == "create":
                 response_data = save_pincard(user)
-                logger.debug("Created new pincard for user with uid ({}).".format(user))
+                logger.debug(f"Created/Recreated pincard for username: ({user}).")
 
             if command == "reset":
                 uid = request.data.get("uid")
                 pinlist = request.data.get("pinlist")
                 reset_response, reset_status = reset_password(user, uid, pinlist)
                 response_data = {"response": reset_response, "status": reset_status}
-                logger.debug(
-                    "Received password reset request for user ({}).".format(user)
-                )
+                logger.debug(f"Processed password reset request for username ({user}).")
+                logger.debug(f"reset status: ({reset_status}).")
 
             return Response(response_data)
-        e_msg = ("Unsupported command ({}). Valid commands are create, reset.").format(
-            command
-        )
+
+        e_msg = f"Unsupported command ({command}). Valid commands are create, reset."
         handle_exception(Exception(e_msg), request)

--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -202,6 +202,7 @@ def smbpasswd(username, passwd):
     rc = p.returncode
     if rc != 0:
         raise CommandException(cmd, out, err, rc)
+    logger.info(f"Command (smbpasswd -s -a) run for username: ({username}).")
     return out, err, rc
 
 


### PR DESCRIPTION
Move associated code from Python 2.7 to 3.

Fixes #2958 

Includes:
- Adding typehints.
- User facing text refinement through-out.
- Reword/simplify Pincard Manager dialog.
- Move code comments to DocStrings.
- Use String.format.
- Add pincard icon colour flag. Green exists, red indicates no pincard exists.
- Pincard logging tweaks.
- Add info log to all smbpasswd calls.

---

Caveat: on final testing we have working `root` user and initial setup-created/webui admin user password reset.

But there remains a bug in non-webui managed user reset where-by no response is given after valid codes are entered. It is proposed that this be addressed at a later date under another issue as this is a less common scenario and does not pertain to the original issue addressed here: in that a pincode is successfully generated and presented for a non-webui-user during tests against this branch: see https://github.com/rockstor/rockstor-core/pull/2959#issuecomment-2682819549 below.