### PR TITLE
Insufficient timeout on zypper list-updates call #3032

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -560,7 +560,7 @@ def zypper_killed_cleanup():
     )
 
 
-def pkg_updates_info(max_wait: int = 15) -> typing.List[dict[str:str]]:
+def pkg_updates_info(max_wait: int = 40) -> typing.List[dict[str:str]]:
     """
     Fetch info on installable updates across all repos via zypper xml output call.
     Resolves as per 'zypper up' excluding packages with dependency problems.


### PR DESCRIPTION
Increase the max_wait timeout on `zypper --xmlout list-updates` from 15 to 40 seconds due to excessive timeouts observed in wider testing.

Fixes #3032

---

Thanks to @Hooverdan96 for development assistance on this issue.