### PR TITLE
Unused dependency declared - urlobject #3003

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1309,16 +1309,6 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
-name = "urlobject"
-version = "2.1.1"
-description = "A utility class for manipulating URLs."
-optional = false
-python-versions = "*"
-files = [
-    {file = "URLObject-2.1.1.tar.gz", hash = "sha256:06462b6ab3968e7be99442a0ecaf20ac90fdf0c50dca49126019b7bf803b1d17"},
-]
-
-[[package]]
 name = "wheel"
 version = "0.45.1"
 description = "A built-package format for Python"
@@ -1456,4 +1446,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "86175029fb6c63c2678784e5ccc779971b63767788e77d5a60f6ceaa90272242"
+content-hash = "a83d84a6bc619cfee44d8b0b3629574b3b6e0254292d53bc32bc93ee87897486"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ psutil = "==5.9.4"
 # pyzmq requires libzmq5 on system unless in wheel form.
 pyzmq = "*"
 distro = "*"
-URLObject = "==2.1.1"
 keyring-pass = "*"
 zypper-changelog-lib = "0.7.9"
 # zypper-changelog-lib = {path = "/path/zypper-changelog-lib/dist/zypper_changelog_lib-0.7.9-py3-none-any.whl"}


### PR DESCRIPTION
Remove redundant/orphaned/legacy 'urlobject' dependency via poetry.

Fixes #3003 

```
poetry remove urlobject
Updating dependencies
Resolving dependencies... (0.3s)

Package operations: 0 installs, 0 updates, 1 removal

  • Removing urlobject (2.1.1)

Writing lock file
```

---

Re-submission of PR #3004 post rebase on latest testing branch - otherwise un-changed. Linking to prior @FroggyFlox review:

- https://github.com/rockstor/rockstor-core/pull/3004#pullrequestreview-2987046601