### PR TITLE
Bump version to a 5.5.2 base - release 1 #3120

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rockstor"
-version = "5.5.1"
+version = "5.5.2"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 readme = "README.md"
 # Source0: (rockstor-core) is GPL-3.0-or-later, Source1: (rockstor-jslibs) has mixed licensing:


### PR DESCRIPTION
pyproject.toml [project] "version = ...".

The release element here related to the GitHub release, (5.5.2-1) as there is no release within our Poetry config.

This issue was missed in a prior GitHub release. And we now already have a public tag in play!

Fixes #3120 