### PR TITLE
Normalise menu capitalisation #2960

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/common/navbar.jst
@@ -13,7 +13,7 @@
         <li><a href="#replication"><i class="fa fa-long-arrow-right"></i> Send</a></li>
         <li><a href="#replication-receive"><i class="fa fa-long-arrow-left"></i> Receive</a></li>
       </ul>
-      <li><span><i class="glyphicon glyphicon-share"></i> File sharing</span></li>
+      <li><span><i class="glyphicon glyphicon-share"></i> File Sharing</span></li>
       <ul style="list-style-type: none">
         <li><a href="#nfs-exports">NFS</a></li>
         <li><a href="#samba-exports">Samba</a></li>
@@ -51,9 +51,9 @@
     </a>
     <ul class="dropdown-menu">
       <li><a id="documentation_nav" href="https://rockstor.com/docs" target="_blank">Documentation</a></li>
-      <li><a href="https://forum.rockstor.com/" target="_blank">Community forum</a></li>
-      <li><a href="https://github.com/rockstor/rockstor-core/issues?state=open" target="_blank">Issue tracker</a></li>
-      <li><a href="mailto:support@rockstor.com" target="_blank">Team email</a></li>
+      <li><a href="https://forum.rockstor.com/" target="_blank">Community Forum</a></li>
+      <li><a href="https://github.com/rockstor/rockstor-core/issues?state=open" target="_blank">Issue Tracker</a></li>
+      <li><a href="mailto:support@rockstor.com" target="_blank">Support Email</a></li>
     </ul>
   </li>
   <li><a href="https://opencollective.com/the-rockstor-project" target="_blank">Open Collective</a></li>
@@ -85,17 +85,17 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-	<h3 id="shutdownModalLabel">Shutdown</h3>
+    <h3 id="shutdownModalLabel">Shutdown</h3>
       </div>
       <div class="modal-body">
-	<h4 id="message" >Graceful system shutdown is in progress. Please wait... &nbsp;&nbsp; </h4>
-	<br>
-	<div style="text-align: center">
-	  <img id="timer" src="/static/storageadmin/img/ajax-loader-big.gif">
-	  <div id="time-left"></div>
-	</div>
-	<div id="user-msg" style="display: none"><h4> Shutdown still not complete. Connect to the console for current status of the system. </h4> </div>
-	<div id="user-msg2" style="display: none"><h4> System is now shutdown.</h4></div>
+    <h4 id="message" >Graceful system shutdown is in progress. Please wait... &nbsp;&nbsp; </h4>
+    <br>
+    <div style="text-align: center">
+      <img id="timer" src="/static/storageadmin/img/ajax-loader-big.gif">
+      <div id="time-left"></div>
+    </div>
+    <div id="user-msg" style="display: none"><h4> Shutdown still not complete. Connect to the console for current status of the system. </h4> </div>
+    <div id="user-msg2" style="display: none"><h4> System is now shutdown.</h4></div>
       </div>
     </div>
   </div>
@@ -105,17 +105,17 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-	<h3 id="rebootModalLabel">Reboot</h3>
+    <h3 id="rebootModalLabel">Reboot</h3>
       </div>
       <div class="modal-body">
-	<h4 id="reboot-message" >Graceful system reboot is in progress. Please wait... &nbsp;&nbsp; </h4>
-	<br>
-	<div style="text-align: center">
-	  <img id="reboot-timer" src="/static/storageadmin/img/ajax-loader-big.gif">
-	  <div id="reboot-time-left"></div>
-	</div>
-	<div id="reboot-user-msg" style="display: none"><h4> System reboot still not complete. Connect to the console for current status of the system.</h4> </div>
-	<div id="reboot-user-msg2" style="display: none"><h3> Rockstor is now up and running. Please refresh your browser window.</h3></div>
+    <h4 id="reboot-message" >Graceful system reboot is in progress. Please wait... &nbsp;&nbsp; </h4>
+    <br>
+    <div style="text-align: center">
+      <img id="reboot-timer" src="/static/storageadmin/img/ajax-loader-big.gif">
+      <div id="reboot-time-left"></div>
+    </div>
+    <div id="reboot-user-msg" style="display: none"><h4> System reboot still not complete. Connect to the console for current status of the system.</h4> </div>
+    <div id="reboot-user-msg2" style="display: none"><h3> Rockstor is now up and running. Please refresh your browser window.</h3></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #2960 

- Adjust capitalization in Top Navigation Bar
- make indentation consistent (spaces instead of tab on some tags).

With new built (and collected statics):

<img width="121" alt="image" src="https://github.com/user-attachments/assets/6b29087d-66f0-4f22-a8cf-27de4d63cba1" /> 
<img width="120" alt="image" src="https://github.com/user-attachments/assets/63f56666-f094-4802-9814-6f59f1a915e2" />