### PR TITLE
Remove dnf-yum use #2979

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1173,6 +1173,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rpm"
+version = "0.4.0"
+description = "Shim RPM module for use in virtualenvs."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "rpm-0.4.0-py3-none-any.whl", hash = "sha256:0ef697cb5fb73bf9300a13d423529d7ec215239bf95c5ecb145e6610645f6067"},
+    {file = "rpm-0.4.0.tar.gz", hash = "sha256:79adbefa82318e2625d6e4fa16666cf88543498a1f2c10dc3879165d1dc3ecee"},
+]
+
+[package.extras]
+testing = ["tox"]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -1435,6 +1449,22 @@ setuptools = "*"
 docs = ["Sphinx", "furo", "repoze.sphinx.autointerface"]
 test = ["coverage[toml]", "zope.event", "zope.testing"]
 testing = ["coverage[toml]", "zope.event", "zope.testing"]
+
+[[package]]
+name = "zypper-changelog-lib"
+version = "0.7.8"
+description = "Changelogs for installable pending updates, or available/uninstalled packages"
+optional = false
+python-versions = "<4.0,>=3.11"
+files = [
+    {file = "zypper_changelog_lib-0.7.8-py3-none-any.whl", hash = "sha256:f961156c64aca2cf569945474b7ec5228734da94251fbf3fa22d2ca399280261"},
+    {file = "zypper_changelog_lib-0.7.8.tar.gz", hash = "sha256:da54a852160c3328f6543eada14e61966eccc4816f1b5753890a289b3e47aa2b"},
+]
+
+[package.dependencies]
+keyring-pass = "*"
+requests = "*"
+rpm = "*"
 
 [metadata]
 lock-version = "2.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1469,4 +1469,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "f4f0388bedabc8496d0067d679680579ab287539e12a65ff85b2fec6a63bbf35"
+content-hash = "36074fe74172638c488154ce5ab6eee6395e19c25e8b7edbf9d8b650d7c0f46e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1452,13 +1452,13 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
 [[package]]
 name = "zypper-changelog-lib"
-version = "0.7.8"
+version = "0.7.9"
 description = "Changelogs for installable pending updates, or available/uninstalled packages"
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "zypper_changelog_lib-0.7.8-py3-none-any.whl", hash = "sha256:f961156c64aca2cf569945474b7ec5228734da94251fbf3fa22d2ca399280261"},
-    {file = "zypper_changelog_lib-0.7.8.tar.gz", hash = "sha256:da54a852160c3328f6543eada14e61966eccc4816f1b5753890a289b3e47aa2b"},
+    {file = "zypper_changelog_lib-0.7.9-py3-none-any.whl", hash = "sha256:f5784eb1e93bdb9a663e9d4156f0564474c32f39b44719e0fcee591877719bce"},
+    {file = "zypper_changelog_lib-0.7.9.tar.gz", hash = "sha256:f1a601a7607c190241d741db0c21ec9857b937c92786068c333c352aacd53535"},
 ]
 
 [package.dependencies]
@@ -1469,4 +1469,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "36074fe74172638c488154ce5ab6eee6395e19c25e8b7edbf9d8b650d7c0f46e"
+content-hash = "023bf7a6e3812880ed0a031dd18ecc1612a65bc8f34e76910f264be77f2d3198"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ pyzmq = "*"
 distro = "*"
 URLObject = "==2.1.1"
 keyring-pass = "*"
+zypper-changelog-lib = "0.7.8"
 # https://pypi.org/project/supervisor/ 4.1.0 onwards embeds unmaintained meld3
 supervisor = "==4.2.4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ pyzmq = "*"
 distro = "*"
 URLObject = "==2.1.1"
 keyring-pass = "*"
-zypper-changelog-lib = "0.7.8"
+zypper-changelog-lib = "0.7.9"
+# zypper-changelog-lib = {path = "/path/zypper-changelog-lib/dist/zypper_changelog_lib-0.7.9-py3-none-any.whl"}
 # https://pypi.org/project/supervisor/ 4.1.0 onwards embeds unmaintained meld3
 supervisor = "==4.2.4"
 

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -306,6 +306,11 @@ LOGGING = {
             "level": LOG_LEVEL,
             "propagate": True,
         },
+        "zypper_changelog_lib": {
+            "handlers": ["file"],
+            "level": LOG_LEVEL,
+            "propagate": True,
+        },
     },
 }
 

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -63,7 +63,7 @@ from storageadmin.models import Disk, Pool  # noqa E402
 from smart_manager.models import Service  # noqa E402
 from system.services import service_status  # noqa E402
 from cli.api_wrapper import APIWrapper  # noqa E402
-from system.pkg_mgmt import rockstor_pkg_update_check, pkg_update_check  # noqa E402
+from system.pkg_mgmt import rockstor_pkg_update_check, pkg_updates_info  # noqa E402
 import distro
 import logging  # noqa E402
 
@@ -1025,7 +1025,7 @@ class SysinfoNamespace(RockstorIO):
     def yum_updates(self):
 
         while self.start:
-            packages = pkg_update_check()
+            packages = pkg_updates_info()
             data = {}
             if packages:  # Non empty lists are True.
                 data["yum_updates"] = True

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -1025,6 +1025,7 @@ class SysinfoNamespace(RockstorIO):
     def yum_updates(self):
 
         while self.start:
+            gevent.sleep(1)  # Hack to avoid zypper toes of rockstor_pkg_update_check()
             packages = pkg_updates_info()
             data = {}
             if packages:  # Non empty lists are True.

--- a/src/rockstor/smart_manager/views/smartd_service.py
+++ b/src/rockstor/smart_manager/views/smartd_service.py
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework.response import Response
 from system.services import systemctl
-from system.pkg_mgmt import install_pkg
 from django.db import transaction
 from smart_manager.views.base_service import BaseServiceDetailView
 import os
@@ -42,7 +41,8 @@ class SMARTDServiceView(BaseServiceDetailView):
         e_msg = "Failed to %s S.M.A.R.T service due to system error." % command
         with self._handle_exception(request, e_msg):
             if not os.path.exists(SMART):
-                install_pkg("smartmontools")
+                logger.info(f"{SMART} binary not found: try `zypper in smartmontools`")
+                raise Exception
             if command == "config":
                 service = Service.objects.get(name=self.service_name)
                 config = request.data.get("config", {})

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -30,7 +30,7 @@ $(document).ready(function(){
         <a href="https://rockstor.com/docs/update-channels/update_channels.html" target="_blank"> update channels. </a>
         Please activate appropriately for your needs.
         <br>- <strong>Stable updates</strong>: recommended for production use (paid) -
-        <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support</i></a> eligible.
+        <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a> eligible.
         <br>- <strong>Testing updates</strong>: for development / actively testing latest code (free).
         <br>See our <a href="https://forum.rockstor.com/" target="_blank">friendly forum</a> for advise.
       </p>
@@ -140,7 +140,7 @@ $(document).ready(function(){
       , and
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates </a>
       subscriptions with their associated
-      <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support</i></a> option.
+      <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a> option.
     </h4>
   </div>
   {{/is_sub_active}}
@@ -169,7 +169,7 @@ $(document).ready(function(){
     <p>
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
       are <strong>activated</strong> - install eligible for
-      <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support.</i></a>
+      <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support.</i></a>
       <br><br>
       While it's not recommended, if you are absolutely sure,
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -114,7 +114,7 @@ $(document).ready(function(){
 <br><br>
 <div class="col-sm-offset-2 col-sm-8 col-sm-offset-2">
   <div id="changeSection">
-    <p>List of changes in this update</p>
+    <p>List of changes in this update (try page reload if empty)</p>
     <ul>
       {{#each changeMap}}
       <li><p>{{this}}</p></li>

--- a/src/rockstor/storageadmin/util.py
+++ b/src/rockstor/storageadmin/util.py
@@ -23,8 +23,9 @@ logger = logging.getLogger(__name__)
 
 # module level variable so it's computed once per process.
 version = "unknown"
+build_date = None
 try:
-    version = current_version()
+    version, build_date = current_version()
 except Exception as e:
     logger.exception(e)
 

--- a/src/rockstor/storageadmin/util.py
+++ b/src/rockstor/storageadmin/util.py
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 from storageadmin.exceptions import RockStorAPIException
-from system.pkg_mgmt import rpm_build_info
+from system.pkg_mgmt import current_version
 import traceback
 import logging
 
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # module level variable so it's computed once per process.
 version = "unknown"
 try:
-    version, date = rpm_build_info("rockstor")
+    version = current_version()
 except Exception as e:
     logger.exception(e)
 
@@ -42,7 +42,7 @@ def handle_exception(e, request, e_msg=None, status_code=500):
         e_msg = e.__str__()
 
     logger.exception("Exception: {}".format(e.__str__()))
-    logger.debug("Current Rockstor version: {}".format(version))
+    logger.debug(f"Current Rockstor version: {version}")
     raise RockStorAPIException(
         status_code=status_code, detail=e_msg, trace=traceback.format_exc()
     )

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -247,7 +247,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "update-check":
             try:
-                subo = None
+                subo: None | UpdateSubscription = None
                 try:
                     subo = UpdateSubscription.objects.get(
                         name="Stable", status="active"

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -286,7 +286,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "current-version":
             try:
-                return Response(current_version())
+                return Response(current_version()[0])
             except Exception as e:
                 e_msg = (
                     "Unable to check current version due to this exception: ({})."

--- a/src/rockstor/storageadmin/views/home.py
+++ b/src/rockstor/storageadmin/views/home.py
@@ -64,16 +64,12 @@ def home(request):
         "page_size": settings.REST_FRAMEWORK["PAGE_SIZE"],
         "update_channel": update_channel,
     }
-    logger.debug("context={}".format(context))
     if request.user.is_authenticated:
-        logger.debug("ABOUT TO RENDER INDEX")
         return render(request, "index.html", context)
     else:
         if setup.setup_user:
-            logger.debug("ABOUT TO RENDER LOGIN")
             return render(request, "login.html", context)
         else:
-            logger.debug("ABOUT TO RENDER SETUP")
             return render(request, "setup.html", context)
 
 

--- a/src/rockstor/storageadmin/views/update_subscription.py
+++ b/src/rockstor/storageadmin/views/update_subscription.py
@@ -43,7 +43,7 @@ class UpdateSubscriptionListView(rfc.GenericView):
             offo = UpdateSubscription.objects.get(name=fcd["name"])
             offo.status = "inactive"
             offo.save()
-            switch_repo(offo, on=False)
+            switch_repo(offo, enable_repo=False)
         except UpdateSubscription.DoesNotExist:
             pass
 

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -341,7 +341,7 @@ def scan_disks(min_size: int, test_mode: bool = False) -> list[Disk]:
             )
             for key, value in zip(line[::2], line[1::2])
         }
-        logger.debug(f"Scan_disks() using: blk_dev_properties={blk_dev_properties}")
+        # logger.debug(f"Scan_disks() using: blk_dev_properties={blk_dev_properties}")
         # Disk namedtuple from lsblk line dictionary.
         dev: Disk = Disk(**blk_dev_properties)
         # Set up our line / dev dependant variables.
@@ -409,9 +409,9 @@ def scan_disks(min_size: int, test_mode: bool = False) -> list[Disk]:
                 base_dev_pattern = dname[5:] + pattern
                 # str[5:] strips "/dev/" from our full path names.
                 if re.fullmatch(base_dev_pattern, dev.name[5:], re.ASCII) is not None:
-                    logger.debug(
-                        f"({dname}) is parent of partition ({dev.name}): backporting info to parent."
-                    )
+                    # logger.debug(
+                    #     f"({dname}) is parent of partition ({dev.name}): backporting info to parent."
+                    # )
                     # Our partition device name has a base/parent device entry of interest saved.
                     # I.e. we have scanned and saved sdb previously, but we are now looking at sdb3.
                     # Update our base dev's entry in dnames accordingly. Informs DB Disk.role related mechanisms.

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -224,13 +224,16 @@ def remove_rockstor_repo(
                 cmd_list,
                 capture_output=False,
                 timeout=max_wait,
-                check=True,  # rc = 7 when zypper locked.
+                check=True,
             )
         except CalledProcessError as e:
+            if e.returncode in zypp_info_codes.keys():
+                logger.info(f"Remove repo returned {zypp_info_codes[e.returncode]}.")
+                return True
             if e.returncode != ZYPPER_EXIT_ZYPP_LOCKED:
                 logger.error(f"Error removing Rockstor-* repositories: {e}")
                 raise CommandException(cmd_list, e.stdout, e.stderr, e.returncode)
-            if attempt < retries - 1:
+            if attempt <= retries:
                 logger.info(f"--- Zypper locked: attempt {attempt +1}, retrying in 1s.")
                 sleep(1)
                 continue  # retry on zypper locked.

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -523,12 +523,9 @@ def pkg_latest_available(pkg_name, arch, distro_id):
     :return:
     """
     new_version = None
-    # TODO: We might use "zypper se -s --match-exact rockstor" and parse first
-    #  line with rockstor in second column but unit test will be defunct.
-    #  Advantage: works with no rockstor version installed, no so dnf-yum
-    # Add quite & XML output: zypper --quiet --xmlout se -s --match-exact rockstor
-    # Maybe https://github.com/martinblech/xmltodict via pip install xmltodict
-    # Or
+    # Legacy YUM/DNF path: scheduled for deprecation/removal after 5.1.0-0
+    # Deprecated by RPM & zypper only path in rockstor_pkg_update_check(),
+    # which uses zypper-changelog-lib, and recent improvements in rpm_build_info().
     o, e, rc = run_command([YUM, "update", pkg_name, "--assumeno"], throw=False)
     if rc == 1:
         for line in o:

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -575,6 +575,9 @@ def pkg_updates_info(max_wait: int = 15) -> typing.List[dict[str:str]]:
             # "repo_alias": update.find("source").get("alias")
         }
         if pkg_info["name"] == "rockstor":
-            continue  # See: rockstor_pkg_update_check()
+            pkg_info["description"] = (
+                "-- See: 'SYSTEM -> Software Update' to apply --.\n"
+                + pkg_info["description"]
+            )
         updates_info.append(pkg_info)
     return updates_info

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -107,7 +107,9 @@ def current_version(get_build_date: bool = False) -> (str, str | None):
     # 'Version-Release' (first line)
     # 'Thu May 01 2025' (second line)
     tags = "%{VERSION}\-%{RELEASE}\\\n%{BUILDTIME:day}"
-    out, err, rc = run_command([RPM, "-q", "--queryformat", tags, "rockstor"], throw=False)
+    out, err, rc = run_command(
+        [RPM, "-q", "--queryformat", tags, "rockstor"], throw=False
+    )
     if rc != 0:  # Not installed is rc=1
         return "0.0.0-0", None
     date_list = []
@@ -116,7 +118,9 @@ def current_version(get_build_date: bool = False) -> (str, str | None):
             # we get on second line: "Thu May 01 2025" we want 2025-May-01
             date_list = out[1].split()[1:]  # ["May",  "01",  "2025"]
         except Exception as e:
-            logger.debug(f"failed to parse build date from 'rpm -qi rockstor`: {e.__str__}")
+            logger.debug(
+                f"failed to parse build date from 'rpm -qi rockstor`: {e.__str__}"
+            )
             return out[0].strip(), None
         return out[0].strip(), f"{date_list[2]}-{date_list[0]}-{date_list[1]}"
     return out[0].strip(), None
@@ -693,7 +697,7 @@ def pkg_update_check():
     return packages
 
 
-def pkg_updates_info(max_wait: int = 14) -> typing.List[dict[str : str]]:
+def pkg_updates_info(max_wait: int = 15) -> typing.List[dict[str:str]]:
     """
     Fetch info on installable updates across all repos via zypper xml output call.
     Resolves as per 'zypper up' excluding packages with dependency problems.
@@ -706,7 +710,7 @@ def pkg_updates_info(max_wait: int = 14) -> typing.List[dict[str : str]]:
     """
     # Proposed output:
     # [ {'name': 'binutils', available': '2.43-6.1', 'installed': '2.43-5.2', 'description': 'C compiler ...'}, ...]
-    updates_info: typing.List[dict[str : str]] = []
+    updates_info: typing.List[dict[str:str]] = []
     try:
         # rc = 1 when out = "package * is not installed"
         zypp_run = run(
@@ -737,6 +741,6 @@ def pkg_updates_info(max_wait: int = 14) -> typing.List[dict[str : str]]:
             # "repo_alias": update.find("source").get("alias")
         }
         if pkg_info["name"] == "rockstor":
-            continue
+            continue  # See: rockstor_pkg_update_check()
         updates_info.append(pkg_info)
     return updates_info

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -103,7 +103,7 @@ def current_version(get_build_date: bool = False) -> (str, str | None):
     # The following tags gives us a pre-formatted:
     # 'Version-Release' (first line)
     # 'Thu May 01 2025' (second line)
-    tags = "%{VERSION}\-%{RELEASE}\n%{BUILDTIME:day}"
+    tags = "%{VERSION}\-%{RELEASE}\\\n%{BUILDTIME:day}"
     out, err, rc = run_command([RPM, "-q", "--queryformat", tags, "rockstor"], throw=False)
     if rc != 0:  # Not installed is rc=1
         return "0.0.0-0", None
@@ -115,7 +115,8 @@ def current_version(get_build_date: bool = False) -> (str, str | None):
         except Exception as e:
             logger.debug(f"failed to parse build date from 'rpm -qi rockstor`: {e.__str__}")
             return out[0].strip(), None
-    return out[0].strip(), f"{date_list[2]}-{date_list[0]}-{date_list[1]}"
+        return out[0].strip(), f"{date_list[2]}-{date_list[0]}-{date_list[1]}"
+    return out[0].strip(), None
 
 
 def rpm_build_info(pkg: str) -> tuple[str, str | None]:

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -178,6 +178,8 @@ def zypper_repos_list(max_wait: int = 1) -> typing.List[str]:
             check=True,
         )
     except CalledProcessError as e:
+        if e.returncode in zypp_info_codes.keys():
+            logger.info(f"list repos returned {zypp_info_codes[e.returncode]}.")
         if e.returncode != ZYPPER_EXIT_ERR_INVALID_ARGS:
             logger.error(f"{e.stdout}Error fetching repository list: ({e})")
             return []

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -50,6 +50,7 @@ STABLE_CREDENTIALS_FILE = "/etc/zypp/credentials.d/Rockstor-Stable"
 # Zypper return codes:
 ZYPPER_EXIT_ERR_INVALID_ARGS = 3
 ZYPPER_EXIT_ZYPP_LOCKED = 7
+ZYPPER_EXIT_INF_REPOS_SKIPPED = 106
 
 
 def auto_update(enable=True):
@@ -514,6 +515,7 @@ def pkg_updates_info(max_wait: int = 15) -> typing.List[dict[str:str]]:
             check=True,
         )
     except CalledProcessError as e:
+        # TODO: Catch and ignore ZYPPER_EXIT_INF_REPOS_SKIPPED
         logger.error(f"Error fetching updates: {e}")
         return updates_info
     except TimeoutExpired as e:

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+import typing
 import unittest
 from unittest.mock import patch
 
@@ -37,6 +38,8 @@ class SystemPackageTests(unittest.TestCase):
     """
 
     def setUp(self):
+        # Avoid default of first Docstring in verbose mode
+        unittest.TestCase.shortDescription = lambda x: None
         self.patch_run_command = patch("system.pkg_mgmt.run_command")
         self.mock_run_command = self.patch_run_command.start()
 
@@ -262,23 +265,23 @@ class SystemPackageTests(unittest.TestCase):
                 "expected = ({}).".format(returned, expected),
             )
 
-#     @patch("system.pkg_mgmt.subprocess.run")
-#     def test_pkg_updates_info(self, mock_subproc_run):
-          # No updates available:
-#         run_out = [
-#             """<?xml version='1.0'?>
-# <stream>
-# <message type="info">Loading repository data...</message>
-# <message type="info">Reading installed packages...</message>
-# <update-status version="0.6">
-# <update-list>
-# </update-list>
-# </update-status>
-# </stream>"""
-#         ]
-#
-#         # Need mocking setup for subprocess.run
-#         returned = pkg_updates_info()
+    #     @patch("system.pkg_mgmt.subprocess.run")
+    #     def test_pkg_updates_info(self, mock_subproc_run):
+    # No updates available:
+    #         run_out = [
+    #             """<?xml version='1.0'?>
+    # <stream>
+    # <message type="info">Loading repository data...</message>
+    # <message type="info">Reading installed packages...</message>
+    # <update-status version="0.6">
+    # <update-list>
+    # </update-list>
+    # </update-status>
+    # </stream>"""
+    #         ]
+    #
+    #         # Need mocking setup for subprocess.run
+    #         returned = pkg_updates_info()
 
     def test_zypper_repos_list(self):
         # Test empty return values

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -20,13 +20,8 @@ import unittest
 from unittest.mock import patch
 
 from system.pkg_mgmt import (
-    pkg_update_check,
-    pkg_changelog,
-    zypper_repos_list_legacy,
     rpm_build_info,
-    pkg_latest_available,
     current_version,
-    pkg_updates_info,
 )
 
 
@@ -48,225 +43,11 @@ class SystemPackageTests(unittest.TestCase):
         self.patch_distro = patch("system.pkg_mgmt.distro")
         self.mock_distro = self.patch_distro.start()
 
-        # Mock pkg_infos to return "" to simplify higher level testing.
-        self.patch_pkg_infos = patch("system.pkg_mgmt.pkg_infos")
-        self.mock_pkg_infos = self.patch_pkg_infos.start()
-        self.mock_pkg_infos.return_value = ""
-
     def tearDown(self):
         patch.stopall()
 
-    def test_pkg_changelog(self):
-        """
-        Test pkg_changelog, a package changelog (including update changes)
-        parser and presenter
-        :return:
-        """
-        pass
-        # Example output from "yum changelog 1 sos.noarch" such as is executed
-        # in pkg_changelog()
-        # out = [
-        #     [
-        #         "==================== Installed Packages ====================",  # noqa E501
-        #         "sos-3.6-17.el7.centos.noarch             installed",  # noqa E501
-        #         "* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos",  # noqa E501
-        #         "- Roll in CentOS Branding",  # noqa E501
-        #         ""  # noqa E501
-        #         "==================== Available Packages ====================",  # noqa E501
-        #         "sos-3.7-6.el7.centos.noarch              updates",  # noqa E501
-        #         "* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos",  # noqa E501
-        #         "- Roll in CentOS Branding",  # noqa E501
-        #         "",  # noqa E501
-        #         "changelog stats. 2 pkgs, 2 source pkgs, 2 changelogs",  # noqa E501
-        #         "",  # noqa E501
-        #     ]
-        # ]
-        # err = [[""]]
-        # rc = [0]
-        # expected_results = [
-        #     {
-        #         "available": "sos-3.7-6.el7.centos.noarch              updates[line]* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-        #         "description": "",
-        #         "name": "fake",
-        #         "installed": "sos-3.6-17.el7.centos.noarch             installed[line]* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-        #     }
-        # ]
-        # distro_id = ["rockstor"]
-        #
-        # TODO: add openSUSE Leap example output. But currently exactly the same
-        #  command but no available is listed as yum knows only rockstor repos.
-        #
-        # for o, e, r, expected, distro in zip(out, err, rc, expected_results, distro_id):
-        #     self.mock_run_command.return_value = (o, e, r)
-        #     returned = pkg_changelog("fake.123", distro)
-        #     self.assertEqual(
-        #         returned,
-        #         expected,
-        #         msg="Un-expected pkg_changelog() result:\n "
-        #         "returned = ({}).\n "
-        #         "expected = ({}).".format(returned, expected),
-        #     )
-
-    def test_pkg_update_check(self):
-        """
-        N.B. to be superseded by pkg_updates_info()
-        Test pkg_update_check() across distro.id values and consequently different
-        output format of:
-        distro.id = "opensuse" N.B. this was "opensuse-leap" in distro <= 1.6.0
-        zypper -q list-updates
-        and:
-        distro.id = "opensuse-tumbleweed"
-        same command as for "opensuse"
-        """
-        # Mock pkg_changelog to allow for isolated testing of yum_check
-        # Only pertains to legacy YUM/DNF targets
-        self.patch_pkg_changelog = patch("system.pkg_mgmt.pkg_changelog")
-        self.mock_pkg_changelog = self.patch_pkg_changelog.start()
-        # TODO:
-
-        def fake_pkg_changelog(*args, **kwargs):
-            """
-            Stubbed out fake pkg_changelog to allow for isolation of caller
-            N.B. currenlty only uses single package test data to simply dict
-            comparisons, ie recersive dict sort othewise required.
-            :param args:
-            :param kwargs:
-            :return: Dict indexed by name=arg[0], installed, available, and description.
-            last 3 are = [] unless arg[1] is not "rockstor" then available has different
-            content.
-            """
-            pkg_info = {"name": args[0].split(".")[0]}
-            pkg_info["installed"] = ""
-            pkg_info["available"] = ""
-            if args[1] != "rockstor":
-                pkg_info["available"] = (
-                    "Version and changelog of update not available in openSUSE"
-                )
-            pkg_info["description"] = ""
-            return pkg_info
-
-        self.mock_pkg_changelog.side_effect = fake_pkg_changelog
-
-        # TODO: We need more example here of un-happy paths
-        # zypper spaces in Repository name Example,
-        out = [
-            [
-                "S | Repository             | Name                    | Current Version                       | Available Version                     | Arch  ",  # noqa E501
-                "--+------------------------+-------------------------+---------------------------------------+---------------------------------------+-------",  # noqa E501
-                "v | Main Update Repository | aaa_base                | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.6.1 | x86_64",  # noqa E501
-                "",
-            ]
-        ]
-        expected_result = [
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base",
-                    "installed": "",
-                }
-            ]
-        ]
-        err = [[""]]
-        rc = [0]
-        dist_id = ["opensuse"]
-        #
-        # zypper no spaces in Repository name Example,
-        # actual Leap 15.0 but no-space repos also seen in other openSUSE variants.
-        out.append(
-            [
-                "S | Repository                | Name                            | Current Version                             | Available Version                           | Arch",  # noqa E501
-                "--+---------------------------+---------------------------------+---------------------------------------------+---------------------------------------------+-------",  # noqa E501
-                "v | openSUSE-Leap-15.0-Update | NetworkManager                  | 1.10.6-lp150.4.6.1                          | 1.10.6-lp150.4.9.1                          | x86_64",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "NetworkManager",
-                    "installed": "",
-                }
-            ]
-        )
-        err.append([""])
-        rc.append(0)
-        dist_id.append("opensuse")
-        #
-        # When we have a poorly repo.
-        #     '/usr/bin/zypper', '--non-interactive', '-q', 'list-updates']
-        out.append(
-            [
-                "",
-                "",
-                "",
-                "",
-                "File 'repomd.xml' from repository 'Rockstor-Testing' is unsigned, continue? [yes/no] (no): no",  # noqa E501
-                "Warning: Skipping repository 'Rockstor-Testing' because of the above error.",  # noqa E501
-                "S | Repository             | Name                    | Current Version                       | Available Version                     | Arch  ",  # noqa E501
-                "--+------------------------+-------------------------+---------------------------------------+---------------------------------------+-------",  # noqa E501
-                "v | Main Update Repository | aaa_base                | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.9.1 | x86_64",  # noqa E501
-                "v | Main Update Repository | aaa_base-extras         | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.9.1 | x86_64",  # noqa E501
-                "v | Main Update Repository | apparmor-parser         | 2.12.2-lp151.3.2                      | 2.12.3-lp151.4.3.1                    | x86_64",  # noqa E501
-                "v | Main Update Repository | bash                    | 4.4-lp151.9.53                        | 4.4-lp151.10.3.1                      | x86_64",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base-extras",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "apparmor-parser",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "bash",
-                    "installed": "",
-                },
-            ]
-        )
-        err.append(
-            [
-                "Repository 'Rockstor-Testing' is invalid.",
-                "[Rockstor-Testing|http://updates.rockstor.com:8999/rockstor-testing/leap/15.1] Valid metadata not found at specified URL",  # noqa E501
-                "Some of the repositories have not been refreshed because of an error.",  # noqa E501
-                "",
-            ]
-        )
-        rc.append(106)
-        dist_id.append("opensuse")
-        #
-        for o, e, r, expected, distro in zip(out, err, rc, expected_result, dist_id):
-            self.mock_run_command.return_value = (o, e, r)
-            self.mock_distro.id.return_value = distro
-            returned = pkg_update_check()
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected yum_check() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
-
-    #     @patch("system.pkg_mgmt.subprocess.run")
-    #     def test_pkg_updates_info(self, mock_subproc_run):
+    # @patch("system.pkg_mgmt.subprocess.run")
+    # def test_pkg_updates_info(self, mock_subproc_run):
     # No updates available:
     #         run_out = [
     #             """<?xml version='1.0'?>
@@ -282,65 +63,6 @@ class SystemPackageTests(unittest.TestCase):
     #
     #         # Need mocking setup for subprocess.run
     #         returned = pkg_updates_info()
-
-    def test_zypper_repos_list_legacy(self):
-        # Test empty return values
-        out = [[""]]
-        err = [[""]]
-        rc = [0]
-        expected_results = [[]]
-        # test typical output
-        out.append(
-            [
-                "",
-                "#  | Alias                     | Name                               | Enabled | GPG Check | Refresh",  # noqa E501
-                "---+---------------------------+------------------------------------+---------+-----------+--------",  # noqa E501
-                " 1 | Local-Repository          | Local-Repository                   | Yes     | ( p) Yes  | Yes    ",  # noqa E501
-                " 2 | Rockstor-Testing          | Rockstor-Testing                   | Yes     | ( p) Yes  | Yes    ",  # noqa E501
-                " 3 | illuusio                  | illuusio                           | Yes     | (r ) Yes  | Yes    ",  # noqa E501
-                " 4 | repo-debug                | Debug Repository                   | No      | ----      | ----   ",  # noqa E501
-                " 5 | repo-debug-non-oss        | Debug Repository (Non-OSS)         | No      | ----      | ----   ",  # noqa E501
-                " 6 | repo-debug-update         | Update Repository (Debug)          | No      | ----      | ----   ",  # noqa E501
-                " 7 | repo-debug-update-non-oss | Update Repository (Debug, Non-OSS) | No      | ----      | ----   ",  # noqa E501
-                " 8 | repo-non-oss              | Non-OSS Repository                 | Yes     | (r ) Yes  | No     ",  # noqa E501
-                " 9 | repo-oss                  | Main Repository                    | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "10 | repo-source               | Source Repository                  | No      | ----      | ----   ",  # noqa E501
-                "11 | repo-source-non-oss       | Source Repository (Non-OSS)        | No      | ----      | ----   ",  # noqa E501
-                "12 | repo-update               | Main Update Repository             | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "13 | repo-update-non-oss       | Update Repository (Non-Oss)        | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "",
-            ]
-        )
-        err.append([""])
-        rc.append(0)
-        expected_results.append(
-            [
-                "Local-Repository",
-                "Rockstor-Testing",
-                "illuusio",
-                "repo-debug",
-                "repo-debug-non-oss",
-                "repo-debug-update",
-                "repo-debug-update-non-oss",
-                "repo-non-oss",
-                "repo-oss",
-                "repo-source",
-                "repo-source-non-oss",
-                "repo-update",
-                "repo-update-non-oss",
-            ]
-        )
-
-        for o, e, r, expected in zip(out, err, rc, expected_results):
-            self.mock_run_command.return_value = (o, e, r)
-            returned = zypper_repos_list_legacy()
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected zypper_repos_list() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
 
     def test_current_version(self):
         """
@@ -395,56 +117,20 @@ class SystemPackageTests(unittest.TestCase):
         """
         rpm_build_info strips out and concatenates Version and Release info for the
         rockstor package. This is returned along with a standardised date format for
-        the Buildtime which is also parse out. N.B. the build time has 1 day added
-        to it for historical reasons.
+        the Buildtime which is also parse out.
         """
-        # Leap15.1 dnf-yum
-        dist_id = ["opensuse"]
-        out = [
-            [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
-                "DNF version: 4.2.6",
-                "cachedir: /var/cache/dnf",
-                "Waiting for process with pid 30565 to finish.",
-                "No module defaults found",
-                "Installed Packages",
-                "Name         : rockstor",
-                "Version      : 3.9.2",
-                "Release      : 50.2093",
-                "Architecture : x86_64",
-                "Size         : 82 M",
-                "Source       : rockstor-3.9.2-50.2093.src.rpm",
-                "Repository   : @System",
-                "Packager     : None",
-                "Buildtime    : Sat 30 Nov 2019 11:50:41 AM GMT",
-                "Install time : Sun 01 Dec 2019 03:23:03 PM GMT",
-                "Summary      : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL          : http://rockstor.com/",
-                "License      : GPL",
-                "Description  : Software raid, snapshot capable NAS solution with built-in file",
-                "             : integrity protection. Allows for file sharing between network",
-                "             : attached devices.",
-                "",
-                "",
-            ]
-        ]
-        err = [[""]]
-        rc = [0]
-        expected_results = [("3.9.2-50.2093", "2019-Dec-01")]
         # Tumbleweed using rpm -q --query-format
-        dist_id.append("opensuse-tumbleweed")
-        out.append(
+        out = [
             [
                 "3.9.2-50.2093",
                 "Fri Nov 29 2019",
             ]
-        )
-        err.append([""])
-        rc.append(0)
+        ]
+        err = [[""]]
+        rc = [0]
         # N.B. we no longer add a day to work around yum/dnf 'changelog --since' issues.
-        expected_results.append(("3.9.2-50.2093", "2019-Nov-29"))
+        expected_results = [("3.9.2-50.2093", "2019-Nov-29")]
         # Slowroll using rpm -q --query-format
-        dist_id.append("opensuse-slowroll")
         out.append(
             [
                 "5.0.15-2969",
@@ -455,24 +141,7 @@ class SystemPackageTests(unittest.TestCase):
         rc.append(0)
         # N.B. we no longer add a day to work around yum/dnf 'changelog --since' issues.
         expected_results.append(("5.0.15-2969", "2025-Mar-07"))
-        # Source install where we key from the error message:
-        # N.B. moved test data from TW yum-dnf versions but preserved coverage for the same in leap.
-        # Slowroll dnf-yum before Tumbleweed move to 20250329-0 re dnf-plugins-core issue re dnf major update.
-        dist_id.append("opensuse-leap")
-        out.append(
-            [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",
-                "DNF version: 4.2.6",
-                "cachedir: /var/cache/dnf",
-                "No module defaults found",
-                "",
-            ]
-        )
-        err.append(["Error: No matching Packages to list", ""])
-        rc.append(1)
-        expected_results.append(("Unknown Version", None))
-        # Tumbleweed using rpm -q --query-format with a source install, we key from rc=1
-        dist_id.append("opensuse-tumbleweed")
+        # Tumbleweed using rpm -q --query-format for a source install, we key from rc=1
         out.append(
             [
                 "package rockstor is not installed",
@@ -482,74 +151,13 @@ class SystemPackageTests(unittest.TestCase):
         rc.append(1)
         expected_results.append(("Unknown Version", None))
 
-        for o, e, r, expected, distro in zip(out, err, rc, expected_results, dist_id):
+        for o, e, r, expected in zip(out, err, rc, expected_results):
             self.mock_run_command.return_value = (o, e, r)
-            self.mock_distro.id.return_value = distro
             returned = rpm_build_info("rockstor")
             self.assertEqual(
                 returned,
                 expected,
                 msg="Un-expected rpm_build_info() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
-
-    def test_pkg_latest_available(self):
-        """
-        This procedure was extracted from a fail through position at the end
-        of rockstor_pkg_update_check() to enable discrete testing.
-        :return:
-        """
-        arch = "x86_64"
-        # Tumblweed dnf-yum - no rockstor rpm installed but one available.
-        dist_id = ["opensuse-tumbleweed"]
-        out = [
-            [
-                "Local Repository                                2.9 MB/s | 3.0 kB     00:00    ",
-                "No match for argument: rockstor",
-                "",
-            ]
-        ]
-        err = [
-            [
-                "Package rockstor available, but not installed.",
-                "Error: No packages marked for upgrade.",
-                "",
-            ]
-        ]
-        rc = [1]
-        expected_result = [None]
-        # Leap15.1 dnf-yum - rockstor package installed with update available:
-        dist_id.append("opensuse")
-        out.append(
-            [
-                "Last metadata expiration check: 0:00:10 ago on Mon 02 Dec 2019 06:22:10 PM GMT.",
-                "Dependencies resolved.",
-                "================================================================================",
-                " Package          Architecture   Version                Repository         Size",
-                "================================================================================",
-                "Upgrading:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          15 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total size: 15 M",
-                "",
-            ]
-        )
-        err.append(["Operation aborted.", ""])
-        rc.append(1)
-        expected_result.append("3.9.2-51.2089")
-
-        for o, e, r, expected, distro in zip(out, err, rc, expected_result, dist_id):
-            self.mock_run_command.return_value = (o, e, r)
-            returned = pkg_latest_available("rockstor", arch, distro)
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected pkg_latest_available('rockstor') result:\n "
                 "returned = ({}).\n "
                 "expected = ({}).".format(returned, expected),
             )

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -56,57 +56,54 @@ class SystemPackageTests(unittest.TestCase):
         parser and presenter
         :return:
         """
-        # Example output form "yum changelog 1 sos.noarch" such as is executed
+        pass
+        # Example output from "yum changelog 1 sos.noarch" such as is executed
         # in pkg_changelog()
-        out = [
-            [
-                "==================== Installed Packages ====================",  # noqa E501
-                "sos-3.6-17.el7.centos.noarch             installed",  # noqa E501
-                "* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos",  # noqa E501
-                "- Roll in CentOS Branding",  # noqa E501
-                ""  # noqa E501
-                "==================== Available Packages ====================",  # noqa E501
-                "sos-3.7-6.el7.centos.noarch              updates",  # noqa E501
-                "* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos",  # noqa E501
-                "- Roll in CentOS Branding",  # noqa E501
-                "",  # noqa E501
-                "changelog stats. 2 pkgs, 2 source pkgs, 2 changelogs",  # noqa E501
-                "",  # noqa E501
-            ]
-        ]
-        err = [[""]]
-        rc = [0]
-        expected_results = [
-            {
-                "available": "sos-3.7-6.el7.centos.noarch              updates[line]* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-                "description": "",
-                "name": "fake",
-                "installed": "sos-3.6-17.el7.centos.noarch             installed[line]* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-            }
-        ]
-        distro_id = ["rockstor"]
+        # out = [
+        #     [
+        #         "==================== Installed Packages ====================",  # noqa E501
+        #         "sos-3.6-17.el7.centos.noarch             installed",  # noqa E501
+        #         "* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos",  # noqa E501
+        #         "- Roll in CentOS Branding",  # noqa E501
+        #         ""  # noqa E501
+        #         "==================== Available Packages ====================",  # noqa E501
+        #         "sos-3.7-6.el7.centos.noarch              updates",  # noqa E501
+        #         "* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos",  # noqa E501
+        #         "- Roll in CentOS Branding",  # noqa E501
+        #         "",  # noqa E501
+        #         "changelog stats. 2 pkgs, 2 source pkgs, 2 changelogs",  # noqa E501
+        #         "",  # noqa E501
+        #     ]
+        # ]
+        # err = [[""]]
+        # rc = [0]
+        # expected_results = [
+        #     {
+        #         "available": "sos-3.7-6.el7.centos.noarch              updates[line]* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
+        #         "description": "",
+        #         "name": "fake",
+        #         "installed": "sos-3.6-17.el7.centos.noarch             installed[line]* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
+        #     }
+        # ]
+        # distro_id = ["rockstor"]
         #
         # TODO: add openSUSE Leap example output. But currently exactly the same
         #  command but no available is listed as yum knows only rockstor repos.
         #
-        for o, e, r, expected, distro in zip(out, err, rc, expected_results, distro_id):
-            self.mock_run_command.return_value = (o, e, r)
-            returned = pkg_changelog("fake.123", distro)
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected pkg_changelog() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
+        # for o, e, r, expected, distro in zip(out, err, rc, expected_results, distro_id):
+        #     self.mock_run_command.return_value = (o, e, r)
+        #     returned = pkg_changelog("fake.123", distro)
+        #     self.assertEqual(
+        #         returned,
+        #         expected,
+        #         msg="Un-expected pkg_changelog() result:\n "
+        #         "returned = ({}).\n "
+        #         "expected = ({}).".format(returned, expected),
+        #     )
 
     def test_pkg_update_check(self):
         """
         Test pkg_update_check() across distro.id values and consequently different
-        output format of:
-        distro.id = "rockstor" (CentOS) base
-        yum check-update -q -x rock*
-        and:
         output format of:
         distro.id = "opensuse" N.B. this was "opensuse-leap" in distro <= 1.6.0
         zypper -q list-updates
@@ -189,28 +186,6 @@ class SystemPackageTests(unittest.TestCase):
         err.append([""])
         rc.append(0)
         dist_id.append("opensuse-tumbleweed")
-        #
-        # CentOS yum output example, ie one clear line above.
-        out.append(
-            [
-                "",
-                "epel-release.noarch                                                                        7-12                                                                        epel",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "",
-                    "description": "",
-                    "name": "epel-release",
-                    "installed": "",
-                }
-            ]
-        )
-        err.append([""])
-        rc.append(100)
-        dist_id.append("rockstor")
         #
         # When we have a poorly repo.
         #     '/usr/bin/zypper', '--non-interactive', '-q', 'list-updates']
@@ -348,45 +323,9 @@ class SystemPackageTests(unittest.TestCase):
         the Buildtime which is also parse out. N.B. the build time has 1 day added
         to it for historical reasons.
         """
-        # legacy rockstor/CentOS YUM:
-        dist_id = ["rockstor"]
-        out = [
-            [
-                'Loading "changelog" plugin',
-                'Loading "fastestmirror" plugin',
-                "Config time: 0.010",
-                "Yum version: 3.4.3",
-                "rpmdb time: 0.000",
-                "Installed Packages",
-                "Name        : rockstor",
-                "Arch        : x86_64",
-                "Version     : 3.9.2",
-                "Release     : 50.2093",
-                "Size        : 85 M",
-                "Repo        : installed",
-                "From repo   : localrepo",
-                "Committer   : Philip Guyton <philip@yewtreeapps.com>",
-                "Committime  : Wed Nov 13 04:00:00 2019",
-                "Buildtime   : Fri Nov 29 14:03:17 2019",
-                "Install time: Sun Dec  1 07:23:38 2019",
-                "Installed by: root <root>",
-                "Changed by  : System <unset>",
-                "Summary     : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL         : http://rockstor.com/",
-                "License     : GPL",
-                "Description : Software raid, snapshot capable NAS solution with built-in file",
-                "            : integrity protection. Allows for file sharing between network",
-                "            : attached devices.",
-                "",
-                "",
-            ]
-        ]
-        err = [[""]]
-        rc = [0]
-        expected_results = [("3.9.2-50.2093", "2019-Nov-30")]
         # Leap15.1 dnf-yum
-        dist_id.append("opensuse")
-        out.append(
+        dist_id = ["opensuse"]
+        out = [
             [
                 "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
                 "DNF version: 4.2.6",
@@ -413,10 +352,10 @@ class SystemPackageTests(unittest.TestCase):
                 "",
                 "",
             ]
-        )
-        err.append([""])
-        rc.append(0)
-        expected_results.append(("3.9.2-50.2093", "2019-Dec-01"))
+        ]
+        err = [[""]]
+        rc = [0]
+        expected_results = [("3.9.2-50.2093", "2019-Dec-01")]
         # Tumbleweed dnf-yum
         dist_id.append("opensuse-tumbleweed")
         out.append(
@@ -449,7 +388,7 @@ class SystemPackageTests(unittest.TestCase):
         err.append([""])
         rc.append(0)
         expected_results.append(("3.9.2-50.2093", "2019-Nov-30"))
-        # Slowroll dnf-yum
+        # Slowroll dnf-yum before Tumbleweed move to 20250329-0 re dnf-plugins-core issue re dnf major update.
         dist_id.append("opensuse-slowroll")
         out.append(
             [
@@ -516,122 +455,27 @@ class SystemPackageTests(unittest.TestCase):
         """
         This procedure was extracted from a fail through position at the end
         of rockstor_pkg_update_check() to enable discrete testing.
-        Note that at time of extraction it was not believed to work as intended
-        with dnf-yum.
         :return:
         """
-        # CentOS Legacy yum - rockstor rpm installed with update available.
-        # another process holding the rpm db (not relevant currently)
         arch = "x86_64"
-        dist_id = ["rockstor"]
-        out = [
-            [
-                "Loaded plugins: changelog, fastestmirror",
-                "Loading mirror speeds from cached hostfile",
-                " * base: mirrors.melbourne.co.uk",
-                " * epel: mirrors.coreix.net",
-                " * extras: mozart.ee.ic.ac.uk",
-                " * updates: mirrors.coreix.net",
-                "Resolving Dependencies",
-                "--> Running transaction check",
-                "---> Package rockstor.x86_64 0:3.9.2-50.2093 will be updated",
-                "---> Package rockstor.x86_64 0:3.9.2-51.2089 will be an update",  # This is the parsed in legacy YUM
-                "--> Finished Dependency Resolution",
-                "",
-                "Dependencies Resolved",
-                "",
-                "================================================================================",
-                " Package          Arch           Version                Repository         Size",
-                "================================================================================",
-                "Updating:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          17 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total download size: 17 M",
-                "Exiting on user command",
-                "Your transaction was saved, rerun it with:",
-                " yum load-transaction /tmp/yum_save_tx.2019-12-02.10-37.0b42CF.yumtx",
-                "",
-            ]
-        ]
-        err = [
-            [
-                "Existing lock /var/run/yum.pid: another copy is running as pid 18540.",
-                "Another app is currently holding the yum lock; waiting for it to exit...",
-                "  The other application is: yum",
-                "    Memory :  35 M RSS (712 MB VSZ)",
-                "    Started: Mon Dec  2 10:37:13 2019 - 00:01 ago",
-                "    State  : Sleeping, pid: 18540",
-                "Another app is currently holding the yum lock; waiting for it to exit...",
-                "  The other application is: yum",
-                "    Memory :  35 M RSS (712 MB VSZ)",
-                "    Started: Mon Dec  2 10:37:13 2019 - 00:03 ago",
-                "    State  : Sleeping, pid: 18540",
-                "",
-            ]
-        ]
-        rc = [1]
-        expected_result = ["3.9.2-51.2089"]
-        # CentOS Legacy yum - rockstor rpm installed with update available.
-        # no rpm db lock in place
-        dist_id.append("rockstor")
-        out.append(
-            [
-                "Loaded plugins: changelog, fastestmirror",
-                "Loading mirror speeds from cached hostfile",
-                " * base: mirrors.melbourne.co.uk",
-                " * epel: mirrors.coreix.net",
-                " * extras: mozart.ee.ic.ac.uk",
-                " * updates: mozart.ee.ic.ac.uk",
-                "Resolving Dependencies",
-                "--> Running transaction check",
-                "---> Package rockstor.x86_64 0:3.9.2-50.2093 will be updated",
-                "---> Package rockstor.x86_64 0:3.9.2-51.2089 will be an update",
-                "--> Finished Dependency Resolution",
-                "",
-                "Dependencies Resolved",
-                "",
-                "================================================================================",
-                " Package          Arch           Version                Repository         Size",
-                "================================================================================",
-                "Updating:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          17 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total download size: 17 M",
-                "Exiting on user command",
-                "Your transaction was saved, rerun it with:",
-                " yum load-transaction /tmp/yum_save_tx.2019-12-02.10-47.uHJM6L.yumtx",
-                "",
-            ]
-        )
-        err.append([""])
-        rc.append(1)
-        expected_result.append("3.9.2-51.2089")
         # Tumblweed dnf-yum - no rockstor rpm installed but one available.
-        dist_id.append("opensuse-tumbleweed")
-        out.append(
+        dist_id = ["opensuse-tumbleweed"]
+        out = [
             [
                 "Local Repository                                2.9 MB/s | 3.0 kB     00:00    ",
                 "No match for argument: rockstor",
                 "",
             ]
-        )
-        err.append(
+        ]
+        err = [
             [
                 "Package rockstor available, but not installed.",
                 "Error: No packages marked for upgrade.",
                 "",
             ]
-        )
-        rc.append(1)
-        expected_result.append(None)
+        ]
+        rc = [1]
+        expected_result = [None]
         # Leap15.1 dnf-yum - rockstor package installed with update available:
         dist_id.append("opensuse")
         out.append(

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 from system.pkg_mgmt import (
     pkg_update_check,
     pkg_changelog,
-    zypper_repos_list,
+    zypper_repos_list_legacy,
     rpm_build_info,
     pkg_latest_available,
     current_version,
@@ -283,7 +283,7 @@ class SystemPackageTests(unittest.TestCase):
     #         # Need mocking setup for subprocess.run
     #         returned = pkg_updates_info()
 
-    def test_zypper_repos_list(self):
+    def test_zypper_repos_list_legacy(self):
         # Test empty return values
         out = [[""]]
         err = [[""]]
@@ -333,7 +333,7 @@ class SystemPackageTests(unittest.TestCase):
 
         for o, e, r, expected in zip(out, err, rc, expected_results):
             self.mock_run_command.return_value = (o, e, r)
-            returned = zypper_repos_list()
+            returned = zypper_repos_list_legacy()
             self.assertEqual(
                 returned,
                 expected,


### PR DESCRIPTION
Remove DNF/YUM use for [EDIT all] current distro targets ~~of Tumbleweed & Slowroll~~.

**OS Targets revised to minimise code paths, and help re the next testing phase's relevance to the pending Stable release.**

Fixes #2979
Fixes #2983
Fixes #2984
Fixes #2485
Fixes #2285
Fixes #2286

# Includes:
- Remove all DNF/YUM use project wide, entailing the removal of the CentOS 'rockstor' distro.id target within pkg_mgmt.py.
- Use zypper-changelog-lib, a Rockstor spin-off library, for pending 'rockstor' package changelog retrieval. Replaces prior primary purpose of DNF/YUM.
- Add password-store sync for Web-UI changelog repo authentication: zypper-changelog-lib.
- Make switch_repo() zypper only and remove run_command() use in favour of 'zypper --xmlout' specific wrappers.
- Add pkg_update_info(), a zypper wrapper, to replaces the YUM/DNF cascade calls of now removed pkg_update_check(), pkg_changelog(), and pkg_infos().
- Remove unused downgrade_pkg(): used YUM.
- Remove sole users of install_pkg(): smartmontools is installed via rpm dependency.
- Move storageadmin exception handle from using rpm_build_info(), YUM dependency, to current_version(); an rpm wrapper.
- Enhance current_version(), along with added test coverage.
- Bundled fix for "Fix UnboundLocalError: local variable 'appliance'" #2983
- Fix Installed/Available package versions not appearing in available update details #2984.
- Prioritise rockstor changelog retrieval over updates-list retrieval by delaying the latter - packaging lock contention issue.
- Enact limited zypper re-trys re error 7 (zypper busy), logging either way: #2485
- Improve logging during repo change process.
- Remove/remark-out redundant/excessive logging.
- Associated performance improvement with all of the above rationalisations. #2285 #2286
- Associated type-hint improvements and re-Black formatting.