### PR TITLE
Bump version to a 5.5.4 base #3143

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rockstor"
-version = "5.5.3"
+version = "5.5.4"
 description = "Btrfs Network Attached Storage (NAS) Appliance."
 readme = "README.md"
 # Source0: (rockstor-core) is GPL-3.0-or-later, Source1: (rockstor-jslibs) has mixed licensing:


### PR DESCRIPTION
pyproject.toml [project] "version = ...".

Fixes #3143 