### PR TITLE
Inadvertent Share mount point stat during bootstrap & import #3162

### DIFF
--- a/src/rockstor/storageadmin/views/command.py
+++ b/src/rockstor/storageadmin/views/command.py
@@ -165,7 +165,9 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                     )
                     continue
                 # Import / update db shares counterpart for managed pool.
+                # Includes owner:group & permissions DB update from Pool subvol path.
                 import_shares(p, request)
+                p.save()
 
             for share in Share.objects.all():
                 if share.pool.disk_set.attached().count() == 0:
@@ -180,8 +182,9 @@ class CommandView(DiskMixin, NFSExportMixin, APIView):
                 try:
                     if not share.is_mounted:
                         # System mounted shares i.e. home will already be mounted.
-                        mnt_pt = "{}{}".format(settings.MNT_PT, share.name)
+                        mnt_pt = f"{settings.MNT_PT}{share.name}"
                         mount_share(share, mnt_pt)
+                        share.save()
                 except Exception as e:
                     e_msg = (
                         "Exception while mounting a share ({}) during "

--- a/src/rockstor/storageadmin/views/share_helpers.py
+++ b/src/rockstor/storageadmin/views/share_helpers.py
@@ -168,7 +168,8 @@ def import_shares(pool, request):
 
             # OWNER, GROUP, AND PERMISSIONS UPDATE.
             # Update the existing DB Share entry from the on disk subvol info.
-            share_stat: stat_result = stat(share.mnt_pt)
+            subvol_path = f"{pool.mnt_pt}/{s_in_pool}".replace("//", "/")
+            share_stat: stat_result = stat(subvol_path)
             subvol_owner = user_name(share_stat.st_uid)
             subvol_group = group_name(share_stat.st_gid)
             subvol_perms = oct(S_IMODE(share_stat.st_mode))[2:].zfill(3)
@@ -179,7 +180,7 @@ def import_shares(pool, request):
             if share.perms != subvol_perms:
                 share.perms = subvol_perms
             # COMPRESSION SETTING FROM DISK
-            subvol_compression = get_property(share.mnt_pt, "compression")
+            subvol_compression = get_property(subvol_path, "compression")
             if share.compression_algo != subvol_compression:
                 share.compression_algo = subvol_compression
             share.save()


### PR DESCRIPTION
On reboot, and initial Pool import, we inadvertently used an unpopulated Share mount point instead of the canonical Pool subvol path to update DB Share models. This was self-correcting but left a window that broke SFTP mount based on the temporarily misaligned Share DB ownership info during the bootstrap window.

Contains additional precautionary model.save() entries, and a minor string.format to fstring change.

Thanks to @Hooverdan96 for much of the diagnostic work related to this fix.

Fixes #3162 

---

Predominantly a fix relating back to our initial testing release (v5.5.0-0) in the current phase:
- https://github.com/rockstor/rockstor-core/pull/3079