### PR TITLE
gpg: Note: database_open ... waiting for lock #3117

### DIFF
--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -564,6 +564,8 @@ def zypper_killed_cleanup():
     """
     # See: https://www.gnupg.org/documentation/manuals/gnupg/Agent-Signals.html
     # pkill (procps package) defaults to SIGTERM
+    # TODO: Now we are on Django 6.0 - remove all zypper forced time-outs and establish
+    #  Django task based management of, for example, updates available.
     out, err, rc = run_command(
         ["pkill -f 'gpg-agent --homedir /var/tmp/zypp'"], shell=True, throw=False
     )
@@ -571,6 +573,12 @@ def zypper_killed_cleanup():
         case 0:
             logger.info(
                 "Killed related gpg-agents post zypper process timeout/termination."
+            )
+            logger.info("Removing GPG pubring.db.lock file.")
+            run_command(
+                ["rm", "-f", "/root/.gnupg/public-keys.d/pubring.db.lock"],
+                throw=False,
+                log=True,
             )
         case 1:
             logger.info("No zypper related gpg-agents found or successfully signalled.")


### PR DESCRIPTION
After successfully killing `gpg-agent --homedir /var/tmp/zypp`, ensure the gnupg pubring.db.lock file is removed.

Adds todo for future move to Django tasks, to avoid forced zypper time-outs and consequent clean-up.

Closes #3117 

---

We have, as yet, no reliable reproducer for the referenced issue. As such this 'fix' has undetermined confidence.