### PR TITLE
Suppress creation of visible snapshot NFS exports #2170

### DIFF
--- a/src/rockstor/storageadmin/views/snapshot.py
+++ b/src/rockstor/storageadmin/views/snapshot.py
@@ -87,19 +87,12 @@ class SnapshotView(NFSExportMixin, rfc.GenericView):
         export_pt = snap_mnt_pt.replace(settings.MNT_PT, settings.NFS_EXPORT_ROOT)
         if on:
             mount_snap(share, snap_name, snap_qgroup)
-
-            if NFSExport.objects.filter(share=share).exists():
-                se = NFSExport.objects.filter(share=share)[0]
-                export_group = NFSExportGroup(
-                    host_str=se.export_group.host_str, nohide=True
-                )
-                export_group.save()
-                export = NFSExport(
-                    share=share, export_group=export_group, mount=export_pt
-                )
-                export.full_clean()
-                export.save()
-                cur_exports.append(export)
+            ########################################################
+            # #2007 #1879   For many years the operation of NFS shares has created an NFS export for every snapshot
+            # This has led to numerous bugs with NFS
+            # To simplfy NFS operation this facility has been removed and now NFS behave like SFTP and Samba shares
+            # with an export for only the top level share with snapshots appearing as folders in the share.
+            #########################################################
         else:
             for mnt in (snap_mnt_pt, export_pt):
                 try:


### PR DESCRIPTION
### Background

When first evaluating Rockstor as my potential NAS I did as many people do and just started trying out all the features. When I got as far as trying out NFS shares I quickly ran into problems because I had also created some snapshots, and some of them were marked 'visible'.  It soon became clear that NFS shares and visible snapshots do not play nice together. Forum posts and github issues about problems with NFS went back years although many people had not made the connection with visible snapshots.

Fixes #2170

[Update]
Fixes #2997 
Exports of snapshots are no longer created.

Fixes #2742 
Since #2742 has not had a second reproducer and the symptom is certainly similar to this issue it should probably be closed.

Fixes #1960 

Fixes #1879 
[\Update]


On investigating it became clear that the root of most of these problems is the way exports work with NFS shares that is different to how exports work with samba or sftp shares.
The structure of the file system is exactly the same for nfs as samba, or sftp.
For example
```
/export
└── share1
    ├── .snap-share1-1
    │   └── screen02.png
    ├── .snap-share1-2
    │   ├── .snap-share1-1
    │   ├── Autumn.bmp
    │   └── screen02.png
    ├── Autumn.bmp
    └── screen02.png
```
Visible snapshots are mounted as hidden folders on the parent folder. Successive snapshots contain the contents of older snapshots at the time the snapshot was made.  A user mounting the base folder is therefore able to read the contents of any snapshot if it is marked visible and to write into snapshots if they are marked rw permissions.
What is unique about an NFS share is that there is also an NFS export of every individual snapshot. so in this example
```
exportfs

/export/share1   *.local            #where *.local is the client range (Any host with avahi on the local network)
/export/share1  192.168.1.22    #where 192.168.1.22 is the admin host if present
/export/share1/.snap-share1-1 *.local
/export/share1/.snap-share1-1 192.168.1.22
/export/share1/.snap-share1-2  *.local
/export/share1/.snap-share1-2 192.168.1.22
/export/share1/.snap-share1-2/.snap-share1-1  *.local
/export/share1/.snap-share1-2/.snap-share1-1 192.168.1.22
```
Only the first two entries in this list are useful. All the others are just subsets of the same file system.

Problems arise when the user tries to change things with the share. For example:
#2995 If an NFS share is deleted the exports of the snapshots remain.
#2997 Editing the owner of a share does not change the owner of its snapshots
#1879 Editing the client string of a share does not change the client string of a snapshot
Note:  I have already submitted a PR to fix #2995  That PR is made redundant by this PR which offers a more elegant and comprehensive solution.

### Solution Offered
The fix found for all these issues turned out to be astonishingly simple. It is simply to **NOT**  create NFS exports for snapshots.   Then there is then no need to worry about creating/deleting NFS exports, or maintaining ownerships and permissions among dozens of exports.  Rockstor already does a very good job of mounting, and managing snapshots in the file system since that is what it already does for SFTP and Samba shares.
The attached patch simply removes the code to create snapshot  NFS exports in the file snapshots.py.

The code to delete NFS snapshot exports remains as 'cruft' because I did not want to break anything by removing too much.  It can be removed at a future date.

### Testing
Testing of this PR is quite simple

1. Create a share share1 with ownership uid1000  so a client with uid1000 will be able to write into the share. Create an NFS export giving the IP address of your client machine as the client string.  Mount the share on your client and confirm you can write/read into the share.
2. Once you are confident you have a working NFS share create a visible snapshot. Observe that a hidden folder with the snapshot name has appeared in your share on your client machine. Add more files into the base share.
3. Create a second snapshot. Observe the snapshot has appeared in the base share.  Check the file structure on Rockstor with 'tree -a'.  Check the NFS exports with 'exportfs'.
4. Delete your second snapshot.  It should delete from the base share.
5. Delete the first snapshot.
6. Now add the snapshots again, then edit the share to change the ownership.  Confirm the snapshots ownership has also changed.
7. Delete the share without first deleting the snapshots. Observe the snapshots get deleted and the file system is as expected.
8.  Go mad and try to break it!  Anything that works on an SFTP or Samba share should also work with NFS.
Note: while it is OK to export an NFS share multiple times with different client lists. If you edit a share to give it a client which is included in another export of the same share you will see an error message. This is correct functionality.

### Impact on existing users
If there are any users who already use NFS exports with visible snapshots (which would surprise me since it is so buggy), then migrating to this new operation will not affect existing NFS shares so long as only the base share is mounted. If a snapshot is mounted directly then that mount will no longer work. 

Managing existing NFS shares will operate as it always has with the same buggy operation. Once shares and snapshots have been deleted, then new ones can be created without the buggy operation.
