### PR TITLE
Erase prior GPG key from rpm #2988

### DIFF
--- a/conf/rockstor-pre.service
+++ b/conf/rockstor-pre.service
@@ -21,6 +21,12 @@ ExecStartPre=/usr/bin/pass init rockstor@localhost
 # Rotate Django SECRET_KEY: failure tolerated in rename in case of no prior SECRET_KEY.
 ExecStartPre=-/usr/bin/pass rename --force python-keyring/rockstor/SECRET_KEY python-keyring/rockstor/SECRET_KEY_FALLBACK
 ExecStartPre=/usr/bin/pass generate --no-symbols --force python-keyring/rockstor/SECRET_KEY 100
+# RPM package and repository public GPG/PGP key refresh - ensure rpmkeys is current.
+# Failure tolerated as this key may be defunct or we may be on first boot.
+ExecStartPre=-/usr/bin/rpm --erase gpg-pubkey-5f043187
+# Failure tolerated as non catastrophic: pertains to Rockstor repos only.
+ExecStartPre=-/usr/bin/rpm --import /opt/rockstor/conf/ROCKSTOR-GPG-KEY
+# Python script to establish Django DB etc.
 ExecStart=/usr/local/bin/poetry run initrock
 Type=oneshot
 RemainAfterExit=yes

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -31,7 +31,6 @@ from system.services import systemctl
 import shutil
 import time
 import requests
-from django.conf import settings
 import distro
 import logging
 import keyring
@@ -357,7 +356,6 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
             logger.info("Repo config changed.")
         return None
     repo_alias = "Rockstor-{}".format(subscription.name)
-    rock_pub_key_file = "{}conf/ROCKSTOR-GPG-KEY".format(settings.ROOT_DIR)
     # Historically our base subscription url denotes our CentOS rpm repo.
     subscription_distro_url = subscription.url
     distro_id = distro.id()
@@ -378,8 +376,6 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
     else:
         repo_url = f"http://{subscription_distro_url}"
     logger.debug(f"REPO_URL={repo_url}")
-    # Rockstor public key import call takes around 13 ms.
-    run_command([RPM, "--import", rock_pub_key_file], log=True)
     repos_modified: bool = False
     if subscription.name == "Stable":
         # TODO: After 5.6.0-0 Stable this can be moved to after update_zypp_auth_file().


### PR DESCRIPTION
A silent failure of 'rpm --import' to update our expiration extended public key was observed when the prior non-extended key existed within rpmkeys.

Fixes #2988 

Resolve by blindly removing known prior keys by Version on every rockstor systemd cascade (rockstor-pre specifically), and moving the `rpm --import in-code-private-key` from Web-UI activation to the same systemd service. Both command invocations are set to be failure tolerant.