### PR TITLE
Pool import not reflecting owner:group, perms, and compression #3073

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -752,7 +752,7 @@ def mount_root(pool):
         mnt_options = pool.mnt_options
     if pool.compression is not None:
         if re.search("compress", mnt_options) is None:
-            mnt_options = "{},compress={}".format(mnt_options, pool.compression)
+            mnt_options = f"{mnt_options},compress={pool.compression}"
     if pool.role == "root" and root_pool_mnt != "/":  # boot-to-snap - See pool model
         mnt_options = "{},subvol=/@".format(mnt_options)
     # Prior to a mount by label attempt we call btrfs device scan on all
@@ -2321,10 +2321,11 @@ def set_property(mnt_pt, name, val, mount=True, force=False):
         return run_command(cmd)
 
 
-def get_property(mnt_pt, prop_name=None):
+def get_property(mnt_pt: str, prop_name: str | None=None):
     """
     Convenience wrapper around 'btrfs property get prop_name mnt_pt'.
     :param mnt_pt: Vol(pool)/subvol(share/snap) mount point.
+    :param prop_name: Property name or None for all.
     :return: if called with no prop_name specified then a dict of available
     properties. But if called with a single property then the value and type
     appropriate for that property ie:
@@ -2335,7 +2336,6 @@ def get_property(mnt_pt, prop_name=None):
     N.B. compression property for subvol only, vol/pool uses mount option.
     """
     KNOWN_PROPERTIES = ["ro", "compression", "label"]
-    # TODO: Consider using -t as a form of typesetting on our mnt_pt:
     cmd = [BTRFS, "property", "get", mnt_pt]
     if prop_name is not None:
         cmd.append(prop_name)

--- a/src/rockstor/storageadmin/models/share.py
+++ b/src/rockstor/storageadmin/models/share.py
@@ -40,10 +40,14 @@ class Share(models.Model):
     size = models.BigIntegerField(default=0)
     owner = models.CharField(max_length=4096, default="root")
     group = models.CharField(max_length=4096, default="root")
+    # JS front-end expects 3 char octal string (no leading 0o) for rwxr-xr-x i.e. 755.
+    # Consider moving to int base 10 of S_IMODE(stat.st_mode),
+    # or raw "rwxr-xr-x" via: stat.filemode(stat(mnt_pt).st_mode)[1:] strips front "-".
     perms = models.CharField(max_length=9, default="755")
     toc = models.DateTimeField(auto_now=True)
     subvol_name = models.CharField(max_length=4096)
     replica = models.BooleanField(default=False)
+    # zlib, lzo, and zstd. If null (model default) or "no" then inherited from pool.
     compression_algo = models.CharField(max_length=1024, null=True)
     # rusage and eusage reports original 0/x qgroup size
     # and this has only current share content without snapshots
@@ -54,6 +58,9 @@ class Share(models.Model):
     # to report correct real vol sizes
     pqgroup_rusage = models.BigIntegerField(default=0)
     pqgroup_eusage = models.BigIntegerField(default=0)
+    # TODO: stash our Huey task id to ease sanity checks
+    # Taskid=None means no associated tasks.
+    # taskid = models.CharField(max_length=36, null=True)
 
     def __init__(self, *args, **kwargs):
         super(Share, self).__init__(*args, **kwargs)

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/share_details_layout_view.js
@@ -311,6 +311,8 @@ ShareDetailsLayoutView = RockstorLayoutView.extend({
     },
 
     parsePermStr: function(perms) {
+        // Returns binary string of Share.perms string (assumed 3 chars)!
+        // e.g. "755" to binary "111101101" to represent rwx r-x r-x.
         var p = '';
         for (var i = 0; i < 3; i++) {
             var tmp = parseInt(perms.charAt(i)).toString(2);

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
+from stat import S_IMODE
 from rest_framework import status
 from unittest.mock import patch
 from storageadmin.tests.test_api import APITestMixin
@@ -65,6 +66,11 @@ class ShareTests(APITestMixin):
     databases = "__all__"
     fixtures = ["test_api.json", "test_shares.json", "test_shares-services.json"]
     BASE_URL = "/api/shares"
+    # stat.st_mode=16877 post oct(S_IMODE(16877)) and Octal indicator "0o" strip
+    # equates to our model default of 755.
+    # Similarly, stat.st_mode=16832 equates to 700 (rwx --- ---)
+    ST_MODE_MOCK: int = 16832
+    PERMS_MOCK: str = oct(S_IMODE(ST_MODE_MOCK))[2:].zfill(3)
 
     @classmethod
     def setUpClass(cls):
@@ -108,6 +114,34 @@ class ShareTests(APITestMixin):
         cls.patch_qgroup_create = patch("storageadmin.views.share." "qgroup_create")
         cls.mock_qgroup_create = cls.patch_qgroup_create.start()
         cls.mock_qgroup_create.return_value = "1"
+
+        # E.g. os.stat_result(st_mode=16877, st_ino=256, st_dev=202, st_nlink=1, st_uid=0, st_gid=0, st_size=0, st_atime=1769265087, st_mtime=1769265087, st_ctime=1769265087)
+        cls.patch_os_stat = patch("storageadmin.views.share.stat")
+        cls.mock_os_stat = cls.patch_os_stat.start()
+        cls.mock_os_stat.return_value.st_uid = 1000
+        cls.mock_os_stat.return_value.st_gid = 1000
+        cls.mock_os_stat.return_value.st_mode = cls.ST_MODE_MOCK
+
+        # Provisional mocks ready for futuer test coverage re ACL modifications.
+        # cls.patch_os_stat_helpers = patch("storageadmin.views.share_helpers.stat")
+        # cls.mock_os_stat_helpers = cls.patch_os_stat_helpers.start()
+        # cls.mock_os_stat_helpers.return_value.st_uid = 1000
+        # cls.mock_os_stat_helpers.return_value.st_gid = 1000
+        # cls.mock_os_stat_helpers.return_value.st_mode = 16877
+
+        # View Share mocks for "from system.users import user_name, group_name"
+        cls.patch_user_name = patch("storageadmin.views.share.user_name")
+        cls.mock_user_name = cls.patch_user_name.start()
+        cls.mock_user_name.return_value = "test_user"
+        #
+        cls.patch_group_name = patch("storageadmin.views.share.group_name")
+        cls.mock_group_name = cls.patch_group_name.start()
+        cls.mock_group_name.return_value = "test_group"
+
+        # Mock get_property() - used to retrieve on-disk Share compression setting.
+        cls.patch_get_property = patch("storageadmin.views.share_helpers.get_property")
+        cls.mock_get_property = cls.patch_get_property.start()
+        cls.mock_get_property.return_value = None
 
         cls.patch_volume_usage = patch("storageadmin.views.share.volume_usage")
         cls.mock_volume_usage = cls.patch_volume_usage.start()
@@ -328,6 +362,13 @@ class ShareTests(APITestMixin):
         self.assertEqual(response8.status_code, status.HTTP_200_OK, msg=response8.data)
         self.assertEqual(response8.data["name"], "valid_replica")
         self.assertEqual(response8.data["replica"], True)
+        # http POST in views/share.py creates new shares.
+        # Ensure we are calling os_stat: retrieves owner.group & permissions
+        self.mock_os_stat.assert_called_with("/mnt2/ROOT/valid_replica")
+        # And the DB Share model has our mocked values from user_name() & group_name().
+        self.assertEqual(response8.data["owner"], "test_user")
+        self.assertEqual(response8.data["group"], "test_group")
+        self.assertEqual(response8.data["perms"], self.PERMS_MOCK)
 
         # create share with invalid replica
         data5 = {
@@ -451,16 +492,16 @@ class ShareTests(APITestMixin):
     def test_compression(self):
         """
         Test PUT request to update share compression_algo
-        - Create a share with invalid compression
-        - Create a share with zlib compression
+        - Create share with invalid compression
+        - Create share with zlib compression
         - change compression from zlib to lzo
+        - change compression from lzo to zstd
         - Create a share with lzo compression
+        - disable lzo
+        - re-enable lzo
         - change compression from lzo to zlib
         - disable zlib
-        - enable zlib
-        - disable lzo
-        - enable lzo
-        - change compression from lzo to zstd
+        - re-enable zlib
         """
 
         # create share with invalid compression
@@ -487,6 +528,10 @@ class ShareTests(APITestMixin):
         response = self.client.post(self.BASE_URL, data=compression_test_share)
         self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
         self.assertEqual(response.data["compression_algo"], "zlib")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share", "compression", "zlib"
+        )
+
         share = Share.objects.get(name="compression-test-share")
         sId = share.id
 
@@ -497,6 +542,20 @@ class ShareTests(APITestMixin):
         )
         self.assertEqual(response3.status_code, status.HTTP_200_OK, msg=response3.data)
         self.assertEqual(response3.data["compression_algo"], "lzo")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share", "compression", "lzo"
+        )
+
+        # change compression from lzo to zstd
+        compression_zstd = {"compression": "zstd"}
+        response9 = self.client.put(
+            "{}/{}".format(self.BASE_URL, sId), data=compression_zstd
+        )
+        self.assertEqual(response9.status_code, status.HTTP_200_OK, msg=response.data)
+        self.assertEqual(response9.data["compression_algo"], "zstd")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share", "compression", "zstd"
+        )
 
         # create share with lzo compression
         share_lzo_compression = {
@@ -508,6 +567,33 @@ class ShareTests(APITestMixin):
         response2 = self.client.post(self.BASE_URL, data=share_lzo_compression)
         self.assertEqual(response2.status_code, status.HTTP_200_OK, msg=response2.data)
         self.assertEqual(response2.data["compression_algo"], "lzo")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", "lzo"
+        )
+
+        share = Share.objects.get(name="compression-test-share2")
+        sId = share.id
+
+        # disable lzo compression
+        compression_disable = {"compression": "no"}
+        response7 = self.client.put(
+            "{}/{}".format(self.BASE_URL, sId), data=compression_disable
+        )
+        self.assertEqual(response7.status_code, status.HTTP_200_OK, msg=response7.data)
+        self.assertEqual(response7.data["compression_algo"], "no")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", ""
+        )
+
+        # re-enable lzo compression
+        response8 = self.client.put(
+            "{}/{}".format(self.BASE_URL, sId), data=compression_lzo
+        )
+        self.assertEqual(response8.status_code, status.HTTP_200_OK, msg=response8.data)
+        self.assertEqual(response8.data["compression_algo"], "lzo")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", "lzo"
+        )
 
         # change compression from lzo to zlib
         compression_zlib = {"compression": "zlib"}
@@ -516,43 +602,30 @@ class ShareTests(APITestMixin):
         )
         self.assertEqual(response4.status_code, status.HTTP_200_OK, msg=response4.data)
         self.assertEqual(response4.data["compression_algo"], "zlib")
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", "zlib"
+        )
 
         # disable zlib compression
-        compression_disable = {"compression": "no"}
         response5 = self.client.put(
             "{}/{}".format(self.BASE_URL, sId), data=compression_disable
         )
         self.assertEqual(response5.status_code, status.HTTP_200_OK, msg=response5.data)
         self.assertEqual(response5.data["compression_algo"], "no")
+        # http PUT, when request contains "no" translates this to ""
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", ""
+        )
 
-        # enable zlib compression
+        # re-enable zlib compression
         response6 = self.client.put(
             "{}/{}".format(self.BASE_URL, sId), data=compression_zlib
         )
         self.assertEqual(response6.status_code, status.HTTP_200_OK, msg=response6.data)
         self.assertEqual(response6.data["compression_algo"], "zlib")
-
-        # disable lzo compression
-        response7 = self.client.put(
-            "{}/{}".format(self.BASE_URL, sId), data=compression_disable
+        self.mock_set_property.assert_called_with(
+            "/mnt2/compression-test-share2", "compression", "zlib"
         )
-        self.assertEqual(response7.status_code, status.HTTP_200_OK, msg=response7.data)
-        self.assertEqual(response7.data["compression_algo"], "no")
-
-        # enable lzo compression
-        response8 = self.client.put(
-            "{}/{}".format(self.BASE_URL, sId), data=compression_lzo
-        )
-        self.assertEqual(response8.status_code, status.HTTP_200_OK, msg=response8.data)
-        self.assertEqual(response8.data["compression_algo"], "lzo")
-
-        # change compression from lzo to zstd
-        compression_zstd = {"compression": "zstd"}
-        response9 = self.client.put(
-            "{}/{}".format(self.BASE_URL, sId), data=compression_zstd
-        )
-        self.assertEqual(response9.status_code, status.HTTP_200_OK, msg=response.data)
-        self.assertEqual(response9.data["compression_algo"], "zstd")
 
     def test_delete_exported_replicated(self):
         """

--- a/src/rockstor/storageadmin/views/share.py
+++ b/src/rockstor/storageadmin/views/share.py
@@ -15,7 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+from os import stat, stat_result
+from stat import S_IMODE
 import re
+
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from django.db import transaction
@@ -52,6 +55,8 @@ import json
 from smart_manager.models import Service
 
 import logging
+
+from system.users import user_name, group_name
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +142,7 @@ class ShareListView(ShareMixin, rfc.GenericView):
         # new qgroup: 2015/<some_number> whenever a Share is
         # created. <some_number> starts from 1 and is incremented as more
         # Shares are created. So, for the very first Share in a pool, it's
-        # qgroup will be 1/1. 2015 is arbitrarily chose.
+        # 'rockstor' qgroup will be 2015/1. 2015 is arbitrarily chose.
 
         # Before creating a new Share, we create the qgroup for it. And during
         # it's creation, we assign this qgroup to it. During it's creation a
@@ -201,14 +206,21 @@ class ShareListView(ShareMixin, rfc.GenericView):
                     e_msg = f"Replica must be a boolean, not ({type(replica)})."
                     handle_exception(Exception(e_msg), request)
             pqid = qgroup_create(pool)
+            # Create our new subvol within its parent Pool (btrfs Vol).
             add_share(pool, sname, pqid)
             qid = qgroup_id(pool, sname)
+            # Use Pool subvol path for stat info; Share not yet independently mounted.
+            subvol_path = f"{pool.mnt_pt}/{sname}".replace("//", "/")
+            share_stat: stat_result = stat(subvol_path)
             s = Share(
                 pool=pool,
                 qgroup=qid,
                 pqgroup=pqid,
                 name=sname,
                 size=size,
+                owner=user_name(share_stat.st_uid),
+                group=group_name(share_stat.st_gid),
+                perms=oct(S_IMODE(share_stat.st_mode))[2:].zfill(3),
                 subvol_name=sname,
                 replica=replica,
                 compression_algo=compression,
@@ -219,7 +231,7 @@ class ShareListView(ShareMixin, rfc.GenericView):
             if pqid != PQGROUP_DEFAULT:
                 update_quota(pool, pqid, size * 1024)
                 share_pqgroup_assign(pqid, s)
-            mnt_pt = "%s%s" % (settings.MNT_PT, sname)
+            mnt_pt = f"{settings.MNT_PT}{sname}"
             if not s.is_mounted:
                 mount_share(s, mnt_pt)
             if compression != "no":
@@ -286,7 +298,7 @@ class ShareDetailView(ShareMixin, rfc.GenericView):
                 new_compression = self._validate_compression(request)
                 if share.compression_algo != new_compression:
                     share.compression_algo = new_compression
-                    mnt_pt = "%s%s" % (settings.MNT_PT, share.name)
+                    mnt_pt = f"{settings.MNT_PT}{share.name}"
                     if new_compression == "no":
                         new_compression = ""
                     set_property(mnt_pt, "compression", new_compression)

--- a/src/rockstor/storageadmin/views/share_acl.py
+++ b/src/rockstor/storageadmin/views/share_acl.py
@@ -15,14 +15,17 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+from os import stat, stat_result
+from stat import S_IMODE
+
 from rest_framework.response import Response
 from django.db import transaction
-from django.conf import settings
 from storageadmin.models import Share
 from storageadmin.serializers import ShareSerializer
-from fs.btrfs import mount_share, umount_root
+from fs.btrfs import mount_share, umount_root, get_property
 from storageadmin.views import ShareListView
 from system.acl import chown, chmod
+from system.users import user_name, group_name
 
 
 class ShareACLView(ShareListView):
@@ -30,32 +33,48 @@ class ShareACLView(ShareListView):
     def post(self, request, sid):
         with self._handle_exception(request):
             share = Share.objects.get(id=sid)
-            options = {
-                "owner": "root",
-                "group": "root",
-                "perms": "755",
-                "orecursive": True,
-                "precursive": True,
+            # OWNER, GROUP, AND PERMISSIONS UPDATE.
+            # Get the on disk subvol info.
+            mnt_pt = share.mnt_pt
+            share_stat: stat_result = stat(mnt_pt)
+            subvol_owner = user_name(share_stat.st_uid)
+            subvol_group = group_name(share_stat.st_gid)
+            subvol_perms = oct(S_IMODE(share_stat.st_mode))[2:].zfill(3)
+            # Establish the requested owner, group, perms, defaulting to on disk info.
+            options: dict[str, str | bool] = {
+                "owner": request.data.get("owner", subvol_owner),
+                "group": request.data.get("group", subvol_group),
+                "perms": request.data.get("perms", subvol_perms),
+                # Owner and group recursive (unimplemented in Web-UI)
+                "orecursive": request.data.get("orecursive", True),
+                # Permissions recursive (unimplemented in Web-UI)
+                "precursive": request.data.get("precursive", True),
             }
-            options["owner"] = request.data.get("owner", options["owner"])
-            options["group"] = request.data.get("group", options["group"])
-            options["perms"] = request.data.get("perms", options["perms"])
-            options["orecursive"] = request.data.get(
-                "orecursive", options["orecursive"]
-            )
-            options["precursive"] = request.data.get(
-                "precursive", options["precursive"]
-            )
-            share.owner = options["owner"]
-            share.group = options["group"]
-            share.perms = options["perms"]
-            share.save()
+            # Align Share DB with requested owner, group, perms: if required.
+            changed_fields: list[str] = []
+            if share.owner != options["owner"]:
+                share.owner = options["owner"]
+                changed_fields.append("owner")
+            if share.group != options["group"]:
+                share.group = options["group"]
+                changed_fields.append("group")
+            if share.perms != options["perms"]:
+                share.perms = options["perms"]
+                changed_fields.append("perms")
+            # COMPRESSION SETTING FROM DISK
+            # Opportunistically update DB Share.compression_algo.
+            compression: str = get_property(mnt_pt, "compression")
+            if share.compression_algo != compression:
+                share.compression_algo = compression
+                changed_fields.append("compression_algo")
+            share.save(update_fields=changed_fields)
 
-            mnt_pt = "%s%s" % (settings.MNT_PT, share.name)
             force_mount = False
             if not share.is_mounted:
                 mount_share(share, mnt_pt)
                 force_mount = True
+            # TODO: Huey task that will return immediately, but are run asynchronously
+            #  around a second after being called.
             chown(mnt_pt, options["owner"], options["group"], options["orecursive"])
             chmod(mnt_pt, options["perms"], options["precursive"])
             if force_mount is True:

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -14,8 +14,12 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
+
 import re
 from datetime import datetime, timezone
+from os import stat, stat_result
+from stat import S_IMODE
+
 from django.conf import settings
 from storageadmin.models import Share, Snapshot, SFTP
 from smart_manager.models import ShareUsage
@@ -31,11 +35,14 @@ from fs.btrfs import (
     update_quota,
     share_pqgroup_assign,
     qgroup_assign,
+    get_property,
 )
 from storageadmin.util import handle_exception
 from copy import deepcopy
 
 import logging
+
+from system.users import user_name, group_name
 
 logger = logging.getLogger(__name__)
 
@@ -100,17 +107,18 @@ def import_shares(pool, request):
     for s_in_pool_db in shares_in_pool_db:
         if s_in_pool_db not in shares_in_pool:
             logger.debug(
-                "Removing, missing on disk, share db entry ({}) from "
-                "pool ({}).".format(s_in_pool_db, pool.name)
+                f"Removing, missing on disk, share db entry ({s_in_pool_db}) from pool ({pool.name})."
             )
             Share.objects.get(pool=pool, name=s_in_pool_db).delete()
     # Check if each share in pool also has a db counterpart.
     for s_in_pool in shares_in_pool:
-        logger.debug("---- Share name = {}.".format(s_in_pool))
+        logger.debug(f"---- Share name = {s_in_pool}.")
         if s_in_pool in shares_in_pool_db:
             logger.debug("Updating pre-existing same pool db share entry.")
             # We have a pool db share counterpart so retrieve and update it.
             share = Share.objects.get(name=s_in_pool, pool=pool)
+
+            # QUOTA GROUPS AND ASSOCIATED USAGE UPDATE.
             # Initially default our pqgroup value to db default of '-1/-1'
             # This way, unless quotas are enabled, all pqgroups will be
             # returned to db default.
@@ -157,6 +165,23 @@ def import_shares(pool, request):
                 update_shareusage_db(s_in_pool, rusage, eusage)
             else:
                 update_shareusage_db(s_in_pool, rusage, eusage, UPDATE_TS)
+
+            # OWNER, GROUP, AND PERMISSIONS UPDATE.
+            # Update the existing DB Share entry from the on disk subvol info.
+            share_stat: stat_result = stat(share.mnt_pt)
+            subvol_owner = user_name(share_stat.st_uid)
+            subvol_group = group_name(share_stat.st_gid)
+            subvol_perms = oct(S_IMODE(share_stat.st_mode))[2:].zfill(3)
+            if share.owner != subvol_owner:
+                share.owner = subvol_owner
+            if share.group != subvol_group:
+                share.group = subvol_group
+            if share.perms != subvol_perms:
+                share.perms = subvol_perms
+            # COMPRESSION SETTING FROM DISK
+            subvol_compression = get_property(share.mnt_pt, "compression")
+            if share.compression_algo != subvol_compression:
+                share.compression_algo = subvol_compression
             share.save()
             continue
         try:
@@ -180,9 +205,12 @@ def import_shares(pool, request):
                 )
                 handle_exception(Exception(e_msg), request)
             else:
-                # Update the prior existing db share entry previously
-                # associated with another pool.
+                # Update the prior existing DB share entry previously associated with
+                # another pool. N.B. Until DB share.save() we cannot use share.mnt_pt.
+                # See Share model: mnt_pt property is construction from share.pool.
+                # Consider wiping DB entry and raising exception Share.DoesNotExist
                 logger.debug("Updating prior db entry from another pool.")
+                subvol_path = f"{pool.mnt_pt}/{s_in_pool}".replace("//", "/")
                 cshare.pool = pool
                 cshare.qgroup = shares_in_pool[s_in_pool]
                 cshare.size = pool.size
@@ -193,6 +221,15 @@ def import_shares(pool, request):
                     cshare.pqgroup_rusage,
                     cshare.pqgroup_eusage,
                 ) = volume_usage(pool, cshare.qgroup, cshare.pqgroup)
+                # OWNER, GROUP, AND PERMISSIONS UPDATE.
+                # Update the existing DB Share entry from the on disk subvol info.
+                share_stat: stat_result = stat(subvol_path)
+                cshare.owner = user_name(share_stat.st_uid)
+                cshare.group = group_name(share_stat.st_gid)
+                cshare.perms = oct(S_IMODE(share_stat.st_mode))[2:].zfill(3)
+                # COMPRESSION SETTING FROM DISK
+                cshare.compression_algo = get_property(subvol_path, "compression")
+                pool.save()
                 cshare.save()
                 update_shareusage_db(s_in_pool, cshare.rusage, cshare.eusage)
         except Share.DoesNotExist:
@@ -203,8 +240,8 @@ def import_shares(pool, request):
             replica = False
             share_name = s_in_pool
             if re.match(".snapshot", s_in_pool) is not None:
-                # We have an initial replication share, non snap in .snapshots.
-                # We could change it's name here but still a little mixing
+                # We have an initial replication share, non-snap in .snapshots.
+                # We could change its name here but still a little mixing
                 # of name and subvol throughout project.
                 replica = True
                 logger.debug(
@@ -219,22 +256,30 @@ def import_shares(pool, request):
             rusage, eusage, pqgroup_rusage, pqgroup_eusage = volume_usage(
                 pool, qid, pqid
             )
+            # Use Pool subvol path for stat info; Share not yet independently mounted.
+            subvol_path = f"{pool.mnt_pt}/{share_name}".replace("//", "/")
+            share_stat: stat_result = stat(subvol_path)
             nso = Share(
                 pool=pool,
                 qgroup=qid,
                 pqgroup=pqid,
                 name=share_name,
-                size=pool.size,
+                size=pool.size,  # Default to size of Pool.
+                owner=user_name(share_stat.st_uid),
+                group=group_name(share_stat.st_gid),
+                perms=oct(S_IMODE(share_stat.st_mode))[2:].zfill(3),
                 subvol_name=s_in_pool,
                 rusage=rusage,
                 eusage=eusage,
                 pqgroup_rusage=pqgroup_rusage,
                 pqgroup_eusage=pqgroup_eusage,
                 replica=replica,
+                compression_algo=get_property(subvol_path, "compression"),
             )
+            pool.save()
             nso.save()
             update_shareusage_db(s_in_pool, rusage, eusage)
-            mount_share(nso, "{}{}".format(settings.MNT_PT, s_in_pool))
+            mount_share(nso, f"{settings.MNT_PT}{s_in_pool}")
 
 
 def import_snapshots(share):
@@ -283,7 +328,7 @@ def update_shareusage_db(subvol_name, rusage, eusage, new_entry=True):
     :param new_entry: If True create a new entry with the passed params,
     otherwise attempt to update the latest (by id) entry with time and count.
     """
-    ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+    ts = datetime.now(timezone.utc)
     if new_entry:
         su = ShareUsage(name=subvol_name, r_usage=rusage, e_usage=eusage, ts=ts)
         su.save()

--- a/src/rockstor/system/acl.py
+++ b/src/rockstor/system/acl.py
@@ -16,19 +16,19 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from system.osi import run_command
+# from huey.contrib.djhuey import task
 
 CHOWN = "/usr/bin/chown"
 CHMOD = "/usr/bin/chmod"
-
 
 def chown(share: str, owner: str, group: str | None = None, recursive: bool = False):
     cmd: list[str] = [
         CHOWN,
     ]
-    if recursive is True:
+    if recursive:
         cmd.append("-R")
     if group is not None:
-        owner = "%s:%s" % (owner, group)
+        owner = f"{owner}:{group}"
     cmd.extend([owner, share])
     return run_command(cmd)
 
@@ -37,7 +37,7 @@ def chmod(share: str, perm_bits: str, recursive: bool = False):
     cmd: list[str] = [
         CHMOD,
     ]
-    if recursive is True:
+    if recursive:
         cmd.append("-R")
     cmd.extend([perm_bits, share])
     return run_command(cmd)

--- a/src/rockstor/system/users.py
+++ b/src/rockstor/system/users.py
@@ -14,6 +14,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+
 import logging
 import os
 import pwd
@@ -364,6 +365,40 @@ def group_gid(group_name: str) -> int:
         # Assume utf-8 encoded gr_name str
         gid = entry.gr_gid
     except KeyError:
-        logger.warning(f"Group ({group_name}) not found in system groups. Using gid (0)")
+        logger.warning(
+            f"Group ({group_name}) not found in system groups. Using gid (0)"
+        )
         return 0
     return gid
+
+
+def group_name(gid: int) -> str:
+    """
+    Return the system username for a given group ID, if it exists.
+    Otherwise, return the passed gid as a string.
+    :param gid: User ID.
+    :return: String of the username, or if non found then str(gid)
+    """
+    try:
+        entry = grp.getgrgid(gid)
+        g_name = entry.gr_name
+    except KeyError:
+        logger.warning(f"Group ID ({gid}) not found in system. Converting to str.")
+        return str(gid)
+    return g_name
+
+
+def user_name(uid: int) -> str:
+    """
+    Return the system username for a given user ID, if it exists.
+    Otherwise, return the uid as a string
+    :param uid: User ID.
+    :return: String of the username, or if non found then str(uid)
+    """
+    try:
+        entry = pwd.getpwuid(uid)
+        u_name = entry.pw_name  # Login name
+    except KeyError:
+        logger.warning(f"User ID ({uid}) not found in system. Converting to str.")
+        return str(uid)
+    return u_name


### PR DESCRIPTION
Establish source of truth as on-disk re Share; owner, group, permissions, & compression.

Avoid using owner:group, permissions, & compression_algo Share model defaults with user-created (http: POST) Shares; where possible. Resourcing os.stat and subvol property on newly created subvols instead. There-by tracking OS defaults.

During Pool/Share DB import/update:

- Use os.stat for user:group & permissions.
- Use get_property() to read subvol compression properties.

## Incidental changes:

- Use a pool.save() for foreign_key update before newly discovered share.save() in import_shares().
- Comment updates/improvements and more string.format to fstring changes.
- TODO: and comment additions re pending Huey scheduling of chown & chmod.
- Python datime change re timezone awareness.
- Initial testing re subvol as source-of-truth re defaults for owner:group, perms, and compression.
- On ShareACLView post (submit), call os.stat to establish subvol defaults for; owner:group, perms when not specified. Adds Share DB model
  update re compression while we are handling a Share instance.
- Employ update_fields on minor Share updates during ACL changes.

Fixes #3073 