### PR TITLE
Replication: missing slash in snapshot path #3147

### DIFF
--- a/src/rockstor/smart_manager/replication/sender.py
+++ b/src/rockstor/smart_manager/replication/sender.py
@@ -204,7 +204,7 @@ class Sender(ReplicationMixin, Process):
                     self.msg = f"{self.msg}. successful trail found for {self.rlatest_snap}".encode(
                         "utf-8"
                     )
-                    snap_path = f"{settings.MNT_PT}{self.replica.pool}.snapshots/{self.replica.share}/{self.rlatest_snap}"
+                    snap_path = f"{settings.MNT_PT}{self.replica.pool}/.snapshots/{self.replica.share}/{self.rlatest_snap}"
                     if is_subvol(snap_path):
                         self.msg = f"Snapshot({snap_path}) exists in the system and will be used as the parent".encode(
                             "utf-8"


### PR DESCRIPTION
Fix bug introduced in last major re-work of this code. Created a failure to recover under certain circumstances that had previously been accounted for as an existing snapshot could not be identified as a result of this missing path delimiter. Resulting in reduced replication robustness.

Fixes #3147 

---

Thanks to @Hooverdan96 and forum member riceru for discovering and testing this fix. Much appreciated.

The associated bug reduced the robustness of the Replication system, where an existing snapshot, necessary for replication recovery, was not found due to a simply path string error.