### PR TITLE
Remove dnf-yum use #2979

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1173,6 +1173,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rpm"
+version = "0.4.0"
+description = "Shim RPM module for use in virtualenvs."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "rpm-0.4.0-py3-none-any.whl", hash = "sha256:0ef697cb5fb73bf9300a13d423529d7ec215239bf95c5ecb145e6610645f6067"},
+    {file = "rpm-0.4.0.tar.gz", hash = "sha256:79adbefa82318e2625d6e4fa16666cf88543498a1f2c10dc3879165d1dc3ecee"},
+]
+
+[package.extras]
+testing = ["tox"]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -1436,7 +1450,23 @@ docs = ["Sphinx", "furo", "repoze.sphinx.autointerface"]
 test = ["coverage[toml]", "zope.event", "zope.testing"]
 testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
+[[package]]
+name = "zypper-changelog-lib"
+version = "0.7.9"
+description = "Changelogs for installable pending updates, or available/uninstalled packages"
+optional = false
+python-versions = "<4.0,>=3.11"
+files = [
+    {file = "zypper_changelog_lib-0.7.9-py3-none-any.whl", hash = "sha256:f5784eb1e93bdb9a663e9d4156f0564474c32f39b44719e0fcee591877719bce"},
+    {file = "zypper_changelog_lib-0.7.9.tar.gz", hash = "sha256:f1a601a7607c190241d741db0c21ec9857b937c92786068c333c352aacd53535"},
+]
+
+[package.dependencies]
+keyring-pass = "*"
+requests = "*"
+rpm = "*"
+
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "f4f0388bedabc8496d0067d679680579ab287539e12a65ff85b2fec6a63bbf35"
+content-hash = "023bf7a6e3812880ed0a031dd18ecc1612a65bc8f34e76910f264be77f2d3198"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ pyzmq = "*"
 distro = "*"
 URLObject = "==2.1.1"
 keyring-pass = "*"
+zypper-changelog-lib = "0.7.9"
+# zypper-changelog-lib = {path = "/path/zypper-changelog-lib/dist/zypper_changelog_lib-0.7.9-py3-none-any.whl"}
 # https://pypi.org/project/supervisor/ 4.1.0 onwards embeds unmaintained meld3
 supervisor = "==4.2.4"
 

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -306,6 +306,11 @@ LOGGING = {
             "level": LOG_LEVEL,
             "propagate": True,
         },
+        "zypper_changelog_lib": {
+            "handlers": ["file"],
+            "level": LOG_LEVEL,
+            "propagate": True,
+        },
     },
 }
 

--- a/src/rockstor/smart_manager/data_collector.py
+++ b/src/rockstor/smart_manager/data_collector.py
@@ -63,7 +63,7 @@ from storageadmin.models import Disk, Pool  # noqa E402
 from smart_manager.models import Service  # noqa E402
 from system.services import service_status  # noqa E402
 from cli.api_wrapper import APIWrapper  # noqa E402
-from system.pkg_mgmt import rockstor_pkg_update_check, pkg_update_check  # noqa E402
+from system.pkg_mgmt import rockstor_pkg_update_check, pkg_updates_info  # noqa E402
 import distro
 import logging  # noqa E402
 
@@ -1025,7 +1025,8 @@ class SysinfoNamespace(RockstorIO):
     def yum_updates(self):
 
         while self.start:
-            packages = pkg_update_check()
+            gevent.sleep(1)  # Hack to avoid zypper toes of rockstor_pkg_update_check()
+            packages = pkg_updates_info()
             data = {}
             if packages:  # Non empty lists are True.
                 data["yum_updates"] = True

--- a/src/rockstor/smart_manager/views/smartd_service.py
+++ b/src/rockstor/smart_manager/views/smartd_service.py
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework.response import Response
 from system.services import systemctl
-from system.pkg_mgmt import install_pkg
 from django.db import transaction
 from smart_manager.views.base_service import BaseServiceDetailView
 import os
@@ -42,7 +41,8 @@ class SMARTDServiceView(BaseServiceDetailView):
         e_msg = "Failed to %s S.M.A.R.T service due to system error." % command
         with self._handle_exception(request, e_msg):
             if not os.path.exists(SMART):
-                install_pkg("smartmontools")
+                logger.info(f"{SMART} binary not found: try `zypper in smartmontools`")
+                raise Exception
             if command == "config":
                 service = Service.objects.get(name=self.service_name)
                 config = request.data.get("config", {})

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -30,7 +30,7 @@ $(document).ready(function(){
         <a href="https://rockstor.com/docs/update-channels/update_channels.html" target="_blank"> update channels. </a>
         Please activate appropriately for your needs.
         <br>- <strong>Stable updates</strong>: recommended for production use (paid) -
-        <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support</i></a> eligible.
+        <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a> eligible.
         <br>- <strong>Testing updates</strong>: for development / actively testing latest code (free).
         <br>See our <a href="https://forum.rockstor.com/" target="_blank">friendly forum</a> for advise.
       </p>
@@ -114,7 +114,7 @@ $(document).ready(function(){
 <br><br>
 <div class="col-sm-offset-2 col-sm-8 col-sm-offset-2">
   <div id="changeSection">
-    <p>List of changes in this update</p>
+    <p>List of changes in this update (try page reload if empty)</p>
     <ul>
       {{#each changeMap}}
       <li><p>{{this}}</p></li>
@@ -140,7 +140,7 @@ $(document).ready(function(){
       , and
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates </a>
       subscriptions with their associated
-      <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support</i></a> option.
+      <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a> option.
     </h4>
   </div>
   {{/is_sub_active}}
@@ -169,7 +169,7 @@ $(document).ready(function(){
     <p>
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
       are <strong>activated</strong> - install eligible for
-      <a href="https://rockstor.com/commercial_support.html" target="_blank"><i>Paid Support.</i></a>
+      <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support.</i></a>
       <br><br>
       While it's not recommended, if you are absolutely sure,
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>

--- a/src/rockstor/storageadmin/util.py
+++ b/src/rockstor/storageadmin/util.py
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 from storageadmin.exceptions import RockStorAPIException
-from system.pkg_mgmt import rpm_build_info
+from system.pkg_mgmt import current_version
 import traceback
 import logging
 
@@ -23,8 +23,9 @@ logger = logging.getLogger(__name__)
 
 # module level variable so it's computed once per process.
 version = "unknown"
+build_date = None
 try:
-    version, date = rpm_build_info("rockstor")
+    version, build_date = current_version()
 except Exception as e:
     logger.exception(e)
 
@@ -42,7 +43,7 @@ def handle_exception(e, request, e_msg=None, status_code=500):
         e_msg = e.__str__()
 
     logger.exception("Exception: {}".format(e.__str__()))
-    logger.debug("Current Rockstor version: {}".format(version))
+    logger.debug(f"Current Rockstor version: {version}")
     raise RockStorAPIException(
         status_code=status_code, detail=e_msg, trace=traceback.format_exc()
     )

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -247,7 +247,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "update-check":
             try:
-                subo = None
+                subo: None | UpdateSubscription = None
                 try:
                     subo = UpdateSubscription.objects.get(
                         name="Stable", status="active"
@@ -286,7 +286,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "current-version":
             try:
-                return Response(current_version())
+                return Response(current_version()[0])
             except Exception as e:
                 e_msg = (
                     "Unable to check current version due to this exception: ({})."

--- a/src/rockstor/storageadmin/views/home.py
+++ b/src/rockstor/storageadmin/views/home.py
@@ -64,16 +64,12 @@ def home(request):
         "page_size": settings.REST_FRAMEWORK["PAGE_SIZE"],
         "update_channel": update_channel,
     }
-    logger.debug("context={}".format(context))
     if request.user.is_authenticated:
-        logger.debug("ABOUT TO RENDER INDEX")
         return render(request, "index.html", context)
     else:
         if setup.setup_user:
-            logger.debug("ABOUT TO RENDER LOGIN")
             return render(request, "login.html", context)
         else:
-            logger.debug("ABOUT TO RENDER SETUP")
             return render(request, "setup.html", context)
 
 

--- a/src/rockstor/storageadmin/views/update_subscription.py
+++ b/src/rockstor/storageadmin/views/update_subscription.py
@@ -43,14 +43,19 @@ class UpdateSubscriptionListView(rfc.GenericView):
             offo = UpdateSubscription.objects.get(name=fcd["name"])
             offo.status = "inactive"
             offo.save()
-            switch_repo(offo, on=False)
+            ## enable_repos False removes both repositories.
+            switch_repo(offo, enable_repo=False)
         except UpdateSubscription.DoesNotExist:
             pass
-
+        try:
+            appliance = Appliance.objects.get(current_appliance=True)
+        except:
+            raise RockStorAPIException(
+                status_code=400, detail="Error retrieving current Appliance ID"
+            )
         try:
             ono = UpdateSubscription.objects.get(name=ncd["name"])
         except UpdateSubscription.DoesNotExist:
-            appliance = Appliance.objects.get(current_appliance=True)
             ono = UpdateSubscription(
                 name=ncd["name"],
                 description=ncd["description"],
@@ -64,16 +69,14 @@ class UpdateSubscriptionListView(rfc.GenericView):
         ono.save()
         if status == "inactive":
             e_msg = (
-                "Activation code ({}) could not be authorized for your "
-                "appliance ({}). Verify the code and try again. If the "
+                f"Activation code ({ono.password}) could not be authorized for your "
+                f"appliance ({appliance.uuid}). Verify the code and try again. If the "
                 "problem persists, email support@rockstor.com with this "
                 "message."
-            ).format(ono.password, appliance.uuid)
+            )
             raise RockStorAPIException(status_code=400, detail=e_msg)
         if status != "active":
-            e_msg = (
-                "Failed to activate subscription. Status code: {} details: {}"
-            ).format(status, text)
+            e_msg = f"Failed to activate subscription. Status code: {status} details: {text}"
             raise Exception(e_msg)
         switch_repo(ono)
         return ono

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -341,7 +341,7 @@ def scan_disks(min_size: int, test_mode: bool = False) -> list[Disk]:
             )
             for key, value in zip(line[::2], line[1::2])
         }
-        logger.debug(f"Scan_disks() using: blk_dev_properties={blk_dev_properties}")
+        # logger.debug(f"Scan_disks() using: blk_dev_properties={blk_dev_properties}")
         # Disk namedtuple from lsblk line dictionary.
         dev: Disk = Disk(**blk_dev_properties)
         # Set up our line / dev dependant variables.
@@ -409,9 +409,9 @@ def scan_disks(min_size: int, test_mode: bool = False) -> list[Disk]:
                 base_dev_pattern = dname[5:] + pattern
                 # str[5:] strips "/dev/" from our full path names.
                 if re.fullmatch(base_dev_pattern, dev.name[5:], re.ASCII) is not None:
-                    logger.debug(
-                        f"({dname}) is parent of partition ({dev.name}): backporting info to parent."
-                    )
+                    # logger.debug(
+                    #     f"({dname}) is parent of partition ({dev.name}): backporting info to parent."
+                    # )
                     # Our partition device name has a base/parent device entry of interest saved.
                     # I.e. we have scanned and saved sdb previously, but we are now looking at sdb3.
                     # Update our base dev's entry in dnames accordingly. Informs DB Disk.role related mechanisms.

--- a/src/rockstor/system/tests/test_pkg_mgmt.py
+++ b/src/rockstor/system/tests/test_pkg_mgmt.py
@@ -14,15 +14,14 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+
+import typing
 import unittest
 from unittest.mock import patch
 
 from system.pkg_mgmt import (
-    pkg_update_check,
-    pkg_changelog,
-    zypper_repos_list,
     rpm_build_info,
-    pkg_latest_available,
+    current_version,
 )
 
 
@@ -34,6 +33,8 @@ class SystemPackageTests(unittest.TestCase):
     """
 
     def setUp(self):
+        # Avoid default of first Docstring in verbose mode
+        unittest.TestCase.shortDescription = lambda x: None
         self.patch_run_command = patch("system.pkg_mgmt.run_command")
         self.mock_run_command = self.patch_run_command.start()
 
@@ -42,297 +43,68 @@ class SystemPackageTests(unittest.TestCase):
         self.patch_distro = patch("system.pkg_mgmt.distro")
         self.mock_distro = self.patch_distro.start()
 
-        # Mock pkg_infos to return "" to simplify higher level testing.
-        self.patch_pkg_infos = patch("system.pkg_mgmt.pkg_infos")
-        self.mock_pkg_infos = self.patch_pkg_infos.start()
-        self.mock_pkg_infos.return_value = ""
-
     def tearDown(self):
         patch.stopall()
 
-    def test_pkg_changelog(self):
+    # @patch("system.pkg_mgmt.subprocess.run")
+    # def test_pkg_updates_info(self, mock_subproc_run):
+    # No updates available:
+    #         run_out = [
+    #             """<?xml version='1.0'?>
+    # <stream>
+    # <message type="info">Loading repository data...</message>
+    # <message type="info">Reading installed packages...</message>
+    # <update-status version="0.6">
+    # <update-list>
+    # </update-list>
+    # </update-status>
+    # </stream>"""
+    #         ]
+    #
+    #         # Need mocking setup for subprocess.run
+    #         returned = pkg_updates_info()
+
+    def test_current_version(self):
         """
-        Test pkg_changelog, a package changelog (including update changes)
-        parser and presenter
+        current_version() wraps `rpm -q --queryformat ... rockstor` and returns version-release,
+        and optionally Build Date from 2 lines indicating the same.
+        N.B. There is overlap here with test_rpm_build_info() concerning the
+        non-legacy code path as it calls current_version also.
+        But rpm_build_info(), while it exists, performs additional translation of version.
         :return:
         """
-        # Example output form "yum changelog 1 sos.noarch" such as is executed
-        # in pkg_changelog()
-        out = [
-            [
-                "==================== Installed Packages ====================",  # noqa E501
-                "sos-3.6-17.el7.centos.noarch             installed",  # noqa E501
-                "* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos",  # noqa E501
-                "- Roll in CentOS Branding",  # noqa E501
-                ""  # noqa E501
-                "==================== Available Packages ====================",  # noqa E501
-                "sos-3.7-6.el7.centos.noarch              updates",  # noqa E501
-                "* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos",  # noqa E501
-                "- Roll in CentOS Branding",  # noqa E501
-                "",  # noqa E501
-                "changelog stats. 2 pkgs, 2 source pkgs, 2 changelogs",  # noqa E501
-                "",  # noqa E501
-            ]
-        ]
+        # version & date function - rpm installed
+        out = [["5.0.15-2981", "Thu May 01 2025"]]
         err = [[""]]
         rc = [0]
-        expected_results = [
-            {
-                "available": "sos-3.7-6.el7.centos.noarch              updates[line]* Tue Sep  3 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.7-6.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-                "description": "",
-                "name": "fake",
-                "installed": "sos-3.6-17.el7.centos.noarch             installed[line]* Tue Apr 23 05:00:00 2019 CentOS Sources <bugs@centos.org> - 3.6-17.el7.centos[line]- Roll in CentOS Branding",  # noqa E501
-            }
+        get_build_date = [True]
+        expected_results: typing.List[(str, str | None)] = [
+            ("5.0.15-2981", "2025-May-01")
         ]
-        distro_id = ["rockstor"]
-        #
-        # TODO: add openSUSE Leap example output. But currently exactly the same
-        #  command but no available is listed as yum knows only rockstor repos.
-        #
-        for o, e, r, expected, distro in zip(out, err, rc, expected_results, distro_id):
-            self.mock_run_command.return_value = (o, e, r)
-            returned = pkg_changelog("fake.123", distro)
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected pkg_changelog() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
-
-    def test_pkg_update_check(self):
-        """
-        Test pkg_update_check() across distro.id values and consequently different
-        output format of:
-        distro.id = "rockstor" (CentOS) base
-        yum check-update -q -x rock*
-        and:
-        output format of:
-        distro.id = "opensuse" N.B. this was "opensuse-leap" in distro <= 1.6.0
-        zypper -q list-updates
-        and:
-        distro.id = "opensuse-tumbleweed"
-        same command as for "opensuse"
-        """
-        # Mock pkg_changelog to allow for isolated testing of yum_check
-        self.patch_pkg_changelog = patch("system.pkg_mgmt.pkg_changelog")
-        self.mock_pkg_changelog = self.patch_pkg_changelog.start()
-        # TODO:
-
-        def fake_pkg_changelog(*args, **kwargs):
-            """
-            Stubbed out fake pkg_changelog to allow for isolation of caller
-            N.B. currenlty only uses single package test data to simply dict
-            comparisons, ie recersive dict sort othewise required.
-            :param args:
-            :param kwargs:
-            :return: Dict indexed by name=arg[0], installed, available, and description.
-            last 3 are = [] unless arg[1] is not "rockstor" then available has different
-            content.
-            """
-            pkg_info = {"name": args[0].split(".")[0]}
-            pkg_info["installed"] = ""
-            pkg_info["available"] = ""
-            if args[1] != "rockstor":
-                pkg_info[
-                    "available"
-                ] = "Version and changelog of update not available in openSUSE"
-            pkg_info["description"] = ""
-            return pkg_info
-
-        self.mock_pkg_changelog.side_effect = fake_pkg_changelog
-
-        # TODO: We need more example here of un-happy paths
-        # zypper spaces in Repository name Example,
-        out = [
-            [
-                "S | Repository             | Name                    | Current Version                       | Available Version                     | Arch  ",  # noqa E501
-                "--+------------------------+-------------------------+---------------------------------------+---------------------------------------+-------",  # noqa E501
-                "v | Main Update Repository | aaa_base                | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.6.1 | x86_64",  # noqa E501
-                "",
-            ]
-        ]
-        expected_result = [
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base",
-                    "installed": "",
-                }
-            ]
-        ]
-        err = [[""]]
-        rc = [0]
-        dist_id = ["opensuse-tumbleweed"]
-        #
-        # zypper no spaces in Repository name Example,
-        # actual Leap 15.0 but no-space repos also seen in other openSUSE variants.
-        out.append(
-            [
-                "S | Repository                | Name                            | Current Version                             | Available Version                           | Arch",  # noqa E501
-                "--+---------------------------+---------------------------------+---------------------------------------------+---------------------------------------------+-------",  # noqa E501
-                "v | openSUSE-Leap-15.0-Update | NetworkManager                  | 1.10.6-lp150.4.6.1                          | 1.10.6-lp150.4.9.1                          | x86_64",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "NetworkManager",
-                    "installed": "",
-                }
-            ]
-        )
+        # version only - rpm installed
+        out.append(["5.0.15-111.1", "Thu May 01 2025"])
         err.append([""])
         rc.append(0)
-        dist_id.append("opensuse-tumbleweed")
-        #
-        # CentOS yum output example, ie one clear line above.
-        out.append(
-            [
-                "",
-                "epel-release.noarch                                                                        7-12                                                                        epel",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "",
-                    "description": "",
-                    "name": "epel-release",
-                    "installed": "",
-                }
-            ]
-        )
+        get_build_date.append(False)
+        expected_results.append(("5.0.15-111.1", None))
+        # version & date function - no rpm installed
+        out.append(["package rockstor is not installed"])
         err.append([""])
-        rc.append(100)
-        dist_id.append("rockstor")
-        #
-        # When we have a poorly repo.
-        #     '/usr/bin/zypper', '--non-interactive', '-q', 'list-updates']
-        out.append(
-            [
-                "",
-                "",
-                "",
-                "",
-                "File 'repomd.xml' from repository 'Rockstor-Testing' is unsigned, continue? [yes/no] (no): no",  # noqa E501
-                "Warning: Skipping repository 'Rockstor-Testing' because of the above error.",  # noqa E501
-                "S | Repository             | Name                    | Current Version                       | Available Version                     | Arch  ",  # noqa E501
-                "--+------------------------+-------------------------+---------------------------------------+---------------------------------------+-------",  # noqa E501
-                "v | Main Update Repository | aaa_base                | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.9.1 | x86_64",  # noqa E501
-                "v | Main Update Repository | aaa_base-extras         | 84.87+git20180409.04c9dae-lp151.5.3.1 | 84.87+git20180409.04c9dae-lp151.5.9.1 | x86_64",  # noqa E501
-                "v | Main Update Repository | apparmor-parser         | 2.12.2-lp151.3.2                      | 2.12.3-lp151.4.3.1                    | x86_64",  # noqa E501
-                "v | Main Update Repository | bash                    | 4.4-lp151.9.53                        | 4.4-lp151.10.3.1                      | x86_64",  # noqa E501
-                "",
-            ]
-        )
-        expected_result.append(
-            [
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "aaa_base-extras",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "apparmor-parser",
-                    "installed": "",
-                },
-                {
-                    "available": "Version and changelog of update not available in openSUSE",
-                    "description": "",
-                    "name": "bash",
-                    "installed": "",
-                },
-            ]
-        )
-        err.append(
-            [
-                "Repository 'Rockstor-Testing' is invalid.",
-                "[Rockstor-Testing|http://updates.rockstor.com:8999/rockstor-testing/leap/15.1] Valid metadata not found at specified URL",  # noqa E501
-                "Some of the repositories have not been refreshed because of an error.",  # noqa E501
-                "",
-            ]
-        )
-        rc.append(106)
-        dist_id.append("opensuse")
-        #
-        for o, e, r, expected, distro in zip(out, err, rc, expected_result, dist_id):
-            self.mock_run_command.return_value = (o, e, r)
-            self.mock_distro.id.return_value = distro
-            returned = pkg_update_check()
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected yum_check() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
-
-    def test_zypper_repos_list(self):
-        # Test empty return values
-        out = [[""]]
-        err = [[""]]
-        rc = [0]
-        expected_results = [[]]
-        # test typical output
-        out.append(
-            [
-                "",
-                "#  | Alias                     | Name                               | Enabled | GPG Check | Refresh",  # noqa E501
-                "---+---------------------------+------------------------------------+---------+-----------+--------",  # noqa E501
-                " 1 | Local-Repository          | Local-Repository                   | Yes     | ( p) Yes  | Yes    ",  # noqa E501
-                " 2 | Rockstor-Testing          | Rockstor-Testing                   | Yes     | ( p) Yes  | Yes    ",  # noqa E501
-                " 3 | illuusio                  | illuusio                           | Yes     | (r ) Yes  | Yes    ",  # noqa E501
-                " 4 | repo-debug                | Debug Repository                   | No      | ----      | ----   ",  # noqa E501
-                " 5 | repo-debug-non-oss        | Debug Repository (Non-OSS)         | No      | ----      | ----   ",  # noqa E501
-                " 6 | repo-debug-update         | Update Repository (Debug)          | No      | ----      | ----   ",  # noqa E501
-                " 7 | repo-debug-update-non-oss | Update Repository (Debug, Non-OSS) | No      | ----      | ----   ",  # noqa E501
-                " 8 | repo-non-oss              | Non-OSS Repository                 | Yes     | (r ) Yes  | No     ",  # noqa E501
-                " 9 | repo-oss                  | Main Repository                    | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "10 | repo-source               | Source Repository                  | No      | ----      | ----   ",  # noqa E501
-                "11 | repo-source-non-oss       | Source Repository (Non-OSS)        | No      | ----      | ----   ",  # noqa E501
-                "12 | repo-update               | Main Update Repository             | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "13 | repo-update-non-oss       | Update Repository (Non-Oss)        | Yes     | (r ) Yes  | No     ",  # noqa E501
-                "",
-            ]
-        )
+        rc.append(1)
+        get_build_date.append(True)
+        expected_results.append(("0.0.0-0", None))
+        # version only - no rpm installed
+        out.append(["package rockstor is not installed"])
         err.append([""])
-        rc.append(0)
-        expected_results.append(
-            [
-                "Local-Repository",
-                "Rockstor-Testing",
-                "illuusio",
-                "repo-debug",
-                "repo-debug-non-oss",
-                "repo-debug-update",
-                "repo-debug-update-non-oss",
-                "repo-non-oss",
-                "repo-oss",
-                "repo-source",
-                "repo-source-non-oss",
-                "repo-update",
-                "repo-update-non-oss",
-            ]
-        )
-
-        for o, e, r, expected in zip(out, err, rc, expected_results):
+        rc.append(1)
+        get_build_date.append(False)
+        expected_results.append(("0.0.0-0", None))
+        # Need more test data sets.
+        for o, e, r, get_date, expected in zip(
+            out, err, rc, get_build_date, expected_results
+        ):
             self.mock_run_command.return_value = (o, e, r)
-            returned = zypper_repos_list()
+            returned = current_version(get_build_date=get_date)
             self.assertEqual(
                 returned,
                 expected,
@@ -345,324 +117,47 @@ class SystemPackageTests(unittest.TestCase):
         """
         rpm_build_info strips out and concatenates Version and Release info for the
         rockstor package. This is returned along with a standardised date format for
-        the Buildtime which is also parse out. N.B. the build time has 1 day added
-        to it for historical reasons.
+        the Buildtime which is also parse out.
         """
-        # legacy rockstor/CentOS YUM:
-        dist_id = ["rockstor"]
+        # Tumbleweed using rpm -q --query-format
         out = [
             [
-                'Loading "changelog" plugin',
-                'Loading "fastestmirror" plugin',
-                "Config time: 0.010",
-                "Yum version: 3.4.3",
-                "rpmdb time: 0.000",
-                "Installed Packages",
-                "Name        : rockstor",
-                "Arch        : x86_64",
-                "Version     : 3.9.2",
-                "Release     : 50.2093",
-                "Size        : 85 M",
-                "Repo        : installed",
-                "From repo   : localrepo",
-                "Committer   : Philip Guyton <philip@yewtreeapps.com>",
-                "Committime  : Wed Nov 13 04:00:00 2019",
-                "Buildtime   : Fri Nov 29 14:03:17 2019",
-                "Install time: Sun Dec  1 07:23:38 2019",
-                "Installed by: root <root>",
-                "Changed by  : System <unset>",
-                "Summary     : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL         : http://rockstor.com/",
-                "License     : GPL",
-                "Description : Software raid, snapshot capable NAS solution with built-in file",
-                "            : integrity protection. Allows for file sharing between network",
-                "            : attached devices.",
-                "",
-                "",
+                "3.9.2-50.2093",
+                "Fri Nov 29 2019",
             ]
         ]
         err = [[""]]
         rc = [0]
-        expected_results = [("3.9.2-50.2093", "2019-Nov-30")]
-        # Leap15.1 dnf-yum
-        dist_id.append("opensuse")
+        # N.B. we no longer add a day to work around yum/dnf 'changelog --since' issues.
+        expected_results = [("3.9.2-50.2093", "2019-Nov-29")]
+        # Slowroll using rpm -q --query-format
         out.append(
             [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
-                "DNF version: 4.2.6",
-                "cachedir: /var/cache/dnf",
-                "Waiting for process with pid 30565 to finish.",
-                "No module defaults found",
-                "Installed Packages",
-                "Name         : rockstor",
-                "Version      : 3.9.2",
-                "Release      : 50.2093",
-                "Architecture : x86_64",
-                "Size         : 82 M",
-                "Source       : rockstor-3.9.2-50.2093.src.rpm",
-                "Repository   : @System",
-                "Packager     : None",
-                "Buildtime    : Sat 30 Nov 2019 11:50:41 AM GMT",
-                "Install time : Sun 01 Dec 2019 03:23:03 PM GMT",
-                "Summary      : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL          : http://rockstor.com/",
-                "License      : GPL",
-                "Description  : Software raid, snapshot capable NAS solution with built-in file",
-                "             : integrity protection. Allows for file sharing between network",
-                "             : attached devices.",
-                "",
-                "",
+                "5.0.15-2969",
+                "Fri Mar 07 2025",
             ]
         )
         err.append([""])
         rc.append(0)
-        expected_results.append(("3.9.2-50.2093", "2019-Dec-01"))
-        # Tumbleweed dnf-yum
-        dist_id.append("opensuse-tumbleweed")
+        # N.B. we no longer add a day to work around yum/dnf 'changelog --since' issues.
+        expected_results.append(("5.0.15-2969", "2025-Mar-07"))
+        # Tumbleweed using rpm -q --query-format for a source install, we key from rc=1
         out.append(
             [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",  # noqa E501
-                "DNF version: 4.2.6",
-                "cachedir: /var/cache/dnf",
-                "No module defaults found",
-                "Installed Packages",
-                "Name         : rockstor",
-                "Version      : 3.9.2",
-                "Release      : 50.2093",
-                "Architecture : x86_64",
-                "Size         : 84 M",
-                "Source       : rockstor-3.9.2-50.2093.src.rpm",
-                "Repository   : @System",
-                "Packager     : None",
-                "Buildtime    : Fri 29 Nov 2019 10:03:53 PM GMT",
-                "Install time : Sun 01 Dec 2019 03:23:33 PM GMT",
-                "Summary      : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL          : http://rockstor.com/",
-                "License      : GPL",
-                "Description  : Software raid, snapshot capable NAS solution with built-in file",
-                "             : integrity protection. Allows for file sharing between network",
-                "             : attached devices.",
-                "",
-                "",
+                "package rockstor is not installed",
             ]
         )
         err.append([""])
-        rc.append(0)
-        expected_results.append(("3.9.2-50.2093", "2019-Nov-30"))
-        # Slowroll dnf-yum
-        dist_id.append("opensuse-slowroll")
-        out.append(
-            [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, groups-manager, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync, system-upgrade",
-                "YUM version: 4.18.0",
-                "cachedir: /var/cache/dnf",
-                "User-Agent: constructed: 'libdnf (openSUSE Tumbleweed-Slowroll 20250205; generic; Linux.x86_64)'",
-                "Installed Packages",
-                "Name         : rockstor",
-                "Version      : 5.0.15",
-                "Release      : 2969",
-                "Architecture : x86_64",
-                "Size         : 6.6 M",
-                "Source       : rockstor-5.0.15-2969.src.rpm",
-                "Repository   : @System",
-                "Packager     : None",
-                "Buildtime    : Fri 07 Mar 2025 08:16:20 AM WET",
-                "Install time : Fri 07 Mar 2025 08:19:21 AM WET",
-                "Summary      : Btrfs Network Attached Storage (NAS) Appliance.",
-                "URL          : https://rockstor.com/",
-                "License      : GPL-3.0-or-later AND (MIT AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND ISC)",
-                "Description  : Software raid, snapshot capable NAS solution with built-in file integrity protection.",
-                "             : Allows for file sharing between network attached devices.",
-                "",
-                "",
-            ]
-        )
-        err.append(
-            [
-                "allow_vendor_change is disabled. This option is currently not supported for downgrade and distro-sync commands",
-                "",
-            ]
-        )
-        rc.append(0)
-        expected_results.append(("5.0.15-2969", "2025-Mar-08"))
-        # Source install where we key from the error message:
-        dist_id.append("opensuse-tumbleweed")
-        out.append(
-            [
-                "Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync",
-                "DNF version: 4.2.6",
-                "cachedir: /var/cache/dnf",
-                "No module defaults found",
-                "",
-            ]
-        )
-        err.append(["Error: No matching Packages to list", ""])
         rc.append(1)
         expected_results.append(("Unknown Version", None))
 
-        for o, e, r, expected, distro in zip(out, err, rc, expected_results, dist_id):
+        for o, e, r, expected in zip(out, err, rc, expected_results):
             self.mock_run_command.return_value = (o, e, r)
-            self.mock_distro.id.return_value = distro
             returned = rpm_build_info("rockstor")
             self.assertEqual(
                 returned,
                 expected,
                 msg="Un-expected rpm_build_info() result:\n "
-                "returned = ({}).\n "
-                "expected = ({}).".format(returned, expected),
-            )
-
-    def test_pkg_latest_available(self):
-        """
-        This procedure was extracted from a fail through position at the end
-        of rockstor_pkg_update_check() to enable discrete testing.
-        Note that at time of extraction it was not believed to work as intended
-        with dnf-yum.
-        :return:
-        """
-        # CentOS Legacy yum - rockstor rpm installed with update available.
-        # another process holding the rpm db (not relevant currently)
-        arch = "x86_64"
-        dist_id = ["rockstor"]
-        out = [
-            [
-                "Loaded plugins: changelog, fastestmirror",
-                "Loading mirror speeds from cached hostfile",
-                " * base: mirrors.melbourne.co.uk",
-                " * epel: mirrors.coreix.net",
-                " * extras: mozart.ee.ic.ac.uk",
-                " * updates: mirrors.coreix.net",
-                "Resolving Dependencies",
-                "--> Running transaction check",
-                "---> Package rockstor.x86_64 0:3.9.2-50.2093 will be updated",
-                "---> Package rockstor.x86_64 0:3.9.2-51.2089 will be an update",  # This is the parsed in legacy YUM
-                "--> Finished Dependency Resolution",
-                "",
-                "Dependencies Resolved",
-                "",
-                "================================================================================",
-                " Package          Arch           Version                Repository         Size",
-                "================================================================================",
-                "Updating:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          17 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total download size: 17 M",
-                "Exiting on user command",
-                "Your transaction was saved, rerun it with:",
-                " yum load-transaction /tmp/yum_save_tx.2019-12-02.10-37.0b42CF.yumtx",
-                "",
-            ]
-        ]
-        err = [
-            [
-                "Existing lock /var/run/yum.pid: another copy is running as pid 18540.",
-                "Another app is currently holding the yum lock; waiting for it to exit...",
-                "  The other application is: yum",
-                "    Memory :  35 M RSS (712 MB VSZ)",
-                "    Started: Mon Dec  2 10:37:13 2019 - 00:01 ago",
-                "    State  : Sleeping, pid: 18540",
-                "Another app is currently holding the yum lock; waiting for it to exit...",
-                "  The other application is: yum",
-                "    Memory :  35 M RSS (712 MB VSZ)",
-                "    Started: Mon Dec  2 10:37:13 2019 - 00:03 ago",
-                "    State  : Sleeping, pid: 18540",
-                "",
-            ]
-        ]
-        rc = [1]
-        expected_result = ["3.9.2-51.2089"]
-        # CentOS Legacy yum - rockstor rpm installed with update available.
-        # no rpm db lock in place
-        dist_id.append("rockstor")
-        out.append(
-            [
-                "Loaded plugins: changelog, fastestmirror",
-                "Loading mirror speeds from cached hostfile",
-                " * base: mirrors.melbourne.co.uk",
-                " * epel: mirrors.coreix.net",
-                " * extras: mozart.ee.ic.ac.uk",
-                " * updates: mozart.ee.ic.ac.uk",
-                "Resolving Dependencies",
-                "--> Running transaction check",
-                "---> Package rockstor.x86_64 0:3.9.2-50.2093 will be updated",
-                "---> Package rockstor.x86_64 0:3.9.2-51.2089 will be an update",
-                "--> Finished Dependency Resolution",
-                "",
-                "Dependencies Resolved",
-                "",
-                "================================================================================",
-                " Package          Arch           Version                Repository         Size",
-                "================================================================================",
-                "Updating:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          17 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total download size: 17 M",
-                "Exiting on user command",
-                "Your transaction was saved, rerun it with:",
-                " yum load-transaction /tmp/yum_save_tx.2019-12-02.10-47.uHJM6L.yumtx",
-                "",
-            ]
-        )
-        err.append([""])
-        rc.append(1)
-        expected_result.append("3.9.2-51.2089")
-        # Tumblweed dnf-yum - no rockstor rpm installed but one available.
-        dist_id.append("opensuse-tumbleweed")
-        out.append(
-            [
-                "Local Repository                                2.9 MB/s | 3.0 kB     00:00    ",
-                "No match for argument: rockstor",
-                "",
-            ]
-        )
-        err.append(
-            [
-                "Package rockstor available, but not installed.",
-                "Error: No packages marked for upgrade.",
-                "",
-            ]
-        )
-        rc.append(1)
-        expected_result.append(None)
-        # Leap15.1 dnf-yum - rockstor package installed with update available:
-        dist_id.append("opensuse")
-        out.append(
-            [
-                "Last metadata expiration check: 0:00:10 ago on Mon 02 Dec 2019 06:22:10 PM GMT.",
-                "Dependencies resolved.",
-                "================================================================================",
-                " Package          Architecture   Version                Repository         Size",
-                "================================================================================",
-                "Upgrading:",
-                " rockstor         x86_64         3.9.2-51.2089          localrepo          15 M",
-                "",
-                "Transaction Summary",
-                "================================================================================",
-                "Upgrade  1 Package",
-                "",
-                "Total size: 15 M",
-                "",
-            ]
-        )
-        err.append(["Operation aborted.", ""])
-        rc.append(1)
-        expected_result.append("3.9.2-51.2089")
-
-        for o, e, r, expected, distro in zip(out, err, rc, expected_result, dist_id):
-            self.mock_run_command.return_value = (o, e, r)
-            returned = pkg_latest_available("rockstor", arch, distro)
-            self.assertEqual(
-                returned,
-                expected,
-                msg="Un-expected pkg_latest_available('rockstor') result:\n "
                 "returned = ({}).\n "
                 "expected = ({}).".format(returned, expected),
             )


### PR DESCRIPTION
Remove DNF/YUM use for all current distro targets, replace primary prior function with zypper-changelog-lib.

Fixes #2979
Fixes #2983
Fixes #2984
Fixes #2485
Fixes #2285
Fixes #2286

# Includes:
- Remove all DNF/YUM use project wide, entailing the removal of the CentOS 'rockstor' distro.id target within pkg_mgmt.py.
- Use zypper-changelog-lib, a Rockstor spin-off library, for pending 'rockstor' package changelog retrieval. Replaces prior primary purpose of DNF/YUM.
- Add password-store sync for Web-UI changelog repo authentication: zypper-changelog-lib.
- Make switch_repo() zypper only and remove run_command() use in favour of 'zypper --xmlout' specific wrappers.
- Add pkg_update_info(), a zypper wrapper, to replaces the YUM/DNF cascade calls of now removed pkg_update_check(), pkg_changelog(), and pkg_infos().
- Remove unused downgrade_pkg(): used YUM.
- Remove sole users of install_pkg(): smartmontools is installed via rpm dependency.
- Move storageadmin exception handle from using rpm_build_info(), YUM dependency, to current_version(); an rpm wrapper.
- Enhance current_version(), along with added test coverage.
- Bundled fix for "Fix UnboundLocalError: local variable 'appliance'" #2983
- Fix Installed/Available package versions not appearing in available update details #2984.
- Prioritise rockstor changelog retrieval over updates-list retrieval by delaying the latter - packaging lock contention issue.
- Enact limited zypper re-trys re error 7 (zypper busy), logging either way: #2485
- Improve logging during repo change process.
- Remove/remark-out redundant/excessive logging.
- Associated performance improvement with all of the above rationalisations. #2285 #2286
- Associated type-hint improvements and re-Black formatting.
- User hint re possible page refresh requirement: no changelog displayed.
- Avoid re-direct by using updated url: re paid support.

---

Note associated rpmbuild changes addressed in:

- https://github.com/rockstor/rockstor-rpmbuild/pull/86

# Caveat
There is the following know header indicator regression.
As per the faked scenario re older 'rockstor' version DB wise, in order that this branch sees its own rpm as an update, we are missing the 'rockstor' package update available Web-UI header indicator up-arrow to the left of the current version (top-right) indication:

![missing-indicator-bug](https://github.com/user-attachments/assets/d964e08e-9824-4135-a62e-49f80e58472d)

With the above image taken from a system otherwise detailing both a changelog and newer version details , via 'SYSTEM -> Software Updates', as well as the same Installed/Available details displayed within the generalised flashing 'wifi' like indicator:

![Existing-notification-re-rockstor-update-available](https://github.com/user-attachments/assets/cde32666-17fc-41cf-8257-3b3d89235cd8)

which in turn gives directions towards the dedicated page. Given this redundancy, it is proposed that this know regression is spun-off into a dedicated issue. Likely to be addressed during the next testing phase; with a possible cherry-pick to pending next Stable phase. 