### PR TITLE
Address py3.13 syntax warnings #3136

### DIFF
--- a/src/rockstor/fs/btrfs.py
+++ b/src/rockstor/fs/btrfs.py
@@ -587,7 +587,7 @@ def get_pool_info(disk):
         elif re.match("\tTotal devices", l) is not None:
             fields = l.split()
             full_dev_count = int(fields[2])
-        elif re.match("\t\*\*\* Some devices missing", l) is not None:
+        elif re.match(r"\t\*\*\* Some devices missing", l) is not None:
             pool_info["hasMissingDev"] = True
     pool_info["fullDevCount"] = full_dev_count
     pool_info["missingDevCount"] = full_dev_count - attached_dev_count
@@ -811,7 +811,7 @@ def umount_root(root_pool_mnt):
         if ce.rc == 32:
             for l in ce.err:
                 l = l.strip()
-                if re.search("not mounted\.$", l) is not None:
+                if re.search(r"not mounted\.$", l) is not None:
                     return
             raise ce
     for i in range(20):
@@ -1775,7 +1775,7 @@ def pool_usage(mnt_pt):
 
     used = 0
     for line in out:
-        fields = re.split("\W+", line)
+        fields = re.split(r"\W+", line)
         if line.startswith("Data"):
             used += int(fields[5])
         elif re.search("Size", line):

--- a/src/rockstor/smart_manager/views/task_scheduler.py
+++ b/src/rockstor/smart_manager/views/task_scheduler.py
@@ -130,7 +130,7 @@ class TaskSchedulerMixin(object):
                     if td.crontabwindow is not None:
                         # add crontabwindow as 2nd arg to task script, new line
                         # moved here
-                        tab = "{} \{}\n".format(tab, td.crontabwindow)
+                        tab = fr"{tab} \{td.crontabwindow}" + "\n"
                     else:
                         logger.error("missing crontab window value")
                         continue

--- a/src/rockstor/storageadmin/models/validators.py
+++ b/src/rockstor/storageadmin/models/validators.py
@@ -23,9 +23,9 @@ from django.core.validators import validate_ipv46_address
 def validate_nfs_host_str(value):
     error_count = 0
     host_regex = (
-        "^(([a-zA-Z0-9\*]|[a-zA-Z0-9\*][a-zA-Z0-9\-\*]*"
-        "[a-zA-Z0-9\*])\.)*([A-Za-z0-9\*]|[A-Za-z0-9\*]"
-        "[A-Za-z0-9\-\*]*[A-Za-z0-9\*])$"
+        r"^(([a-zA-Z0-9\*]|[a-zA-Z0-9\*][a-zA-Z0-9\-\*]*"
+        r"[a-zA-Z0-9\*])\.)*([A-Za-z0-9\*]|[A-Za-z0-9\*]"
+        r"[A-Za-z0-9\-\*]*[A-Za-z0-9\*])$"
     )
     if re.match(host_regex, value) is None:
         error_count += 1

--- a/src/rockstor/storageadmin/views/rockon_helpers.py
+++ b/src/rockstor/storageadmin/views/rockon_helpers.py
@@ -536,7 +536,7 @@ def owncloud_install(rockon):
             cur_wait = 0
             while True:
                 o, e, rc = run_command(
-                    [DOCKER, "exec", c.name, "psql", "-U", "postgres", "-c", "\l"],
+                    [DOCKER, "exec", c.name, "psql", "-U", "postgres", "-c", r"\l"],
                     throw=False,
                 )
                 if rc == 0:

--- a/src/rockstor/system/directory_services.py
+++ b/src/rockstor/system/directory_services.py
@@ -115,7 +115,7 @@ def sssd_update_ad(domain, config):
                     # empty line or new section without empty line before it.
                     tfo.write(ol)
                     domain_section = False
-            elif re.match("\[domain/%s]" % domain, line) is not None:
+            elif re.match(r"\[domain/%s]" % domain, line) is not None:
                 domain_section = True
             tfo.write(line)
         if domain_section is True:
@@ -170,9 +170,9 @@ def sssd_add_ldap(ldap_params):
                 for k, v in opts.items():
                     if re.match(k, line) is None:
                         tfo.write("{} = {}\n".format(k, v))
-            elif re.match("\[sssd]", line) is not None:
+            elif re.match(r"\[sssd]", line) is not None:
                 sssd_section = True
-            elif re.match("\[domain/{}]".format(server), line) is not None:
+            elif re.match(r"\[domain/{}]".format(server), line) is not None:
                 domain_section = True
             tfo.write(line)
         if domain_section is False:
@@ -212,9 +212,9 @@ def sssd_remove_ldap(server):
                     continue
             elif domain_section is True:
                 continue
-            elif re.match("\[sssd]", line) is not None:
+            elif re.match(r"\[sssd]", line) is not None:
                 sssd_section = True
-            elif re.match("\[domain/{}]".format(server), line) is not None:
+            elif re.match(r"\[domain/{}]".format(server), line) is not None:
                 domain_section = True
                 continue
             elif len(line.strip()) == 0:

--- a/src/rockstor/system/nut.py
+++ b/src/rockstor/system/nut.py
@@ -194,9 +194,9 @@ def update_upssched_early_shutdown(seconds):
     """
     distro_id = distro.id()
     # setup out match patterns (with escaped '*') and associated lines
-    timer_start_pattern = "AT ONBATT \* START-TIMER early-shutdown"
+    timer_start_pattern = r"AT ONBATT \* START-TIMER early-shutdown"
     timer_start_line = "AT ONBATT * START-TIMER early-shutdown"
-    timer_stop_pattern = "AT ONLINE \* CANCEL-TIMER early-shutdown"
+    timer_stop_pattern = r"AT ONLINE \* CANCEL-TIMER early-shutdown"
     timer_stop_line = "AT ONLINE * CANCEL-TIMER early-shutdown"
     start_timer_found = False
     stop_timer_found = False

--- a/src/rockstor/system/osi.py
+++ b/src/rockstor/system/osi.py
@@ -137,7 +137,7 @@ Disk = collections.namedtuple(
 # - sda3 parent is sda, sdag3 parent is sdag
 # nvme, md, or mmcblk have partitions with 'p' + >= one digit e.g.:
 # - nvme0n1p4 | md126p3 | mmcblk0p2 parents are nvme0n1 | md126 | mmcblk0
-base_dev_patterns = [("sd|vd", "\d+"), ("nvme|md|mmcblk", "p\d+")]
+base_dev_patterns = [("sd|vd", r"\d+"), ("nvme|md|mmcblk", r"p\d+")]
 
 
 def replace_line_if_found(Original_file, new_file, regex, replacement_line):
@@ -975,7 +975,7 @@ def root_disk():
                     # Note: this same pattern is also shared by mmcblk (sdcard) devices.
                     # Base device examples: mmcblk1 or mmcblk2
                     # First partition on the first device would be mmcblk1p1
-                    end = re.search("\d+", disk).end()
+                    end = re.search(r"\d+", disk).end()
                     return disk[:end]
                 if re.match("/dev/nvme", disk) is not None:
                     # We have an nvme device. These have the following naming

--- a/src/rockstor/system/pkg_mgmt.py
+++ b/src/rockstor/system/pkg_mgmt.py
@@ -131,7 +131,7 @@ def current_version(get_build_date: bool = False) -> (str, str | None):
     # The following tags gives us a pre-formatted:
     # 'Version-Release' (first line)
     # 'Thu May 01 2025' (second line)
-    tags = "%{VERSION}\-%{RELEASE}\\\n%{BUILDTIME:day}"
+    tags = "%{VERSION}\\-%{RELEASE}\\\n%{BUILDTIME:day}"
     out, err, rc = run_command(
         [RPM, "-q", "--queryformat", tags, "rockstor"], throw=False
     )

--- a/src/rockstor/system/samba.py
+++ b/src/rockstor/system/samba.py
@@ -179,7 +179,7 @@ def get_global_config():
         global_custom_section = False
         for l in sfo.readlines():
             # Check one, entering smb.conf [global] section
-            if re.match("\[global]", l) is not None:
+            if re.match(r"\[global]", l) is not None:
                 global_section = True
                 continue
             # Check two, entering Rockstor custome params section under
@@ -200,7 +200,7 @@ def get_global_config():
                 or re.match(";", l) is not None
             ):
                 continue
-            if global_section and re.match("\[", l) is not None:
+            if global_section and re.match(r"\[", l) is not None:
                 global_section = False
                 continue
             fields = l.strip().split(" = ")

--- a/src/rockstor/system/smart.py
+++ b/src/rockstor/system/smart.py
@@ -151,7 +151,7 @@ def capabilities(device, custom_options="", test_mode=TESTMODE):
             prev_line = None
             cur_cap = None
             for j in range(i + 2, len(o)):
-                if re.match(".*:\s+\(.*\)", o[j]) is not None:
+                if re.match(r".*:\s+\(.*\)", o[j]) is not None:
                     cap = o[j][: o[j].index(":")]
                     flag = o[j][(o[j].index("(") + 1) : o[j].index(")")].strip()
                     val = o[j][(o[j].index(")") + 1) :].strip()
@@ -163,7 +163,7 @@ def capabilities(device, custom_options="", test_mode=TESTMODE):
                         prev_line = None
                     cur_cap = cap
                     cap_d[cur_cap] = [flag, val]
-                elif re.match("\s", o[j]) is not None:
+                elif re.match(r"\s", o[j]) is not None:
                     cap_d[cur_cap][1] += "\n"
                     cap_d[cur_cap][1] += o[j].strip()
                 else:


### PR DESCRIPTION
Fixes #3136 
- Adjust expressions to raw strings
- Adjust one escaping instance ambiguity (instead of splitting string with raw strings indicator) in pgk_mgmt.py