### PR TITLE
Add Django debug toolbar #2939

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -405,6 +405,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "6.0.0"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "django_debug_toolbar-6.0.0-py3-none-any.whl", hash = "sha256:0cf2cac5c307b77d6e143c914e5c6592df53ffe34642d93929e5ef095ae56841"},
+    {file = "django_debug_toolbar-6.0.0.tar.gz", hash = "sha256:6eb9fa6f4a5884bf04004700ffb5a44043f1fff38784447fc52c1633448c8c14"},
+]
+
+[package.dependencies]
+django = ">=4.2.9"
+sqlparse = ">=0.2"
+
+[[package]]
 name = "django-oauth-toolkit"
 version = "2.4.0"
 description = "OAuth2 Provider for Django"
@@ -1441,4 +1456,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "5c155bd2349615183842a6a8354470d5ff1be6007279440a048f5629ccf6ce55"
+content-hash = "86175029fb6c63c2678784e5ccc779971b63767788e77d5a60f6ceaa90272242"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ zypper-changelog-lib = "0.7.9"
 # zypper-changelog-lib = {path = "/path/zypper-changelog-lib/dist/zypper_changelog_lib-0.7.9-py3-none-any.whl"}
 # https://pypi.org/project/supervisor/ 4.1.0 onwards embeds unmaintained meld3
 supervisor = "==4.2.4"
+django-debug-toolbar = "^6.0.0" # used only when DEBUG = True
 
 # `poetry install --with dev`
 [tool.poetry.group.dev]

--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -18,6 +18,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 # Django settings for Rockstor project.
 import os
+import sys
+
 import distro
 import keyring
 from huey import SqliteHuey
@@ -475,3 +477,27 @@ OS_DISTRO_NAME = distro.name()  # Rockstor, openSUSE Leap, openSUSE Tumbleweed-S
 # Note that the following will capture the build os version.
 # For live updates (running system) we call distro.version() directly in code.
 OS_DISTRO_VERSION = distro.version()  # 3, 15.6, 20250205
+
+# DJANGO DEBUG TOOLBAR settings and configuration
+# recommended NOT to use the toolbar when running tests
+# so enable it only when in DEBUG mode and NOT running tests
+TESTING = "test" in sys.argv
+if (not TESTING) and DEBUG:
+    INSTALLED_APPS = [
+        *INSTALLED_APPS,
+        "debug_toolbar",
+    ]
+    MIDDLEWARE = [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+        *MIDDLEWARE,
+    ]
+    INTERNAL_IPS = [
+        "127.0.0.1", # It seems requests always come from this when using DRF
+    ]
+
+    # https://django-debug-toolbar.readthedocs.io/en/stable/configuration.html
+    DEBUG_TOOLBAR_CONFIG = {
+        # Ensure the latest AJAX request is selected
+        # Previous queries can still be seen and inspected in the "History" panel.
+        "UPDATE_ON_FETCH": True
+    }

--- a/src/rockstor/urls.py
+++ b/src/rockstor/urls.py
@@ -149,6 +149,16 @@ urlpatterns = [
     ),
 ]
 
+# DJANGO DEBUG TOOLBAR
+# recommended NOT to use the toolbar when running tests
+# so enable it only when in DEBUG mode and NOT running tests
+if (not settings.TESTING) and settings.DEBUG:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
+    urlpatterns = [
+        *urlpatterns,
+    ] + debug_toolbar_urls()
+
 # Django Admin Docs
 urlpatterns += [path('radmin/doc/', include('django.contrib.admindocs.urls'))]
 # Django Admin


### PR DESCRIPTION
Fixes #2939 
@phillxnet, @Hooverdan96: ready for review.

# Add the Django debug toolbar as a new Django application


Reference: https://django-debug-toolbar.readthedocs.io/en/latest/
See #2939 for rationale and further details.
This Pull Request (PR) follows a previous WIP (#2940) that led to the following decisions:
- install the `django-debug-toolbar` package for all users. This way, anyone can enable it as needed more simply.
- activate it only when `DEBUG = True`
- disable it while running unit tests as recommended by the package authors

## Notes
As explained above, to enable the toolbar, one needs the following:
1. Build from source:
```console
srbuildvm:~ # cd ~ && \
> systemctl start postgresql && \
> cd /opt/rockstor/ && \
> chmod +x build.sh && \
> ./build.sh && \
> poetry run initrock && \
> cd ~ && \
> systemctl enable --now rockstor-bootstrap
```

2. Turn ON debug mode and then collect static files:
```console
srbuildvm:~ # cd /opt/rockstor/ && poetry run debug-mode ON
DEBUG flag is now set to True
srbuildvm:/opt/rockstor # poetry run django-admin collectstatic --clear --no-input
(...)
523 static files copied to '/opt/rockstor/static', 525 post-processed. # is 516 and 518 when DEBUG mode is OFF
```

3. Open Rockstor webUI and explore all the additional info on the right panel:
<img width="1718" height="855" alt="image" src="https://github.com/user-attachments/assets/dcdf72d6-442c-4b4b-9911-ad247307ba34" />

## Testing
An RPM was successfully built from this branch for Leap 15.6, implying that all unit tests still pass.
On a Slowroll VM (updated to latest snapshot: 20250701):
```console
srbuildvm:/opt/rockstor/src/rockstor # cd src/rockstor/ && poetry run python manage.py test
(...)
----------------------------------------------------------------------
Ran 292 tests in 17.587s

OK
```

This 
Note that we are here installing it be default but not activating it. To activate it, the user needs indeed to first enable DEBUG in settings.py, and collect static files again.

- Update django-debug-toolbar to ~~5.2.0~~ 6.0.0
- As recommended, enable the toolbar only when DEBUG is True and we are NOT running tests.