### PR TITLE
Fix remaining utc treatment #3111

### DIFF
--- a/src/rockstor/smart_manager/agents/nfsd_calls.py
+++ b/src/rockstor/smart_manager/agents/nfsd_calls.py
@@ -15,7 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from smart_manager.models import (
     NFSDCallDistribution,
     NFSDClientDistribution,
@@ -27,7 +27,7 @@ from smart_manager.models import (
 
 
 def get_datetime(ts):
-    return datetime.datetime.utcfromtimestamp(float(ts)).replace(tzinfo=timezone.utc)
+    return datetime.datetime.fromtimestamp(float(ts), tz=UTC)
 
 
 def process_nfsd_calls(output, rid, l):


### PR DESCRIPTION
Fixes #3111 .

Coding updated as per described in the above issue to ensure future compatibility with higher versions of python (namely 3.13 and up).

Executing all tests:

----------------------------------------------------------------------
Ran 292 tests in 73.206s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
Also realized that I think there are no nfs specific tests currently in the library.

In any case, created an nfs export, and connected from a Ubuntu instance to it. Ability to see and open files worked successfully. Again, not entirely sure whether this particular function was called during any of it. However, no syntax errors, etc. have been observed.