### PR TITLE
Update django-pipeline #3047

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -512,14 +512,14 @@ requests = ">=2.13.0"
 
 [[package]]
 name = "django-pipeline"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pipeline is an asset packaging library for Django."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "django_pipeline-4.0.0-py3-none-any.whl", hash = "sha256:90e50c15387a6e051ee1a6ce2aaca333823ccfb23695028790f74412bde7d7db"},
-    {file = "django_pipeline-4.0.0.tar.gz", hash = "sha256:0ab1190d9dc64e2f7b72be3f7b023c06aca7cc1cc61e7dc9f0343838e29bbc88"},
+    {file = "django_pipeline-4.1.0-py3-none-any.whl", hash = "sha256:bdb84feb8db73b9fe8298fd9d0f6e50f30d78eb28a8ed28f73ca5d154080c3d5"},
+    {file = "django_pipeline-4.1.0.tar.gz", hash = "sha256:aa1d79df6f215b78396cdd50ed162f8741dc4993e9fba2c78483d9b6f1e722b4"},
 ]
 
 [package.dependencies]
@@ -1560,4 +1560,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "f633c15119fc5ed7b8badd9cc549445c59e0692532de614543f8f5b4c0a49126"
+content-hash = "72acf48a277dcd7f1d580aee8e41d3dc38f7a77efdfd72379b117c14b764af04"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "django-oauth-toolkit (==2.4.*)",
     # DRF next version (3.16.0) changes behaviour!
     "djangorestframework (==3.15.2)",
-    "django-pipeline (==4.0.0)",
+    "django-pipeline (==4.1.0)",
     # "django-pipeline @ git+https://github.com/jazzband/django-pipeline.git@927ca9ad",
     "docutils (==0.21.*)",
     "python-engineio (==4.8.0)",


### PR DESCRIPTION
Update pinning to latest version and refresh poetry.lock via: `poetry update`
```
Package operations: 0 installs, 1 update, 0 removals

  - Updating django-pipeline (4.0.0 -> 4.1.0)

Writing lock file
```

Fixes #3047