### PR TITLE
Ensure DB format upgrade script uses target pg_upgrade #3018

### DIFF
--- a/src/rockstor/scripts/db_upgrade.sh
+++ b/src/rockstor/scripts/db_upgrade.sh
@@ -2,7 +2,7 @@
 # exit on error
 set -o errexit
 #
-# Upgrade the database format from 10 to 13.
+# Upgrade the database format from 10 to 13, or 13 to 17 post Rockstor 5.1.0-0.
 # Testing RPM version 5.0.6-0 updated to Django LTS 4.2 & psycopg3.
 # These are no longer compatibility with databases created
 # with Postgres version 10, i.e. installs originally created from:
@@ -10,13 +10,16 @@ set -o errexit
 # or earlier.
 # - RPM version 4.5.0-0 added a Postgresql V13 dependency.
 # - RPM version 5.0.2-0 enforced Postgresql alternative to V13.
+# - RPM version 5.5.0-0 enforces Postgresql alternative to V17.
 #
 # Uses pg_upgrade https://www.postgresql.org/docs/13/pgupgrade.html
+#  or pg_upgrade https://www.postgresql.org/docs/17/pgupgrade.html
 # Informed by:
 # - https://en.opensuse.org/SDB:PostgreSQL#Upgrading_major_PostgreSQL_version
 # - https://progress.opensuse.org/news/113
 # ps aufx | grep '^postgres.* -D'
 # V10: /usr/lib/postgresql10/bin/postgres -D /var/lib/pgsql/data
+#  or V13: /usr/lib/postgresql13/bin/postgres -D /var/lib/pgsql/data
 #
 FROM_VERSION="$1"
 TO_VERSION="$2"
@@ -24,7 +27,7 @@ TO_VERSION="$2"
 if [ $# -ne 2 ]; then
     echo "This script upgrades the Rockstor Postgres database format."
     echo "It requires two integer numbers: the 'current' and 'target' DB formats."
-    echo "Example: 10 13"
+    echo "Example: 13 17"
     exit 1
 fi
 # OpenSUSE postgres user home (~) is: /var/lib/pgsql/
@@ -59,6 +62,7 @@ fi
 # Postgres binary directory paths, e.g.:
 # 10: /usr/lib/postgresql10/bin/
 # 13: /usr/lib/postgresql13/bin/
+# 17: /usr/lib/postgresql17/bin/
 BIN_BASEDIR="/usr/lib/postgresql"
 
 # Check for expected postgres server bin dir locations.
@@ -76,7 +80,7 @@ if ! test -e "${BIN_BASEDIR}${TO_VERSION}/bin/pg_upgrade"; then
   exit 0
 fi
 
-echo "Updating DB format from ${CURRENT_DATA_VERSION} to ${TO_VERSION} via pg_upgrade."
+echo "Updating DB format from ${CURRENT_DATA_VERSION} to ${TO_VERSION} via ${BIN_BASEDIR}${TO_VERSION}/bin/pg_upgrade."
 
 # Push onto dir stack our pwd and change to postgres user's home dir.
 # (required as pg_upgrade creates files in pwd)
@@ -85,7 +89,7 @@ pushd /var/lib/pgsql
 # Initialise TO_VERSION database in "${DATA_BASEDIR}/data${TO_VERSION}" directory.
 # install -d -m 0700 -o postgres -g postgres "${DATA_BASEDIR}/data${TO_VERSION}"
 # initdb creates the --pgdata directory with its preferred rights if it does not exist.
-# initdb: https://www.postgresql.org/docs/13/app-initdb.html
+# initdb: https://www.postgresql.org/docs/17/app-initdb.html
 # encoding: https://docs.djangoproject.com/en/4.2/ref/databases/#encoding
 # `locale` https://man7.org/linux/man-pages/man1/locale.1.html has LC_COLLATE as implied/quoted from LANG.
 # Establish LANG from install.
@@ -95,16 +99,16 @@ echo "Adopting installs' LANG=${LANG}"
 sudo -u postgres "${BIN_BASEDIR}${TO_VERSION}/bin/initdb" --locale="${LANG}" --encoding=UTF8 --pgdata="${DATA_BASEDIR}/data${TO_VERSION}"
 
 # Stop Postgres - may fail from within another systemd service.
-echo "Stopping postgresql"
+echo "Stopping postgresql systemd service"
 systemctl stop postgresql.service
 
 # Move default 'data' dir DB to version-specific dir:
 echo
 echo "mv ${DATA_BASEDIR}/data ${DATA_BASEDIR}/data${CURRENT_DATA_VERSION}"
-mv ${DATA_BASEDIR}/data ${DATA_BASEDIR}/data"${CURRENT_DATA_VERSION}"
+mv ${DATA_BASEDIR}/data "${DATA_BASEDIR}/data${CURRENT_DATA_VERSION}"
 
 echo
-sudo -u postgres pg_upgrade \
+sudo -u postgres "${BIN_BASEDIR}${TO_VERSION}/bin/pg_upgrade" \
      --old-bindir="${BIN_BASEDIR}${CURRENT_DATA_VERSION}/bin"     \
      --new-bindir="${BIN_BASEDIR}${TO_VERSION}/bin"       \
      --old-datadir="${DATA_BASEDIR}/data${CURRENT_DATA_VERSION}/" \
@@ -112,7 +116,7 @@ sudo -u postgres pg_upgrade \
 echo
 echo "Linking data -> data${TO_VERSION}"
 # Restore default 'data' dir as symlink to the /data${TO_VERSION}
-# e.g. lrwxrwxrwx 1 postgres postgres ... data -> data13
+# e.g. lrwxrwxrwx 1 postgres postgres ... data -> data17
 sudo -u postgres ln --force --symbolic data"${TO_VERSION}" data
 
 # Remove old database (approximately 80-100MB)
@@ -120,16 +124,18 @@ sudo -u postgres ln --force --symbolic data"${TO_VERSION}" data
 
 # Start Postgres to enable vacuumdb & reindexdb operations.
 echo
-echo "Starting postgresql"
+echo "Starting postgresql systemd service"
 systemctl start postgresql.service
 
 # Vacuum & reindex new DB as per pg_upgrade recommendation:
 echo
-sudo -u postgres ${BIN_BASEDIR}"${TO_VERSION}"/bin/vacuumdb --all --analyze-in-stages
-# https://www.postgresql.org/docs/13/app-reindexdb.html
+echo "Running ${BIN_BASEDIR}${TO_VERSION}/bin/vacuumdb"
+sudo -u postgres "${BIN_BASEDIR}${TO_VERSION}/bin/vacuumdb" --all --analyze-in-stages
+# https://www.postgresql.org/docs/17/app-reindexdb.html
 # `--concurrently` slower but allows for concurrent user.
 echo
-sudo -u postgres ${BIN_BASEDIR}"${TO_VERSION}"/bin/reindexdb --all
+echo "Running ${BIN_BASEDIR}${TO_VERSION}/bin/reindexdb"
+sudo -u postgres "${BIN_BASEDIR}${TO_VERSION}/bin/reindexdb" --all
 
 # Restore our prior pwd.
 echo
@@ -141,5 +147,5 @@ echo "All Rockstor services, if running, will have been stopped."
 echo "Restart via 'systemctl start rockstor-bootstrap.service'"
 
 # ps aufx | grep '^postgres.* -D'
-# V13: /usr/lib/postgresql13/bin/postgres -D /var/lib/pgsql/data
+# V17: /usr/lib/postgresql17/bin/postgres -D /var/lib/pgsql/data
 


### PR DESCRIPTION
Update db_upgrade.sh script to enforce the target binary is versioned as per the passed TO_VERSION parameter. Previously this script relied on the alternatives system for its selection of this binary, but all others were intentionally versioned. I.e. address an anomaly re binary selection by passed version.

Fixes #3018 
Fixes #3010