### PR TITLE
"Quotas Disabled" loop - unhandled "rescan is running" #3098

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -1320,7 +1320,9 @@ def are_quotas_enabled(mnt_pt):
     """
     o, e, rc = run_command([BTRFS, "qgroup", "show", "-f", "--raw", mnt_pt])
     if rc == 0 and (
-        e[0] == "" or e[0] == "WARNING: qgroup data inconsistent, rescan recommended"
+        e[0] == ""
+        or e[0] == "WARNING: qgroup data inconsistent, rescan recommended"
+        or e[0] == "WARNING: rescan is running, qgroup data may be incorrect"
     ):
         return True
     # Note on above e[0] clauses:


### PR DESCRIPTION

Fixes #3098

## Changes

`fs/btrfs.py`: add `"WARNING: rescan is running, qgroup data may be incorrect"` to the accepted stderr patterns in `are_quotas_enabled()`.

A rescan in progress means quotas **are** enabled — the data is simply being recalculated. Treating this warning as a failure caused Rockstor to re-enable quotas in a loop on startup, accumulating stale `2015/N` qgroups and showing "Quotas Disabled" in the WUI.

## Testing

- Rockstor 5.5.0-0 (also reproduced on 5.1.0-0), kernel `6.4.0-150600.23.92-default`, openSUSE Leap 15.6
- After applying the fix, restarting the Rockstor service no longer causes the re-enable loop
- WUI correctly shows quotas as enabled while a rescan is in progress
- No accumulation of stale `2015/N` qgroups observed after restart

## Related

- Community forum discussion: https://forum.rockstor.com/t/cant-enable-quotas/10729
- #1624