### PR TITLE
Py3.13 SyntaxWarning in intended raw test strings #2684

### DIFF
--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -397,7 +397,7 @@ class PoolTests(APITestMixin):
             "Pa$sign",
             "/pool",
             ":pool",
-            "\pool",
+            r"\pool",
             "Pquestion?mark",
             "Pasteri*",
             "",

--- a/src/rockstor/storageadmin/tests/test_shares.py
+++ b/src/rockstor/storageadmin/tests/test_shares.py
@@ -237,7 +237,7 @@ class ShareTests(APITestMixin):
             "Share 1",
             "a$sign" "/share",
             ":share",
-            "\share",
+            r"\share",
             "question?mark",
             "asterix*",
             "",

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -3886,10 +3886,10 @@ class OSITests(unittest.TestCase):
 
         # /etc/cron.d/rockstortab, True
         source_contents.append(
-            "42 3 * * 6 root /opt/rockstor/bin/st-system-power 1 \*-*-*-*-*-*"
+            r"42 3 * * 6 root /opt/rockstor/bin/st-system-power 1 \*-*-*-*-*-*"
         )
         target_contents.append(
-            "42 3 * * 6 root /opt/rockstor/.venv/bin/st-system-power 1 \*-*-*-*-*-*"
+            r"42 3 * * 6 root /opt/rockstor/.venv/bin/st-system-power 1 \*-*-*-*-*-*"
         )
         outputs.append(True)
 
@@ -3902,17 +3902,17 @@ class OSITests(unittest.TestCase):
 
         # /etc/cron.d/rockstortab, False
         source_contents.append(
-            "42 3 * * 6 root /opt/rockstor/.venv/bin/st-system-power 1 \*-*-*-*-*-*"
+            r"42 3 * * 6 root /opt/rockstor/.venv/bin/st-system-power 1 \*-*-*-*-*-*"
         )
         target_contents.append(None)
         outputs.append(False)
 
         # /etc/cron.d/rockstortab, True
         source_contents.append(
-            "42 3 * * 5 root /opt/rockstor//bin/st-pool-scrub 1 \*-*-*-*-*-*"
+            r"42 3 * * 5 root /opt/rockstor//bin/st-pool-scrub 1 \*-*-*-*-*-*"
         )
         target_contents.append(
-            "42 3 * * 5 root /opt/rockstor/.venv/bin/st-pool-scrub 1 \*-*-*-*-*-*"
+            r"42 3 * * 5 root /opt/rockstor/.venv/bin/st-pool-scrub 1 \*-*-*-*-*-*"
         )
         outputs.append(True)
 


### PR DESCRIPTION
A warning renamed in Py3.12:
- Before: DeprecationWarning: invalid escape sequence
- After: SyntaxWarning: invalid escape sequence

Move all reports to raw string definitions.

Fixes #2684 