### PR TITLE
update pool mount options #3044

### DIFF
--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/add_pool_template.jst
@@ -54,7 +54,7 @@
             <div class="form-group">
                 <label class="col-sm-4 control-label" for="mnt_options">Mount options</label>
                 <div class="col-sm-6">
-                    <input class="form-control" type="text" name="mnt_options" id="mnt_options" data-html="true" title="This is for <strong>Advanced users</strong> to provide specific BTRFS mount options.<br>Type them as a comma separated string of options without any spaces.<br> Allowed options are <strong>alloc_start, autodefrag, clear_cache, commit, compress-force, degraded, discard, fatal_errors, inode_cache, max_inline, metadata_ratio, noacl, noatime, nodatacow, nodatasum, nospace_cache, nossd, ro, rw, skip_balance, space_cache, ssd, ssd_spread, thread_pool</strong>">
+                    <input class="form-control" type="text" name="mnt_options" id="mnt_options" data-html="true" title="This is for <strong>Advanced users</strong> to provide specific BTRFS mount options.<br>Type them as a comma separated string of options without any spaces.<br> Allowed options are <strong>autodefrag, clear_cache, commit, compress-force, degraded, discard, enospc_debug, fatal_errors, flushoncommit, max_inline, metadata_ratio, noacl, noatime, nobarrier, nodatacow, nodatasum, nologreplay, nospace_cache, nossd, notreelog, ro, rw, skip_balance, space_cache, ssd, ssd_spread, thread_pool, usebackuproot, user_subvol_rm_allowed</strong>">
                 </div>
             </div>
             <div class="form-group">

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/compression_info.jst
@@ -29,9 +29,10 @@
             <strong>
             <a href="#" id="mntOptions" data-type='text' data-title="This is for <strong>Advanced users</strong> to provide specific BTRFS mount options.<br>
             Type them as a comma separated string of options without any spaces.<br>
-            Allowed options are <strong>alloc_start, autodefrag, clear_cache, commit, compress-force, degraded, discard,
-            fatal_errors, inode_cache, max_inline, metadata_ratio, noacl, noatime, nodatacow, nodatasum, nospace_cache, 
-            nossd, ro, rw, skip_balance, space_cache, ssd, ssd_spread, thread_pool</strong>">
+            Allowed options are <strong>autodefrag, clear_cache, commit, compress-force,
+            degraded, discard, enospc_debug, fatal_errors, flushoncommit, max_inline, metadata_ratio, noacl, noatime,
+            nobarrier, nodatacow, nodatasum, nologreplay, nospace_cache, nossd, notreelog, ro, rw, skip_balance,
+            space_cache, ssd, ssd_spread, thread_pool, usebackuproot, user_subvol_rm_allowed</strong>">
             {{pool.mnt_options}}</a>
             </strong>
             {{/if}}

--- a/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
+++ b/src/rockstor/storageadmin/static/storageadmin/js/templates/pool/pools_table.jst
@@ -78,10 +78,10 @@
                     <strong><a href="#" class="mntOptns" data-name="mntOptns" data-type="text" data-comp="{{this.compression}}"
                                data-value="{{this.mnt_options}}" data-pid="{{this.id}}" data-title="This is for <strong>Advanced
                                users</strong> to provide specific BTRFS mount options.<br> Type them as a comma separated string
-                               of options without any spaces.<br> Allowed options are <strong>alloc_start, autodefrag, clear_cache,
-                               commit, compress-force, degraded, discard, fatal_errors, inode_cache, max_inline, metadata_ratio,
-                               noacl, noatime, nodatacow, nodatasum, nospace_cache, nossd, ro, rw, skip_balance, space_cache, ssd,
-                               ssd_spread, thread_pool</strong>">
+                               of options without any spaces.<br> Allowed options are <strong>autodefrag, clear_cache, commit, compress-force,
+                               degraded, discard, enospc_debug, fatal_errors, flushoncommit, max_inline, metadata_ratio, noacl, noatime,
+                               nobarrier, nodatacow, nodatasum, nologreplay, nospace_cache, nossd, notreelog, ro, rw, skip_balance,
+                               space_cache, ssd, ssd_spread, thread_pool, usebackuproot, user_subvol_rm_allowed</strong>">
                     {{this.mnt_options}}</a></strong>
                 {{/if}}
             </td>

--- a/src/rockstor/storageadmin/tests/test_pools.py
+++ b/src/rockstor/storageadmin/tests/test_pools.py
@@ -564,23 +564,26 @@ class PoolTests(APITestMixin):
         """
         # We need this to construct our e_msg later
         allowed_options = {
-            "alloc_start": int,
             "autodefrag": None,
             "clear_cache": None,
             "commit": int,
             "compress-force": settings.COMPRESSION_TYPES,
             "degraded": None,
             "discard": None,
+            "enospc_debug": None,
             "fatal_errors": None,
-            "inode_cache": None,
+            "flushoncommit": None,
             "max_inline": int,
             "metadata_ratio": int,
             "noacl": None,
             "noatime": None,
+            "nobarrier": None,
             "nodatacow": None,
             "nodatasum": None,
+            "nologreplay": None,
             "nospace_cache": None,
             "nossd": None,
+            "notreelog": None,
             "ro": None,
             "rw": None,
             "skip_balance": None,
@@ -588,6 +591,8 @@ class PoolTests(APITestMixin):
             "ssd": None,
             "ssd_spread": None,
             "thread_pool": int,
+            "usebackuproot": None,
+            "user_subvol_rm_allowed": None,
             "": None,
         }
 
@@ -614,9 +619,9 @@ class PoolTests(APITestMixin):
         )
         self.assertEqual(response.data[0], e_msg)
 
-        # valid alloc_start but without value
-        data["mnt_options"] = "alloc_start"
-        e_msg = "Value for mount option (alloc_start) must be an integer."
+        # valid commit but without value
+        data["mnt_options"] = "commit"
+        e_msg = "Value for mount option (commit) must be an integer."
         response = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
             response.status_code,
@@ -625,8 +630,8 @@ class PoolTests(APITestMixin):
         )
         self.assertEqual(response.data[0], e_msg)
 
-        # valid alloc_start with non integer value
-        data["mnt_options"] = "alloc_start=derp"
+        # valid commit with non integer value
+        data["mnt_options"] = "commit=derp"
         response3 = self.client.post(self.BASE_URL, data=data)
         self.assertEqual(
             response3.status_code,
@@ -645,12 +650,12 @@ class PoolTests(APITestMixin):
         self.assertEqual(response.data["compression"], "zlib")
 
         valid_mnt_options = (
-            "alloc_start=3,autodefrag,clear_cache,commit=4,"
-            "degraded,discard,fatal_errors,inode_cache,"
-            "max_inline=2,metadata_ratio=5,noacl,noatime,"
-            "nodatacow,nodatasum,nospace_cache,nossd,ro,"
+            "autodefrag,clear_cache,commit=4,"
+            "degraded,discard,enospc_debug,fatal_errors,flushoncommit,"
+            "max_inline=2,metadata_ratio=5,noacl,noatime,nobarrier,"
+            "nodatacow,nodatasum,nologreplay,nospace_cache,nossd,notreelog,ro,"
             "rw,skip_balance,space_cache,ssd,ssd_spread,"
-            "thread_pool=1"
+            "thread_pool=1,usebackuproot,user_subvol_rm_allowed"
         )
 
         # hacky as depends on above success in creating this pool.

--- a/src/rockstor/storageadmin/views/pool.py
+++ b/src/rockstor/storageadmin/views/pool.py
@@ -165,23 +165,26 @@ class PoolMixin(object):
         if mnt_options is None:
             return ""
         allowed_options = {
-            "alloc_start": int,
             "autodefrag": None,
             "clear_cache": None,
             "commit": int,
             "compress-force": settings.COMPRESSION_TYPES,
             "degraded": None,
             "discard": None,
+            "enospc_debug": None,
             "fatal_errors": None,
-            "inode_cache": None,
+            "flushoncommit": None,
             "max_inline": int,
             "metadata_ratio": int,
             "noacl": None,
             "noatime": None,
+            "nobarrier": None,
             "nodatacow": None,
             "nodatasum": None,
+            "nologreplay": None,
             "nospace_cache": None,
             "nossd": None,
+            "notreelog": None,
             "ro": None,
             "rw": None,
             "skip_balance": None,
@@ -189,6 +192,8 @@ class PoolMixin(object):
             "ssd": None,
             "ssd_spread": None,
             "thread_pool": int,
+            "usebackuproot": None,
+            "user_subvol_rm_allowed": None,
             "": None,
         }
         o_fields = mnt_options.split(",")


### PR DESCRIPTION
Fixes #3044.
Update btrfs mount options:
- remove deprecated options
- - [EDIT phillxnet: alloc_start, inode_cache]
- add additional available options
- - [EDIT phillxnet: enospc_debug, flushoncommit, nobarrier, nologreplay, notreelog, usebackuproot, user_subvol_rm_allowed]
- adjusted mount option tests

See updated matrix for current list of allowed options in Rockstor

On | Off | Default | Version   Comments | Current   Rockstor list
-- | -- | -- | -- | --
**BTRFS SPECIFIC OPTIONS**
acl | noacl | on |   | noacl
autodefrag | noautodefrag | off | default   since 3.0 | autodefrag
barrier | nobarrier | on |   | nobarrier 
clear_cache |   |   |   | clear_cache
commit=<seconds> |   | 30 | default   since 3.0 | commit
compress,   compress=<type[:level]>, compress-force,   compress-force=<type[:level]> |   | off (default level when set: 3 for zstd and zlib)| level   support since 5.1 | compress-force
datacow | nodatacow | on |   | nodatacow
datasum | nodatasum | on |   | nodatasum
degraded |   | off |   | degraded
device=<devicepath> |   |   |   |  
discard,   discard=sync, discard=async | nodiscard | async (since 6.2, if   devices support it) | async   since 5.2 | discard
enospc_debug | noenospc_debug | off |   | enospc_debug
fatal_errors=<action> |   | bug | default   since 3.4 | fatal_errors
flushoncommit | noflushoncommit | off |   | flushoncommit 
fragment=<type> |   | off | default   since 4.4 |  
nologreplay |   | off |   | nologreplay
max_inline=<bytes> |   | 2048 | default   since kernel 4.6 | max_inline
metadata_ratio=<value> |   | 0 |   | metadata_ratio
norecovery |   | off | default   since 4.5 | norecovery
rescan_uuid_tree |   | off | default   since 3.12 |  
rescue |   |   | since   5.9 |  
skip_balance |   | off | default   since 3.3 | skip_balance
space_cache,   space_cache=<version> | nospace_cache | v2 | default   since 4.5 | space_cache,   nospace_cache
ssd,   ssd_spread | nossd,   nossd_spread | SSD autodetected | Since 4.14,   the block layout optimizations have been dropped. This used to help with   first generations of SSD devices - see additional notes in documentation | ssd,   ssd_spread, nossd
subvol=<path> |   |   |   |  
thread_pool=<number> |   | min(NRCPUS +   2, 8) |   | thread_pool
treelog |notreelog |on |   | notreelog
usebackuproot  |   | off | default   since 4.6 |usebackuproot 
user_subvol_rm_allowed |   | off |   | user_subvol_rm_allowed 
---------- | ---------- | ---------- | ---------- | ----------
**STANDARD MOUNTING OPTIONS**
context |   |   | The   context refers to the SELinux contexts and policy definitions passed as mount   options. Since version 6.8 |  
atime,   relatime | noatime | relatime | default   since kernel 2.6.30 | noatime
rw | ro | rw |   | ro, rw
---------- | ---------- | ---------- | ---------- | ----------
**DEPRECATED MOUNTING OPTIONS**
recovery |   |   | since: 3.2,   default: off, deprecated since: 4.5 |  
inode_cache | noinode_cache |   | removed in:   5.11, since: 3.0, default: off | removed
check_int,   check_int_data, check_int_print_mask=<value> |   |   | removed in:   6.7, since: 3.0, default: off |  
alloc_start |   |   | removed 4.13 | removed


Testing (not all tests, just storageadmin related tests):

```
rocksenf:/opt/rockstor/src/rockstor/storageadmin/tests # poetry run django-admin test -v 2

----------------------------------------------------------------------
Ran 165 tests in 71.993s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```

Updated tooltip (notice the the `alloc_start` option is removed and the list starts with `autodefrag`:

<img width="382" height="304" alt="image" src="https://github.com/user-attachments/assets/ecf0c535-c4ed-4c92-81a8-c1f95d3c0047" />

