### PR TITLE
Adapt to Slowroll os-release #2971

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -465,8 +465,8 @@ TASK_SCHEDULER = {"max_log": 100}  # max number of task log entries to keep
 # Establish our OS base id, name, and version:
 # Use id for code path decisions. Others are for Web-UI display purposes.
 # Examples given are for CentOS Rockstor variant, Leap 15, and Tumblweed.
-OS_DISTRO_ID = distro.id()  # rockstor, opensuse-leap/opensuse, opensuse-tumbleweed
-OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed
+OS_DISTRO_ID = distro.id()  # rockstor, opensuse, opensuse-slowroll, opensuse-tumbleweed
+OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed-Slowroll, openSUSE Tumbleweed
 # Note that the following will capture the build os version.
 # For live updates (running system) we call distro.version() directly in code.
-OS_DISTRO_VERSION = distro.version()  # 3, 15.0 ,20181107
+OS_DISTRO_VERSION = distro.version()  # 3, 15.6, 20250205

--- a/src/rockstor/smart_manager/views/docker_service.py
+++ b/src/rockstor/smart_manager/views/docker_service.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 DOCKERD = "/usr/bin/dockerd"
 
 # Distros for which we have had known working conf/docker-distroid.service files.
-# This mechanism has now been superseded but is maintained just-in-case for now.
-KNOWN_DISTRO_IDS = ["rockstor", "opensuse", "opensuse-tumbleweed"]
+# The docker-distroid file mechanism has now been removed, but the following is still referenced.
+KNOWN_DISTRO_IDS = ["rockstor", "opensuse", "opensuse-slowroll", "opensuse-tumbleweed"]
 
 
 class DockerServiceView(BaseServiceDetailView):

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -122,10 +122,12 @@ def rpm_build_info(pkg):
         if re.match("Buildtime", line) is not None:
             # Legacy Rockstor (using original yum):
             #     "Buildtime   : Tue Dec  5 13:34:06 2017"
-            # openSUSE Rocsktor (using dnf-yum):
+            # earlier openSUSE Rockstor (using dnf-yum):
             #     "Buildtime    : Fri 29 Nov 2019 18:34:43 GMT"
-            # we return 2017-Dec-06 or 2019-Nov-29
-            # Note the plus-one day on from retrieved Buildtime with zero padding.
+            # opensuse-tumblweed | opensuse-slowroll Rockstor (using dnf-yum):
+            #     "Buildtime    : Fri 07 Mar 2025 08:16:20 AM WET"
+            # we return 2017-Dec-06 | 2019-Nov-30 | 2025-Mar-08 respectively.
+            # Note the plus-one day on from retrieved Build time with zero padding.
             dfields = line.strip().split()
             if distro_id == "rockstor":  # CentOS based Rockstor conditional
                 dstr = dfields[6] + " " + dfields[3] + " " + dfields[4]
@@ -218,7 +220,7 @@ def switch_repo(subscription, on=True):
     # Accommodate for distro 1.7.0 onwards reporting "opensuse" for id.
     if distro_id == "opensuse-leap" or distro_id == "opensuse":
         subscription_distro_url += "/leap/{}".format(distro_version)
-    elif distro_id == "opensuse-tumbleweed":
+    elif distro_id == "opensuse-tumbleweed" or distro_id == "opensuse-slowroll":
         subscription_distro_url += "/tumbleweed"
     else:
         use_zypper = False
@@ -446,7 +448,7 @@ def update_run(subscription=None, update_all_other=False):
     # Accommodate for distro 1.7.0 onwards reporting "opensuse" for id.
     if distro_id == "opensuse-leap" or distro_id == "opensuse":
         pkg_update_all = "{} --non-interactive update --no-recommends\n".format(ZYPPER)
-    if distro_id == "opensuse-tumbleweed":
+    if distro_id == "opensuse-tumbleweed" or distro_id == "opensuse-slowroll":
         pkg_update_all = "{} --non-interactive dist-upgrade --no-recommends\n".format(
             ZYPPER
         )

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -63,6 +63,12 @@ SSHD_CONFIG = {
         AllowUsers="/etc/ssh/sshd_config",
     ),
     # Newer overload  - type files
+    "opensuse-slowroll": sshd_files(
+        sshd="/etc/ssh/sshd_config.d/rockstor-sshd.conf",
+        sshd_os="/usr/etc/ssh/sshd_config",
+        sftp="/etc/ssh/sshd_config.d/rockstor-sftp.conf",
+        AllowUsers="/etc/ssh/sshd_config.d/rockstor-AllowUsers.conf",
+    ),
     "opensuse-tumbleweed": sshd_files(
         sshd="/etc/ssh/sshd_config.d/rockstor-sshd.conf",
         sshd_os="/usr/etc/ssh/sshd_config",

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -30,7 +30,6 @@ class SystemPackageTests(unittest.TestCase):
     """
     The tests in this suite can be run via the following command:
     cd /opt/rockstor/src/rockstor
-    export DJANGO_SETTINGS_MODULE=settings
     poetry run django-admin test -p test_pkg_mgmt.py -v 2
     """
 
@@ -125,7 +124,7 @@ class SystemPackageTests(unittest.TestCase):
             Stubbed out fake pkg_changelog to allow for isolation of caller
             N.B. currenlty only uses single package test data to simply dict
             comparisons, ie recersive dict sort othewise required.
-            :param args:  
+            :param args:
             :param kwargs:
             :return: Dict indexed by name=arg[0], installed, available, and description.
             last 3 are = [] unless arg[1] is not "rockstor" then available has different
@@ -450,11 +449,47 @@ class SystemPackageTests(unittest.TestCase):
         err.append([""])
         rc.append(0)
         expected_results.append(("3.9.2-50.2093", "2019-Nov-30"))
+        # Slowroll dnf-yum
+        dist_id.append("opensuse-slowroll")
+        out.append(
+            [
+                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, groups-manager, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync, system-upgrade",
+                "YUM version: 4.18.0",
+                "cachedir: /var/cache/dnf",
+                "User-Agent: constructed: 'libdnf (openSUSE Tumbleweed-Slowroll 20250205; generic; Linux.x86_64)'",
+                "Installed Packages",
+                "Name         : rockstor",
+                "Version      : 5.0.15",
+                "Release      : 2969",
+                "Architecture : x86_64",
+                "Size         : 6.6 M",
+                "Source       : rockstor-5.0.15-2969.src.rpm",
+                "Repository   : @System",
+                "Packager     : None",
+                "Buildtime    : Fri 07 Mar 2025 08:16:20 AM WET",
+                "Install time : Fri 07 Mar 2025 08:19:21 AM WET",
+                "Summary      : Btrfs Network Attached Storage (NAS) Appliance.",
+                "URL          : https://rockstor.com/",
+                "License      : GPL-3.0-or-later AND (MIT AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND ISC)",
+                "Description  : Software raid, snapshot capable NAS solution with built-in file integrity protection.",
+                "             : Allows for file sharing between network attached devices.",
+                "",
+                "",
+            ]
+        )
+        err.append(
+            [
+                "allow_vendor_change is disabled. This option is currently not supported for downgrade and distro-sync commands",
+                "",
+            ]
+        )
+        rc.append(0)
+        expected_results.append(("5.0.15-2969", "2025-Mar-08"))
         # Source install where we key from the error message:
         dist_id.append("opensuse-tumbleweed")
         out.append(
             [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
+                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",
                 "DNF version: 4.2.6",
                 "cachedir: /var/cache/dnf",
                 "No module defaults found",


### PR DESCRIPTION
Accommodate for openSUSE Slowroll (currently beta) re our use of Python distro as an abstraction of /etc/os-release.

Fixes #2971

Includes trivial changes to:
- Docker service config/setup.
- Update repository config/setup.
- Updated test_rpm_build_info() test data.
- SSHD/SFTP config/setup.
- Comment changes only in settings.py.