### PR TITLE
SMB Admin user 3 char minimum validator #3041

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/add_samba_export.js
@@ -167,7 +167,7 @@ AddSambaExportView = RockstorLayoutView.extend({
             return null;
         }
         this.$('#admin_users').select2({
-            minimumInputLength: 3,
+            minimumInputLength: 2,
             allowClear: true,
             placeholder: '',
             matcher: matchCustom


### PR DESCRIPTION
Fixes #3041

Changed the Select2 validator limit from minumum 3 characters long to minumum 2 characters long for finding/entering a user to the Samba Export & Admins input field.

This allows to search and enter a short named users like "ha".