### PR TITLE
Add 'edge' repo tier #3094

### DIFF
--- a/src/rockstor/settings.py
+++ b/src/rockstor/settings.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -462,6 +462,11 @@ UPDATE_CHANNELS = {
         "name": "Testing",
         "description": "Subscription channel for testing updates",
         "url": "updates.rockstor.com:8999/rockstor-testing",
+    },
+    "edge": {
+        "name": "Edge",
+        "description": "Subscription channel for edge updates",
+        "url": "updates.rockstor.com:8999/rockstor-edge",
     },
 }
 

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/home/home_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/home/home_template.jst
@@ -1,21 +1,21 @@
 <script>
-/*
-* Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
-*
-* Rockstor is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published
-* by the Free Software Foundation; either version 2 of the License,
-* or (at your option) any later version.
-*
-* Rockstor is distributed in the hope that it will be useful, but
-* WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+    /*
+    * Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
+    *
+    * Rockstor is free software; you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published
+    * by the Free Software Foundation; either version 2 of the License,
+    * or (at your option) any later version.
+    *
+    * Rockstor is distributed in the hope that it will be useful, but
+    * WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    * General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program. If not, see <http://www.gnu.org/licenses/>.
+    *
+    */
 </script>
 
 <div class="widgets-container"></div>
@@ -34,19 +34,24 @@
 <div class="modal fade" id="update-version-modal">
   <div class="modal-dialog justify-content-center">
     <div class="modal-content">
-      <div class="modal-body" >
+      <div class="modal-body">
         <h2 id="update-version-modal-label">Welcome to the Rockstor Web User Interface (Web-UI)</h2>
-        <h3> Activating a Rockstor package
+        <p>
+          Activating a Rockstor package
           <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank">Update Channel</a>
-          and updating is recommended. All pending system updates will be included.
-          <em> Please be patient, this can take some time.</em></h3>
-        <h4><em>Our Open Source development is dependant upon update channel subscriptions and donations.</em></h4>
-        <h4>Would you like to update now?</h4>
+          and updating is recommended, but not required. A reminder will be presented on each Dashboard visit.
+          <em> Please be patient during these updates as they can take some time.</em>
+        </p>
+        <strong>This selection does not affect our upstream 'Built on openSUSE' updates.</strong>
         <br>
+        <strong><a href="https://rockstor.com/about-us.html" target="_blank">We</a>
+          are a <i>non-profit</i> community endeavour fiscally hosted by
+          <a href="https://opensourceeurope.org/" target="_blank"> Open Source Europe (OSE).</a>
+        </strong>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
-        <a id="updateYes" class="btn btn-primary" title="Update">Update Now</a>
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Dismiss</button>
+        <a id="updateYes" class="btn btn-primary" title="Update">More information</a>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
@@ -57,16 +62,22 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">
-        <h2 id="update-channel-modal-label">Please select a Rockstor package <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank">Update Channel</a></h2>
-        <h3>- Stable updates: recommended for production use (paid).
-          <br>
-          - Testing updates: for development / actively testing latest code (free).</h3>
-        <h4><em>Our Open Source development is dependant upon update channel subscriptions and donations.</em></h4>
-        <br>
+        <h2 id="update-channel-modal-label">Select a Rockstor package
+          <a href="http://rockstor.com/docs/update-channels/update_channels.html" target="_blank">Update Channel</a>
+        </h2>
+        <p>
+          <br>- <strong>Stable updates</strong>: Intended for production use (<i>non-profit</i> subscription).
+          <br>- <strong>Testing updates</strong>: Field-testing towards future Stable releases (free).
+          <br>- <strong>Edge updates</strong>: Untested releases - developers only (free).
+        </p>
+        <strong><a href="https://rockstor.com/about-us.html" target="_blank">We</a>
+          are a <i>non-profit</i> community endeavour fiscally hosted by
+          <a href="https://opensourceeurope.org/" target="_blank"> Open Source Europe (OSE).</a>
+        </strong>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">No, Thanks</button>
-        <a id="activate" class="btn btn-primary" title="Update">I'll activate</a>
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Dismiss</button>
+        <a id="activate" class="btn btn-primary" title="Update">More information</a>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/update/version_info.jst
@@ -1,102 +1,155 @@
 <script>
-$(document).ready(function(){
-  $("#subscription-table tr td:first-child").css( "color", "#eb6841" );
-});
+    $(document).ready(function () {
+        $("#subscription-table tr td:first-child").css("color", "#eb6841");
+    });
 </script>
 
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
 
-    {{#is_sub_active defaultSub}}
-    <div class="alert alert-danger">
+    {{#is_sub_active defaultSub}} <!-- Testing active header-->
+    <div class="alert alert-warning">
       <p>
         <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
-        are <strong>activated</strong>. These are cutting edge updates that should
-        be applied only after careful consideration. When an update is released,
-        read the changelog and proceed with caution.
+        are <strong>activated</strong>.
+        These are in-development / pre-stable updates that should be applied only after careful consideration.
+        Whenever an update is released, be sure to read the changelog carefully before proceeding.
+        <strong>Be advised that production use of Testing updates is discouraged.</strong>
       </p>
       <p>
         Alternatively,
         <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
-        are generally recommended as shown below.
+        are generally recommended for production.
       </p>
     </div>
     {{/is_sub_active}}
 
-    {{#no_sub_active}}
-    <div class="alert alert-success">
+    {{#is_sub_active edgeSub}} <!-- Edge active header-->
+    <div class="alert alert-danger">
+      <p>
+        <a href="https://rockstor.com/docs/update-channels/update_channels.html#edge-channel" target="_blank">Edge Updates</a>
+        are <strong>activated</strong>.
+        These updates are NOT field-tested, and are intended for development use only.
+        They are expected to install;
+        but they may not provide even basic functionality, including upgrading from prior releases.
+      </p>
+      <p>
+        Due to the edge nature of this channel, changelogs may not always be available or functional.
+        <strong>Edge updates are definitely not intended for production use.</strong>
+      </p>
+      <p>
+        Alternatively,
+        <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
+        are generally recommended for production use.
+      </p>
+    </div>
+    {{/is_sub_active}}
+
+    {{#no_sub_active}} <!-- No subscription active header-->
+    <div id="updateInfo" class="alert alert-success">
       <p>
         Rockstor package
         <a href="https://rockstor.com/docs/update-channels/update_channels.html" target="_blank"> update channels. </a>
-        Please activate appropriately for your needs.
-        <br>- <strong>Stable updates</strong>: recommended for production use (paid) -
-        <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a> eligible.
-        <br>- <strong>Testing updates</strong>: for development / actively testing latest code (free).
+        Activate appropriately for your needs and/or intentions.
+        <br>- <strong>Stable updates</strong>: Intended for production use (<i>non-profit</i> subscription).
+        <br>- <strong>Testing updates</strong>: Field-testing towards future Stable releases (free).
+        <br>- <strong>Edge updates</strong>: Untested releases - developers only (free).
         <br>See our <a href="https://forum.rockstor.com/" target="_blank">friendly forum</a> for advise.
       </p>
+      <strong>This selection does not affect our upstream 'Built on openSUSE' updates.</strong>
+      <br>
+      <strong><a href="https://rockstor.com/about-us.html" target="_blank">We</a>
+        are a <i>non-profit</i> community endeavour fiscally hosted by
+        <a href="https://opensourceeurope.org/" target="_blank"> Open Source Europe (OSE).</a>
+      </strong>
     </div>
     {{/no_sub_active}}
 
     {{#is_sub_active stableSub}}
-    {{else}}
+    <!-- Only show the overview table when NOT Stable subscribed - Stable has its own overview page. -->
+    {{ else }}
     <table class="table table-hover" id="subscription-table">
       <thead>
-	<tr class="active">
-          <th>Feature</th>
-          <th><a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a></th>
-          <th><a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a></th>
-	</tr>
+      <tr class="active">
+        <th>Feature</th>
+        <th>
+          <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
+        </th>
+        <th>
+          <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
+        </th>
+        <th>
+          <a href="https://rockstor.com/docs/update-channels/update_channels.html#edge-channel" target="_blank">Edge Updates</a>
+        </th>
+      </tr>
       </thead>
       <tbody>
-	<tr>
-          <td>Update Frequency</td>
-          <td>2-4 Months</td>
-          <td>2-4 Weeks</td>
-	</tr>
-	<tr>
-          <td>Priority of bug fixes</td>
-          <td>Highest</td>
-          <td>Varies</td>
-	</tr>
-	<tr>
-          <td>Automated functional testing</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-check"></i></td>
-	</tr>
-	<tr>
-          <td>Tested in development environment</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-check"></i></td>
-	</tr>
-	<tr>
-          <td>Low risk of regressions</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-times"></i></td>
-	</tr>
-	<tr>
-          <td>Tested in production environment</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-times"></i></td>
-	</tr>
-	<tr>
-          <td>Tested by community</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-times"></i></td>
-	</tr>
-  <tr>
-          <td>Paid Support available</td>
-          <td><i class="fa fa-check"></i></td>
-          <td><i class="fa fa-times"></i></td>
-  </tr>
-	<tr>
-          <td></td>
-          <td><a id="stable-modal" class="btn btn-success" title="Activate Stable subscription">Activate</a></td>
-	  {{#is_sub_active defaultSub}}
-          <td><a id="testing-modal" class="btn btn-danger" title="Activate Testing subscription" disabled>Currently Active</a></td>
-	  {{else}}
-          <td><a id="testing-modal" class="btn btn-danger" title="Activate Testing subscription">Activate</a></td>
-	  {{/is_sub_active}}
-	</tr>
+      <tr>
+        <td>Update Frequency</td>
+        <td>3-6 Months</td>
+        <td>3-6 Weeks</td>
+        <td>3-6 Days</td>
+      </tr>
+      <tr>
+        <td>Priority of bug fixes</td>
+        <td>Highest</td>
+        <td>Varies</td>
+        <td>None</td>
+      </tr>
+      <tr>
+        <td>Risk of regressions</td>
+        <td>Low</td>
+        <td>Medium</td>
+        <td>High</td>
+      </tr>
+      <tr>
+        <td>Automated unit testing</td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-check"></i></td>
+      </tr>
+      <tr>
+        <td>Tested in development environment</td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-times"></i></td>
+      </tr>
+      <tr>
+        <td>Tested by community</td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-times"></i></td>
+      </tr>
+      <tr>
+        <td>Tested in production environment</td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-times"></i></td>
+        <td><i class="fa fa-times"></i></td>
+      </tr>
+      <tr>
+        <td>Eligible for <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support</i></a></td>
+        <td><i class="fa fa-check"></i></td>
+        <td><i class="fa fa-times"></i></td>
+        <td><i class="fa fa-times"></i></td>
+      </tr>
+      <tr>
+        <td></td>
+        <!-- stableSub (Stable) always disabled on this page - hence only an "Activate" button -->
+        <td><a id="stable-modal" class="btn btn-success" title="Activate Stable subscription">Activate</a></td>
+        <!-- defaultSub (Testing) -->
+        {{#is_sub_active defaultSub}}
+        <td><a id="testing-modal" class="btn btn-warning" title="Reactivate Testing subscription">Currently Active</a>
+        </td>
+        {{ else }}
+        <td><a id="testing-modal" class="btn btn-warning" title="Activate Testing subscription">Activate</a></td>
+        {{/is_sub_active}}
+        <!-- edgeSub (Edge) -->
+        {{#is_sub_active edgeSub}}
+        <td><a id="edge-modal" class="btn btn-danger" title="Reactivate Edge subscription">Currently Active</a></td>
+        {{ else }}
+        <td><a id="edge-modal" class="btn btn-danger" title="Activate Edge subscription">Activate</a></td>
+        {{/is_sub_active}}
+      </tr>
       </tbody>
     </table>
     {{/is_sub_active}}
@@ -108,7 +161,7 @@ $(document).ready(function(){
 <br>
 <div class="col-sm-offset-3 col-sm-6 col-sm-offset-3">
   <div id="updateInfo">
-    <h3><strong>Rockstor {{mostRecentVersion}}</strong> update is available! </h3>
+    <h3><strong>Rockstor {{ mostRecentVersion }}</strong> update is available! </h3>
   </div>
 </div>&nbsp;&nbsp;&nbsp;&nbsp;
 <br><br>
@@ -117,14 +170,14 @@ $(document).ready(function(){
     <p>List of changes in this update (try page reload if empty)</p>
     <ul>
       {{#each changeMap}}
-      <li><p>{{this}}</p></li>
+      <li><p>{{ this }}</p></li>
       {{/each}}
     </ul>
     {{#is_sub_active defaultSub}}
     <p>
-      You should review the
-      changelog <a href="https://github.com/rockstor/rockstor-core/commits/master"
-		   target="_blank">here</a> before proceeding with the update.
+      You should review the relevant changelog
+      <a href="https://github.com/rockstor/rockstor-core/releases" target="_blank">Releases</a>
+      before proceeding with the update.
     </p>
     {{/is_sub_active}}
   </div>
@@ -136,7 +189,8 @@ $(document).ready(function(){
     <h4>Our Open Source development is dependant upon active
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates </a>
       participation,
-      <a href="https://opencollective.com/the-rockstor-project/contribute" target="_blank"> donations (Open Collective)</a>
+      <a href="https://opencollective.com/the-rockstor-project/contribute" target="_blank"> donations (Open
+        Collective)</a>
       , and
       <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates </a>
       subscriptions with their associated
@@ -147,17 +201,17 @@ $(document).ready(function(){
   <a id="update" class="btn btn-primary" title="start update">Start Update</a>
 </div>
 
-{{else}}
+{{ else }}
 <div class="col-md-offset-3 col-md-6 col-md-offset-3">
   <div id="updateInfo">
-    <h3>System is running Rockstor version: {{currentVersion}}</h3>
-    <p>If you've updated recently, reload the browser<b>(Ctrl+Shift+R)</b> for latest UI changes.</p><br>
+    <h3>System is running Rockstor version: {{ currentVersion }}</h3>
+    <p>If you've recently updated, refresh the browser cache via <b>(Ctrl+Shift+R)</b> for the latest changes.</p><br>
 
-<!--    {{#if autoUpdateEnabled}}-->
-<!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor is configured to check for available system updates and automatically upgrade all packages on a daily basis. This will keep your entire system up to date. While it's not recommended, you can disable this feature and only update when you want to.">Disable auto update</a>-->
-<!--    {{else}}-->
-<!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor can be configured to check for available system updates and automatically upgrade all packages on a daily basis. We recommend you enable this feature to keep your entire system up to date without delay.">Enable auto update</a>-->
-<!--    {{/if}}-->
+    <!--    {{#if autoUpdateEnabled}}-->
+    <!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor is configured to check for available system updates and automatically upgrade all packages on a daily basis. This will keep your entire system up to date. While it's not recommended, you can disable this feature and only update when you want to.">Disable auto update</a>-->
+    <!--    {{else}}-->
+    <!--    <a id="autoUpdateSwitch" class="btn btn-primary" title="Rockstor can be configured to check for available system updates and automatically upgrade all packages on a daily basis. We recommend you enable this feature to keep your entire system up to date without delay.">Enable auto update</a>-->
+    <!--    {{/if}}-->
   </div>
 </div>
 {{/update_available}}
@@ -167,13 +221,25 @@ $(document).ready(function(){
   <div id="updateInfo" class="alert alert-success">
     <p></p>
     <p>
-      <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
-      are <strong>activated</strong> - install eligible for
-      <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support.</i></a>
-      <br><br>
-      While it's not recommended, if you are absolutely sure,
-      <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">Testing Updates</a>
-      can be activated by clicking <a id="testing-modal"> here.</a>
+      <strong>
+        <a href="https://rockstor.com/docs/update-channels/update_channels.html#stable-channel" target="_blank">Stable Updates</a>
+        are activated - install is eligible for
+        <a href="https://rockstor.com/paid_support.html" target="_blank"><i>Paid Support.</i></a>
+      </strong>
+    <hr>
+    The following development orientated channels are available:<br>
+    <dl>
+      <dt>
+        <a href="https://rockstor.com/docs/update-channels/update_channels.html#testing-channel" target="_blank">About Testing Updates</a>
+        - Field-testing towards future Stable releases.
+      <dd>Activate: <a id="testing-modal">Testing</a>.</dd>
+      </dt>
+      <dt>
+        <a href="https://rockstor.com/docs/update-channels/update_channels.html#edge-channel" target="_blank">About Edge Updates</a>
+        - Untested releases - developers only.
+      <dd>Activate: <a id="edge-modal">Edge</a>.</dd>
+      </dt>
+    </dl>
     </p>
   </div>
   {{/is_sub_active}}
@@ -183,14 +249,17 @@ $(document).ready(function(){
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-	<h4>Rockstor is being updated to the latest version in the selected update channel. Please wait... &nbsp;&nbsp; </h4>
+        <h4>Rockstor is updating to the latest version in the selected update channel. Please wait...
+          &nbsp;&nbsp; </h4>
       </div>
       <div class="modal-body">
-	<div style="text-align: center">
-	  <img src="/static/storageadmin/img/ajax-loader-big.gif">
-	  <div id="time-left"></div>
-	</div>
-	<div id="user-msg" style="display: none">The Rockstor update is still going on. if the page does not automatically refresh after a few minutes, please try manually refreshing after some time.</div>
+        <div style="text-align: center">
+          <img src="/static/storageadmin/img/ajax-loader-big.gif">
+          <div id="time-left"></div>
+        </div>
+        <div id="user-msg" style="display: none">The Rockstor update is still going on. if this page does not
+          automatically refresh after a few minutes, try manually refreshing.
+        </div>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
@@ -203,41 +272,45 @@ $(document).ready(function(){
         <h3 class="modal-title">Activate Stable updates.</h3>
       </div>
       <div style="font-size: 13px" class="modal-body">
-	<p>
-	  Please follow these steps to activate Stable Updates.<br>
-    <div style="text-align: center;">
-         <strong><i>Steps 1 & 2 will each send confirmation / information emails.</i></strong>
-      </div>
-	</p>
-	<ol>
-    <li>Become a "Stable Updates subscription" contributor / member at our
-        <a href="https://opencollective.com/the-rockstor-project/contribute" target="_blank">Open Collective.</a></li>
-    <li>Enter / Edit / Check your <span style="color:green">Current Appliance ID</span> in your
-      <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.</li>
-    <li>Enter your Activation code below, emailed by <strong>Appman</strong> immediately after step 2.</li>
-	</ol>
-        Thank you for helping to support Rockstor's development.
-	<form id="activate-stable-form" name="aform" class="form-horizontal">
-	  <div class="form-group">
-	    <label class="col-sm-4 control-label" for="activation-code">Activation Code <span class="required">*</span></label>
-	    <div class="col-sm-4">
-	      {{#if stableSub}}
-	      <input class="form-control" type="text" id="activation-code" value="{{stableSub.password}}"name="activation-code">
-	      {{else}}
-	      <input class="form-control" type="text" id="activation-code" name="activation-code">
-	      {{/if}}
-	    </div>
-	  </div>
-	  <p style="color:green">Current Appliance ID: {{applianceId}}</p>
-    <br>
-    Note your complementary self service <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.
-    <br>
-    The above 'Current Appliance ID' should match that within Appman for this computer.
-	  <div class="modal-footer">
-  	    <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-  	    <a id="activateStable" class="btn btn-primary" title="Activate">Activate</a>
-	  </div>
-	</form>
+        <p>
+          Please follow these steps to activate Stable Updates.<br>
+        <div style="text-align: center;">
+          <strong><i>Steps 1 & 2 will each send confirmation / information emails.</i></strong>
+        </div>
+        </p>
+        <ol>
+          <li>Become a "Stable Updates subscription" contributor / member at our
+            <a href="https://opencollective.com/the-rockstor-project/contribute" target="_blank">Open Collective.</a>
+          </li>
+          <li>Enter / Edit / Check your <span style="color:green">Current Appliance ID</span> in your
+            <a href="https://appman.rockstor.com/" target="_blank">Appliance ID manager</a> <strong>Appman</strong>.
+          </li>
+          <li>Enter your Activation code below, emailed by <strong>Appman</strong> immediately after step 2.</li>
+        </ol>
+        Thank you for helping to support Rockstor's non-profit development.
+        <form id="activate-stable-form" name="aform" class="form-horizontal">
+          <div class="form-group">
+            <label class="col-sm-4 control-label" for="activation-code">Activation Code <span class="required">*</span></label>
+            <div class="col-sm-4">
+              {{#if stableSub}}
+              <input class="form-control" type="text" id="activation-code" value="{{ stableSub.password }}"
+                     name="activation-code">
+              {{ else }}
+              <input class="form-control" type="text" id="activation-code" name="activation-code">
+              {{/if}}
+            </div>
+          </div>
+          <p style="color:green">Current Appliance ID: {{ applianceId }}</p>
+          <br>
+          Note your complementary self-service <a href="https://appman.rockstor.com/" target="_blank">Appliance ID
+          manager</a> <strong>Appman</strong>.
+          <br>
+          The above 'Current Appliance ID' should match that within Appman for this computer.
+          <div class="modal-footer">
+            <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+            <a id="activateStable" class="btn btn-primary" title="Activate">Activate</a>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -251,22 +324,51 @@ $(document).ready(function(){
         <h4 class="modal-title">Activate Testing updates</h4>
       </div>
       <div class="modal-body">
-	<p>
-	  Testing updates are high frequency updates that are released just
-	  after development environment testing, as opposed to Stable updates
-	  that are released only after significant testing and qualification
-	  processes. Because of this, Testing updates are higher risk and are
-	  generally not recommended.
-	</p>
-	<p>
-	  Whenever an update is released, read the changelog and decide to
-	  update or not only after careful consideration.
-	</p>
-      	<p>Are you sure?</p>
+        <p>
+          Testing releases are inherited periodically from the Edge update channel.
+          As such, early-on in each testing phases, there can still be significant known, and unknown issues.
+          <strong>Be advised that production use of Testing updates is discouraged.</strong>
+          Stable updates, intended for production, are take from the end of each testing phase.
+        </p>
+        <p>
+          Whenever an update is released, be sure to read the changelog carefully before proceeding.
+        </p>
+        <p>Are you sure?</p>
       </div>
       <div class="modal-footer">
-      <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-      <a id="activateTesting" class="btn btn-primary" title="Activate">Activate</a>
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+        <a id="activateTesting" class="btn btn-primary" title="Activate">Activate</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="activate-edge" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Activate Edge updates</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          Edge updates are NOT field-tested, and intended for development use only.
+          Packages in this update channel have passed only rudimentary rpmbuild tests.
+          After moderate install and upgrade testing, select packages in Edge are
+          promoted to the Testing updates channel for wider field-testing.
+        </p>
+        <p>
+          Edge updates have the highest risk. They are expected to install,
+          but they may not provide all basic functionality, including upgrading from prior releases.
+          <strong>Edge updates are definitely not intended for production use.</strong>
+        </p>
+        <p>
+          Due to the edge nature of this channel, changelogs may not always be available or functional.
+        </p>
+        <p>Are you sure?</p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+        <a id="activateEdge" class="btn btn-primary" title="Activate">Activate</a>
       </div>
     </div>
   </div>
@@ -276,45 +378,45 @@ $(document).ready(function(){
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-	{{#if autoUpdateEnabled}}
+        {{#if autoUpdateEnabled}}
         <h4 class="modal-title">Disable auto updates</h4>
-	{{else}}
-	<h4 class="modal-title">Enable auto updates</h4>
-	{{/if}}
+        {{ else }}
+        <h4 class="modal-title">Enable auto updates</h4>
+        {{/if}}
       </div>
       <div class="modal-body">
-	{{#if autoUpdateEnabled}}
-	<p>
-	  Currently Rockstor is configured to check for available system updates
-	  and automatically upgrade all packages on a daily basis. This will keep
-	  your entire system up to date. Disabling auto updates is only
-	  recommended when you have Testing updates activated.
-	</p>
-	{{else}}
-	{{#is_sub_active defaultSub}}
-	<div class="alert alert-danger">
-	  <p>
-	    Testing updates are activated on this system. Enabling auto updates
-	    is strongly discouraged while this is the case.
-	  </p>
-	</div>
-	{{/is_sub_active}}
-	<p>
-	  By enabling auto updates, Rockstor will check for available system
-	  updates and automatically upgrade all packages on a daily
-	  basis. Enabling this feature is recommended except when Testing
-	  updates are active.
-	</p>
-	{{/if}}
-      	<p>Are you sure?</p>
-	<div class="modal-footer">
-	  <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
-	  {{#if autoUpdateEnabled}}
-	  <a id="disableAuto" class="btn btn-primary" title="Activate">Disable auto updates</a>
-	  {{else}}
-	  <a id="enableAuto" class="btn btn-primary" title="Activate">Enable auto updates</a>
-	  {{/if}}
-	</div>
+        {{#if autoUpdateEnabled}}
+        <p>
+          Currently, Rockstor is configured to check for available system updates
+          and automatically upgrade all packages on a daily basis. This will keep
+          your entire system up to date. Disabling auto updates is only
+          recommended when you have Testing updates activated.
+        </p>
+        {{ else }}
+        {{#is_sub_active defaultSub}}
+        <div class="alert alert-danger">
+          <p>
+            Testing updates are activated on this system. Enabling auto updates
+            is strongly discouraged while this is the case.
+          </p>
+        </div>
+        {{/is_sub_active}}
+        <p>
+          By enabling auto updates, Rockstor will check for available system
+          updates and automatically upgrade all packages on a daily
+          basis. Enabling this feature is recommended except when Testing
+          updates are active.
+        </p>
+        {{/if}}
+        <p>Are you sure?</p>
+        <div class="modal-footer">
+          <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Cancel</button>
+          {{#if autoUpdateEnabled}}
+          <a id="disableAuto" class="btn btn-primary" title="Activate">Disable auto updates</a>
+          {{ else }}
+          <a id="enableAuto" class="btn btn-primary" title="Activate">Enable auto updates</a>
+          {{/if}}
+        </div>
       </div>
     </div>
   </div>

--- a/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
+++ b/src/rockstor/storageadmin/static/storageadmin/js/views/version.js
@@ -3,7 +3,7 @@
  * @licstart  The following is the entire license notice for the
  * JavaScript code in this page.
  *
- * Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+ * Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
  *
  * Rockstor is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published
@@ -31,8 +31,10 @@ VersionView = RockstorLayoutView.extend({
         'click #disableAuto': 'disableAutoUpdate',
         'click #stable-modal': 'showStableModal',
         'click #testing-modal': 'showTestingModal',
+        'click #edge-modal': 'showEdgeModal',
         'click #activateStable': 'activateStable',
-        'click #activateTesting': 'activateTesting'
+        'click #activateTesting': 'activateTesting',
+        'click #activateEdge': 'activateEdge'
     },
 
     initialize: function() {
@@ -89,12 +91,16 @@ VersionView = RockstorLayoutView.extend({
 
         var stableSub = null;
         var defaultSub = null;
+        var edgeSub = null;
         this.subscriptions.each(function(s) {
             if (s.get('name') == 'Stable') {
                 stableSub = s.toJSON();
             }
             if (s.get('name') == 'Testing') {
                 defaultSub = s.toJSON();
+            }
+            if (s.get('name') == 'Edge') {
+                edgeSub = s.toJSON();
             }
         });
         var currentAppliance = this.appliances.find(function(a) {
@@ -109,6 +115,7 @@ VersionView = RockstorLayoutView.extend({
             autoUpdateEnabled: this.autoUpdateEnabled,
             stableSub: stableSub,
             defaultSub: defaultSub,
+            edgeSub: edgeSub,
             applianceId: currentAppliance.get('uuid')
         }));
         this.$('#update-modal').modal({
@@ -279,6 +286,10 @@ VersionView = RockstorLayoutView.extend({
         this.$('#activate-testing').modal('show');
     },
 
+    showEdgeModal: function() {
+        this.$('#activate-edge').modal('show');
+    },
+
     activateStable: function() {
         var button = this.$('activateStable');
         if (buttonDisabled(button)) return false;
@@ -318,6 +329,22 @@ VersionView = RockstorLayoutView.extend({
         });
     },
 
+    activateEdge: function() {
+        var _this = this;
+        var button = this.$('activateEdge');
+        if (buttonDisabled(button)) return false;
+        disableButton(button);
+        console.log('Inactive edge');
+        $.ajax({
+            url: '/api/update-subscriptions/activate-edge',
+            type: 'POST',
+            dataType: 'json',
+            success: function(data, status, xhr) {
+                _this.reloadWindow();
+            }
+        });
+    },
+
     initHandlebarHelpers: function() {
         Handlebars.registerHelper('is_sub_active', function(sub, options) {
             if (sub && sub.status == 'active') {
@@ -326,7 +353,7 @@ VersionView = RockstorLayoutView.extend({
             return options.inverse(this);
         });
         Handlebars.registerHelper('no_sub_active', function(options) {
-            if (!this.defaultSub && !this.stableSub) {
+            if (!this.defaultSub && !this.stableSub && !this.edgeSub) {
                 return options.fn(this);
             }
             return options.inverse(this);

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -22,8 +22,14 @@ from storageadmin.auth import DigestAuthentication
 from rest_framework.permissions import IsAuthenticated
 from storageadmin.views import DiskMixin
 from system.osi import uptime, kernel_info, get_device_mapper_map
-from fs.btrfs import mount_share, mount_root, get_dev_pool_info, get_pool_raid_levels, mount_snap, \
-    get_pool_raid_profile
+from fs.btrfs import (
+    mount_share,
+    mount_root,
+    get_dev_pool_info,
+    get_pool_raid_levels,
+    mount_snap,
+    get_pool_raid_profile,
+)
 from system.ssh import sftp_mount_map, sftp_mount
 from system.osi import (
     system_shutdown,
@@ -44,7 +50,11 @@ from storageadmin.util import handle_exception
 from datetime import datetime, timezone
 from django.conf import settings
 from django.db import transaction
-from storageadmin.views.share_helpers import sftp_snap_toggle, import_shares, import_snapshots
+from storageadmin.views.share_helpers import (
+    sftp_snap_toggle,
+    import_shares,
+    import_snapshots,
+)
 from rest_framework_custom.oauth_wrapper import RockstorOAuth2Authentication
 from system.pkg_mgmt import (
     auto_update,
@@ -247,22 +257,15 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
 
         if command == "update-check":
             try:
-                subo: None | UpdateSubscription = None
+                sub_object: None | UpdateSubscription = None
                 try:
-                    subo = UpdateSubscription.objects.get(
-                        name="Stable", status="active"
-                    )
+                    sub_object = UpdateSubscription.objects.get(status="active")
                 except UpdateSubscription.DoesNotExist:
-                    try:
-                        subo = UpdateSubscription.objects.get(
-                            name="Testing", status="active"
-                        )
-                    except UpdateSubscription.DoesNotExist:
-                        pass
-                return Response(rockstor_pkg_update_check(subscription=subo))
+                    pass
+                return Response(rockstor_pkg_update_check(subscription=sub_object))
             except Exception as e:
-                e_msg = ("Unable to check update due to a system error: ({}).").format(
-                    e.__str__()
+                e_msg = (
+                    f"Unable to check update due to a system error: ({e.__str__()})."
                 )
                 handle_exception(Exception(e_msg), request)
 

--- a/src/rockstor/storageadmin/views/update_subscription.py
+++ b/src/rockstor/storageadmin/views/update_subscription.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -35,18 +35,30 @@ class UpdateSubscriptionListView(rfc.GenericView):
     def get_queryset(self, *args, **kwargs):
         return UpdateSubscription.objects.all()
 
-    def _toggle_repos(self, on="stable", off="testing", password=None):
-        # toggle between testing and stable repos
-        ncd = settings.UPDATE_CHANNELS[on]
-        fcd = settings.UPDATE_CHANNELS[off]
-        try:
-            offo = UpdateSubscription.objects.get(name=fcd["name"])
-            offo.status = "inactive"
-            offo.save()
-            ## enable_repos False removes both repositories.
-            switch_repo(offo, enable_repo=False)
-        except UpdateSubscription.DoesNotExist:
-            pass
+    def _toggle_repos(self, on:str = "stable", password:str | None = None):
+        """
+        Toggle between settings.UPDATE_CHANNELS repos tiers. Initially in DB,
+        then pass the intended only tier DB object on-to system.pkg_mgmt.switch_repo()
+        to do the system level package repository changes themselves.
+        :param on: UPDATE_CHANNELS identifier string.
+        :param password:
+        :return:
+        """
+        on_channel = settings.UPDATE_CHANNELS[on]
+        # e.g. off_channel_names default value would be: ['Testing', 'Edge']
+        off_channel_names: list[str] = [
+            info["name"]
+            for channel, info in settings.UPDATE_CHANNELS.items()
+            if channel != on
+        ]
+        for name in off_channel_names:
+            try:
+                off_object = UpdateSubscription.objects.get(name=name)
+                if off_object.status != "inactive":
+                    off_object.status = "inactive"
+                    off_object.save(update_fields=["status"])
+            except UpdateSubscription.DoesNotExist:  # no interest if no prior entry.
+                pass
         try:
             appliance = Appliance.objects.get(current_appliance=True)
         except:
@@ -54,22 +66,22 @@ class UpdateSubscriptionListView(rfc.GenericView):
                 status_code=400, detail="Error retrieving current Appliance ID"
             )
         try:
-            ono = UpdateSubscription.objects.get(name=ncd["name"])
+            on_object = UpdateSubscription.objects.get(name=on_channel["name"])
         except UpdateSubscription.DoesNotExist:
-            ono = UpdateSubscription(
-                name=ncd["name"],
-                description=ncd["description"],
-                url=ncd["url"],
+            on_object = UpdateSubscription(
+                name=on_channel["name"],
+                description=on_channel["description"],
+                url=on_channel["url"],
                 appliance=appliance,
                 status="active",
             )
-        ono.password = password
-        status, text = repo_status(ono)
-        ono.status = status
-        ono.save()
+        on_object.password = password
+        status, text = repo_status(on_object)
+        on_object.status = status
+        on_object.save()
         if status == "inactive":
             e_msg = (
-                f"Activation code ({ono.password}) could not be authorized for your "
+                f"Activation code ({on_object.password}) could not be authorized for your "
                 f"appliance ({appliance.uuid}). Verify the code and try again. If the "
                 "problem persists, email support@rockstor.com with this "
                 "message."
@@ -78,34 +90,38 @@ class UpdateSubscriptionListView(rfc.GenericView):
         if status != "active":
             e_msg = f"Failed to activate subscription. Status code: {status} details: {text}"
             raise Exception(e_msg)
-        switch_repo(ono)
-        return ono
+        switch_repo(on_object)
+        return on_object
 
     @transaction.atomic
     def post(self, request, command):
         with self._handle_exception(request):
-            if command == "activate-stable":
-                password = request.data.get("activation_code", None)
-                if password is None:
-                    e_msg = "Activation code is required for Stable subscription."
-                    handle_exception(Exception(e_msg), request, status_code=400)
-                # remove any leading or trailing white spaces. happens enough
-                # times due to copy-paste.
-                password = password.strip()
-                stableo = self._toggle_repos(password=password)
-                return Response(UpdateSubscriptionSerializer(stableo).data)
-
-            if command == "activate-testing":
-                testingo = self._toggle_repos(on="testing", off="stable")
-                return Response(UpdateSubscriptionSerializer(testingo).data)
-
-            if command == "check-status":
-                name = request.data.get("name")
-                stableo = UpdateSubscription.objects.get(name=name)
-                if stableo.password is not None:
-                    stableo.status, text = repo_status(stableo)
-                    stableo.save()
-                return Response(UpdateSubscriptionSerializer(stableo).data)
+            match command:
+                case "activate-stable":
+                    password = request.data.get("activation_code", None)
+                    if password is None:
+                        e_msg = "Activation code is required for Stable subscription."
+                        handle_exception(Exception(e_msg), request, status_code=400)
+                    # remove any leading or trailing white spaces. happens enough
+                    # times due to copy-paste.
+                    password = password.strip()
+                    # Defaults to on="stable".
+                    stableo = self._toggle_repos(password=password)
+                    return Response(UpdateSubscriptionSerializer(stableo).data)
+                case "activate-testing":
+                    testingo = self._toggle_repos(on="testing")
+                    return Response(UpdateSubscriptionSerializer(testingo).data)
+                case "activate-edge":
+                    edgeo = self._toggle_repos(on="edge")
+                    return Response(UpdateSubscriptionSerializer(edgeo).data)
+                case "check-stable":
+                    name = request.data.get("name")
+                    stableo = UpdateSubscription.objects.get(name=name)
+                    if stableo.password is not None:
+                        stableo.status, text = repo_status(stableo)
+                        stableo.save()
+                    return Response(UpdateSubscriptionSerializer(stableo).data)
+            return Response()
 
 
 class UpdateSubscriptionDetailView(rfc.GenericView):

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -24,6 +24,8 @@ from subprocess import run, CalledProcessError, TimeoutExpired
 from time import sleep
 from xml.etree.ElementTree import fromstring, ElementTree
 from tempfile import mkstemp
+
+import settings
 from storageadmin.models import UpdateSubscription
 from system.exceptions import CommandException
 from system.osi import run_command
@@ -161,7 +163,7 @@ def rpm_build_info(pkg: str) -> tuple[str, str | None]:
 
 def zypper_repos_list(max_wait: int = 1) -> typing.List[str]:
     """
-    Simple wrapper for "zypper --xmlout lr Rockstor-Testing Rockstor-Stable".
+    Simple wrapper for "zypper --xmlout lr Rockstor-Edge Rockstor-Testing Rockstor-Stable".
     Retrieves a list of enabled Rockstor repositories.
     :return: list of enabled Rockstor repos by alias.
     """
@@ -169,7 +171,14 @@ def zypper_repos_list(max_wait: int = 1) -> typing.List[str]:
     stdout_value: str | None = None
     try:
         zypp_run = run(
-            ["zypper", "--xmlout", "lr", "Rockstor-Testing", "Rockstor-Stable"],
+            [
+                "zypper",
+                "--xmlout",
+                "lr",
+                "Rockstor-Edge",
+                "Rockstor-Testing",
+                "Rockstor-Stable",
+            ],
             capture_output=True,
             encoding="utf-8",  # stdout and stderr as string
             universal_newlines=True,
@@ -187,7 +196,9 @@ def zypper_repos_list(max_wait: int = 1) -> typing.List[str]:
         logger.error(f"Package system may be busy: {e}")
         return []
     if not stdout_value:
-        logger.info(f"Both Testing and Stable were inadvertently enabled")
+        logger.info(
+            f"More than one of Edge, Testing, & Stable were inadvertently enabled"
+        )
         stdout_value = zypp_run.stdout
     repo_tree = ElementTree(fromstring(stdout_value))
     repo_root = repo_tree.getroot()
@@ -201,7 +212,7 @@ def rockstor_repo_mgmt(
     zypp_cmd: str,
     repo_list: list[str] | None = None,
     url: str | None = None,
-    max_wait: int = 1,
+    max_wait: int = 2,
     retries: int = 2,
 ) -> bool:
     """
@@ -217,8 +228,8 @@ def rockstor_repo_mgmt(
     :param max_wait: Max seconds expected for each execution.
     :return: Bool if zypper return code indicates a change was made.
     """
-    if repo_list is None:
-        repo_list = ["Rockstor-Testing", "Rockstor-Stable"]
+    if repo_list is None or repo_list == []:
+        repo_list = ["Rockstor-Edge", "Rockstor-Testing", "Rockstor-Stable"]
     # Only the fist match case gets executed
     match zypp_cmd:
         case "removerepo":
@@ -342,7 +353,7 @@ def update_password_store(user, password):
 
 def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
     logger.info(
-        f"++ switch_repo({subscription.name}, enable_repo={enable_repo}) called."
+        f"!!! switch_repo({subscription.name}, enable_repo={enable_repo}) called."
     )
     repos_dir = "/etc/yum.repos.d"
     # Yum repo clean-up scheduled for removal post 5.1.0-0 Stable release.
@@ -353,9 +364,18 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
             os.remove(yum_file)
         repos_modified = rockstor_repo_mgmt(zypp_cmd="removerepo")
         if repos_modified:
-            logger.info("Repo config changed.")
+            logger.info("Repo config changed as all Rockstor-* repos removing.")
         return None
-    repo_alias = "Rockstor-{}".format(subscription.name)
+    repo_alias = f"Rockstor-{subscription.name}"
+    other_repo_aliases: list[str] = [
+        f"Rockstor-{info['name']}"
+        for info in settings.UPDATE_CHANNELS.values()
+        if info["name"] != subscription.name
+    ]
+    current_repo_list = zypper_repos_list()
+    repos_to_remove: list[str] = [
+        alias for alias in other_repo_aliases if alias in current_repo_list
+    ]
     # Historically our base subscription url denotes our CentOS rpm repo.
     subscription_distro_url = subscription.url
     distro_id = distro.id()
@@ -367,7 +387,6 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
     elif distro_id == "opensuse-tumbleweed" or distro_id == "opensuse-slowroll":
         subscription_distro_url += "/tumbleweed"
     # From Tumblweed/Slowroll 20250329-0 onwards remove all DNF/YUM use.
-    current_repo_list = zypper_repos_list()
     # As from Leap15.4, update repositories are multi-arch. Maintain 15.3_aarch for now.
     if distro_version == "15.3" and machine_arch != "x86_64":
         subscription_distro_url += "_{}".format(machine_arch)
@@ -377,18 +396,25 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
         repo_url = f"http://{subscription_distro_url}"
     logger.debug(f"REPO_URL={repo_url}")
     repos_modified: bool = False
+    # Remove all other repos in the current_repos_list, if any exist:
+    if repos_to_remove:  # Avoids call if there are no repos to remove.
+        logger.info(f"--- Removing repos {repos_to_remove}.")
+        repos_modified = rockstor_repo_mgmt(
+            zypp_cmd="removerepo", repo_list=repos_to_remove
+        )
+        if not repos_modified:  # Bail to avoid compounding a repo change problem.
+            e_msg = (
+                f"Failed to removing {repos_to_remove}. Aborting change. "
+                f"Retry your Activation as the package system was likely busy."
+            )
+            raise Exception(e_msg)
     if subscription.name == "Stable":
         # TODO: After 5.6.0-0 Stable this can be moved to after update_zypp_auth_file().
         # Required for now to update password-store on existing Stable systems.
-        logger.info("Syncing password-store auth for Web-UI changelog feature.")
+        logger.info("*** Syncing password-store auth for Web-UI changelog feature.")
         update_password_store(subscription.appliance.uuid, subscription.password)
         if repo_alias not in current_repo_list:
-            logger.info("++++ Enabling Stable as not in current repo list")
-            if "Rockstor-Testing" in current_repo_list:
-                logger.info("--- Testing enabled - removing repo")
-                repos_modified = rockstor_repo_mgmt(
-                    zypp_cmd="removerepo", repo_list=["Rockstor-Testing"]
-                )
+            logger.info("+++ Enabling Stable as not in current repo list")
             update_zypp_auth_file(subscription.appliance.uuid, subscription.password)
             repos_modified = rockstor_repo_mgmt(
                 zypp_cmd="addrepo",
@@ -397,31 +423,25 @@ def switch_repo(subscription: UpdateSubscription, enable_repo: bool = True):
             )
         else:
             logger.info("*** Stable repo already enabled.")
-        if repos_modified:
-            logger.info("Repo config changed.")
-    elif subscription.name == "Testing":
+    elif subscription.name == "Testing" or subscription.name == "Edge":
         if repo_alias not in current_repo_list:
-            logger.info("++++ Enabling Testing as not in current repo list")
-            if "Rockstor-Stable" in current_repo_list:
-                logger.info("--- Stable enabled - removing repo")
-                repos_modified = rockstor_repo_mgmt(
-                    zypp_cmd="removerepo", repo_list=["Rockstor-Stable"]
-                )
+            logger.info(f"+++ Enabling {repo_alias} as not in current repo list")
             repos_modified = rockstor_repo_mgmt(
                 zypp_cmd="addrepo", repo_list=[repo_alias], url=repo_url
             )
         else:
-            logger.info("*** Testing already enabled.")
-        if repos_modified:
-            logger.info("Repo config changed.")
+            logger.info(f"*** {repo_alias} already enabled.")
     else:
         logger.info(f"The subscription name ({subscription.name}) is unknown.")
-        # Possible 'Edge' release.
         return None
+    if repos_modified:
+        logger.info("*** Repo config changed.")
+    else:
+        logger.info("*** Repo config NOT changed.")
     return None
 
 
-def repo_status(subscription):
+def repo_status(subscription: UpdateSubscription):
     if subscription.password is None:
         return "active", "public repo"
     try:
@@ -458,8 +478,6 @@ def rockstor_pkg_update_check(
     :return:
     """
     machine_arch = platform.machine()
-    if subscription is not None:
-        switch_repo(subscription)
     pkg = f"rockstor*{machine_arch}"
     rpm_installed: bool = False  # Until we find otherwise
     version, date = rpm_build_info(pkg)
@@ -471,7 +489,7 @@ def rockstor_pkg_update_check(
     # Retrieve changelog via zypper-changelog-lib
     if subscription is None:
         return version, version, updates
-    # Rockstor's Repo alias is either "Rockstor-Testing" or "Rockstor-Stable".
+    # Rockstor's Repo alias are "Rockstor-Edge", "Rockstor-Testing" & "Rockstor-Stable".
     zyppchange = get_zypper_changelog(
         pkg_list=["rockstor"],
         repo_list=[f"Rockstor-{subscription.name}"],
@@ -487,9 +505,7 @@ def rockstor_pkg_update_check(
     return version, new_version, changelog_list
 
 
-def update_run(subscription=None, update_all_other=False):
-    if subscription is not None:
-        switch_repo(subscription)
+def update_run(update_all_other=False):
     run_command([SYSTEMCTL, "start", "atd"])
     fh, npath = mkstemp()
     # Set system-wide package manager refresh command according to distro.


### PR DESCRIPTION
Revises existing update repo tiers of "Testing" & "Stable" by adding "Edge".

Includes:
- Enhancements on all repo tier explanations.
- Remove an existing & redundant 'double-calling' of switch_repo() made by rockstor_pkg_update_check().
- Removed an optional but unused use of switch_repo() by update_run().
- Improved overall robustness and feedback on repo tier switching.
- Fails any repo tier switch if any prior tier is not first removed. Includes user feedback to re-try in this scenario.
- Additional Python type hints on modified code.

Fixes #3094