### PR TITLE
Reference emerging Rock-on norms re Share (owner:group) etc #3074

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/custom_choice.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/custom_choice.jst
@@ -3,8 +3,10 @@
     <span class="sr-only">60% Complete</span>
   </div>
 </div>
-<div class="alert alert-warning">
-  <p>Additional configuration is needed for this Rock-on. Read mouseover <i class="fa fa-info-circle"></i> tooltips for specific information before making your selection.</p>
+<div class="alert alert-info">
+  <p>Additional configuration is needed. Square brackets [], if present, contain suggestions/hints.</p>
+  <p><i>UID and GID, if requested, reference the user ID & group ID to run this Rock-on under.</i></p>
+  <p>See also each mouse-over <i class="fa fa-info-circle"></i> info pop-up.</p>
 </div>
 
 <div id="ph-cc-form"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/device_choice.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/device_choice.jst
@@ -3,7 +3,7 @@
     <span class="sr-only">60% Complete</span>
   </div>
 </div>
-<div class="alert alert-warning">
+<div class="alert alert-info">
   <p>Additional configuration is needed for this Rock-on. Read mouseover <i class="fa fa-info-circle"></i> tooltips for specific information before making your selection.</p>
 </div>
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports_form.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/edit_ports_form.jst
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-md-10">
-        <div class="alert alert-warning">
+        <div class="alert alert-info">
             <p>
                 You can choose to unpublish any port currently exported by this rock-on. Be aware,
                 however, that this is likely to interfere with its proper function, so change these settings

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/install_choice.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/install_choice.jst
@@ -1,9 +1,13 @@
 <div class="progress">
   <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 25%;"></div>
 </div>
-<div class="alert alert-warning">
-  <p>Shares provide storage to the Rock-on. Read mousever <i class="fa fa-info-circle"></i> tooltips for specific information before making a selection. We strongly recommend creating dedicated Share assignments. If a Config or Data Share is assigned to more than one Rock-on, it could cause strange behavior.</p>
-  <p>To create needed Storage(Shares) and come back, <a href="#add_share">click here.</a></p>
+<div class="alert alert-info">
+  <p>Shares provide storage for the Rock-on;
+  so the selected Share's owner:group must match any provided "(user/UID:group/GID)" in the matched mouse-over <i class="fa fa-info-circle"></i> info pop-up.
+  Or similar UID & GID entry request later-on in this wizard.</p>
+  <p><i>Visit STORAGE -> Shares ->  <a href="#add_share">Create Share</a> if the required Share/s do not already exist.</i>
+  <p>The square brackets [] contain Share name suggestions.</p>
+  <p>Use each Share's <strong>Access control (tab) & Edit (button)</strong> to view & set owner:group and permissions before completing this install.</p>
 </div>
 
 <div id="ph-vols-table"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/install_summary.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/install_summary.jst
@@ -3,8 +3,11 @@
     <span class="sr-only">60% Complete</span>
   </div>
 </div>
-<div class="alert alert-warning">
-  <p>Please verify your input and click submit to start the installation.</p>
+<div class="alert alert-info">
+  <p>Please verify and 'Submit' your input to start the installation.</p>
+  <p><i>Be sure that all listed/mapped Share 'Resources' have had their <strong>Access control (tab)</strong> set accordingly.</i></p>
+  <p><i>If unsure, close this wizard, check the relevant owner:group & permissions, and restart this Rock-on install.</i></p>
+  <p>See also each mouse-over <i class="fa fa-info-circle"></i> info pop-up.</p>
 </div>
 
 <div id="ph-summary-table"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/port_choice.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/port_choice.jst
@@ -2,7 +2,7 @@
   <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 50%;">
   </div>
 </div>
-<div class="alert alert-warning">
-  <p>Ports provide network access to the Rock-on. Preferred default values are provided for convenience. Read mouseover <i class="fa fa-info-circle"></i> tooltips for more information.</p>
+<div class="alert alert-info">
+  <p>Ports provide network access to the Rock-on. The square brackets [] contain suggestions. See also each mouse-over <i class="fa fa-info-circle"></i> info pop-up.</p>
 </div>
 <div id="ph-ports-form"></div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/rockons.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/rockons.jst
@@ -54,7 +54,7 @@
 </div>
 {{else}}
 <div class="alert alert-info">
-  <strong>Note:</strong> The Rock-on service is not running. Turn it ON to enable this OCI image Docker/Podman based plugin system.
+  <strong>Note:</strong> The Rock-on service is not running. Turn it ON to enable this OCI image plugin system based on Docker.
   <p><i>See our online <a href="https://rockstor.com/docs/interface/overview.html" target="_blank">Rock-ons (Docker Plugins)"</a> guide for full setup instructions.</i></p>
 </div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/rockons.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/rockons/rockons.jst
@@ -53,7 +53,8 @@
   </div>
 </div>
 {{else}}
-<div class="alert alert-warning">
-  <strong>Warning!</strong> Rock-on service is not running. Please turn it on to use features on this screen.
+<div class="alert alert-info">
+  <strong>Note:</strong> The Rock-on service is not running. Turn it ON to enable this OCI image Docker/Podman based plugin system.
+  <p><i>See our online <a href="https://rockstor.com/docs/interface/overview.html" target="_blank">Rock-ons (Docker Plugins)"</a> guide for full setup instructions.</i></p>
 </div>
 {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/services/configure_docker.jst
@@ -18,15 +18,19 @@
 */
 </script>
 
-<div class="alert alert-warning">
-    <p>We strongly recommend that you create a separate Share (at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.</p>
-    <p>To create a new Share, <a href="#add_share">click here.</a></p>
+<div class="alert alert-info">
+    <p><strong>The Rock-on system requires a dedicated Share of at least 5GB</strong> with the default (owner:group) and permissions.
+    As Rock-ons are installed, many snapshots will be created within this Share.
+    These snapshots/subvols are the program or application part of each Rock-on installed.</p>
+    <p><i>WARNING: Be sure not to delete these snapshots as this will break all Rock-ons whose applications share the affected OCI image layers that these snapshots represent.</i></p>
+    <p>- See our online <a href="https://rockstor.com/docs/interface/overview.html" target="_blank">Rock-ons (Docker Plugins)</a> guide for full setup instructions.</p>
+    <p>Visit STORAGE -> Shares -> "Create Share" if a suitable dedicated Share does not already exist.</p>
 </div>
 
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">
-            <div class="panel-heading">Configure {{serviceName}} Service
+            <div class="panel-heading">Configure the {{serviceName}} Service
                 <a href="https://rockstor.com/docs/interface/system/services.html#rock-ons-docker-plugin-system" target="_blank"
                    title="See Rockstor's documentation" rel="tooltip"><i class="glyphicon glyphicon-question-sign"></i></a>
             </div>
@@ -35,7 +39,7 @@
                     <div class="messages"></div>
 
                     <div class="form-group">
-                        <label class="col-sm-4 control-label" for="root_share">Root Share<span class="required"> *</span></label>
+                        <label class="col-sm-4 control-label" for="root_share">Share [e.g. rockons-root]<span class="required"> *</span></label>
                         <div class="col-sm-4">
                             {{display_rockon_shares}}
                         </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/configure_service.js
@@ -218,7 +218,7 @@ ConfigureServiceView = RockstorLayoutView.extend({
         this.$('#docker-form #root_share').tooltip({
             html: true,
             placement: 'right',
-            title: 'We strongly recommend that you create a separate Share(at least 5GB size) for this purpose. During the lifetime of Rock-ons, several snapshots will be created and space could fill up quickly. It is best managed in a separate Share to avoid clobbering other data.'
+            title: 'Select the dedicated Rock-ons root Share of at least 5GB.'
         });
         this.$('#active-directory-form #domain').tooltip({
             html: true,


### PR DESCRIPTION
Improve and update our user-facing instructional / guiding text on Rock-on subsystem setup and Rock-on install.

Predominantly focused on now established Rock-on norms re hints and Share owner:group settings. Note that emphasis on dedicated per Rock-on Share has been reduced as we enforce this in code currently. And some self-evident prior instructions have been striped. Helping to avoid a 'wall-of-text'.

Formatting of these texts elements has also been changed from warning to info - more readable and more appropriate. Plus there is now more use of HTML "strong" and italics for emphasis.

Explicit indication of the relevance of Share owner:group has also been added in both the first and last wizard elements, with the latter indicating a need to end the install wizard if there is doubt.

A doc reference was added to the rockon-subsystem OFF landing page. Intended to ease initial Rock-on subsystem configuration.

N.B. there are no functional changes within this patch. Only user facing text changes and their associated formatting. A borderline case of this is the removal of a non-functional (dialog remained) 'Create Share' link.

Fixes #3074 