### PR TITLE
Add .gitignore entry for poetry-python.txt #3135

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ PKG-INFO
 certs/
 jslibs/
 poetry-install.txt
+poetry-python.txt
 rockstor-jslibs.tar.gz*
 rockstor-tasks-huey.db*
 /static/


### PR DESCRIPTION
Previously missed accommodation for this diagnostic file, added when we moved to using Poetry managed standalone python.

Fixes #3135