### PR TITLE
Fix rockstor-bootstrap timeout fail on slower hardware #3005

### DIFF
--- a/src/rockstor/cli/api_wrapper.py
+++ b/src/rockstor/cli/api_wrapper.py
@@ -67,7 +67,7 @@ class APIWrapper(object):
                 data=token_request_data,
                 headers=auth_headers,
                 verify=False,
-                timeout=2,
+                timeout=(1, 4),
             )
             content = json.loads(response.content.decode("utf-8"))
             self.access_token = content["access_token"]


### PR DESCRIPTION
Fixes https://github.com/rockstor/rockstor-core/issues/3005

In the above I described that the timeout for the oauth token is too strict on slower hardware. This extends the timeout to 4 seconds read, which is enough for my AMD E-450 system.

---

Minor formatting/wording edit by @phillxnet.