### PR TITLE
Align Leap 16 SSH config layout with Slowroll & TW #3160

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -93,113 +93,113 @@ files = [
 
 [[package]]
 name = "cffi"
-version = "2.1.0"
+version = "2.1.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\""
 files = [
-    {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
-    {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
-    {file = "cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46"},
-    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2"},
-    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd"},
-    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3"},
-    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0"},
-    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43"},
-    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c"},
-    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd"},
-    {file = "cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f"},
-    {file = "cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da"},
-    {file = "cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc"},
-    {file = "cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7"},
-    {file = "cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93"},
-    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2"},
-    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c"},
-    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f"},
-    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565"},
-    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c"},
-    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02"},
-    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e"},
-    {file = "cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479"},
-    {file = "cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458"},
-    {file = "cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d"},
-    {file = "cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f"},
-    {file = "cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde"},
-    {file = "cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d"},
-    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7"},
-    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b"},
-    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7"},
-    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66"},
-    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe"},
-    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b"},
-    {file = "cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a"},
-    {file = "cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384"},
-    {file = "cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6"},
-    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda"},
-    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b"},
-    {file = "cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a"},
-    {file = "cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea"},
-    {file = "cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db"},
-    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f"},
-    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d"},
-    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0"},
-    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224"},
-    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c"},
-    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a"},
-    {file = "cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2"},
-    {file = "cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512"},
-    {file = "cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f"},
-    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a"},
-    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3"},
-    {file = "cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d"},
-    {file = "cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac"},
-    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6"},
-    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913"},
-    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d"},
-    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5"},
-    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce"},
-    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326"},
-    {file = "cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd"},
-    {file = "cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb"},
-    {file = "cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804"},
-    {file = "cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714"},
-    {file = "cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376"},
-    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98"},
-    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13"},
-    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d"},
-    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056"},
-    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4"},
-    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94"},
-    {file = "cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76"},
-    {file = "cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5"},
-    {file = "cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8"},
-    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c"},
-    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001"},
-    {file = "cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3"},
-    {file = "cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc"},
-    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699"},
-    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022"},
-    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0"},
-    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1"},
-    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28"},
-    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629"},
-    {file = "cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6"},
-    {file = "cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853"},
-    {file = "cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda"},
-    {file = "cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc"},
-    {file = "cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca"},
-    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d"},
-    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8"},
-    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd"},
-    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f"},
-    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc"},
-    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9"},
-    {file = "cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b"},
-    {file = "cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5"},
-    {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
-    {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be"},
+    {file = "cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9"},
+    {file = "cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659"},
+    {file = "cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9"},
+    {file = "cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41"},
+    {file = "cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12"},
+    {file = "cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af"},
+    {file = "cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a"},
+    {file = "cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa"},
+    {file = "cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3"},
+    {file = "cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0"},
+    {file = "cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0"},
+    {file = "cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e"},
+    {file = "cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517"},
+    {file = "cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735"},
+    {file = "cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e"},
+    {file = "cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a"},
+    {file = "cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e"},
+    {file = "cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6"},
+    {file = "cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3"},
+    {file = "cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b"},
+    {file = "cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7"},
+    {file = "cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac"},
+    {file = "cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d"},
+    {file = "cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c"},
+    {file = "cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54"},
+    {file = "cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03"},
+    {file = "cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527"},
+    {file = "cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13"},
+    {file = "cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c"},
+    {file = "cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48"},
+    {file = "cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3"},
+    {file = "cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29"},
+    {file = "cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e"},
+    {file = "cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f"},
+    {file = "cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e"},
+    {file = "cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d"},
+    {file = "cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4"},
+    {file = "cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779"},
+    {file = "cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688"},
+    {file = "cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7"},
+    {file = "cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac"},
+    {file = "cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960"},
+    {file = "cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc"},
+    {file = "cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231"},
+    {file = "cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94"},
+    {file = "cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5"},
+    {file = "cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3"},
+    {file = "cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692"},
+    {file = "cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be"},
 ]
 
 [package.dependencies]
@@ -715,14 +715,14 @@ files = [
 
 [[package]]
 name = "huey"
-version = "3.3.1"
+version = "3.3.4"
 description = "a little task queue"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "huey-3.3.1-py3-none-any.whl", hash = "sha256:b0ab6bd65fa39774e601429c1224e3c345374b06056345161132cdff19d83ebb"},
-    {file = "huey-3.3.1.tar.gz", hash = "sha256:de3f4b9a9cb045f365599c50558ffab0416d5555b3c87bd35531c7b75c1149d1"},
+    {file = "huey-3.3.4-py3-none-any.whl", hash = "sha256:a6e2e9a8fbda15c2dfb8e33b23a5e6e228326ea8e0087c11027957ef7c210e96"},
+    {file = "huey-3.3.4.tar.gz", hash = "sha256:6de196c6ece2e38b5173f7510600091ab035c0e86b0958d0e5b38a82b9984666"},
 ]
 
 [package.extras]
@@ -958,21 +958,21 @@ re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "peewee"
-version = "4.2.6"
+version = "4.3.0"
 description = "a little orm"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "peewee-4.2.6-py3-none-any.whl", hash = "sha256:b54c0f6e09c987465f8268bb2b4c1cba2e1b2788fcc0974c8e2233af1fd5af8f"},
-    {file = "peewee-4.2.6.tar.gz", hash = "sha256:f40655c64a62eaa447af228e4b84a5e80d3c812d2de34c7b9c621a3ef0c6555c"},
+    {file = "peewee-4.3.0-py3-none-any.whl", hash = "sha256:62a43d5934e7986747285124059c5ad8908cc70e538472aadae5cb5e9f10006c"},
+    {file = "peewee-4.3.0.tar.gz", hash = "sha256:f2e6686e6fc61d236fd12f370bfd42955b7b42bbd9954f207d02434a0328c3de"},
 ]
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet"]
 aiosqlite = ["aiosqlite", "greenlet"]
 asyncpg = ["asyncpg", "greenlet"]
-cysqlite = ["cysqlite"]
+cysqlite = ["cysqlite (>=0.3.5)"]
 mysql = ["pymysql"]
 postgres = ["psycopg2-binary"]
 psycopg3 = ["psycopg[binary]"]
@@ -1070,6 +1070,21 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+
+[[package]]
+name = "pyfakefs"
+version = "6.2.0"
+description = "Implements a fake file system that mocks the Python file system modules."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pyfakefs-6.2.0-py3-none-any.whl", hash = "sha256:0968a49db692694ffed420e54a9f1cbae4636637b880e8ab09c8ccc0f11bd7ae"},
+    {file = "pyfakefs-6.2.0.tar.gz", hash = "sha256:e59a36db447bf509ce9c97ab3d1510c08cc51895c5311325a560a5e5b5dc1940"},
+]
+
+[package.extras]
+doc = ["furo (>=2025.12.19)", "myst-parser (>=5.0.0)", "sphinx (>=7.0.0)"]
 
 [[package]]
 name = "python-engineio"
@@ -1584,4 +1599,4 @@ rpm = "*"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "9d4fbfe4f090170cf85cef75361534ac67039831a60b9ec8b72c5e60151dfc3d"
+content-hash = "34f26728392e2365cf9f3c84c23bf897a6aec82ce74dca351da5543bf5bc63ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     # "zypper-changelog-lib @ file:///path/zypper-changelog-lib/dist/zypper_changelog_lib-0.7.9-py3-none-any.whl",
     # "supervisor (==4.2.4)",
     "django-debug-toolbar (==6.0.0)",  # used only when DEBUG = True
+    "pyfakefs (>=6.2.0,<7.0.0)",
 ]
 
 [project.urls]

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -101,13 +101,13 @@ def init_sftp_config(sshd_config=None):
     sshd_restart = False
     found = False
     if not os.path.isfile(sshd_config):
-        logger.info("SSHD - Creating new configuration file ({}).".format(sshd_config))
+        logger.info(f"SSHD - Creating new configuration file ({sshd_config}).")
     else:
         with open(sshd_config, encoding="utf-8") as sfo:
             for line in sfo.readlines():
                 if line.startswith(SSHD_HEADER):
                     found = True
-                    logger.info("SSHD ({}) already initialised".format(sshd_config))
+                    logger.info(f"SSHD ({sshd_config}) already initialised")
                     break
     if not found:
         # Set initial AllowUsers and Subsystem sftp-internal configuration.
@@ -116,26 +116,26 @@ def init_sftp_config(sshd_config=None):
             sshd_config, mode="a+", encoding="utf-8", opener=sshd_config_opener
         ) as sfo:
             sshd_restart = True
-            sfo.write("{}\n".format(SSHD_HEADER))
-            sfo.write("{}\n".format(INTERNAL_SFTP_STR))
+            sfo.write(f"{SSHD_HEADER}\n")
+            sfo.write(f"{INTERNAL_SFTP_STR}\n")
             # TODO Split out AllowUsers into SSHD_CONFIG[distro.id()].AllowUsers
-            if os.path.isfile("{}/{}".format(settings.CONFROOT, "PermitRootLogin")):
+            if os.path.isfile(f"{settings.CONFROOT}/PermitRootLogin"):
                 sfo.write("AllowUsers root\n")
-        logger.info("SSHD ({}) initialised".format(sshd_config))
+        logger.info(f"SSHD ({sshd_config}) initialised")
     return sshd_restart
 
 
 def update_sftp_user_share_config(input_map):
     """
     Receives sftp-related customization settings and writes them to SSHD_CONFIG files.
-    :param input_map: dictionary of user,directory pairs.
+    :param input_map: dictionary of chown directory values keyed by username.
     :return:
     """
     fo, npath = mkstemp()
     sshd_conf = SshdConfig()
     # TODO: Split out AllowUsers into SSHD_CONFIG[distro.id()].AllowUsers
     userstr = "AllowUsers"
-    if os.path.isfile("{}/{}".format(settings.CONFROOT, "PermitRootLogin")):
+    if os.path.isfile(f"{settings.CONFROOT}/PermitRootLogin"):
         userstr += " root {}".format(" ".join(input_map.keys()))
     else:
         userstr += " {}".format(" ".join(input_map.keys()))
@@ -145,19 +145,19 @@ def update_sftp_user_share_config(input_map):
                 tfo.write(line)
             else:
                 break
-        tfo.write("{}\n".format(SSHD_HEADER))
+        tfo.write(f"{SSHD_HEADER}\n")
         # Detect sftp service status and ensure we maintain it
         if is_sftp_running():
-            tfo.write("{}\n".format(INTERNAL_SFTP_STR))
-        tfo.write("{}\n".format(userstr))
+            tfo.write(f"{INTERNAL_SFTP_STR}\n")
+        tfo.write(f"{userstr}\n")
         # Set options for each user according to openSUSE's defaults:
         # https://en.opensuse.org/SDB:SFTP_server_with_Chroot#Match_rule_block
         # TODO: implement webUI element to re-enable rsync over ssh by omitting
         #   the `ForceCommand internal-sftp` line below.
         for user in input_map:
-            tfo.write("Match User {}\n".format(user))
+            tfo.write(f"Match User {user}\n")
             tfo.write("\tForceCommand internal-sftp\n")
-            tfo.write("\tChrootDirectory {}\n".format(input_map[user]))
+            tfo.write(f"\tChrootDirectory {input_map[user]}\n")
             tfo.write("\tX11Forwarding no\n")
             tfo.write("\tAllowTcpForwarding no\n")
 
@@ -170,7 +170,7 @@ def update_sftp_user_share_config(input_map):
 
 def toggle_sftp_service(switch=True):
     """
-    Toggles the SFTP service on/off by writing or not the
+    Toggles the SFTP service on/off by writing or removing the
     `Subsystem sftp internal-sftp` (INTERNAL_SFTP_STR) declaration in SSHD_CONFIG.
     :param switch:
     :return:
@@ -182,12 +182,12 @@ def toggle_sftp_service(switch=True):
         for line in sfo.readlines():
             if re.match(INTERNAL_SFTP_STR, line) is not None:
                 if switch and not written:
-                    tfo.write("{}\n".format(INTERNAL_SFTP_STR))
+                    tfo.write(f"{INTERNAL_SFTP_STR}\n")
                     written = True
             elif re.match(SSHD_HEADER, line) is not None:
                 tfo.write(line)
                 if switch and not written:
-                    tfo.write("{}\n".format(INTERNAL_SFTP_STR))
+                    tfo.write(f"{INTERNAL_SFTP_STR}\n")
                     written = True
             else:
                 tfo.write(line)

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -80,9 +80,6 @@ class SshdConfig:
         else:
             self.files: sshd_files = SSHD_CONFIG["opensuse-tumbleweed"]
 
-
-sshd_conf = SshdConfig()
-
 PROGS_IN_CHROOT = ["/usr/bin/bash", "/usr/bin/rsync", "/usr/bin/ls"]
 
 
@@ -99,7 +96,7 @@ def init_sftp_config(sshd_config=None):
     :rtype boolean:
     """
     if sshd_config is None:
-        sshd_config = sshd_conf.files.sftp
+        sshd_config = SshdConfig().files.sftp
     sshd_restart = False
     found = False
     if not os.path.isfile(sshd_config):
@@ -134,6 +131,7 @@ def update_sftp_user_share_config(input_map):
     :return:
     """
     fo, npath = mkstemp()
+    sshd_conf = SshdConfig()
     # TODO: Split out AllowUsers into SSHD_CONFIG[distro.id()].AllowUsers
     userstr = "AllowUsers"
     if os.path.isfile("{}/{}".format(settings.CONFROOT, "PermitRootLogin")):
@@ -177,6 +175,7 @@ def toggle_sftp_service(switch=True):
     :return:
     """
     fo, npath = mkstemp()
+    sshd_conf = SshdConfig()
     written = False
     with open(sshd_conf.files.sftp) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
@@ -339,7 +338,7 @@ def is_sftp_subsystem_internal(sshd_config=None):
     """
     # Default to the distro specific sshd sftp file
     if sshd_config is None:
-        sshd_config = sshd_conf.files.sftp
+        sshd_config = SshdConfig().files.sftp
     if not os.path.isfile(sshd_config):
         # a non existent file cannot contain our INTERNAL_SFTP_STR
         return False
@@ -363,7 +362,7 @@ def remove_sftp_server_subsystem(sshd_config=None):
     # Comment out OS default sftp subsystem (if sftp-server).
     # Default to the distro specific sshd OS default config.
     if sshd_config is None:
-        sshd_config = sshd_conf.files.sshd_os
+        sshd_config = SshdConfig().files.sshd_os
     found_and_replaced = False
     if os.path.isfile(sshd_config):
         fh, npath = mkstemp()

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -378,10 +378,10 @@ def remove_sftp_server_subsystem(sshd_config=None):
                         temp_file.write(line)
         if found_and_replaced:
             shutil.move(npath, sshd_config)
-            logger.info("SSHD ({}) sftp-server disabled".format(sshd_config))
+            logger.info(f"SSHD ({sshd_config}) sftp-server disabled")
         else:
-            logger.info("SSHD ({}) sftp-server already disabled".format(sshd_config))
+            logger.info(f"SSHD ({sshd_config}) sftp-server already disabled")
             os.remove(npath)
     else:
-        logger.info("SSHD file ({}) does not exist".format(sshd_config))
+        logger.info(f"SSHD file ({sshd_config}) does not exist")
     return found_and_replaced

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -14,6 +14,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+
 import collections
 import logging
 import os
@@ -50,26 +51,15 @@ sshd_files = collections.namedtuple("sshd_files", "sshd sshd_os sftp AllowUsers"
 
 # Dict of sshd_files indexed by distro.id
 SSHD_CONFIG = {
-    # Account for distro 1.7.0 onwards reporting "opensuse" for id in opensuse-leap.
+    # Distro 1.7.0 onwards reports "opensuse" for id in Leap, including Leap 16.0.
+    # Previous versions reported "opensuse-leap".
     "opensuse": sshd_files(
         sshd="/etc/ssh/sshd_config",
         sshd_os="/etc/ssh/sshd_config",
         sftp="/etc/ssh/sshd_config",
         AllowUsers="/etc/ssh/sshd_config",
     ),
-    "opensuse-leap": sshd_files(
-        sshd="/etc/ssh/sshd_config",
-        sshd_os="/etc/ssh/sshd_config",
-        sftp="/etc/ssh/sshd_config",
-        AllowUsers="/etc/ssh/sshd_config",
-    ),
     # Newer overload  - type files
-    "opensuse-slowroll": sshd_files(
-        sshd="/etc/ssh/sshd_config.d/rockstor-sshd.conf",
-        sshd_os="/usr/etc/ssh/sshd_config",
-        sftp="/etc/ssh/sshd_config.d/rockstor-sftp.conf",
-        AllowUsers="/etc/ssh/sshd_config.d/rockstor-AllowUsers.conf",
-    ),
     "opensuse-tumbleweed": sshd_files(
         sshd="/etc/ssh/sshd_config.d/rockstor-sshd.conf",
         sshd_os="/usr/etc/ssh/sshd_config",
@@ -77,6 +67,21 @@ SSHD_CONFIG = {
         AllowUsers="/etc/ssh/sshd_config.d/rockstor-AllowUsers.conf",
     ),
 }
+
+
+class SshdConfig:
+    """
+    Accessor class for SSHD_CONFIG's sshd_files type values dependent on distro.
+    """
+
+    def __init__(self):
+        if distro.id() == "opensuse" and distro.version().startswith("15"):
+            self.files: sshd_files = SSHD_CONFIG["opensuse"]
+        else:
+            self.files: sshd_files = SSHD_CONFIG["opensuse-tumbleweed"]
+
+
+sshd_conf = SshdConfig()
 
 PROGS_IN_CHROOT = ["/usr/bin/bash", "/usr/bin/rsync", "/usr/bin/ls"]
 
@@ -94,7 +99,7 @@ def init_sftp_config(sshd_config=None):
     :rtype boolean:
     """
     if sshd_config is None:
-        sshd_config = SSHD_CONFIG[distro.id()].sftp
+        sshd_config = sshd_conf.files.sftp
     sshd_restart = False
     found = False
     if not os.path.isfile(sshd_config):
@@ -124,7 +129,7 @@ def init_sftp_config(sshd_config=None):
 
 def update_sftp_user_share_config(input_map):
     """
-    Receives sftp-related customization settings and writes them to SSHD_CONFIG.
+    Receives sftp-related customization settings and writes them to SSHD_CONFIG files.
     :param input_map: dictionary of user,directory pairs.
     :return:
     """
@@ -135,8 +140,7 @@ def update_sftp_user_share_config(input_map):
         userstr += " root {}".format(" ".join(input_map.keys()))
     else:
         userstr += " {}".format(" ".join(input_map.keys()))
-    distro_id = distro.id()
-    with open(SSHD_CONFIG[distro_id].sftp) as sfo, open(npath, "w") as tfo:
+    with open(sshd_conf.files.sftp) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
             if re.match(SSHD_HEADER, line) is None:
                 tfo.write(line)
@@ -158,7 +162,7 @@ def update_sftp_user_share_config(input_map):
             tfo.write("\tX11Forwarding no\n")
             tfo.write("\tAllowTcpForwarding no\n")
 
-    move(npath, SSHD_CONFIG[distro_id].sftp)
+    move(npath, sshd_conf.files.sftp)
     try:
         run_command([SYSTEMCTL, "reload", "sshd"], log=True)
     except:
@@ -174,8 +178,7 @@ def toggle_sftp_service(switch=True):
     """
     fo, npath = mkstemp()
     written = False
-    distro_id = distro.id()
-    with open(SSHD_CONFIG[distro_id].sftp) as sfo, open(npath, "w") as tfo:
+    with open(sshd_conf.files.sftp) as sfo, open(npath, "w") as tfo:
         for line in sfo.readlines():
             if re.match(INTERNAL_SFTP_STR, line) is not None:
                 if switch and not written:
@@ -188,7 +191,7 @@ def toggle_sftp_service(switch=True):
                     written = True
             else:
                 tfo.write(line)
-    move(npath, SSHD_CONFIG[distro_id].sftp)
+    move(npath, sshd_conf.files.sftp)
     try:
         run_command([SYSTEMCTL, "reload", "sshd"], log=True)
     except:
@@ -247,10 +250,15 @@ def rsync_for_sftp(chroot_loc: str | Path):
     user = chroot_path.name
 
     # Create all required subdirectories
-    # TODO: See whether explicit directory creations (aside from /usr/bin) are not necessary anymore 
+    # TODO: See whether explicit directory creations (aside from /usr/bin) are not necessary anymore
     # with dynamic parent directory creation below
     bin_dir = chroot_path / "usr" / "bin"
-    for sub_dir in [bin_dir, chroot_path / "lib", chroot_path / "lib64", chroot_path / "usr" / "lib64"]:
+    for sub_dir in [
+        bin_dir,
+        chroot_path / "lib",
+        chroot_path / "lib64",
+        chroot_path / "usr" / "lib64",
+    ]:
         run_command([MKDIR, "-p", str(sub_dir)], log=True)
 
     # filter list for path components not needed in chroot environment
@@ -331,7 +339,7 @@ def is_sftp_subsystem_internal(sshd_config=None):
     """
     # Default to the distro specific sshd sftp file
     if sshd_config is None:
-        sshd_config = SSHD_CONFIG[distro.id()].sftp
+        sshd_config = sshd_conf.files.sftp
     if not os.path.isfile(sshd_config):
         # a non existent file cannot contain our INTERNAL_SFTP_STR
         return False
@@ -355,7 +363,7 @@ def remove_sftp_server_subsystem(sshd_config=None):
     # Comment out OS default sftp subsystem (if sftp-server).
     # Default to the distro specific sshd OS default config.
     if sshd_config is None:
-        sshd_config = SSHD_CONFIG[distro.id()].sshd_os
+        sshd_config = sshd_conf.files.sshd_os
     found_and_replaced = False
     if os.path.isfile(sshd_config):
         fh, npath = mkstemp()

--- a/src/rockstor/system/ssh.py
+++ b/src/rockstor/system/ssh.py
@@ -80,6 +80,7 @@ class SshdConfig:
         else:
             self.files: sshd_files = SSHD_CONFIG["opensuse-tumbleweed"]
 
+
 PROGS_IN_CHROOT = ["/usr/bin/bash", "/usr/bin/rsync", "/usr/bin/ls"]
 
 

--- a/src/rockstor/system/tests/test_ssh.py
+++ b/src/rockstor/system/tests/test_ssh.py
@@ -1,0 +1,63 @@
+"""
+Copyright (joint work) 2026 The Rockstor Project <https://rockstor.com>
+
+Rockstor is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Rockstor is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+from pathlib import Path
+
+from pyfakefs.fake_filesystem_unittest import TestCase
+from unittest.mock import patch
+
+from system.ssh import init_sftp_config, SSHD_HEADER, INTERNAL_SFTP_STR
+from settings import CONFROOT
+
+
+class SshTests(TestCase):
+    """
+    The tests in this suite can be run via the following command:
+    cd /opt/rockstor/src/rockstor
+    poetry run django-admin test -p test_ssh.py -v 2
+    """
+    def setUp(self):
+        self.setUpPyfakefs()
+        self.patch_distro = patch("system.ssh.distro")
+        self.mock_distro = self.patch_distro.start()
+
+
+    def tearDown(self):
+        # No necessity for self.tearDownPyfakefs()
+        patch.stopall()
+
+    def test_init_sftp_config_no_config(self):
+        self.mock_distro.id.return_value = "opensuse"
+        self.mock_distro.version.return_value = "15.6"
+        sshd_conf_files_sftp = "/etc/ssh/sshd_config"  # 15.6 expected file
+        # - Created if non-existent to account for overlay locations.
+        # Otherwise, the tested code only appends if no SSHD_HEADER line in file.
+        self.assertFalse(os.path.exists(sshd_conf_files_sftp))
+        # Create flag file to add "AllowUsers root" line to sshd_conf_files_sftp.
+        self.fs.create_file(f"{CONFROOT}/PermitRootLogin")
+        # Establish parent directory in fakefs
+        path = Path("/etc/ssh")
+        path.mkdir(parents=True)
+        # Run from initrock during rockstor-pre.service.
+        self.assertTrue(init_sftp_config())
+        # Check sshd_conf_files_sftp created:
+        self.assertTrue(os.path.exists(sshd_conf_files_sftp))
+        expected_contents =[f"{SSHD_HEADER}\n",f"{INTERNAL_SFTP_STR}\n","AllowUsers root\n"]
+        with open(sshd_conf_files_sftp) as written_content:
+            self.assertEqual(written_content.readlines(), expected_contents)
+

--- a/src/rockstor/system/tests/test_ssh.py
+++ b/src/rockstor/system/tests/test_ssh.py
@@ -29,6 +29,7 @@ from system.ssh import (
     INTERNAL_SFTP_STR,
     toggle_sftp_service,
     update_sftp_user_share_config,
+    remove_sftp_server_subsystem,
 )
 from settings import CONFROOT
 
@@ -103,7 +104,7 @@ class SshTests(TestCase):
         file_mode = stat.S_IRUSR | stat.S_IWUSR
         self.fs.create_file(
             sshd_conf_files_sftp,
-            st_mode=stat.S_IRUSR | stat.S_IWUSR,
+            st_mode=file_mode,
             contents=f"{SSHD_HEADER}\n{INTERNAL_SFTP_STR}\n",  # No "AllowUsers root\n",
         )
         input_map = {"radmin": "/mnt3/radmin"}  # user radmin creates a SFTP share.
@@ -125,3 +126,33 @@ class SshTests(TestCase):
         )
         # Check original file permissions were preserved.
         self.assertEqual(S_IMODE(os.stat(sshd_conf_files_sftp).st_mode), file_mode)
+
+    def test_remove_sftp_server_subsystem(self):
+        self.mock_distro.id.return_value = "opensuse-tumbleweed"
+        self.mock_distro.version.return_value = "20260806"
+        # OS SSH config file to edit for TW:
+        sshd_conf_files_sshd_os = "/usr/etc/ssh/sshd_config"
+        file_mode = stat.S_IRUSR | stat.S_IWUSR
+        self.fs.create_file(
+            sshd_conf_files_sshd_os,
+            st_mode=file_mode,
+            contents="# override default of no subsystems\n"
+            "Subsystem       sftp    /usr/libexec/ssh/sftp-server\n",
+        )
+        # TEST RC when change is applied:
+        self.assertTrue(remove_sftp_server_subsystem())
+        # Potential anomaly re "\n" last line in output file.
+        expected = [
+            "# override default of no subsystems\n",
+            "#Subsystem       sftp    /usr/libexec/ssh/sftp-server\n",
+            "\n",
+        ]
+        with open(sshd_conf_files_sshd_os) as written_content:
+            self.assertEqual(written_content.readlines(), expected)
+        # Check original file permissions were preserved.
+        self.assertEqual(S_IMODE(os.stat(sshd_conf_files_sshd_os).st_mode), file_mode)
+        # TEST RC when no changes are made: i.e. line already remarked out:
+        self.assertFalse(remove_sftp_server_subsystem())
+        # TEST rc when no file exists:
+        self.fs.remove(sshd_conf_files_sshd_os)
+        self.assertFalse(remove_sftp_server_subsystem())

--- a/src/rockstor/system/tests/test_ssh.py
+++ b/src/rockstor/system/tests/test_ssh.py
@@ -16,12 +16,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
-from pathlib import Path
+import stat
+from stat import S_IMODE
 
 from pyfakefs.fake_filesystem_unittest import TestCase
 from unittest.mock import patch
 
-from system.ssh import init_sftp_config, SSHD_HEADER, INTERNAL_SFTP_STR
+from system.constants import SYSTEMCTL
+from system.ssh import (
+    init_sftp_config,
+    SSHD_HEADER,
+    INTERNAL_SFTP_STR,
+    toggle_sftp_service,
+    update_sftp_user_share_config,
+)
 from settings import CONFROOT
 
 
@@ -31,33 +39,89 @@ class SshTests(TestCase):
     cd /opt/rockstor/src/rockstor
     poetry run django-admin test -p test_ssh.py -v 2
     """
+
     def setUp(self):
         self.setUpPyfakefs()
         self.patch_distro = patch("system.ssh.distro")
         self.mock_distro = self.patch_distro.start()
-
+        self.patch_run_command = patch("system.ssh.run_command")
+        self.mock_run_command = self.patch_run_command.start()
+        self.patch_is_sftp_running = patch("system.ssh.is_sftp_running")
+        self.mock_is_sftp_running = self.patch_is_sftp_running.start()
 
     def tearDown(self):
         # No necessity for self.tearDownPyfakefs()
         patch.stopall()
 
-    def test_init_sftp_config_no_config(self):
+    def test_init_sftp_config_and_toggle_sftp_service(self):
         self.mock_distro.id.return_value = "opensuse"
         self.mock_distro.version.return_value = "15.6"
+        # - Created if non-existent for overlay compatibility.
+        # N.B. init code only appends if no SSHD_HEADER line found.
         sshd_conf_files_sftp = "/etc/ssh/sshd_config"  # 15.6 expected file
-        # - Created if non-existent to account for overlay locations.
-        # Otherwise, the tested code only appends if no SSHD_HEADER line in file.
         self.assertFalse(os.path.exists(sshd_conf_files_sftp))
         # Create flag file to add "AllowUsers root" line to sshd_conf_files_sftp.
         self.fs.create_file(f"{CONFROOT}/PermitRootLogin")
         # Establish parent directory in fakefs
-        path = Path("/etc/ssh")
-        path.mkdir(parents=True)
-        # Run from initrock during rockstor-pre.service.
+        self.fs.create_dir("/etc/ssh")
+        # Run from initrock during rockstor-pre.service. True is change made:
         self.assertTrue(init_sftp_config())
         # Check sshd_conf_files_sftp created:
         self.assertTrue(os.path.exists(sshd_conf_files_sftp))
-        expected_contents =[f"{SSHD_HEADER}\n",f"{INTERNAL_SFTP_STR}\n","AllowUsers root\n"]
+        expected = [
+            f"{SSHD_HEADER}\n",
+            f"{INTERNAL_SFTP_STR}\n",
+            "AllowUsers root\n",
+        ]
         with open(sshd_conf_files_sftp) as written_content:
-            self.assertEqual(written_content.readlines(), expected_contents)
+            self.assertEqual(written_content.readlines(), expected)
+        # Test return False when existing config found.
+        self.assertFalse(init_sftp_config())
+        with open(sshd_conf_files_sftp) as written_content:
+            self.assertEqual(written_content.readlines(), expected)
+        # TEST DISABLE SFTP - removing INTERNAL_SFTP_STR line from config
+        toggle_sftp_service(switch=False)
+        expected_sftp_disabled = [
+            f"{SSHD_HEADER}\n",
+            "AllowUsers root\n",
+        ]
+        with open(sshd_conf_files_sftp) as written_content:
+            self.assertEqual(written_content.readlines(), expected_sftp_disabled)
+        # See also: system/tests/test_services.py for sshd run_command calls.
+        self.mock_run_command.assert_called_once_with(
+            [SYSTEMCTL, "reload", "sshd"], log=True
+        )
 
+    def test_update_sftp_user_share_config(self):
+        self.mock_distro.id.return_value = "opensuse"
+        self.mock_distro.version.return_value = "16.0"
+        self.mock_is_sftp_running.return_value = True
+
+        sshd_conf_files_sftp = "/etc/ssh/sshd_config.d/rockstor-sftp.conf"
+        # Create file, as per initrock, as 600: "-rw-------" with contents for when
+        # NO "/opt/rockstor/CONF/PermitRootLogin" flag file exists:
+        file_mode = stat.S_IRUSR | stat.S_IWUSR
+        self.fs.create_file(
+            sshd_conf_files_sftp,
+            st_mode=stat.S_IRUSR | stat.S_IWUSR,
+            contents=f"{SSHD_HEADER}\n{INTERNAL_SFTP_STR}\n",  # No "AllowUsers root\n",
+        )
+        input_map = {"radmin": "/mnt3/radmin"}  # user radmin creates a SFTP share.
+        update_sftp_user_share_config(input_map)
+        expected = [
+            f"{SSHD_HEADER}\n",
+            f"{INTERNAL_SFTP_STR}\n",
+            "AllowUsers radmin\n",  # no /opt/rockstor/CONF/PermitRootLogin so no `root`
+            "Match User radmin\n",
+            "\tForceCommand internal-sftp\n",
+            "\tChrootDirectory /mnt3/radmin\n",
+            "\tX11Forwarding no\n",
+            "\tAllowTcpForwarding no\n",
+        ]
+        with open(sshd_conf_files_sftp) as written_content:
+            self.assertEqual(written_content.readlines(), expected)
+        self.mock_run_command.assert_called_once_with(
+            [SYSTEMCTL, "reload", "sshd"], log=True
+        )
+        # Check original file permissions were preserved.
+        self.assertEqual(S_IMODE(os.stat(sshd_conf_files_sftp).st_mode), file_mode)


### PR DESCRIPTION
Rationalise our SSHD_CONFIG dictionary of ssh config files and add an access class to maintain support for Leap 15.6 by further version enquiry when distro.id reports "opensuse", which pertains to both Leap 15.6 and Leap 16.0.

Fresh Black formatting applied to the modified file.

Fixes #3160 