### PR TITLE
Use RegEx to parse LDD output (#2973)

### DIFF
--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -1984,25 +1984,46 @@ def get_devname(device_name, addPath=False):
     return None
 
 
+# Module level compilation to reduce overhead
+LDD_PATTERN = re.compile(
+    r'^\s*'                                 # Trim leading spaces
+    r'(?:(?P<so_name>\S+)\s+=>\s+)?'        # Shared Object Name (so_name) and arrow
+    r'(?P<path>\S+)\s+'                     # The actual file path (or so_name if no arrow)
+    r'\((?P<address>0x[0-9a-fA-F]+)\)$'     # The memory address
+)
+
+# Library exclusion list (easier for future exclusions)
+EXCLUDED_LIBS = ("linux-vdso")
+
 def get_libs(program_path: str) -> list[str]:
     """
     Wrapper around `ldd program_path`
     @param program_path: Binary to query ldd about
-    @return: list of OS paths or empty list if error or non found.
+    @return: list of OS paths or empty list if error or none found.
     """
-    libs: list[str] = []
-    out, err, rc = run_command([LDD, f"{program_path}"], throw=False)
-    if len(out) > 0 and rc == 0:
-        for each_line in out:
-            line_fields: list = each_line.strip().split()
-            match len(line_fields):
-                case 2:
-                    if re.match("linux-vdso", line_fields[0]) is not None:
-                        continue
-                    else:
-                        libs.append(line_fields[0])
-                case 4:
-                    libs.append(line_fields[2])
+    out, err, rc = run_command([LDD, program_path], throw=False)
+    
+    if rc != 0 or not out:
+        return []
+        
+    libs = []
+    for line in out:
+        match = LDD_PATTERN.match(line)
+        if match:
+            path = match.group('path')
+            so_name = match.group('so_name')
+            
+            # The identifier to check against exclusions (so_name if it exists, otherwise the path itself)
+            lib_name = so_name if so_name else path
+            
+            # Skip any library that starts with an excluded string
+            if lib_name.startswith(EXCLUDED_LIBS):
+                continue
+                
+            # Filter out any remaining virtual libraries that don't have absolute paths
+            if path.startswith('/'):
+                libs.append(path)
+                
     return libs
 
 

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -22,6 +22,7 @@ import shutil
 import stat
 from shutil import move, copy
 from tempfile import mkstemp
+from pathlib import Path
 
 import distro
 from django.conf import settings
@@ -237,25 +238,50 @@ def sftp_mount(share, mnt_prefix, sftp_mnt_prefix, mnt_map, editable="rw"):
             )
 
 
-def rsync_for_sftp(chroot_loc):
+def rsync_for_sftp(chroot_loc: str | Path):
     """
     Populate passed chroot_loc path with libraries sufficient for PROGS_IN_CHROOT.
     Dependencies retrieved via ldd.
     """
-    user = chroot_loc.split("/")[-1]
-    run_command([MKDIR, "-p", f"{chroot_loc}/usr/bin"], log=True)
-    run_command([MKDIR, "-p", f"{chroot_loc}/lib"], log=True)
-    run_command([MKDIR, "-p", f"{chroot_loc}/lib64"], log=True)
-    run_command([MKDIR, "-p", f"{chroot_loc}/usr/lib64"], log=True)
+    chroot_path = Path(chroot_loc)
+    user = chroot_path.name
 
+    # Create all required subdirectories
+    # TODO: See whether explicit directory creations (aside from /usr/bin) are not necessary anymore 
+    # with dynamic parent directory creation below
+    bin_dir = chroot_path / "usr" / "bin"
+    for sub_dir in [bin_dir, chroot_path / "lib", chroot_path / "lib64", chroot_path / "usr" / "lib64"]:
+        run_command([MKDIR, "-p", str(sub_dir)], log=True)
+
+    # filter list for path components not needed in chroot environment
+    FILTER_DIRS = {"zlib-ng-compat"}
+
+    # TODO: determine whether get_libs() can also be refactored to accept and return path objects
     lib_list: list[str] = []
+
     # Copy chroot binaries and resolve lib dependencies
     for prog in PROGS_IN_CHROOT:
-        copy(prog, f"{chroot_loc}/usr/bin")
-        lib_list = lib_list + get_libs(prog)
+        prog_path = Path(prog)
+        # Copy binary explicitly to target destination path
+        copy(prog_path, bin_dir / prog_path.name)
+        lib_list.extend(get_libs(prog))
+
     # Copy libs for PROGS_IN_CHROOT to chroot
     for lib in set(lib_list):
-        copy(lib, f"{chroot_loc}{lib}")
+        path_obj = Path(lib)
+
+        # Filter out unwanted directories
+        filtered_parts = [part for part in path_obj.parts if part not in FILTER_DIRS]
+        clean_lib_path = Path(*filtered_parts)
+
+        # Assemble target path
+        chroot_target = chroot_path / clean_lib_path.relative_to(path_obj.anchor)
+
+        # Ensure parent directory exists before copying, then copy library
+        chroot_target.parent.mkdir(parents=True, exist_ok=True)
+        copy(path_obj, chroot_target)
+
+    # Explicitly make bash the user shell
     run_command([USERMOD, "-s", "/usr/bin/bash", user], log=True)
 
 

--- a/src/rockstor/system/tests/test_osi.py
+++ b/src/rockstor/system/tests/test_osi.py
@@ -14,6 +14,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+
 import operator
 import unittest
 from unittest.mock import patch, mock_open, call
@@ -1713,8 +1714,8 @@ class OSITests(unittest.TestCase):
                     uuid=None,
                     parted=False,
                     root=False,
-                    partitions={}
-                )
+                    partitions={},
+                ),
             ]
         ]
         # As all serials are available via the lsblk we can avoid mocking
@@ -3977,7 +3978,64 @@ class OSITests(unittest.TestCase):
                 "/lib64/ld-linux-x86-64.so.2",
             ]
         ]
-        # Tumbleweed x86_64 `ldd /usr/bin/bash`
+        # Leap 16.0 x86_64
+        prog.append("/usr/bin/rsync")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x00007f1c2b9ac000)",
+                "\tlibacl.so.1 => /lib64/libacl.so.1 (0x00007f1c2b902000)",
+                "\tlibpopt.so.0 => /lib64/libpopt.so.0 (0x00007f1c2b8f3000)",
+                "\tliblz4.so.1 => /lib64/liblz4.so.1 (0x00007f1c2b8cb000)",
+                "\tlibzstd.so.1 => /lib64/libzstd.so.1 (0x00007f1c2b80a000)",
+                "\tlibxxhash.so.0 => /lib64/libxxhash.so.0 (0x00007f1c2b800000)",
+                "\tlibcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007f1c2b000000)",
+                "\tlibz.so.1 => /usr/lib64/zlib-ng-compat/libz.so.1 (0x00007f1c2b7dd000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f1c2ae07000)",
+                "\tlibjitterentropy.so.3 => /lib64/libjitterentropy.so.3 (0x00007f1c2b7d0000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f1c2b9ae000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libacl.so.1",
+                "/lib64/libpopt.so.0",
+                "/lib64/liblz4.so.1",
+                "/lib64/libzstd.so.1",
+                "/lib64/libxxhash.so.0",
+                "/lib64/libcrypto.so.3",
+                "/usr/lib64/zlib-ng-compat/libz.so.1",
+                "/lib64/libc.so.6",
+                "/lib64/libjitterentropy.so.3",
+                "/lib64/ld-linux-x86-64.so.2",
+            ]
+        )
+        prog.append("/usr/bin/ls")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x00007f9a48658000)",
+                "\tlibselinux.so.1 => /lib64/libselinux.so.1 (0x00007f9a485f5000)",
+                "\tlibcap.so.2 => /lib64/libcap.so.2 (0x00007f9a485e9000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f9a483f0000)",
+                "\tlibpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007f9a48336000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f9a4865a000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libselinux.so.1",
+                "/lib64/libcap.so.2",
+                "/lib64/libc.so.6",
+                "/lib64/libpcre2-8.so.0",
+                "/lib64/ld-linux-x86-64.so.2",
+            ]
+        )
+        # Older Tumbleweed x86_64 `ldd /usr/bin/bash`
         prog.append("/usr/bin/bash")
         out.append(
             [
@@ -3999,7 +4057,7 @@ class OSITests(unittest.TestCase):
                 "/lib64/ld-linux-x86-64.so.2",
             ]
         )
-        # Tumbleweed aarch64 `ldd /usr/bin/bash`
+        # Older Tumbleweed aarch64 `ldd /usr/bin/bash`
         prog.append("/usr/bin/bash")
         out.append(
             [
@@ -4021,7 +4079,7 @@ class OSITests(unittest.TestCase):
                 "/lib64/libtinfo.so.6",
             ]
         )
-        # Tumbleweed aarch64 `ldd /usr/bin/rsync`
+        # Older Tumbleweed aarch64 `ldd /usr/bin/rsync`
         prog.append("/usr/bin/rsync")
         out.append(
             [
@@ -4051,6 +4109,40 @@ class OSITests(unittest.TestCase):
                 "/lib64/libcrypto.so.3",
                 "/lib64/libc.so.6",
                 "/lib/ld-linux-aarch64.so.1",
+            ]
+        )
+        # Tumbleweed-Slowroll X86_64 VERSION_ID="20260707"
+        prog.append("/usr/bin/rsync")
+        out.append(
+            [
+                "\tlinux-vdso.so.1 (0x00007f7adfb98000)",
+                "\tlibacl.so.1 => /lib64/libacl.so.1 (0x00007f7adfae7000)",
+                "\tlibpopt.so.0 => /lib64/libpopt.so.0 (0x00007f7adfad7000)",
+                "\tliblz4.so.1 => /lib64/liblz4.so.1 (0x00007f7adfaa8000)",
+                "\tlibzstd.so.1 => /lib64/libzstd.so.1 (0x00007f7adf9c2000)",
+                "\tlibxxhash.so.0 => /lib64/libxxhash.so.0 (0x00007f7adf9b8000)",
+                "\tlibcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007f7adf200000)",
+                "\tlibz.so.1 => /usr/lib64/zlib-ng-compat/libz.so.1 (0x00007f7adf98e000)",
+                "\tlibc.so.6 => /lib64/libc.so.6 (0x00007f7adee00000)",
+                "\tlibjitterentropy.so.3 => /lib64/libjitterentropy.so.3 (0x00007f7adf981000)",
+                "\t/lib64/ld-linux-x86-64.so.2 (0x00007f7adfb9a000)",
+                "",
+            ]
+        )
+        err.append([""])
+        rc.append(0)
+        expected_result.append(
+            [
+                "/lib64/libacl.so.1",
+                "/lib64/libpopt.so.0",
+                "/lib64/liblz4.so.1",
+                "/lib64/libzstd.so.1",
+                "/lib64/libxxhash.so.0",
+                "/lib64/libcrypto.so.3",
+                "/usr/lib64/zlib-ng-compat/libz.so.1",
+                "/lib64/libc.so.6",
+                "/lib64/libjitterentropy.so.3",
+                "/lib64/ld-linux-x86-64.so.2",
             ]
         )
         # p in prog is cosmetic as we mock run_command.


### PR DESCRIPTION
Fixes #2973.

Tested on Leap 16.0 as well as TW.

Before fix failure to add sftp shares as described in above mentioned Issue. Post coding changes, sftp shares were successfully added. The missing shared object library was added to the `lib64` folder located directly below the sftp chroot. sftp connection, navigation and upload/download worked as expected (using FileZilla as sftp client).

Also ran tests in storageadmin folder:
```
~#:/opt/rockstor/src/rockstor/storageadmin/tests # export DJANGO_SETTINGS_MODULE=settings
~#:/opt/rockstor/src/rockstor/storageadmin/tests # poetry run django-admin test -v 2
Found 165 test(s).

Ran 165 tests in 93.591s

OK
Destroying test database for alias 'default' ('test_storageadmin')...
Destroying test database for alias 'smart_manager' ('test_smartdb')...
```