### PR TITLE
Ignore spurious error when setting APM #3075

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1567,6 +1567,19 @@ def get_disk_APM_level(dev_byid):
             return level
     return 0
 
+def hdparm_stderr_ok(stderr: list[str]) -> bool:
+    """
+    For some hardware, hdparm prints error messages to stderr even when it's
+    able to successfully perform the request.  This function takes the stderr
+    output from hdparm and returns True if we believe the command ran OK, i.e.
+    the error text was spurious.  Returns False if it seems to be a real error.
+    :param stderr: The stderr output from hdparm, split on newlines into a list.
+    :return: True if the command seemed to run OK, meaning any stderr error
+    message was spurious, and False if there seemed to be a real error.
+    """
+    spurious = r"SG_IO: bad/missing sense data, sb\[\]: ( [0-9A-Fa-f]{2}){32}"
+    return len(stderr) == 1 or (len(stderr) == 2 and
+                                re.fullmatch(spurious, stderr[0]) is not None)
 
 def set_disk_spindown(
     dev_byid, spindown_time, apm_value, spindown_message="no comment"
@@ -1620,7 +1633,7 @@ def set_disk_spindown(
         # Try running this -B only hdparm to see if it will run without
         # error or non zero return code.
         out, err, rc = run_command(hdparm_command, throw=False)
-        if rc == 0 and len(err) == 1:
+        if rc == 0 and hdparm_stderr_ok(err):
             # if execution of the -B switch ran OK then add to switch list
             switch_list += apm_switch_list
         else:


### PR DESCRIPTION
Fixes #3075

See friendly forum thread: https://forum.rockstor.com/t/apm-not-persisted-due-to-spurious-drive-error/10857

In short, when running hdparm commands on certain drives (at least a couple of Seagate and Western Digital USB drives) it will return 0 but give a spurious error when setting some options, including the APM setting `-B` needed for spindown to work.  The operation does work regardless of the message in stderr.

Before this change, I had to use a systemd service override to force in the `-B 127` setting.  Trying to set it in Rockstor's spindown interface did nothing because of the conditional being modified in this PR, and the error would show up in Rockstor logs.

This change checks for the specific spurious error message and continues if that's all it sees and the command returned 0.  (The new function could be used in other places if the same spurious error is preventing other actions, but I haven't run into any others.)

**Testing:**

I tested the new function on its own against a bunch of good and bad arguments to be sure it only excused the specific error under discussion.  Then I tested on my Rockstor server and confirmed that the systemd service has the requested `-B` option without an override.