### PR TITLE
Replace deprecated utc timezone related artifacts #3102

### DIFF
--- a/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
+++ b/src/rockstor/scripts/scheduled_tasks/pool_scrub.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -18,11 +18,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 import time
 import sys
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from scripts.scheduled_tasks import crontabwindow
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper
-from django.utils.timezone import utc
 import logging
 
 logger = logging.getLogger(__name__)
@@ -71,7 +70,7 @@ def main():
                         "A new task will not be run." % (cur_state, tid)
                     )
 
-        now = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=utc)
+        now = datetime.now(UTC).replace(second=0, microsecond=0)
         t = Task(task_def=tdo, state="started", start=now)
         url = "pools/%s/scrub" % meta["pool"]
         try:
@@ -89,7 +88,7 @@ def main():
             cur_state = update_state(t, meta["pool"], aw)
             if cur_state in TERMINAL_SCRUB_STATES:
                 logger.debug("task(%d) finished with state(%s)." % (tid, cur_state))
-                t.end = datetime.utcnow().replace(tzinfo=utc)
+                t.end = datetime.now(UTC)
                 t.save()
                 break
             logger.debug(

--- a/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
+++ b/src/rockstor/scripts/scheduled_tasks/reboot_shutdown.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import sys
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from scripts.scheduled_tasks import crontabwindow
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper
@@ -110,7 +110,7 @@ def main():
             )
             return
 
-        now = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=timezone.utc)
+        now = datetime.now(UTC).replace(second=0, microsecond=0)
         schedule = now + timedelta(minutes=3)
         t = Task(task_def=tdo, state="scheduled", start=now, end=schedule)
 
@@ -154,7 +154,7 @@ def main():
             logger.exception(e)
 
         finally:
-            # t.end = datetime.utcnow().replace(tzinfo=utc)
+            # t.end = datetime.now(UTC)
             t.save()
 
     else:

--- a/src/rockstor/scripts/scheduled_tasks/snapshot.py
+++ b/src/rockstor/scripts/scheduled_tasks/snapshot.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -17,12 +17,11 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import sys
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from scripts.scheduled_tasks import crontabwindow
 from storageadmin.models import Share, Snapshot
 from smart_manager.models import Task, TaskDefinition
 from cli.api_wrapper import APIWrapper
-from django.utils.timezone import utc
 from django.conf import settings
 import logging
 
@@ -111,7 +110,7 @@ def main():
         max_count = int(float(meta["max_count"]))
         prefix = "%s_" % meta["prefix"]
 
-        now = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=utc)
+        now = datetime.now(UTC).replace(second=0, microsecond=0)
         t = Task(task_def=tdo, state="started", start=now)
 
         snap_created = False
@@ -141,7 +140,7 @@ def main():
             logger.error("Failed to create snapshot at %s" % url)
             logger.exception(e)
         finally:
-            t.end = datetime.utcnow().replace(tzinfo=utc)
+            t.end = datetime.now(UTC)
             t.save()
 
         # best effort pruning without erroring out. If deletion fails, we'll

--- a/src/rockstor/smart_manager/stap_dispatcher.py
+++ b/src/rockstor/smart_manager/stap_dispatcher.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -19,11 +19,10 @@ from multiprocessing import Process, Queue
 import zmq
 import os
 import time
-from datetime import datetime
+from datetime import datetime, UTC
 from smart_manager.models import SProbe
 from django.conf import settings
-from django.utils.timezone import utc
-from stap_worker import StapWorker
+from smart_manager.stap_worker import StapWorker
 import logging
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ class Stap(Process):
                 if ec != 0:
                     ro = SProbe.objects.get(id=w)
                     ro.state = "error"
-                    ro.end = datetime.utcnow().replace(tzinfo=utc)
+                    ro.end = datetime.now(UTC)
                     self._sink_put(sink_socket, ro)
                 del self.workers[w]
 
@@ -115,7 +114,7 @@ class Stap(Process):
                 ro.state = "running"
             else:
                 ro.state = "error"
-                ro.end = datetime.utcnow().replace(tzinfo=utc)
+                ro.end = datetime.now(UTC)
             return self._sink_put(sink_socket, ro)
 
         if task["action"] == "stop":
@@ -124,5 +123,5 @@ class Stap(Process):
                 sworker.task["queue"].put("stop")
             ro = SProbe.objects.get(id=task["roid"])
             ro.state = "stopped"
-            ro.end = datetime.utcnow().replace(tzinfo=utc)
+            ro.end = datetime.now(UTC)
             return self._sink_put(sink_socket, ro)

--- a/src/rockstor/smart_manager/views/base_service.py
+++ b/src/rockstor/smart_manager/views/base_service.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -23,7 +23,7 @@ import rest_framework_custom as rfc
 from rest_framework.response import Response
 from system.services import service_status
 from django.db import transaction
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class ServiceMixin(object):
         return json.loads(service.config)
 
     def _get_or_create_sso(self, service):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+        ts = datetime.now(UTC)
         so = None
         if ServiceStatus.objects.filter(service=service).exists():
             so = ServiceStatus.objects.filter(service=service).order_by("-ts")[0]

--- a/src/rockstor/smart_manager/views/receive_trail.py
+++ b/src/rockstor/smart_manager/views/receive_trail.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -20,7 +20,7 @@ from django.conf import settings
 from rest_framework.response import Response
 from smart_manager.models import ReplicaShare, ReceiveTrail
 from smart_manager.serializers import ReceiveTrailSerializer
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 import rest_framework_custom as rfc
 
 
@@ -37,7 +37,7 @@ class ReceiveTrailListView(rfc.GenericView):
     def post(self, request, rid):
         with self._handle_exception(request):
             rs = ReplicaShare.objects.get(id=rid)
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             snap_name = request.data.get("snap_name")
             rt = ReceiveTrail(
                 rshare=rs, snap_name=snap_name, status="pending", receive_pending=ts
@@ -50,7 +50,7 @@ class ReceiveTrailListView(rfc.GenericView):
         with self._handle_exception(request):
             days = int(request.data.get("days", 30))
             rs = ReplicaShare.objects.get(id=rid)
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             ts0 = ts - timedelta(days=days)
             if ReceiveTrail.objects.filter(rshare=rs).count() > 100:
                 ReceiveTrail.objects.filter(rshare=rs, end_ts__lt=ts0).delete()
@@ -78,7 +78,7 @@ class ReceiveTrailDetailView(rfc.GenericView):
     def put(self, request, rtid):
         with self._handle_exception(request):
             rt = ReceiveTrail.objects.get(id=rtid)
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             if "receive_succeeded" in request.data:
                 rt.receive_succeeded = ts
             rt.status = request.data.get("status", rt.status)

--- a/src/rockstor/smart_manager/views/replica_share.py
+++ b/src/rockstor/smart_manager/views/replica_share.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -22,7 +22,7 @@ from storageadmin.models import Share, Appliance
 from smart_manager.models import ReplicaShare, ReceiveTrail
 from smart_manager.serializers import ReplicaShareSerializer
 from storageadmin.util import handle_exception
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 import rest_framework_custom as rfc
 
 
@@ -44,7 +44,7 @@ class ReplicaShareListView(rfc.GenericView):
         aip = request.data["appliance"]
         self._validate_appliance(aip, request)
         src_share = request.data["src_share"]
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+        ts = datetime.now(UTC)
         r = ReplicaShare(
             share=sname, appliance=aip, pool=share.pool.name, src_share=src_share, ts=ts
         )

--- a/src/rockstor/smart_manager/views/replica_trail.py
+++ b/src/rockstor/smart_manager/views/replica_trail.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -19,7 +19,7 @@ from django.db import transaction
 from rest_framework.response import Response
 from smart_manager.models import Replica, ReplicaTrail
 from smart_manager.serializers import ReplicaTrailSerializer
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 import rest_framework_custom as rfc
 
 
@@ -42,7 +42,7 @@ class ReplicaTrailListView(rfc.GenericView):
         with self._handle_exception(request):
             replica = Replica.objects.get(id=rid)
             snap_name = request.data["snap_name"]
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             rt = ReplicaTrail(
                 replica=replica,
                 snap_name=snap_name,
@@ -57,7 +57,7 @@ class ReplicaTrailListView(rfc.GenericView):
         with self._handle_exception(request):
             days = int(request.data.get("days", 30))
             replica = Replica.objects.get(id=rid)
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             ts0 = ts - timedelta(days=days)
             if ReplicaTrail.objects.filter(replica=replica).count() > 100:
                 ReplicaTrail.objects.filter(replica=replica, end_ts__lt=ts0).delete()
@@ -86,7 +86,7 @@ class ReplicaTrailDetailView(rfc.GenericView):
             if "kb_sent" in request.data:
                 rt.kb_sent = request.data["kb_sent"]
             if rt.status in ("failed", "succeeded",):
-                ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+                ts = datetime.now(UTC)
                 rt.end_ts = ts
                 if rt.status == "failed":
                     rt.send_failed = ts

--- a/src/rockstor/smart_manager/views/replication.py
+++ b/src/rockstor/smart_manager/views/replication.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -26,7 +26,7 @@ from storageadmin.models import Share, Appliance, EmailClient
 from smart_manager.models import Replica, ReplicaTrail
 from smart_manager.serializers import ReplicaSerializer
 from storageadmin.util import handle_exception
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from django.conf import settings
 import rest_framework_custom as rfc
 import logging
@@ -109,7 +109,7 @@ class ReplicaListView(ReplicaMixin, rfc.GenericView):
             replication_ip = request.data.get("listener_ip", None)
             if replication_ip is not None and len(replication_ip.strip()) == 0:
                 replication_ip = None
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             r = Replica(
                 task_name=task_name,
                 share=sname,
@@ -175,7 +175,7 @@ class ReplicaDetailView(ReplicaMixin, rfc.GenericView):
             r.data_port = self._validate_port(
                 request.data.get("listener_port", r.data_port), request
             )
-            ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+            ts = datetime.now(UTC)
             r.ts = ts
             r.save()
             self._refresh_crontab()

--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -47,7 +47,7 @@ from storageadmin.models import (
     AdvancedNFSExport,
 )
 from storageadmin.util import handle_exception
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from django.conf import settings
 from django.db import transaction
 from storageadmin.views.share_helpers import (
@@ -244,7 +244,7 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
             return Response()
 
         if command == "utcnow":
-            return Response(datetime.utcnow().replace(tzinfo=timezone.utc))
+            return Response(datetime.now(UTC))
 
         if command == "uptime":
             return Response(uptime())

--- a/src/rockstor/storageadmin/views/disk_smart.py
+++ b/src/rockstor/storageadmin/views/disk_smart.py
@@ -1,5 +1,5 @@
 """
-Copyright (joint work) 2024 The Rockstor Project <https://rockstor.com>
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
 
 Rockstor is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published
@@ -40,7 +40,7 @@ from system.smart import (
     test_logs,
     run_test,
 )
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 import logging
 
@@ -75,7 +75,7 @@ class DiskSMARTDetailView(rfc.GenericView):
         e_summary, e_lines = error_logs(disk.name, disk.smart_options)
         smartid = info(disk.name, disk.smart_options)
         test_d, log_lines = test_logs(disk.name, disk.smart_options)
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+        ts = datetime.now(UTC)
         si = SMARTInfo(disk=disk, toc=ts)
         si.save()
         for k in sorted(attributes.keys(), reverse=True):


### PR DESCRIPTION
Fixes #3102.

Proposed PR includes:
- removing the deprecated 
`from django.utils.timezone import utc` and migrate towards using python's `datetime` functionality.
- In addition, since the representation of `utcnow` is deprecated in python 3.12 it is further proposed to change the relevant statements to use `datetime`'s `UTC` parameter, to represent a timezone aware timestamp for the subsequent functions.
- updating copyright year in the header of the changed files to 2026. 